### PR TITLE
adding one example about displacement texture realtime being viewed at maya viewport

### DIFF
--- a/examples/mayaUVDisplacementViewer2011/cudaInit.h
+++ b/examples/mayaUVDisplacementViewer2011/cudaInit.h
@@ -1,0 +1,85 @@
+
+#ifndef OSD_CUDA_INIT_H
+#define OSD_CUDA_INIT_H
+
+// From "NVIDIA GPU Computing SDK 4.2/C/common/inc/cutil_inline_runtime.h":
+
+// Beginning of GPU Architecture definitions
+inline int _ConvertSMVer2Cores_local(int major, int minor)
+{
+    // Defines for GPU Architecture types (using the SM version to determine the # of cores per SM
+    typedef struct {
+        int SM; // 0xMm (hexidecimal notation), M = SM Major version, and m = SM minor version
+        int Cores;
+    } sSMtoCores;
+
+    sSMtoCores nGpuArchCoresPerSM[] =
+    { { 0x10,  8 }, // Tesla Generation (SM 1.0) G80 class
+      { 0x11,  8 }, // Tesla Generation (SM 1.1) G8x class
+      { 0x12,  8 }, // Tesla Generation (SM 1.2) G9x class
+      { 0x13,  8 }, // Tesla Generation (SM 1.3) GT200 class
+      { 0x20, 32 }, // Fermi Generation (SM 2.0) GF100 class
+      { 0x21, 48 }, // Fermi Generation (SM 2.1) GF10x class
+      { 0x30, 192}, // Fermi Generation (SM 3.0) GK10x class
+      {   -1, -1 }
+    };
+
+    int index = 0;
+    while (nGpuArchCoresPerSM[index].SM != -1) {
+        if (nGpuArchCoresPerSM[index].SM == ((major << 4) + minor) ) {
+            return nGpuArchCoresPerSM[index].Cores;
+        }
+        index++;
+    }
+    printf("MapSMtoCores undefined SMversion %d.%d!\n", major, minor);
+    return -1;
+}
+// end of GPU Architecture definitions
+
+// This function returns the best GPU (with maximum GFLOPS)
+inline int cutGetMaxGflopsDeviceId()
+{
+    int current_device   = 0, sm_per_multiproc = 0;
+    int max_compute_perf = 0, max_perf_device  = 0;
+    int device_count     = 0, best_SM_arch     = 0;
+    cudaDeviceProp deviceProp;
+
+    cudaGetDeviceCount( &device_count );
+    // Find the best major SM Architecture GPU device
+    while ( current_device < device_count ) {
+        cudaGetDeviceProperties( &deviceProp, current_device );
+        if (deviceProp.major > 0 && deviceProp.major < 9999) {
+            best_SM_arch = std::max(best_SM_arch, deviceProp.major);
+        }
+        current_device++;
+    }
+
+    // Find the best CUDA capable GPU device
+    current_device = 0;
+    while( current_device < device_count ) {
+        cudaGetDeviceProperties( &deviceProp, current_device );
+        if (deviceProp.major == 9999 && deviceProp.minor == 9999) {
+            sm_per_multiproc = 1;
+        } else {
+            sm_per_multiproc = _ConvertSMVer2Cores_local(deviceProp.major, deviceProp.minor);
+        }
+        int compute_perf  = deviceProp.multiProcessorCount * sm_per_multiproc * deviceProp.clockRate;
+        if( compute_perf  > max_compute_perf ) {
+            // If we find GPU with SM major > 2, search only these
+            if ( best_SM_arch > 2 ) {
+                // If our device==dest_SM_arch, choose this, or else pass
+                if (deviceProp.major == best_SM_arch) {
+                    max_compute_perf  = compute_perf;
+                    max_perf_device   = current_device;
+                }
+            } else {
+                max_compute_perf  = compute_perf;
+                max_perf_device   = current_device;
+            }
+        }
+        ++current_device;
+    }
+    return max_perf_device;
+}
+
+#endif //OSD_CUDA_INIT_H

--- a/examples/mayaUVDisplacementViewer2011/cudaUtil.cpp
+++ b/examples/mayaUVDisplacementViewer2011/cudaUtil.cpp
@@ -1,0 +1,12 @@
+#include <GL/glew.h>
+
+#include <cuda_runtime_api.h>
+#include <cuda_gl_interop.h>
+#include <stdio.h>
+#include <algorithm>
+#include "cudaInit.h"
+
+void cudaInit()
+{
+    cudaGLSetGLDevice( cutGetMaxGflopsDeviceId() );
+}

--- a/examples/mayaUVDisplacementViewer2011/hbrUtil.cpp
+++ b/examples/mayaUVDisplacementViewer2011/hbrUtil.cpp
@@ -1,0 +1,169 @@
+
+//
+#include "hbrUtil.h"
+#include <far/mesh.h>
+#include <hbr/mesh.h>
+#include <hbr/bilinear.h>
+#include <hbr/loop.h>
+#include <hbr/catmark.h>
+
+#define OSD_ERROR printf  // XXXX
+
+OpenSubdiv::OsdHbrMesh * ConvertToHBR(int nVertices,
+                                      std::vector<int>   const & numIndices,
+                                      std::vector<int>   const & faceIndices,
+                                      std::vector<int>   const & vtxCreaseIndices,
+                                      std::vector<float> const & vtxCreases,
+                                      std::vector<int>   const & edgeCrease1Indices, // face index, local edge index
+                                      std::vector<float> const & edgeCreases1,
+                                      std::vector<int>   const & edgeCrease2Indices, // 2 vertex indices (Maya friendly)
+                                      std::vector<float> const & edgeCreases2,
+									  std::vector<std::vector<float>> const & alluvs,
+                                      int interpBoundary, int scheme,
+									  int varCount,int * fvarindices,int* fvarwidth,int totalfarwidth)
+{
+    static OpenSubdiv::HbrBilinearSubdivision<OpenSubdiv::OsdVertex> _bilinear;
+    static OpenSubdiv::HbrLoopSubdivision<OpenSubdiv::OsdVertex> _loop;
+    static OpenSubdiv::HbrCatmarkSubdivision<OpenSubdiv::OsdVertex> _catmark;
+
+    OpenSubdiv::OsdHbrMesh *hbrMesh;
+    if (scheme == 0)
+        hbrMesh = new OpenSubdiv::OsdHbrMesh(&_catmark,varCount,fvarindices,fvarwidth,totalfarwidth);
+		//hbrMesh = new OpenSubdiv::OsdHbrMesh(&_catmark);
+    else if (scheme == 1)
+        hbrMesh = new OpenSubdiv::OsdHbrMesh(&_loop);
+    else 
+        hbrMesh = new OpenSubdiv::OsdHbrMesh(&_bilinear);
+
+	//hbrMesh->SetFVarInterpolateBoundaryMethod(OpenSubdiv::OsdHbrMesh::k_InterpolateBoundaryAlwaysSharp);
+
+
+    OpenSubdiv::OsdVertex v;
+    for(int i = 0; i < nVertices; ++i){
+        // create empty vertex : actual vertices will be initialized in UpdatePoints();
+        hbrMesh->NewVertex(i, v);
+    }
+
+    // get face indices
+    std::vector<int> vIndex;
+    int nFaces = (int)numIndices.size(), offset = 0;
+    for (int i = 0; i < nFaces; ++i) {
+        int numVertex = numIndices[i];
+        vIndex.resize(numVertex);
+
+        bool valid=true;
+        for (int j=0; j<numVertex; ++j) {
+            vIndex[j] = faceIndices[j + offset];
+            int vNextIndex = faceIndices[(j+1)%numVertex + offset];
+
+            // check for non-manifold face
+            OpenSubdiv::OsdHbrVertex * origin = hbrMesh->GetVertex( vIndex[j] );
+            OpenSubdiv::OsdHbrVertex * destination = hbrMesh->GetVertex( vNextIndex );
+            if (!origin || !destination) {
+                OSD_ERROR("ERROR : An edge was specified that connected a nonexistent vertex");
+                valid=false;
+            }
+
+            if (origin == destination) {
+                OSD_ERROR("ERROR : An edge was specified that connected a vertex to itself");
+                valid=false;
+            }
+
+            OpenSubdiv::OsdHbrHalfedge * opposite = destination->GetEdge(origin);
+            if (opposite && opposite->GetOpposite()) {
+                OSD_ERROR("ERROR : A non-manifold edge incident to more than 2 faces was found");
+                valid=false;
+            }
+
+            if (origin->GetEdge(destination)) {
+                OSD_ERROR("ERROR : An edge connecting two vertices was specified more than once. "
+                          "It's likely that an incident face was flipped");
+                valid=false;
+            }
+        }
+
+        if ( valid ) {
+            if (scheme == 1) { // loop
+                // triangulate
+                int triangle[3];
+                triangle[0] = vIndex[0];
+                for (int j=2; j<numVertex; ++j) {
+                    triangle[1] = vIndex[j-1];
+                    triangle[2] = vIndex[j];
+                    hbrMesh->NewFace(3, triangle, 0);
+                }
+
+            } else {
+                OpenSubdiv::HbrFace<OpenSubdiv::OsdVertex> *face=
+					hbrMesh->NewFace(numVertex, &(vIndex[0]), 0);
+
+
+ 				for(int mm=0;mm<numVertex;mm++)
+ 				{
+ 					OpenSubdiv::HbrVertex<OpenSubdiv::OsdVertex> *aVert=face->GetVertex(mm);
+ 					OpenSubdiv::HbrFVarData<OpenSubdiv::OsdVertex>& newData=aVert->NewFVarData(face);
+ 					newData.SetAllData(hbrMesh->GetTotalFVarWidth(),(float*)&alluvs[i][mm*hbrMesh->GetTotalFVarWidth()]);
+ 				}
+
+            }
+        } else {
+            OSD_ERROR("Face %d will be ignored\n", i);
+        }
+
+        offset += numVertex;
+    }
+
+    // XXX: use hbr enum or redefine same enum in gsd
+    hbrMesh->SetInterpolateBoundaryMethod((OpenSubdiv::OsdHbrMesh::InterpolateBoundaryMethod)interpBoundary);
+
+    // set edge crease in two different indexing way
+    int nEdgeCreases = (int)edgeCreases1.size();
+    for (int i = 0; i < nEdgeCreases; ++i) {
+        if( edgeCreases1[i] <= 0. )
+            continue;
+
+        OpenSubdiv::OsdHbrHalfedge * e = hbrMesh->GetFace(edgeCrease1Indices[i*2])->GetEdge(edgeCrease1Indices[i*2+1]);
+        if (!e) {
+            OSD_ERROR("Can't find edge (face %d edge %d)\n", edgeCrease1Indices[i*2], edgeCrease1Indices[i*2+1]);
+            continue;
+        }
+        e->SetSharpness( (float)edgeCreases1[i] );
+    }
+    nEdgeCreases = (int)edgeCreases2.size();
+    for (int i = 0; i < nEdgeCreases; ++i) {
+        if( edgeCreases2[i] <= 0. )
+            continue;
+
+        OpenSubdiv::OsdHbrVertex * v0 = hbrMesh->GetVertex(edgeCrease2Indices[i*2]);
+        OpenSubdiv::OsdHbrVertex * v1 = hbrMesh->GetVertex(edgeCrease2Indices[i*2+1]);
+        OpenSubdiv::OsdHbrHalfedge * e = NULL;
+
+        if ( v0 && v1 )
+            if ( ! (e = v0->GetEdge(v1)) )
+                e = v1->GetEdge(v0);
+        if (!e) {
+            OSD_ERROR("ERROR can't find edge");
+            continue;
+        }
+        e->SetSharpness( (float)edgeCreases2[i] );
+    }
+
+    // set corner
+    {
+        int nVertexCreases = (int)vtxCreases.size();
+        for ( int i = 0; i< nVertexCreases; ++i ) {
+            if( vtxCreases[i] <= 0. )
+                continue;
+            OpenSubdiv::OsdHbrVertex * v = hbrMesh->GetVertex(vtxCreaseIndices[i]);
+            if (!v) {
+                OSD_ERROR("Can't find vertex %d\n", vtxCreaseIndices[i]);
+                continue;
+            }
+            v->SetSharpness( (float)vtxCreases[i] );
+        }
+    }
+
+    hbrMesh->Finish();
+    return hbrMesh;
+}
+

