### PR TITLE
Return success status from openSubdiv_finishEvaluatorDescr()

### DIFF
--- a/opensubdiv/osdutil/evaluator_capi.cpp
+++ b/opensubdiv/osdutil/evaluator_capi.cpp
@@ -90,20 +90,23 @@ void openSubdiv_createEvaluatorDescrFace(OpenSubdiv_EvaluatorDescr *evaluator_de
         }
 }
 
-void openSubdiv_finishEvaluatorDescr(OpenSubdiv_EvaluatorDescr *evaluator_descr,
-                                int refinementLevel)
+int openSubdiv_finishEvaluatorDescr(OpenSubdiv_EvaluatorDescr *evaluator_descr,
+                                    int refinementLevel)
 {
     std::string errorMessage;
     evaluator_descr->topology.refinementLevel = refinementLevel;
-    
+    // TODO: Pass the error message to the callee function so it know what's going on.
     if (not evaluator_descr->topology.IsValid(&errorMessage)) {
         std::cout <<"OpenSubdiv topology is not valid due to " << errorMessage << std::endl;
+        return 0;
     } else {
         if (not evaluator_descr->evaluator.Initialize(
                 evaluator_descr->topology, &errorMessage)) {
             std::cout <<"OpenSubdiv uniform evaluator initialization failed due to " << errorMessage << std::endl;
+            return 0;
         }
     }
+    return 1;
 }
 
 

--- a/opensubdiv/osdutil/evaluator_capi.h
+++ b/opensubdiv/osdutil/evaluator_capi.h
@@ -38,7 +38,7 @@ struct OpenSubdiv_EvaluatorDescr;
 struct OpenSubdiv_EvaluatorDescr *openSubdiv_createEvaluatorDescr(int numVertices);
 void openSubdiv_deleteEvaluatorDescr(struct OpenSubdiv_EvaluatorDescr *evaluator_descr);
 void openSubdiv_createEvaluatorDescrFace(struct OpenSubdiv_EvaluatorDescr *evaluator_descr, int num_vertices, int *indices);
-void openSubdiv_finishEvaluatorDescr(struct OpenSubdiv_EvaluatorDescr *evaluator_descr, int refinementLevel);
+int openSubdiv_finishEvaluatorDescr(struct OpenSubdiv_EvaluatorDescr *evaluator_descr, int refinementLevel);
 
 /* Set the positions of points on the coarse mesh and refine. This method    */
 /* will perform catmull/clark refinement on the CVs to be ready to call      */


### PR DESCRIPTION
Before this change the given function used to fail silently in
cases topology is bad or uniform evaluator initialization failed.
This used to leave evaluator in a state which is not usable for
further processing but callee function would never know this and
will likely crash later when evaluating subdivision limit surface.

Ideally error message or code need to be passed to the calle, but
that's marked as TODO for now.
