### PR TITLE
Add a public constructor to OsdMesh

### DIFF
--- a/opensubdiv/osd/d3d11Mesh.h
+++ b/opensubdiv/osd/d3d11Mesh.h
@@ -65,20 +65,43 @@ public:
         FarMeshFactory<OsdVertex> meshFactory(hmesh, level, bits.test(MeshAdaptive));
         _farMesh = meshFactory.Create(bits.test(MeshFVarData));
 
-        ID3D11Device * pd3d11Device;
-        _pd3d11DeviceContext->GetDevice(&pd3d11Device);
+        _initialize(numVertexElements, numVaryingElements, bits);
+    }
 
-        int numVertices = _farMesh->GetNumVertices();
-        _vertexBuffer = VertexBuffer::Create(numVertexElements, numVertices, pd3d11Device);
-        if (numVaryingElements)
-            _vertexBuffer = VertexBuffer::Create(numVaryingElements, numVertices, pd3d11Device);
-        _computeContext = ComputeContext::Create(_farMesh->GetSubdivisionTables(),
-                                                 _farMesh->GetVertexEditTables());
-        _drawContext = DrawContext::Create(_farMesh->GetPatchTables(),
-                                           _pd3d11DeviceContext,
-                                           numVertexElements,
-                                           bits.test(MeshFVarData));
-        assert(_drawContext);
+    OsdMesh(ComputeController * computeController,
+            FarMesh<OsdVertex> * fmesh,
+            int numVertexElements,
+            int numVaryingElements,
+            OsdMeshBitset bits,
+            ID3D11DeviceContext *d3d11DeviceContext) :
+
+            _farMesh(fmesh),
+            _vertexBuffer(0),
+            _varyingBuffer(0),
+            _computeContext(0),
+            _computeController(computeController),
+            _drawContext(0),
+            _pd3d11DeviceContext(d3d11DeviceContext)
+    {
+        _initialize(numVertexElements, numVaryingElements, bits);
+    }
+
+    OsdMesh(ComputeController * computeController,
+            FarMesh<OsdVertex> * fmesh,
+            VertexBuffer * vertexBuffer,
+            VertexBuffer * varyingBuffer,
+            ComputeContext * computeContext,
+            DrawContext * drawContext,
+            ID3D11DeviceContext *d3d11DeviceContext) :
+
+            _farMesh(fmesh),
+            _vertexBuffer(vertexBuffer),
+            _varyingBuffer(varyingBuffer),
+            _computeContext(computeContext),
+            _computeController(computeController),
+            _drawContext(drawContext),
+            _pd3d11DeviceContext(d3d11DeviceContext)
+    {
         _drawContext->UpdateVertexTexture(_vertexBuffer, _pd3d11DeviceContext);
     }
 
@@ -113,8 +136,38 @@ public:
     virtual DrawContext * GetDrawContext() {
         return _drawContext;
     }
+    virtual VertexBuffer * GetVertexBuffer() {
+        return _vertexBuffer;
+    }
+    virtual VertexBuffer * GetVaryingBuffer() {
+        return _varyingBuffer;
+    }
+    virtual FarMesh<OsdVertex> const * GetFarMesh() const {
+        return _farMesh;
+    }
 
 private:
+
+    void _initialize( int numVertexElements,
+                      int numVaryingElements,
+                      OsdMeshBitset bits)
+    {
+        ID3D11Device * pd3d11Device;
+        _pd3d11DeviceContext->GetDevice(&pd3d11Device);
+
+        int numVertices = _farMesh->GetNumVertices();
+        if (numVertexElements)
+            _vertexBuffer = VertexBuffer::Create(numVertexElements, numVertices, pd3d11Device);
+        if (numVaryingElements)
+            _varyingBuffer = VertexBuffer::Create(numVaryingElements, numVertices, pd3d11Device);
+        _computeContext = ComputeContext::Create(_farMesh->GetSubdivisionTables(), _farMesh->GetVertexEditTables());
+        _drawContext = DrawContext::Create(_farMesh->GetPatchTables(),
+                                           _pd3d11DeviceContext,
+                                           numVertexElements,
+                                           bits.test(MeshFVarData));
+        _drawContext->UpdateVertexTexture(_vertexBuffer, _pd3d11DeviceContext);
+    }
+
     FarMesh<OsdVertex> *_farMesh;
     VertexBuffer *_vertexBuffer;
     VertexBuffer *_varyingBuffer;
