### PR TITLE
cmake: ignore MSVC C4350 and C4548 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,12 @@ elseif(MSVC)
     list(APPEND OSD_COMPILER_FLAGS
                     /W3     # Use warning level recommended for production purposes.
                     /WX     # Treat all compiler warnings as errors.
+
+                    # these warnings are being triggered from inside VC's header files
+                    # warning C4350: behavior change: 'member1' called instead of 'member2'
+                    /wd 4350
+                    # warning C4548: expression before comma has no effect; expected expression with side-effect
+                    /wd 4548
                     
                     # Make sure WinDef.h does not define min and max macros which
                     # will conflict with std::min() and std::max().


### PR DESCRIPTION
These warnings are being triggered from inside VC's header files when `/Wall` is set.
More info on **C4350** [here](http://connect.microsoft.com/VisualStudio/feedback/details/767960/warning-c4350-behavior-change-when-including-string-and-no-precompiled-header). These warnings will probably be fixed in future updates/versions? We probably just have to ignore these for now.

**C4350** warning:

```
c:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\INCLUDE\xstring(689) : warning C4350: behavior change: 'std::_Wrap_alloc<_Alloc>::_Wrap_alloc(const std::_Wrap_alloc<_Alloc> &) throw()' called instead of '
        with
        [
            _Alloc=std::allocator<char>
        ]
        c:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\INCLUDE\xmemory0(838) : see declaration of 'std::_Wrap_alloc<_Alloc>::_Wrap_alloc'
        with
        [
            _Alloc=std::allocator<char>
        ]
        c:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\INCLUDE\xmemory0(850) : see declaration of 'std::_Wrap_alloc<_Alloc>::_Wrap_alloc'
        with
        [
            _Alloc=std::allocator<char>
        ]
        A non-const reference may only be bound to an lvalue
        c:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\INCLUDE\xstring(688) : while compiling class template member function 'std::_Wrap_alloc<_Alloc> std::_String_alloc<_Al_has_storage,_Alloc_types>::_G
        with
        [
            _Alloc=std::allocator<char>,
            _Al_has_storage=false,
            _Alloc_types=std::_String_base_types<char,std::allocator<char>>
        ]
        c:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\INCLUDE\xstring(898) : see reference to function template instantiation 'std::_Wrap_alloc<_Alloc> std::_String_alloc<_Al_has_storage,_Alloc_types>::
        with
        [
            _Alloc=std::allocator<char>,
            _Al_has_storage=false,
            _Alloc_types=std::_String_base_types<char,std::allocator<char>>
        ]
        c:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\INCLUDE\xstring(700) : see reference to class template instantiation 'std::_String_alloc<_Al_has_storage,_Alloc_types>' being compiled
        with
        [
            _Al_has_storage=false,
            _Alloc_types=std::_String_base_types<char,std::allocator<char>>
        ]
        c:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\INCLUDE\stdexcept(31) : see reference to class template instantiation 'std::basic_string<_Elem,_Traits,_Alloc>' being compiled
        with
        [
            _Elem=char,
            _Traits=std::char_traits<char>,
            _Alloc=std::allocator<char>
        ]
```

**C4548** warning:

```
c:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\INCLUDE\malloc.h(253) : warning C4548: expression before comma has no effect; expected expression with side-effect
```
