### PR TITLE
Fix referencing of python directory for source of custom command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,7 +381,7 @@ if(PYTHONINTERP_FOUND AND SWIG_FOUND)
         add_custom_command(
             OUTPUT ${PROJECT_BINARY_DIR}/python/osd
             COMMAND ${PYCMD}
-            WORKING_DIRECTORY ../python
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python
             DEPENDS osd_static_cpu osd_dynamic_cpu
             COMMENT "Building Python bindings with distutils"
         )


### PR DESCRIPTION
... ${CMAKE_SOURCE_DIR} instead of .. for consistency