@@ -153,20 +206,43 @@ public:
         FarMeshFactory<OsdVertex> meshFactory(hmesh, level, bits.test(MeshAdaptive));
         _farMesh = meshFactory.Create(bits.test(MeshFVarData));
 
-        ID3D11Device * pd3d11Device;
-        _pd3d11DeviceContext->GetDevice(&pd3d11Device);
+        _initialize(numVertexElements, numVaryingElements, bits);
+    }
 
-        int numVertices = _farMesh->GetNumVertices();
-        _vertexBuffer = VertexBuffer::Create(numVertexElements, numVertices, pd3d11Device);
-        if (numVaryingElements)
-            _varyingBuffer = VertexBuffer::Create(numVaryingElements, numVertices, pd3d11Device);
-        _computeContext = ComputeContext::Create(_farMesh->GetSubdivisionTables(),
-                                                 _farMesh->GetVertexEditTables(),
-                                                 _pd3d11DeviceContext);
-        _drawContext = DrawContext::Create(_farMesh->GetPatchTables(),
-                                           _pd3d11DeviceContext,
-                                           numVertexElements,
-                                           bits.test(MeshFVarData));
+    OsdMesh(ComputeController * computeController,
+            FarMesh<OsdVertex> * fmesh,
+            int numVertexElements,
+            int numVaryingElements,
+            OsdMeshBitset bits,
+            ID3D11DeviceContext *d3d11DeviceContext) :
+
+            _farMesh(fmesh),
+            _vertexBuffer(0),
+            _varyingBuffer(0),
+            _computeContext(0),
+            _computeController(computeController),
+            _drawContext(0),
+            _pd3d11DeviceContext(d3d11DeviceContext)
+    {
+        _initialize(numVertexElements, numVaryingElements, bits);
+    }
+
+    OsdMesh(ComputeController * computeController,
+            FarMesh<OsdVertex> * fmesh,
+            VertexBuffer * vertexBuffer,
+            VertexBuffer * varyingBuffer,
+            ComputeContext * computeContext,
+            DrawContext * drawContext,
+            ID3D11DeviceContext *d3d11DeviceContext) :
+
+            _farMesh(fmesh),
+            _vertexBuffer(vertexBuffer),
+            _varyingBuffer(varyingBuffer),
+            _computeContext(computeContext),
+            _computeController(computeController),
+            _drawContext(drawContext),
+            _pd3d11DeviceContext(d3d11DeviceContext)
+    {
         _drawContext->UpdateVertexTexture(_vertexBuffer, _pd3d11DeviceContext);
     }
 
@@ -201,8 +277,40 @@ public:
     virtual DrawContext * GetDrawContext() {
         return _drawContext;
     }
+    virtual VertexBuffer * GetVertexBuffer() {
+        return _vertexBuffer;
+    }
+    virtual VertexBuffer * GetVaryingBuffer() {
+        return _varyingBuffer;
+    }
+    virtual FarMesh<OsdVertex> const * GetFarMesh() const {
+        return _farMesh;
+    }
 
 private:
+
+    void _initialize( int numVertexElements,
+                      int numVaryingElements,
+                      OsdMeshBitset bits)
+    {
+        ID3D11Device * pd3d11Device;
+        _pd3d11DeviceContext->GetDevice(&pd3d11Device);
+
+        int numVertices = _farMesh->GetNumVertices();
+        if (numVertexElements)
+            _vertexBuffer = VertexBuffer::Create(numVertexElements, numVertices, pd3d11Device);
+        if (numVaryingElements)
+            _varyingBuffer = VertexBuffer::Create(numVaryingElements, numVertices, pd3d11Device);
+        _computeContext = ComputeContext::Create(_farMesh->GetSubdivisionTables(),
+                                                 _farMesh->GetVertexEditTables(),
+                                                 _pd3d11DeviceContext);
+        _drawContext = DrawContext::Create(_farMesh->GetPatchTables(),
+                                           _pd3d11DeviceContext,
+                                           numVertexElements,
+                                           bits.test(MeshFVarData));
+        _drawContext->UpdateVertexTexture(_vertexBuffer, _pd3d11DeviceContext);
+    }
+
     FarMesh<OsdVertex> *_farMesh;
     VertexBuffer *_vertexBuffer;
     VertexBuffer *_varyingBuffer;
