### PR TITLE
fix compilation of examples/simpleCpu in OSX

### DIFF
--- a/examples/simpleCpu/CMakeLists.txt
+++ b/examples/simpleCpu/CMakeLists.txt
@@ -101,6 +101,8 @@ if(APPLE)
 _add_glut_executable(simpleCpu
     mainApple.mm
     simpleCpuSubdivision.cpp
+    ${SHADER_FILES}
+    ${INC_FILES}
 )
 else()
 _add_glut_executable(simpleCpu

--- a/examples/simpleCpu/mainApple.mm
+++ b/examples/simpleCpu/mainApple.mm
@@ -1,7 +1,8 @@
 #import <Cocoa/Cocoa.h>
 #import <wchar.h>
 #import <iostream>
-
+#import <OpenGL/OpenGL.h>
+#import <OpenGL/glu.h>
 //
 // Hooks back into the example code
 //


### PR DESCRIPTION
The example simpleCpu compilation was failing, thanks to:

a) Missing include/imports in mainApple.mm (compiler failed to find definition of glGetError() and associated enums)

b) Missing generation of string-fied shader for inclusion into the source code files.

This patch fixes both issues.

Signed-off-by: Adenilson Cavalcanti cavalcantii@gmail.com