--- a/examples/mayaUVDisplacementViewer2011/hbrUtil.h
+++ b/examples/mayaUVDisplacementViewer2011/hbrUtil.h
@@ -1,0 +1,22 @@
+
+#ifndef OSD_HBR_UTIL_H
+#define OSD_HBR_UTIL_H
+
+#include <vector>
+#include <osd/mutex.h>
+#include <osd/mesh.h>
+
+extern "C" OpenSubdiv::OsdHbrMesh * ConvertToHBR(int nVertices,
+                                                 std::vector<int>   const & numIndices,
+                                                 std::vector<int>   const & faceIndices,
+                                                 std::vector<int>   const & vtxCreaseIndices,
+                                                 std::vector<float> const & vtxCreases,
+                                                 std::vector<int>   const & edgeCrease1Indices,
+                                                 std::vector<float> const & edgeCreases1,
+                                                 std::vector<int>   const & edgeCrease2Indices,
+                                                 std::vector<float> const & edgeCreases2,
+												 std::vector<std::vector<float>> const & alluvs,
+                                                 int interpBoundary,
+                                                 int scheme,
+												 int varCount,int * fvarindices,int* fvarwidth,int totalfarwidth);
+#endif

--- a/examples/mayaUVDisplacementViewer2011/meshTopology.h
+++ b/examples/mayaUVDisplacementViewer2011/meshTopology.h
@@ -1,0 +1,884 @@
+#include <maya/MFnMesh.h>
+#include <maya/MItMeshPolygon.h>
+#include <maya/MFloatArray.h>
+#include <maya/MFloatVectorArray.h>
+
+#include <GL/glew.h>
+#include <maya/MFnPlugin.h>
+#include <maya\MPxNode.h>
+
+#include <maya/MDataBlock.h>
+#include <maya/MPlug.h>
+#include <maya/MFnMesh.h>
+#include <maya/MFnMeshData.h>
+
+#include <maya/MMeshSmoothOptions.h>
+
+#include <maya/MFnTypedAttribute.h>
+#include <maya/MFnNumericAttribute.h>
+
+#include <maya/MPointArray.h>
+#include <maya/MItMeshPolygon.h>
+#include <maya/MIntArray.h>
+
+#include <maya/MItMeshEdge.h>
+#include <maya/MItMeshVertex.h>
+
+#include <maya/MMatrix.h>
+
+#include <maya/MGlobal.h>
+#include <maya/MString.h>
+
+#include <maya/MPxSurfaceShape.h>
+#include <maya/MPxSurfaceShapeUI.h>
+
+#include <maya/MDrawRequest.h>
+#include <maya/M3dView.h>
+#include <maya/MDrawData.h>
+
+#include <maya/MFnEnumAttribute.h>
+
+#include <GL/GL.H>
+
+#include <maya/MMaterial.h>
+#include <maya/MDagPath.h>
+
+#include <maya/MFloatArray.h>
+
+#include <maya/MRenderUtil.h>
+#include <maya/MPlugArray.h>
+#include <maya/MFloatVectorArray.h>
+#include <maya/MFloatVector.h>
+#include <maya/MFloatMatrix.h>
+
+#include <maya/MGlobal.h>
+
+#include <maya/MItMeshPolygon.h>
+#include <maya/MItMeshFaceVertex.h>
+
+#include <osd/mutex.h>
+#include <osd/mesh.h>
+#include <osd/cpuDispatcher.h>
+#include <osd/clDispatcher.h>
+#include <osd/cudaDispatcher.h>
+#include <osd/elementArrayBuffer.h>
+#include <osd/ptexCoordinatesTextureBuffer.h>
+
+#include <maya/MUintArray.h>
+
+#include <maya/MSelectInfo.h>
+#include <maya/MSelectionList.h>
+#include <maya/MSelectionMask.h>
+#include <maya/MFloatPointArray.h>
+#include <maya/MFloatPoint.h>
+
+#include <maya/MMatrix.h>
+
+#include <osd/glslDispatcher.h>
+
+#include <far/table.h>
+
+#include <exception>
+
+#include "hbrUtil.h"
+extern void cudaInit();
+
+#define LEAD_COLOR				18	// green
+#define ACTIVE_COLOR			15	// white
+#define ACTIVE_AFFECTED_COLOR	8	// purple
+#define DORMANT_COLOR			4	// blue
+#define HILITE_COLOR			17	// pale blue
+#define DORMANT_VERTEX_COLOR	8	// purple
+#define ACTIVE_VERTEX_COLOR		16	// yellow
+
+const int NOTHINGCHANGE=0;
+const int TOPOLOGYCHANGE=1;
+const int UVCHANGE=2;
+const int VERTEXCHANGE=3;
+
+template<class T> static bool
+	CompareArray(const T &a, const T &b)
+{
+	if(a.length() != b.length()) return false;
+	for(unsigned int i = 0; i < a.length(); ++i){
+		if(a[i] != b[i]) return false;
+	}
+	return true;
+}
+
+template<class T> static bool
+	CompareVectorArray(const T &a, const T &b)
+{
+	if(a.size() != b.size()) return false;
+	for(unsigned int i = 0; i < a.size(); ++i){
+		if(a[i] != b[i]) return false;
+	}
+	return true;
+}
+
+struct meshTopology
+{
+	
+
+	int _level;
+
+	int changeStatus;
+
+	std::vector<int> vertexCount, vertexList, edgeCreaseIndices, vtxCreaseIndices;
+	std::vector<int> edgeCreaseVtxIndices;
+	std::vector<float> edgeCreases, vtxCreases;
+	std::vector<std::vector<float>> uvWeight;
+
+	int faceCount;
+	int vertexNum;
+	std::vector<int> grpIdx;
+
+	MPointArray positions;
+	MFloatVectorArray normals;
+	MFloatArray uvDatas;
+
+	meshTopology(){_level=3;changeStatus=NOTHINGCHANGE;faceCount=0;}
+	meshTopology(const MObject &meshObj)
+	{
+		MIntArray _vertexCount;
+		//std::vector<int> vertexCount;
+		MIntArray _vertexList;
+		//std::vector<int> vertexList;
+		MUintArray _edgeIds, _vtxIds;
+		//std::vector<int> edgeCreaseIndices, vtxCreaseIndices;
+		//std::vector<int> edgeCreaseVtxIndices;
+		MDoubleArray _edgeCreaseData, _vtxCreaseData;
+		//std::vector<float> edgeCreases, vtxCreases;
+		
+		MFnMesh fnMesh(meshObj);
+		fnMesh.getVertices(_vertexCount,_vertexList);
+		fnMesh.getCreaseEdges(_edgeIds,_edgeCreaseData);
+		fnMesh.getCreaseVertices(_vtxIds,_vtxCreaseData);
+
+		vertexCount.resize(_vertexCount.length());
+		for(int i = 0; i < (int)_vertexCount.length(); ++i) 
+			vertexCount[i] = _vertexCount[i];
+		vertexList.resize(_vertexList.length());
+		for(int i = 0; i < (int)_vertexList.length(); ++i) 
+			vertexList[i] = _vertexList[i];
+		vtxCreaseIndices.resize(_vtxIds.length());
+		for(int i = 0; i < (int)_vtxIds.length(); ++i) 
+			vtxCreaseIndices[i] = _vtxIds[i];
+		vtxCreases.resize(_vtxCreaseData.length());
+		for(int i = 0; i < (int)_vtxCreaseData.length(); ++i) 
+			vtxCreases[i] = (float)_vtxCreaseData[i];
+		edgeCreases.resize(_edgeCreaseData.length());
+		for(int i = 0; i < (int)_edgeCreaseData.length(); ++i) 
+			edgeCreases[i] = (float)_edgeCreaseData[i];
+
+		int nEdgeIds = _edgeIds.length();
+		edgeCreaseVtxIndices.resize(nEdgeIds*2);
+		edgeCreaseIndices.resize(nEdgeIds);
+		for(int i = 0; i < nEdgeIds; ++i)
+		{
+			int2 vertices;
+			fnMesh.getEdgeVertices(_edgeIds[i], vertices) ;
+			edgeCreaseVtxIndices[i*2] = vertices[0];
+			edgeCreaseVtxIndices[i*2+1] = vertices[1];
+			edgeCreaseIndices[i]=_edgeIds[i];
+		}
+
+		uvWeight.resize(_vertexCount.length());
+		MItMeshPolygon itFace(meshObj);
+		for(itFace.reset();!itFace.isDone();itFace.next())
+		{
+			uvWeight[itFace.index()].resize(itFace.polygonVertexCount()*4);
+			for(int i=0;i<itFace.polygonVertexCount();i++)
+			{
+				float2 uvpoint;
+				itFace.getUV(i,uvpoint);
+				uvDatas.append(uvpoint[0]);
+				uvDatas.append(uvpoint[1]);
+
+				uvWeight[itFace.index()][i*4]=0;
+				uvWeight[itFace.index()][i*4+1]=0;
+				uvWeight[itFace.index()][i*4+2]=0;
+				uvWeight[itFace.index()][i*4+3]=0;
+				uvWeight[itFace.index()][i*4+i]=1;
+			}
+			if(itFace.polygonVertexCount()==3)
+			{
+				uvDatas.append(0);
+				uvDatas.append(0);
+			}
+		}
+		fnMesh.getPoints(positions,MSpace::kObject);
+		fnMesh.getVertexNormals(false,normals);
+
+		faceCount=fnMesh.numPolygons();
+		cout<<"face"<<faceCount<<" "<<vertexCount.size()<<endl;
+		vertexNum=fnMesh.numVertices();
+		grpIdx.resize(faceCount,0);
+	}
+
+	void update(meshTopology& newMeshTopo)
+	{
+		vertexCount.resize(newMeshTopo.vertexCount.size());
+		for(int i=0;i<newMeshTopo.vertexCount.size();i++)
+			vertexCount[i]=newMeshTopo.vertexCount[i];
+
+		vertexList.resize(newMeshTopo.vertexList.size());
+		for(int i=0;i<newMeshTopo.vertexList.size();i++)
+			vertexList[i]=newMeshTopo.vertexList[i];
+
+		edgeCreaseIndices.resize(newMeshTopo.edgeCreaseIndices.size());
+		for(int i=0;i<newMeshTopo.edgeCreaseIndices.size();i++)
+			edgeCreaseIndices[i]=newMeshTopo.edgeCreaseIndices[i];
+
+		edgeCreaseVtxIndices.resize(newMeshTopo.edgeCreaseVtxIndices.size());
+		for(int i=0;i<newMeshTopo.edgeCreaseVtxIndices.size();i++)
+			edgeCreaseVtxIndices[i]=newMeshTopo.edgeCreaseVtxIndices[i];
+
+		edgeCreases.resize(newMeshTopo.edgeCreases.size());
+		for(int i=0;i<newMeshTopo.edgeCreases.size();i++)
+			edgeCreases[i]=newMeshTopo.edgeCreases[i];
+
+		vtxCreaseIndices.resize(newMeshTopo.vtxCreaseIndices.size());
+		for(int i=0;i<newMeshTopo.vtxCreaseIndices.size();i++)
+			vtxCreaseIndices[i]=newMeshTopo.vtxCreaseIndices[i];
+
+		vtxCreases.resize(newMeshTopo.vtxCreases.size());
+		for(int i=0;i<newMeshTopo.vtxCreases.size();i++)
+			vtxCreases[i]=newMeshTopo.vtxCreases[i];
+
+		uvWeight.resize(newMeshTopo.uvWeight.size());
+		for(int i=0;i<newMeshTopo.uvWeight.size();i++)
+		{
+			uvWeight[i].resize(newMeshTopo.uvWeight[i].size());
+			for(int j=0;j<newMeshTopo.uvWeight[i].size();j++)
+				uvWeight[i][j]=newMeshTopo.uvWeight[i][j];
+		}
+	
+/*
+// 		vertexList.clear();
+// 		vertexList.swap(newMeshTopo.vertexList);
+// 		edgeCreaseIndices.clear();
+// 		edgeCreaseIndices.swap(newMeshTopo.edgeCreaseIndices);
+// 		edgeCreaseVtxIndices.clear();
+// 		edgeCreaseVtxIndices.swap(newMeshTopo.edgeCreaseVtxIndices);
+// 		edgeCreases.clear();
+// 		edgeCreases.swap(newMeshTopo.edgeCreases);
+// 		vtxCreaseIndices.clear();
+// 		vtxCreaseIndices.swap(newMeshTopo.vtxCreaseIndices);
+// 		vtxCreases.clear();
+// 		vtxCreases.swap(newMeshTopo.vtxCreases);
+// 		uvWeight.clear();
+// 		uvWeight.swap(newMeshTopo.uvWeight);
+*/
+		uvDatas=newMeshTopo.uvDatas;
+		positions=newMeshTopo.positions;
+		normals=newMeshTopo.normals;
+		faceCount=newMeshTopo.faceCount;
+		vertexNum=newMeshTopo.vertexNum;
+		grpIdx.resize(faceCount,0);
+	}
+
+	void getUpdateInfo(meshTopology& newMeshTopo)
+	{
+		if(		!(CompareVectorArray(vertexCount,newMeshTopo.vertexCount)&&
+				CompareVectorArray(vertexList,newMeshTopo.vertexList)&&
+				CompareVectorArray(edgeCreaseIndices,newMeshTopo.edgeCreaseIndices)&&
+				CompareVectorArray(vtxCreaseIndices,newMeshTopo.vtxCreaseIndices)&&
+				CompareVectorArray(edgeCreases,newMeshTopo.edgeCreases)&&
+				CompareVectorArray(vtxCreases,newMeshTopo.vtxCreases)))
+		{
+			update(newMeshTopo);
+			changeStatus=TOPOLOGYCHANGE;
+		}
+		else if(!CompareArray(uvDatas,newMeshTopo.uvDatas))
+		{
+			update(newMeshTopo);
+			changeStatus=UVCHANGE;
+		}
+		else if(!CompareArray(positions,newMeshTopo.positions))
+		{
+			update(newMeshTopo);
+			changeStatus=VERTEXCHANGE;
+		}
+		else
+			changeStatus=NOTHINGCHANGE;
+
+	}
+	void getUpdateInfo(int subLevel)
+	{
+		if(_level!=subLevel)
+		{
+			_level=subLevel;
+			changeStatus=TOPOLOGYCHANGE;
+		}
+	}
+};
+
+struct drawData
+{
+	OpenSubdiv::OsdGpuVertexBuffer *_gpuVertexBuffer,*_gpuNormalBuffer;
+	OpenSubdiv::OsdElementArrayBuffer *_elementArrayBuffer;
+	int length;
+	bool draw;
+	drawData()
+	{
+		cout<<"drawData"<<endl;
+		length=0;
+		cout<<"drawData"<<endl;
+		_gpuNormalBuffer=NULL;
+		_gpuVertexBuffer=NULL;
+		_elementArrayBuffer=NULL;
+/*
+// 		if(_gpuNormalBuffer)
+// 			delete _gpuNormalBuffer;
+// 		cout<<"drawData"<<endl;
+// 		if(_gpuVertexBuffer)
+// 			delete _gpuVertexBuffer;
+// 		cout<<"drawData"<<endl;
+// 		if(_elementArrayBuffer)
+// 			delete _elementArrayBuffer;
+// 		cout<<"drawData"<<endl;
+*/
+	}
+
+ 	~drawData()
+ 	{
+ 		if(_gpuNormalBuffer)
+ 			delete _gpuNormalBuffer;
+ 		if(_gpuVertexBuffer)
+ 			delete _gpuVertexBuffer;
+ 		if(_elementArrayBuffer)
+ 			delete _elementArrayBuffer;
+		length=0;
+ 	}
+
+};
+
+struct dataCompute
+{
+	vector<float> vertex,normal,oriVertex,oriNormal;
+	int length;
+	MFloatPointArray oriVertexFor3D;
+	MFloatVectorArray color;
+	//vector<float> color;
+	bool dirty;
+	dataCompute(){}
+	void setLength(int length)
+	{
+		this->length=length;
+		vertex.resize(length);
+		normal.resize(length);
+		oriVertex.resize(length);
+		oriNormal.resize(length);
+		oriVertexFor3D.setLength(length/3);
+		color.setLength(length/3);
+	}
+	void build3DVertex()
+	{
+		for(int i=0;i<length/3;i++)
+		{
+			oriVertexFor3D.set(MFloatPoint(oriVertex[3*i+0],
+															oriVertex[3*i+1],
+															oriVertex[3*i+2]),
+											i);
+		}
+	}
+	
+	void sample(int & dirtyCount,MString texName)
+	{
+		if(dirty)
+		{
+			dirtyCount++;
+			//sample
+			if (texName!="")
+			{
+				MFloatMatrix cam;
+				MFloatVectorArray resultTrans;
+				MRenderUtil::sampleShadingNetwork(texName,length/3,false,false,
+					cam,&oriVertexFor3D,NULL,NULL,NULL,&oriVertexFor3D,NULL,NULL,NULL,color,resultTrans);
+			}
+			else
+			{
+				cout<<"clear3d"<<endl;
+				color.clear();
+				color=MFloatVectorArray(length/3);
+			}
+			dirty=false;
+		}
+	}
+};
+
+struct uvInfo
+{
+	float u;
+	float v;
+	int faceid;
+	float w0,w1,w2,w3;
+
+	uvInfo()
+	{
+		faceid=-1;
+	}
+};
+
+struct uv2DColor
+{
+	vector<uvInfo> uv2dInfo;
+	vector<float> color;//finalColor
+	int length;
+	bool dirty;
+	//MFloatVectorArray color;
+	uv2DColor(){}
+	void setLength(int length)
+	{
+		this->length=length;
+		uv2dInfo.resize(this->length);
+		color.resize(this->length);
+	}
+
+	void updateUV(MFloatArray uvDatas)
+	{
+		for(int i=0;i<length;i++)
+		{
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+			if(uv2dInfo[i].faceid==-1)
+				continue;
+			uv2dInfo[i].u=uvDatas[8*uv2dInfo[i].faceid]*uv2dInfo[i].w0
+				+uvDatas[8*uv2dInfo[i].faceid+2]*uv2dInfo[i].w1
+				+uvDatas[8*uv2dInfo[i].faceid+4]*uv2dInfo[i].w2
+				+uvDatas[8*uv2dInfo[i].faceid+6]*uv2dInfo[i].w3+10;
+			uv2dInfo[i].u-=(int)uv2dInfo[i].u;
+			uv2dInfo[i].v=uvDatas[8*uv2dInfo[i].faceid+1]*uv2dInfo[i].w0
+				+uvDatas[8*uv2dInfo[i].faceid+3]*uv2dInfo[i].w1
+				+uvDatas[8*uv2dInfo[i].faceid+5]*uv2dInfo[i].w2
+				+uvDatas[8*uv2dInfo[i].faceid+7]*uv2dInfo[i].w3+10;
+			uv2dInfo[i].v-=(int)uv2dInfo[i].v;
+		}
+	}
+};
+
+struct picture2D
+{
+	int size;
+	MFloatVectorArray color;
+	MString texture;
+	bool dirty;
+	picture2D()
+	{
+		dirty=true;
+	}
+	picture2D(MString texture,int size)
+	{
+		this->texture=texture;
+		this->size=size;
+		dirty=true;
+		color.setLength(size*size);
+	}
+	void update(const picture2D& newPicture)
+	{
+		texture=newPicture.texture;
+		size=newPicture.size;
+		dirty=true;
+		color.setLength(size*size);
+	}
+	void setSize(int size)
+	{
+		if(this->size!=size)
+		{
+			dirty=true;
+			color.setLength(size*size);
+		}
+		this->size=size;
+	}
+	void sample(int & dirtyCount)
+	{
+		cout<<"sampe2d"<<" "<<dirty<<endl;
+		if(dirty)
+		{
+			dirtyCount++;
+			//sample
+			MFloatArray uarray(size*size);
+			MFloatArray varray(size*size);
+
+			//set uv value
+
+			for(int i=0;i<size;i++)
+			{
+				for(int j=0;j<size;j++)
+				{
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+					uarray[i*size+j]=(1.0*j)/size;
+					varray[i*size+j]=(1.0*i)/size;
+				}
+			}
+
+			MFloatMatrix cam;
+			MFloatVectorArray resultTrans;
+			MRenderUtil::sampleShadingNetwork(texture,size*size,false,false,
+				cam,NULL,&uarray,&varray,NULL,NULL,NULL,NULL,NULL,color,resultTrans);
+		}
+		dirty=false;
+	}
+};
+
+struct meshSubdivide
+{
+	//vector<int> grouptID;
+	meshTopology meshInfo;
+	OpenSubdiv::OsdMesh *_osdmesh;
+	OpenSubdiv::OsdHbrMesh *_hbrMesh;
+	vector<int> remap;
+	drawData dataForUI;
+	dataCompute dataForCompute;
+	uv2DColor uv2DColorInfo;
+
+	int varCount;
+	int fvarindice[4];
+	int fvarwidths[4];
+	int totalfarwidth;
+
+	meshSubdivide()
+	{
+		cout<<"meshSubdivide"<<endl;
+		_osdmesh=NULL;
+		cout<<"meshSubdivide"<<endl;
+		_osdmesh = new OpenSubdiv::OsdMesh();
+		cout<<"meshSubdivide"<<endl;
+/*
+// 		if(_hbrMesh)
+// 			delete _hbrMesh;
+*/
+		cout<<"meshSubdivide"<<endl;
+		_hbrMesh=NULL;
+		cout<<"meshSubdivide"<<endl;
+		varCount=4;
+		fvarindice[0]=0;
+		fvarindice[1]=1;
+		fvarindice[2]=2;
+		fvarindice[3]=3;
+		fvarwidths[0]=1;
+		fvarwidths[1]=1;
+		fvarwidths[2]=1;
+		fvarwidths[3]=1;
+		totalfarwidth=4;
+		cout<<"meshSubdivide"<<endl;
+	}
+	~meshSubdivide()
+	{
+		if(_osdmesh)
+			delete _osdmesh;
+		if(_hbrMesh)
+			delete _hbrMesh;
+	}
+	
+	
+
+	void setMeshClear()
+	{
+		meshInfo.changeStatus=NOTHINGCHANGE;
+		dataForCompute.dirty=false;
+	}
+
+	void update(int level)
+	{
+		meshInfo.getUpdateInfo(level);
+		//todo:dealing with stateChange
+		switch (meshInfo.changeStatus)
+		{
+		case TOPOLOGYCHANGE:
+			topologyChange();
+			break;
+		case UVCHANGE:
+			uvChange();
+			break;
+		case VERTEXCHANGE:
+			vertexChange();
+			break;
+		default:
+			break;
+		}
+	}
+
+	void update(meshTopology& newMeshTopo)
+	{
+		cout<<"ddddd"<<endl;
+		meshInfo.getUpdateInfo(newMeshTopo);
+		cout<<meshInfo.changeStatus<<endl;
+		//todo:dealing with stateChange
+		switch (meshInfo.changeStatus)
+		{
+		case TOPOLOGYCHANGE:
+			cout<<"topo"<<endl;
+			topologyChange();
+			break;
+		case UVCHANGE:
+			cout<<"uv"<<endl;
+			uvChange();
+			break;
+		case VERTEXCHANGE:
+			cout<<"vertex"<<endl;
+			vertexChange();
+			break;
+		default:
+			break;
+		}
+	}
+
+	void topologyChange()
+	{
+		cout<<"1"<<endl;
+		buildOsdHbr();
+		cout<<"2"<<endl;
+		buildDrawData();
+		cout<<"3"<<endl;
+		buildUVInfo();
+		cout<<"4"<<endl;
+		uvChange();
+		cout<<"5"<<endl;
+		vertexChange();
+		cout<<"6"<<endl;
+	}
+
+	void buildOsdHbr()
+	{
+		cout<<"aaa"<<endl;
+		
+
+		if(_hbrMesh)
+			delete _hbrMesh;
+		cout<<meshInfo.vertexCount.size()<<" "
+			<<meshInfo.vertexList.size()<<" "
+			<<meshInfo.uvWeight.size()<<endl;
+		_hbrMesh = ConvertToHBR(meshInfo.vertexNum, meshInfo.vertexCount, meshInfo.vertexList,
+			meshInfo.vtxCreaseIndices, meshInfo.vtxCreases,
+			std::vector<int>(), std::vector<float>(),
+			meshInfo.edgeCreaseVtxIndices, meshInfo.edgeCreases,
+			meshInfo.uvWeight,
+			2, false,
+			varCount,fvarindice,fvarwidths,totalfarwidth);
+		_hbrMesh->PrintStats(cout);
+		cout<<"aaa"<<endl;
+		int kernel = OpenSubdiv::OsdKernelDispatcher::kCPU;
+		if (OpenSubdiv::OsdKernelDispatcher::HasKernelType(OpenSubdiv::OsdKernelDispatcher::kOPENMP)) {
+			kernel = OpenSubdiv::OsdKernelDispatcher::kOPENMP;
+		}
+		if (OpenSubdiv::OsdKernelDispatcher::HasKernelType(OpenSubdiv::OsdKernelDispatcher::kCUDA)) {
+			kernel = OpenSubdiv::OsdKernelDispatcher::kCUDA;
+			cout<<"cuda"<<endl;
+		}
+		cout<<"aaa"<<endl;
+		remap.clear();
+		cout<<meshInfo._level<<endl;
+		//,&remap
+		bool test=_osdmesh->Create(_hbrMesh, meshInfo._level, kernel,&remap);
+		cout<<"aaa"<<test<<endl;
+	}
+
+	void buildDrawData()
+	{
+		cout<<_osdmesh->GetTotalVertices()<<"ttt"<<endl;
+		if(dataForUI._gpuNormalBuffer)
+			delete dataForUI._gpuNormalBuffer;
+		cout<<_osdmesh->GetTotalVertices()<<"ttt"<<endl;
+		if(dataForUI._gpuVertexBuffer)
+			delete dataForUI._gpuVertexBuffer;
+		cout<<_osdmesh->GetTotalVertices()<<"ttt"<<endl;
+		dataForUI._gpuVertexBuffer=dynamic_cast<OpenSubdiv::OsdGpuVertexBuffer *>(_osdmesh->InitializeVertexBuffer(3));
+		//dataForUI._gpuVertexBuffer=_osdmesh->InitializeVertexBuffer(3);
+		cout<<_osdmesh->GetTotalVertices()<<"ttt"<<endl;
+		dataForUI._gpuNormalBuffer=dynamic_cast<OpenSubdiv::OsdGpuVertexBuffer *>(_osdmesh->InitializeVertexBuffer(3));
+		//dataForUI._gpuNormalBuffer=_osdmesh->InitializeVertexBuffer(3);
+		cout<<_osdmesh->GetTotalVertices()<<"ttt"<<endl;
+		if(dataForUI._elementArrayBuffer)
+			delete dataForUI._elementArrayBuffer;
+		cout<<meshInfo._level<<"ttt"<<endl;
+		dataForUI._elementArrayBuffer=_osdmesh->CreateElementArrayBuffer(meshInfo._level);
+		cout<<_osdmesh->GetTotalVertices()<<"ttt"<<endl;
+		dataForCompute.setLength(3*_osdmesh->GetTotalVertices());
+		cout<<_osdmesh->GetTotalVertices()<<"ttt"<<endl;
+	}
+
+	void buildUVInfo()
+	{
+		uv2DColorInfo.setLength(_osdmesh->GetTotalVertices());
+		for(int i=0;i<_osdmesh->GetTotalVertices();i++)
+		{
+			int farVID=remap[i];
+			OpenSubdiv::OsdHbrVertex* vertex=_hbrMesh->GetVertex(i);
+			OpenSubdiv::OsdHbrFace * face=vertex->GetFace();
+			float *f=vertex->GetFVarData(face).GetData(0);
+			uv2DColorInfo.uv2dInfo[farVID].w0=f[0];
+			uv2DColorInfo.uv2dInfo[farVID].w1=f[1];
+			uv2DColorInfo.uv2dInfo[farVID].w2=f[2];
+			uv2DColorInfo.uv2dInfo[farVID].w3=f[3];
+			uv2DColorInfo.uv2dInfo[farVID].faceid=face->GetPath().topface;
+		}
+	}
+
+	void uvChange()
+	{
+		uv2DColorInfo.updateUV(meshInfo.uvDatas);
+		uv2DColorInfo.dirty=true;
+	}
+
+	void vertexChange()
+	{
+		std::vector<float> vertexOnly;
+		vertexOnly.resize(meshInfo.vertexNum*3);
+
+		std::vector<float> normalOnly;
+		normalOnly.resize(meshInfo.vertexNum*3);
+
+		for(int i = 0; i < meshInfo.vertexNum; ++i)
+		{
+			vertexOnly[i*3+0]=meshInfo.positions[i].x;
+			vertexOnly[i*3+1]=meshInfo.positions[i].y;
+			vertexOnly[i*3+2]=meshInfo.positions[i].z;
+
+			normalOnly[i*3+0]=meshInfo.normals[i].x;
+			normalOnly[i*3+1]=meshInfo.normals[i].y;
+			normalOnly[i*3+2]=meshInfo.normals[i].z;
+		}
+
+		dataForUI._gpuVertexBuffer->UpdateData(&vertexOnly.at(0),meshInfo.vertexNum);
+		dataForUI._gpuNormalBuffer->UpdateData(&normalOnly.at(0),meshInfo.vertexNum);
+
+		_osdmesh->Subdivide(dataForUI._gpuVertexBuffer,NULL);
+		_osdmesh->Subdivide(dataForUI._gpuNormalBuffer,NULL);
+
+		prepareComputeData();
+	}
+
+	void prepareComputeData()
+	{
+		dataForUI._gpuVertexBuffer->GetBufferData(&dataForCompute.oriVertex[0],0,_osdmesh->GetTotalVertices());
+		dataForUI._gpuNormalBuffer->GetBufferData(&dataForCompute.oriNormal[0],0,_osdmesh->GetTotalVertices());
+		//normalize(&dataForCompute.oriNormal[0]);
+		dataForCompute.build3DVertex();
+		dataForCompute.dirty=true;
+	}
+
+	void updateColor(map<int,picture2D>& picture2dInfo,vector<int>& grpIdx)
+	{
+		map<int,picture2D>::iterator pictureIterTest=picture2dInfo.find(0);
+		if(pictureIterTest!=picture2dInfo.end())
+		{
+			cout<<"exist"<<endl;
+		}
+		else
+		{
+			cout<<"uexist"<<endl;
+		}
+		for(int i=0;i<uv2DColorInfo.length;i++)
+		{
+			//cout<<i<<endl;
+ 			int faceid=uv2DColorInfo.uv2dInfo[i].faceid;
+ 			if(faceid==-1)
+ 				continue;
+			//cout<<faceid<<" "<<grpIdx.size()<<endl;
+			int gid=0;
+			if(faceid<grpIdx.size())
+ 				gid=grpIdx.at(faceid);
+			//cout<<gid<<endl;
+ 			map<int,picture2D>::iterator pictureIter=picture2dInfo.find(gid);
+ 			if(pictureIter==picture2dInfo.end())
+ 			{
+				//cout<<"3d"<<endl;
+ 				uv2DColorInfo.color[i]=dataForCompute.color[i].x;
+ 				continue;
+ 			}
+ 			int w=min(max(0,(int)(uv2DColorInfo.uv2dInfo[i].u*pictureIter->second.size)),pictureIter->second.size-1);
+ 			int h=min(max(0,(int)(uv2DColorInfo.uv2dInfo[i].v*pictureIter->second.size)),pictureIter->second.size-1);
+			//cout<<i<<endl;
+			uv2DColorInfo.color[i]=pictureIter->second.color[h*pictureIter->second.size+w].x+dataForCompute.color[i].x;
+			//uv2DColorInfo.color[i]=0;
+		}
+		updatePositionNormal();
+	}
+
+	void updatePositionNormal()
+	{
+		cout<<"ffff"<<uv2DColorInfo.length<<" "<<dataForCompute.length<<" "<<dataForUI.length<<endl;
+		if(uv2DColorInfo.length<=0)
+			return;
+		for(int i=0;i<uv2DColorInfo.length;i++)
+		{
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+			dataForCompute.vertex[i*3+0]=dataForCompute.oriVertex[i*3+0]+dataForCompute.oriNormal[i*3+0]*uv2DColorInfo.color[i];
+			dataForCompute.vertex[i*3+1]=dataForCompute.oriVertex[i*3+1]+dataForCompute.oriNormal[i*3+1]*uv2DColorInfo.color[i];
+			dataForCompute.vertex[i*3+2]=dataForCompute.oriVertex[i*3+2]+dataForCompute.oriNormal[i*3+2]*uv2DColorInfo.color[i];
+		}
+		calcNormals();
+		dataForUI._gpuVertexBuffer->UpdateData(&dataForCompute.vertex[0],uv2DColorInfo.length);
+		dataForUI._gpuNormalBuffer->UpdateData(&dataForCompute.normal[0],uv2DColorInfo.length);
+		dataForUI.length=uv2DColorInfo.length;
+	}
+
+	void calcNormals()
+	{
+		//calc normal vectors
+		int nverts = (int)uv2DColorInfo.length/3;
+
+		int nfaces = _hbrMesh->GetNumFaces();
+
+		for (int i = 0; i < nfaces; ++i) 
+		{
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+
+			OpenSubdiv::OsdHbrFace * f = _hbrMesh->GetFace(i);
+
+			float const * p0 = &dataForCompute.vertex[remap[f->GetVertex(0)->GetID()]*3],
+				* p1 = &dataForCompute.vertex[remap[f->GetVertex(1)->GetID()]*3],
+				* p2 = &dataForCompute.vertex[remap[f->GetVertex(2)->GetID()]*3];
+
+			float n[3];
+			cross( n, p0, p1, p2 );
+
+			for (int j = 0; j < f->GetNumVertices(); j++) {
+				int idx = remap[f->GetVertex(j)->GetID()] * 3;
+				dataForCompute.normal[idx  ] += n[0];
+				dataForCompute.normal[idx+1] += n[1];
+				dataForCompute.normal[idx+2] += n[2];
+			}
+		}
+		for (int i = 0; i < nverts; ++i)
+		{
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+			normalize( &dataForCompute.normal[i*3] );
+		}
+	}
+
+	void cross(float *n, const float *p0, const float *p1, const float *p2) 
+	{
+
+		float a[3] = { p1[0]-p0[0], p1[1]-p0[1], p1[2]-p0[2] };
+		float b[3] = { p2[0]-p0[0], p2[1]-p0[1], p2[2]-p0[2] };
+		n[0] = a[1]*b[2]-a[2]*b[1];
+		n[1] = a[2]*b[0]-a[0]*b[2];
+		n[2] = a[0]*b[1]-a[1]*b[0];
+
+		float rn = 1.0f/sqrtf(n[0]*n[0] + n[1]*n[1] + n[2]*n[2]);
+		n[0] *= rn;
+		n[1] *= rn;
+		n[2] *= rn;
+	}
+
+	void normalize(float * p) {
+
+		float dist = sqrtf( p[0]*p[0] + p[1]*p[1]  + p[2]*p[2] );
+		p[0]/=dist;
+		p[1]/=dist;
+		p[2]/=dist;
+	}
+	
+};