@@ -255,20 +363,51 @@ public:
         FarMeshFactory<OsdVertex> meshFactory(hmesh, level, bits.test(MeshAdaptive));
         _farMesh = meshFactory.Create(bits.test(MeshFVarData));
 
-        ID3D11Device * pd3d11Device;
-        _pd3d11DeviceContext->GetDevice(&pd3d11Device);
+        _initialize(numVertexElements, numVaryingElements, bits);
+    }
 
-        int numVertices = _farMesh->GetNumVertices();
-        _vertexBuffer = typename VertexBuffer::Create(numVertexElements, numVertices, _clContext, pd3d11Device);
-        if (numVaryingElements)
-            _varyingBuffer = typename VertexBuffer::Create(numVaryingElements, numVertices, _clContext, pd3d11Device);
-        _computeContext = ComputeContext::Create(_farMesh->GetSubdivisionTables(),
-                                                 _farMesh->GetVertexEditTables(), _clContext);
-        _drawContext = DrawContext::Create(_farMesh->GetPatchTables(),
-                                           _pd3d11DeviceContext,
-                                           numVertexElements,
-                                           bits.test(MeshFVarData));
-        assert(_drawContext);
+    OsdMesh(ComputeController * computeController,
+            FarMesh<OsdVertex> * fmesh,
+            int numVertexElements,
+            int numVaryingElements,
+            OsdMeshBitset bits,
+            cl_context clContext,
+            cl_command_queue clQueue,
+            ID3D11DeviceContext *d3d11DeviceContext) :
+
+            _farMesh(fmesh),
+            _vertexBuffer(0),
+            _varyingBuffer(0),
+            _computeContext(0),
+            _computeController(computeController),
+            _drawContext(0),
+            _clContext(clContext),
+            _clQueue(clQueue),
+            _pd3d11DeviceContext(d3d11DeviceContext)
+    {
+        _initialize(numVertexElements, numVaryingElements, bits);
+    }
+
+    OsdMesh(ComputeController * computeController,
+            FarMesh<OsdVertex> * fmesh,
+            VertexBuffer * vertexBuffer,
+            VertexBuffer * varyingBuffer,
+            ComputeContext * computeContext,
+            DrawContext * drawContext,
+            cl_context clContext,
+            cl_command_queue clQueue,
+            ID3D11DeviceContext *d3d11DeviceContext) :
+
+            _farMesh(fmesh),
+            _vertexBuffer(vertexBuffer),
+            _varyingBuffer(varyingBuffer),
+            _computeContext(computeContext),
+            _computeController(computeController),
+            _drawContext(drawContext),
+            _clContext(clContext),
+            _clQueue(clQueue),
+            _pd3d11DeviceContext(d3d11DeviceContext)
+    {
         _drawContext->UpdateVertexTexture(_vertexBuffer, _pd3d11DeviceContext);
     }
 
@@ -307,8 +446,38 @@ public:
     virtual DrawContext * GetDrawContext() {
         return _drawContext;
     }
+    virtual VertexBuffer * GetVertexBuffer() {
+        return _vertexBuffer;
+    }
+    virtual VertexBuffer * GetVaryingBuffer() {
+        return _varyingBuffer;
+    }
+    virtual FarMesh<OsdVertex> const * GetFarMesh() const {
+        return _farMesh;
+    }
 
 private:
+
+    void _initialize( int numVertexElements,
+                      int numVaryingElements,
+                      OsdMeshBitset bits)
+    {
+        ID3D11Device * pd3d11Device;
+        _pd3d11DeviceContext->GetDevice(&pd3d11Device);
+
+        int numVertices = _farMesh->GetNumVertices();
+        _vertexBuffer = typename VertexBuffer::Create(numVertexElements, numVertices, _clContext, pd3d11Device);
+        if (numVaryingElements)
+            _varyingBuffer = typename VertexBuffer::Create(numVaryingElements, numVertices, _clContext, pd3d11Device);
+        _computeContext = ComputeContext::Create(_farMesh->GetSubdivisionTables(),
+                                                 _farMesh->GetVertexEditTables(), _clContext);
+        _drawContext = DrawContext::Create(_farMesh->GetPatchTables(),
+                                           _pd3d11DeviceContext,
+                                           numVertexElements,
+                                           bits.test(MeshFVarData));
+        _drawContext->UpdateVertexTexture(_vertexBuffer, _pd3d11DeviceContext);
+    }
+
     FarMesh<OsdVertex> *_farMesh;
     VertexBuffer *_vertexBuffer;
     VertexBuffer *_varyingBuffer;

