### PR TITLE
subdivisionTablesFactory: Fix typo in assert()

### DIFF
--- a/opensubdiv/far/subdivisionTablesFactory.h
+++ b/opensubdiv/far/subdivisionTablesFactory.h
@@ -231,7 +231,7 @@ FarSubdivisionTablesFactory<T,U>::FarSubdivisionTablesFactory( HbrMesh<T> const 
         if (depth>maxlevel)
             continue;
 
-        assert( remapTable[ v->GetID() ] = -1 );
+        assert( remapTable[ v->GetID() ] == -1 );
 
         if (depth==0) {
             _vertVertsList[ depth ].push_back( v );


### PR DESCRIPTION
There's a typo in assert() in subdivisionTablesFactory.h
The assert most likely should have been == rather than =