--- a/examples/mayaUVDisplacementViewer2011/vixo_smooth.cpp
+++ b/examples/mayaUVDisplacementViewer2011/vixo_smooth.cpp
@@ -1,0 +1,575 @@
+#include "vixo_smooth.h"
+
+
+MTypeId	vixo_smooth::id( 0x23655 );
+MObject vixo_smooth::inOriMesh;
+MObject vixo_smooth::in2DDisplacementValue;
+MObject vixo_smooth::in3DDisplacementValue;
+MObject vixo_smooth::mapPixel;
+MObject vixo_smooth::inGroupId;
+MObject vixo_smooth::subdivideLevel;
+
+vixo_smooth::vixo_smooth(void)
+{
+
+}
+
+
+vixo_smooth::~vixo_smooth(void)
+{
+
+}
+
+void vixo_smooth::getGroupInfo(int faceTotal)
+{
+
+	MPlug plugGroupID(thisMObject(),inGroupId);
+
+	MIntArray plugGroupIdExist;
+	plugGroupID.getExistingArrayAttributeIndices(plugGroupIdExist);
+
+	MIntArray plugGroupIdConn;
+	plugGroupIdConn.clear();
+	for(int i=0;i<plugGroupIdExist.length();i++)
+	{
+		MPlugArray srcPlugsG;
+		plugGroupID.elementByLogicalIndex(plugGroupIdExist[i]).connectedTo(srcPlugsG,true,false);
+		if(srcPlugsG.length()==0)
+			continue;
+		plugGroupIdConn.append(plugGroupIdExist[i]);
+	}
+
+	groupInfo.resize(faceTotal,-1);
+
+	if(plugGroupIdConn.length()==0)
+	{
+		groupInfo.clear();
+		groupInfo.resize(faceTotal,0);
+	}
+	else
+	{
+		for(int i=0;i<plugGroupIdConn.length();i++)
+		{
+			int gid=plugGroupIdConn[i];
+			MPlugArray srcPlugsG;
+			plugGroupID.elementByLogicalIndex(gid).connectedTo(srcPlugsG,true,false);
+			//listConnections -p 1 -t "mesh" -s 0 -d 1 groupId241.groupId;
+			//body_Shape1.instObjGroups.objectGroups[8].objectGroupId
+			//objectGrpCompList
+			MStringArray res;
+			MGlobal::executeCommand("listConnections -p 1 -t \"mesh\" -s 0 -d 1 "+srcPlugsG[0].info(),res);
+			if(res.length()==0)
+				continue;
+
+			MStringArray resSplit;
+			res[0].split('.',resSplit);
+			MString nodeName=resSplit[0];
+			MString idx=resSplit[2];
+
+			res.clear();
+			MGlobal::executeCommand("getAttr "+nodeName+".instObjGroups."+idx+".objectGrpCompList",res);
+			MString flat="ls -fl";
+			for(int mm=0;mm<res.length();mm++)
+			{
+				flat=flat+" "+nodeName+"."+res[mm];
+			}
+			res.clear();
+			MGlobal::executeCommand(flat,res);
+
+			if(res.length()==0)
+				continue;
+			MIntArray faceidxele(res.length());
+			set<int> faceidxset;
+			for(int mm=0;mm<res.length();mm++)
+			{
+				MStringArray splitres;
+				res[mm].split('[',splitres);
+				MString temp=splitres[1];
+				splitres.clear();
+				temp.split(']',splitres);
+				faceidxele[mm]=splitres[0].asInt();
+				faceidxset.insert(faceidxele[mm]);
+				groupInfo[faceidxele[mm]]=gid;
+			}
+
+		}
+	}
+
+}
+
+drawData* vixo_smooth::getDrawData()
+{
+	MPlug inMeshPlug(thisMObject(),inOriMesh);
+	if(inMeshPlug.isConnected()==false)
+	{
+		meshSubInfo.dataForUI.draw=false;
+		//if(meshSubInfo.dataForUI._gpuVertexBuffer)
+		//	delete meshSubInfo.dataForUI._gpuVertexBuffer;
+		//if(meshSubInfo.dataForUI._gpuNormalBuffer)
+		//	delete meshSubInfo.dataForUI._gpuVertexBuffer;
+		//if(meshSubInfo.dataForUI._elementArrayBuffer)
+		//	delete meshSubInfo.dataForUI._elementArrayBuffer;
+		meshSubInfo.dataForUI.length=0;
+		meshSubInfo.meshInfo.vertexCount.clear();
+		return &meshSubInfo.dataForUI;
+	}
+	MObject inMeshObj=inMeshPlug.asMObject();
+	if(meshSubInfo.meshInfo.faceCount<=0)
+	{
+		isMeshDirty=true;
+		is3dDirty=true;
+		isSubLevelDirty=true;
+		isMapPixelDirty=true;
+		isGroupIdDirty=true;
+		MPlug displace2d(thisMObject(),in2DDisplacementValue);
+		displace2d.getExistingArrayAttributeIndices(dirty2D);
+	}
+	if(isMeshDirty)
+	{
+		MFnMesh fnMesh(inMeshObj);
+		//cout<<fnMesh.numVertices()<<endl;
+		meshTopology newMeshTopo(inMeshObj);
+		//cout<<"apple"<<endl;
+		meshSubInfo.update(newMeshTopo);
+		//cout<<meshSubInfo.dataForUI.length<<endl;
+	}
+	if(is3dDirty)
+	{
+		meshSubInfo.dataForCompute.dirty=true;
+	}
+	if(isSubLevelDirty)
+	{
+		int level=MPlug(thisMObject(),subdivideLevel).asInt();
+		meshSubInfo.update(level);
+	}
+	if(isGroupIdDirty)
+	{
+		//update group id info
+		getGroupInfo(meshSubInfo.meshInfo.faceCount);
+	}
+	if(isMapPixelDirty)
+	{
+		int mapSize=MPlug(thisMObject(),mapPixel).asInt();
+		map<int,picture2D>::iterator pictureIter;
+		for(pictureIter=picture2dInfo.begin();pictureIter!=picture2dInfo.end();pictureIter++)
+		{
+			pictureIter->second.setSize(mapSize);
+		}
+	}
+	//dirty2D
+	int dirtyCount=0;
+	map<int,picture2D>::iterator pictureIter;
+	//cout<<"dddddmmmm"<<dirty2D.length()<<endl;
+	for(int i=0;i<dirty2D.length();i++)
+	{
+		//cout<<"here"<<endl;
+		//unconnect 
+			//delete
+		//connect
+			//setdirty or add
+		updatePicture2d(dirty2D[i],dirtyCount);
+	}
+
+	
+	//clean 2d picture
+	//cout<<"test"<<picture2dInfo.size()<<endl;
+	for(pictureIter=picture2dInfo.begin();pictureIter!=picture2dInfo.end();pictureIter++)
+	{
+		//resample
+		cout<<"resample"<<endl;
+		pictureIter->second.sample(dirtyCount);
+		cout<<dirtyCount<<endl;
+	}
+	//clean 3d picture
+	MPlug map3dPlug(thisMObject(),in3DDisplacementValue);
+	MString tex3d="";
+	if(map3dPlug.isConnected())
+	{
+		MPlugArray plugArr;
+		map3dPlug.connectedTo(plugArr,true,false);
+		tex3d=plugArr[0].info();
+	}
+	meshSubInfo.dataForCompute.sample(dirtyCount,tex3d);
+	cout<<dirtyCount<<endl;
+	if(dirtyCount>0)
+	{
+		cout<<"yyyy"<<endl;
+		//compute final color,position,normal
+		meshSubInfo.updateColor(picture2dInfo,groupInfo);
+		cout<<"yyyy"<<endl;
+	}
+	//cout<<"aa:"<<meshSubInfo.dataForUI.length<<endl;
+	clean();
+	return &meshSubInfo.dataForUI;
+}
+
+void vixo_smooth::updatePicture2d(int idx,int& dirtyCount)
+{
+	MPlug plug(thisMObject(),in2DDisplacementValue);
+	plug=plug.elementByLogicalIndex(idx);
+	if(!plug.isConnected())
+	{
+		plug=plug.child(0);
+		if(!plug.isConnected())
+		{
+			picture2dInfo.erase(idx);
+			dirtyCount++;
+			return;
+		}
+	}
+/*
+// 	{
+// 		cout<<"unconn"<<plug.info().asChar()<<endl;
+// 		picture2dInfo.erase(idx);
+// 		dirtyCount++;
+// 	}
+*/
+	//else
+	//{
+		cout<<"conn"<<plug.info().asChar()<<endl;
+		MPlugArray texPlugs;
+		plug.connectedTo(texPlugs,true,false);
+		map<int,picture2D>::iterator pictureIter=picture2dInfo.find(idx);
+		picture2D pictureEle(texPlugs[0].info(),MPlug(thisMObject(),mapPixel).asInt());
+		if(pictureIter==picture2dInfo.end())
+		{
+			picture2dInfo.insert(make_pair(idx,pictureEle));
+		}
+		else
+		{
+			pictureIter->second.update(pictureEle);
+		}
+	//}
+}
+
+MStatus vixo_smooth::setDependentsDirty(const MPlug& plug, MPlugArray& plugArray)
+{
+	cout<<plug.info().asChar()<<endl;
+	if(plug==MPlug(thisMObject(),inOriMesh))
+		isMeshDirty=true;
+	else if(plug==MPlug(thisMObject(),subdivideLevel))
+		isSubLevelDirty=true;
+	else if(plug==MPlug(thisMObject(),in3DDisplacementValue))
+		is3dDirty=true;
+	else if(plug.isElement()&&plug.array()==MPlug(thisMObject(),inGroupId))
+		isGroupIdDirty=true;
+	else if(plug.array()==MPlug(thisMObject(),in2DDisplacementValue))
+	{
+		dirty2D.append(plug.logicalIndex());
+		cout<<"dirty:"<<plug.logicalIndex()<<endl;
+	}
+	else if(plug.parent().array()==MPlug(thisMObject(),in2DDisplacementValue))
+	{
+		dirty2D.append(plug.parent().logicalIndex());
+		cout<<"dirtyrgb:"<<plug.parent().logicalIndex()<<endl;
+	}
+	else if(plug==MPlug(thisMObject(),mapPixel))
+		isMapPixelDirty=true;
+
+	return MS::kSuccess;
+}
+
+
+MStatus	vixo_smooth::compute( const MPlug& plug, MDataBlock& data )
+{
+	return MS::kSuccess;
+}
+
+void*	vixo_smooth::creator()
+{
+	return new vixo_smooth;
+}
+
+MStatus	vixo_smooth::initialize()
+{
+	MFnTypedAttribute tAttr;
+	MFnNumericAttribute nAttr;
+
+	in2DDisplacementValue=nAttr.createColor("DisplacementValue2D","ddv");
+	nAttr.setCached(false);
+	nAttr.setArray(true);
+	nAttr.setDisconnectBehavior(MFnAttribute::kDelete);
+	in3DDisplacementValue=nAttr.createColor("DisplacementValue3D","tdv");
+	nAttr.setCached(false);
+	inGroupId=nAttr.create("inGroupId","igi",MFnNumericData::kLong);
+	nAttr.setCached(false);
+	nAttr.setArray(true);
+	nAttr.setDisconnectBehavior(MFnAttribute::kDelete);
+	subdivideLevel=nAttr.create("subdivideLevel","subl",MFnNumericData::kInt,3);
+	nAttr.setMin(1);
+	nAttr.setMax(5);
+	nAttr.setCached(false);
+	inOriMesh=tAttr.create("inOriMesh","iom",MFnData::kMesh);
+	tAttr.setCached(false);
+	mapPixel=nAttr.create("mapPixel","mps",MFnNumericData::kInt,128);
+	nAttr.setCached(false);
+
+	addAttribute(in2DDisplacementValue);
+	addAttribute(in3DDisplacementValue);
+	addAttribute(inGroupId);
+	addAttribute(subdivideLevel);
+	addAttribute(mapPixel);
+	addAttribute(inOriMesh);
+
+	return MS::kSuccess;
+}
+
+
+vixo_smoothUI::vixo_smoothUI() {}
+vixo_smoothUI::~vixo_smoothUI() {}
+
+void* vixo_smoothUI::creator()
+{
+	return new vixo_smoothUI();
+}
+
+
+void vixo_smoothUI::getDrawRequests( const MDrawInfo & info, bool objectAndActiveOnly, MDrawRequestQueue & queue )
+{
+	cout<<"request"<<endl;
+	MDrawData data;
+	MDrawRequest request = info.getPrototype( *this );
+	vixo_smooth* shapeNode = (vixo_smooth*)surfaceShape();
+	drawData* drawDatas=shapeNode->getDrawData();
+	cout<<"end"<<endl;
+
+	if(drawDatas->_gpuVertexBuffer==NULL)
+		cout<<"null"<<endl;
+	if(drawDatas->_gpuNormalBuffer==NULL)
+		cout<<"null"<<endl;
+	if(drawDatas->_elementArrayBuffer==NULL)
+		cout<<"null"<<endl;
+
+	getDrawData( drawDatas, data );
+	cout<<"end"<<endl;
+	request.setDrawData( data );
+	cout<<"end"<<endl;
+
+	M3dView::DisplayStyle  appearance    = info.displayStyle();
+	M3dView::DisplayStatus displayStatus = info.displayStatus();
+
+	if ( ! info.objectDisplayStatus( M3dView::kDisplayMeshes ) )
+		return;
+
+	switch ( appearance )
+	{
+	case M3dView::kWireFrame :
+		{
+			request.setToken(M3dView::kWireFrame);
+			M3dView::ColorTable activeColorTable = M3dView::kActiveColors;
+			M3dView::ColorTable dormantColorTable = M3dView::kDormantColors;
+			switch ( displayStatus )
+			{
+			case M3dView::kLead :
+				request.setColor( LEAD_COLOR, activeColorTable );
+				break;
+			case M3dView::kActive :
+				request.setColor( ACTIVE_COLOR, activeColorTable );
+				break;
+			case M3dView::kActiveAffected :
+				request.setColor( ACTIVE_AFFECTED_COLOR, activeColorTable );
+				break;
+			case M3dView::kDormant :
+				request.setColor( DORMANT_COLOR, dormantColorTable );
+				break;
+			case M3dView::kHilite :
+				request.setColor( HILITE_COLOR, activeColorTable );
+				break;
+			default:	
+				break;
+			}
+			cout<<"end"<<endl;
+			queue.add( request );
+			cout<<"end"<<endl;
+			break;
+		}
+	default:
+		{
+			request.setToken(M3dView::kGouraudShaded);
+			queue.add( request );
+			if(displayStatus==M3dView::kActive||displayStatus==M3dView::kLead||displayStatus==M3dView::kHilite)
+			{
+				MDrawRequest wireRequest=info.getPrototype(*this);
+				wireRequest.setDrawData(data);
+				wireRequest.setToken(M3dView::kFlatShaded);
+				wireRequest.setDisplayStyle(M3dView::kWireFrame);
+
+				M3dView::ColorTable activeColorTable = M3dView::kActiveColors;
+				switch ( displayStatus )
+				{
+				case M3dView::kLead :
+					wireRequest.setColor( LEAD_COLOR, activeColorTable );
+					break;
+				case M3dView::kActive :
+					wireRequest.setColor( ACTIVE_COLOR, activeColorTable );
+					break;
+				case M3dView::kHilite :
+					wireRequest.setColor( HILITE_COLOR, activeColorTable );
+					break;
+				default:	
+					break;
+				}
+
+				queue.add(wireRequest);
+
+			}
+			break;
+		}
+		cout<<"ttttt"<<endl;
+	}
+	cout<<"end"<<endl;
+}
+
+void vixo_smoothUI::draw( const MDrawRequest & request, M3dView & view ) const
+{
+	cout<<"draw"<<endl;
+	MDrawData data = request.drawData();
+	drawData* drawDatas=(drawData*)data.geometry();
+	if(drawDatas->length<=0)
+		return;
+	if(drawDatas->_gpuVertexBuffer==NULL)
+		return;
+	if(drawDatas->_gpuNormalBuffer==NULL)
+		return;
+	if(drawDatas->_elementArrayBuffer==NULL)
+		return;
+	int token=request.token();
+	switch(token)
+	{
+		case M3dView::kWireFrame:
+		{
+			drawWireFrame(request,view);
+			break;
+		}
+		case M3dView::kGouraudShaded:
+		{
+			drawShaded(request,view);
+			break;
+		}
+		case M3dView::kFlatShaded:
+		{
+			drawWireFrame(request,view);
+			break;
+		}
+	default:
+		break;
+	}
+}
+
+void vixo_smoothUI::drawWireFrame(const MDrawRequest & request, M3dView & view) const 
+{
+	cout<<"wire"<<endl;
+	MDrawData data = request.drawData();
+	drawData* drawDatas=(drawData*)data.geometry();
+	int token=request.token();
+	
+	view.beginGL();
+
+	glPushAttrib( GL_CURRENT_BIT );
+	glPushAttrib( GL_ENABLE_BIT);
+
+
+ 	bool lightingWasOn = glIsEnabled( GL_LIGHTING ) ? true : false;
+ 	if ( lightingWasOn ) {
+ 		glDisable( GL_LIGHTING );
+ 	}
+
+
+	if(token==M3dView::kFlatShaded)
+		glDepthMask(false);
+
+	//glEnable(GL_LIGHTING);
+	//glEnable(GL_LIGHT0);
+	//glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+	glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+	{
+		int vertexStride = 3*sizeof(float);
+		//        int varyingStride = mesh->GetVaryingStride();
+		//printf("Draw. stride = %d\n", stride);
+		//glBindBuffer(GL_ARRAY_BUFFER, drawDatas->_vertexBuffer->GetGpuBuffer());
+		cout<<"drawwwww"<<endl;
+		glBindBuffer(GL_ARRAY_BUFFER,drawDatas->_gpuVertexBuffer->GetGpuBuffer());
+		glVertexPointer(3, GL_FLOAT, vertexStride, ((char*)(0)));
+		glEnableClientState(GL_VERTEX_ARRAY);
+		cout<<"drawwwww"<<endl;
+
+		//glBindBuffer(GL_ARRAY_BUFFER, drawDatas->_gpuNormalBuffer->GetGpuBuffer());
+		//glNormalPointer(GL_FLOAT, vertexStride, ((char*)(0)));
+		//        glBindBuffer(GL_ARRAY_BUFFER, mesh->GetVaryingBuffer());
+		//        glNormalPointer(GL_FLOAT, varyingStride, ((char*)(0)));
+		//glEnableClientState(GL_NORMAL_ARRAY);
+		//cout<<"drawwwww"<<endl;
+
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, drawDatas->_elementArrayBuffer->GetGlBuffer());
+		glDrawElements(GL_QUADS, drawDatas->_elementArrayBuffer->GetNumIndices(), GL_UNSIGNED_INT, NULL);
+		cout<<"drawwwww"<<endl;
+
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+	}
+	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+
+	if ( lightingWasOn ) {
+		glEnable( GL_LIGHTING );
+	}
+
+	if(token==M3dView::kFlatShaded)
+		glDepthMask(true);
+
+	glPopAttrib();
+	glPopAttrib();
+
+	view.endGL(); 
+}
+
+void vixo_smoothUI::drawShaded(const MDrawRequest & request, M3dView & view)const 
+{
+	MDrawData data = request.drawData();
+
+	drawData* drawDatas=(drawData*)data.geometry();
+
+	view.beginGL();
+	glPushAttrib( GL_CURRENT_BIT );
+	glPushAttrib( GL_ENABLE_BIT);
+
+	//glShadeModel(GL_SMOOTH);
+	glMaterialf(GL_FRONT,GL_SPECULAR,0.5f);
+	glMaterialf(GL_FRONT,GL_SHININESS,50.0f);
+
+	glLightf(GL_LIGHT0,GL_POSITION,1.0f);
+	glLightf(GL_LIGHT0,GL_DIFFUSE,1.0f);
+	glLightf(GL_LIGHT0,GL_SPECULAR,1.0f);
+	glLightModelf(GL_LIGHT_MODEL_AMBIENT,0.2f);
+
+	glEnable(GL_LIGHTING);
+	glEnable(GL_LIGHT0);
+	glEnable(GL_DEPTH_TEST);
+
+	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+	int vertexStride = 3*sizeof(float);
+
+	glBindBuffer(GL_ARRAY_BUFFER,drawDatas->_gpuVertexBuffer->GetGpuBuffer());
+	glVertexPointer(3, GL_FLOAT, vertexStride, ((char*)(0)));
+	glEnableClientState(GL_VERTEX_ARRAY);
+
+	glBindBuffer(GL_ARRAY_BUFFER, drawDatas->_gpuNormalBuffer->GetGpuBuffer());
+	glNormalPointer(GL_FLOAT, vertexStride, ((char*)(0)));
+	
+	glEnableClientState(GL_NORMAL_ARRAY);
+
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, drawDatas->_elementArrayBuffer->GetGlBuffer());
+	glDrawElements(GL_QUADS, drawDatas->_elementArrayBuffer->GetNumIndices(), GL_UNSIGNED_INT, NULL);
+
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+	glDisable(GL_DEPTH_TEST);
+	glDisable(GL_LIGHT0);
+	glDisable(GL_LIGHTING);
+
+	glPopAttrib();
+	glPopAttrib();
+
+	view.endGL();
+}

