### PR TITLE
Fixed a buffer overrun error in OsdCLGLVertexBuffer::UpdateData.

### DIFF
--- a/opensubdiv/osd/clGLVertexBuffer.cpp
+++ b/opensubdiv/osd/clGLVertexBuffer.cpp
@@ -99,7 +99,7 @@ void
 OsdCLGLVertexBuffer::UpdateData(const float *src, int numVertices,
                                 cl_command_queue queue) {
 
-    size_t size = _numVertices * _numElements * sizeof(float);
+    size_t size = numVertices * _numElements * sizeof(float);
 
     map(queue);
     clEnqueueWriteBuffer(queue, _clMemory, true, 0, size, src, 0, NULL, NULL);


### PR DESCRIPTION
This patch prevents a potential segfault when the host memory buffer is smaller than the CL buffer.
