### PR TITLE
OsdUtilPatchPartitioner failure for triangle patches

### DIFF
--- a/opensubdiv/osdutil/patchPartitioner.h
+++ b/opensubdiv/osdutil/patchPartitioner.h
@@ -186,9 +186,10 @@ OsdUtilPatchPartitioner::OsdUtilPatchPartitioner(FarPatchTables const *srcPatchT
 
             // reorder corresponding face-varying table entry
             if (hasFVarData) {
-                for (int j = 0; j < 4 * fvarWidth; ++j) {
+                int fvarVerts = desc.GetType() == FarPatchTables::TRIANGLES ? 3 : 4;
+                for (int j = 0; j < fvarVerts * fvarWidth; ++j) {
                     newFVarDataTable.push_back(
-                        srcFVarData.GetAllData()[patchIndex*4*fvarWidth+j + fvarOffset]);
+                        srcFVarData.GetAllData()[patchIndex*fvarVerts*fvarWidth+j + fvarOffset]);
                 }
             }
         }


### PR DESCRIPTION
Fixes a bug introduced in 808aabf that causes OsdUtilPatchPartitioner to fail to rebuild the face-varying data table correctly for triangle patches.
