### PR TITLE
Make FindGLEW aware of multiarch on linux systems

### DIFF
--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -78,6 +78,7 @@ if (${CMAKE_HOST_UNIX})
             $ENV{GLEW_LOCATION}/lib
             /usr/lib64
             /usr/lib
+            /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
             /usr/local/lib64
             /usr/local/lib
             /sw/lib


### PR DESCRIPTION
Multiarch distros such as Debian are keeping libraries
in /usr/lib/<platform>/ instead of /usr/lib. Added an
additional hint for GLEW library location to deal with
this.