--- a/opensubdiv/osd/glMesh.h
+++ b/opensubdiv/osd/glMesh.h
@@ -77,7 +77,6 @@ public:
             FarMesh<OsdVertex> * fmesh,
             int numVertexElements,
             int numVaryingElements,
-            int level,
             OsdMeshBitset bits) :
 
             _farMesh(fmesh),
@@ -88,6 +87,23 @@ public:
             _drawContext(0)
     {
         _initialize(numVertexElements, numVaryingElements, bits);
+    }
+
+    OsdMesh(ComputeController * computeController,
+            FarMesh<OsdVertex> * fmesh,
+            VertexBuffer * vertexBuffer,
+            VertexBuffer * varyingBuffer,
+            ComputeContext * computeContext,
+            DrawContext * drawContext) :
+
+            _farMesh(fmesh),
+            _vertexBuffer(vertexBuffer),
+            _varyingBuffer(varyingBuffer),
+            _computeContext(computeContext),
+            _computeController(computeController),
+            _drawContext(drawContext)
+    {
+        _drawContext->UpdateVertexTexture(_vertexBuffer);
     }
 
     virtual ~OsdMesh() {
@@ -194,7 +210,6 @@ public:
             FarMesh<OsdVertex> * fmesh,
             int numVertexElements,
             int numVaryingElements,
-            int level,
             OsdMeshBitset bits,
             cl_context clContext,
             cl_command_queue clQueue) :
@@ -209,6 +224,27 @@ public:
             _clQueue(clQueue)
     {
         _initialize(numVertexElements, numVaryingElements, bits);
+    }
+
+    OsdMesh(ComputeController * computeController,
+            FarMesh<OsdVertex> * fmesh,
+            VertexBuffer * vertexBuffer,
+            VertexBuffer * varyingBuffer,
+            ComputeContext * computeContext,
+            DrawContext * drawContext,
+            cl_context clContext,
+            cl_command_queue clQueue) :
+
+            _farMesh(fmesh),
+            _vertexBuffer(vertexBuffer),
+            _varyingBuffer(varyingBuffer),
+            _computeContext(computeContext),
+            _computeController(computeController),
+            _drawContext(drawContext),
+            _clContext(clContext),
+            _clQueue(clQueue)
+    {
+        _drawContext->UpdateVertexTexture(_vertexBuffer);
     }
 
     virtual ~OsdMesh() {

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -111,7 +111,6 @@ public:
             FarMesh<OsdVertex> * fmesh,
             int numVertexElements,
             int numVaryingElements,
-            int level,
             OsdMeshBitset bits = OsdMeshBitset()) :
 
             _farMesh(fmesh),
@@ -122,6 +121,22 @@ public:
             _drawContext(0)
     {
         _initialize(numVertexElements, numVaryingElements, bits);
+    }
+
+    OsdMesh(ComputeController * computeController,
+            FarMesh<OsdVertex> * fmesh,
+            VertexBuffer * vertexBuffer,
+            VertexBuffer * varyingBuffer,
+            ComputeContext * computeContext,
+            DrawContext * drawContext) :
+
+            _farMesh(fmesh),
+            _vertexBuffer(vertexBuffer),
+            _varyingBuffer(varyingBuffer),
+            _computeContext(computeContext),
+            _computeController(computeController),
+            _drawContext(drawContext)
+    {
     }
 
     virtual ~OsdMesh() {


### PR DESCRIPTION
Added a public constructor to OsdMesh that initializes the member objects from its arguments, allowing those members to be created by a subclass or an external function.
- maintainance work on the D3D11 specialization of OsdMesh to bring it in line with the other template specializations
- updated the facePartition example to derive PartitionedMesh from OsdMesh in order to allow other vertex buffer and compute controller configurations