--- a/examples/mayaUVDisplacementViewer2011/vixo_smooth.h
+++ b/examples/mayaUVDisplacementViewer2011/vixo_smooth.h
@@ -1,0 +1,164 @@
+#pragma once
+
+
+
+//#include "typedef.h"
+
+//#include "displacementMap.h"
+#include "meshTopology.h"
+//#include "drawData.h"
+
+
+
+class vixo_smooth : public MPxSurfaceShape
+{
+private:
+	//drawData drawDataUI;
+	meshSubdivide meshSubInfo;
+	vector<int> groupInfo;
+	void getGroupInfo(int faceNum);
+	map<int,picture2D> picture2dInfo;
+	void updatePicture2d(int idx,int& dirtyCount);
+	void clean()
+	{
+		isMeshDirty=false;
+		isSubLevelDirty=false;
+		dirty2D.clear();
+		isMapPixelDirty=false;
+		is3dDirty=false;
+		isGroupIdDirty=false;
+		meshSubInfo.setMeshClear();
+	}
+public:
+	drawData* getDrawData();
+
+public:
+	vixo_smooth(void);
+	virtual~vixo_smooth(void);
+
+	virtual MStatus	compute( const MPlug&, MDataBlock& );
+	virtual MStatus setDependentsDirty(const MPlug& plug, MPlugArray& plugArray);
+
+	static  void *		creator();
+	static  MStatus		initialize();
+
+	virtual void postConstructor()
+	{
+		setRenderable(true);
+	}
+
+	virtual MBoundingBox boundingBox() const
+	{
+		MBoundingBox box;
+		MPlug plugtest(thisMObject(),inOriMesh);
+		if(plugtest.isConnected()==false)
+			return box;
+
+		MPlugArray plugArr;
+		plugtest.connectedTo(plugArr,true,false);
+		if(plugArr[0].node().hasFn(MFn::kMesh)==false)
+			return box;
+
+		MFnDagNode fnDag(plugArr[0].node());
+		MBoundingBox oriBox=fnDag.boundingBox();
+
+		return oriBox;
+	}
+	virtual bool isBounded() const
+	{
+		return true;
+	}
+
+	static MTypeId id;
+	static MObject inOriMesh;
+	static MObject subdivideLevel;
+
+	static MObject in2DDisplacementValue;
+	static MObject in3DDisplacementValue;
+
+	static MObject mapPixel;
+	static MObject inGroupId;
+
+private:
+	bool isMeshDirty;
+	bool isSubLevelDirty;
+	MIntArray dirty2D;
+	bool isMapPixelDirty;
+	bool is3dDirty;
+	bool isGroupIdDirty;
+
+};
+
+
+class vixo_smoothUI : public MPxSurfaceShapeUI
+{
+public:
+	vixo_smoothUI();
+	virtual ~vixo_smoothUI(); 
+
+	virtual void	getDrawRequests( const MDrawInfo & info,
+		bool objectAndActiveOnly,
+		MDrawRequestQueue & requests );
+	virtual void	draw( const MDrawRequest & request,
+		M3dView & view ) const;
+
+	static  void *  creator();
+
+	bool select(MSelectInfo &selectInfo, MSelectionList &selectionList, MPointArray &worldSpaceSelectPts) const
+	{
+
+		bool selected = false;
+		bool componentSelected = false;
+		bool hilited = false;
+
+
+		if ( !selected ) {
+
+			vixo_smooth* meshNode = (vixo_smooth*)surfaceShape();
+
+			// NOTE: If the geometry has an intersect routine it should
+			// be called here with the selection ray to determine if the
+			// the object was selected.
+
+			selected = true;
+			MSelectionMask priorityMask( MSelectionMask::kSelectMeshes );
+			MSelectionList item;
+			item.add( selectInfo.selectPath() );
+			MPoint xformedPt;
+			if ( selectInfo.singleSelection() ) {
+				MPoint center = meshNode->boundingBox().center();
+				xformedPt = center;
+				xformedPt *= selectInfo.selectPath().inclusiveMatrix();
+			}
+
+			selectInfo.addSelection( item, xformedPt, selectionList,
+				worldSpaceSelectPts, priorityMask, false );
+		}
+
+		return selected;
+	}
+
+	void drawWireFrame(const MDrawRequest & request,M3dView & view) const ;
+	void drawShaded(const MDrawRequest & request,M3dView & view) const ;
+};
+
+MStatus initializePlugin( MObject obj )
+{ 
+	glewInit();
+	OpenSubdiv::OsdCpuKernelDispatcher::Register();
+	OpenSubdiv::OsdCudaKernelDispatcher::Register();
+	cudaInit();
+	MFnPlugin plugin( obj, PLUGIN_COMPANY, "3.0", "Any");
+	return plugin.registerShape( "vixo_smooth", vixo_smooth::id,
+		&vixo_smooth::creator,
+		&vixo_smooth::initialize,
+		&vixo_smoothUI::creator  );
+}
+
+MStatus uninitializePlugin( MObject obj)
+{
+	MFnPlugin plugin( obj );
+	return plugin.deregisterNode( vixo_smooth::id );
+}
+
+


### PR DESCRIPTION
deal with 2d texture other than 3d ptex. artists can view the displacement effect in maya's viewport realtime. it can be used to make stone, wall and terrian displacement texture files.
it support maya or mentalray's 2d and 3d textures.
