### PR TITLE
cmake: Make the installation paths customizable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,13 @@ message(STATUS "Compiling ${CMAKE_PROJECT_NAME} version ${OpenSubdiv_VERSION}")
 message(STATUS "Using cmake version ${CMAKE_VERSION}")
 
 # Specify the default install path
-SET( CMAKE_INSTALL_PREFIX
-     ${PROJECT_BINARY_DIR}/ )
+if (NOT DEFINED CMAKE_INSTALL_PREFIX)
+    set( CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR} )
+endif (NOT DEFINED CMAKE_INSTALL_PREFIX)
+
+if (NOT DEFINED CMAKE_LIBDIR_BASE)
+    set( CMAKE_LIBDIR_BASE lib )
+endif (NOT DEFINED CMAKE_LIBDIR_BASE)
 
 # Set the directory where the executables will be stored.
 set(EXECUTABLE_OUTPUT_PATH

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Optional:
 
 ````
 -DCMAKE_BUILD_TYPE=[Debug|Release]
+-DCMAKE_INSTALL_PREFIX=[base path to install OpenSubdiv]
+                       (default: Current directory)
+-DCMAKE_LIBDIR_BASE=[library directory basename (default: lib)]
 -DCUDA_TOOLKIT_ROOT_DIR=[path to CUDA]
 -DPTEX_LOCATION=[path to Ptex]
 -DGLEW_LOCATION=[path to GLEW]

--- a/examples/glutViewer/CMakeLists.txt
+++ b/examples/glutViewer/CMakeLists.txt
@@ -113,3 +113,4 @@ target_link_libraries(glutViewer
     ${PLATFORM_LIBRARIES}
 )
 
+install(TARGETS glutViewer DESTINATION bin)

--- a/examples/mayaViewer/CMakeLists.txt
+++ b/examples/mayaViewer/CMakeLists.txt
@@ -138,3 +138,4 @@ target_link_libraries(maya_plugin
     ${PLATFORM_LIBRARIES}
     ${GLEW_LIBRARY}
 )
+install(TARGETS maya_plugin DESTINATION ${CMAKE_LIBDIR_BASE})

--- a/examples/ptexViewer/CMakeLists.txt
+++ b/examples/ptexViewer/CMakeLists.txt
@@ -109,4 +109,4 @@ _add_glut_executable(ptexViewer
 target_link_libraries(ptexViewer
     ${PLATFORM_LIBRARIES}
 )
-
+install(TARGETS ptexViewer DESTINATION bin)

--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -235,6 +235,7 @@ set_target_properties(osd_static PROPERTIES OUTPUT_NAME osd CLEAN_DIRECT_OUTPUT 
 target_link_libraries(osd_static
     ${PLATFORM_LIBRARIES}
 )
+install( TARGETS osd_static DESTINATION ${CMAKE_LIBDIR_BASE} )
 
 if (NOT WIN32)
     _add_possibly_cuda_library(osd_dynamic SHARED
@@ -250,6 +251,7 @@ if (NOT WIN32)
     target_link_libraries(osd_dynamic
         ${PLATFORM_LIBRARIES}
     )
+    install(TARGETS osd_dynamic DESTINATION ${CMAKE_LIBDIR_BASE})
 
 endif()
 

--- a/opensubdiv/tools/stringify/CMakeLists.txt
+++ b/opensubdiv/tools/stringify/CMakeLists.txt
@@ -59,3 +59,4 @@
 add_executable(stringify
     main.cpp
 )
+install(TARGETS stringify DESTINATION bin)


### PR DESCRIPTION
Allow specifying the installation prefix on the command-line
via e.g. `cmake -DCMAKE_INSTALL_PREFIX=/usr/local`.

Add install() commands so that "make DESTDIR=/tmp install"
works as expected with a custom installation prefix.

Allow the library directory basename to be overridden so that
custom installation layouts, such as $prefix/lib64 (fedora),
can be supported by passing -DCMAKE_LIBDIR_BASE=lib64 to cmake.
