### PR TITLE
Implement C-API accessor to evaluator topology

### DIFF
--- a/opensubdiv/osdutil/evaluator_capi.cpp
+++ b/opensubdiv/osdutil/evaluator_capi.cpp
@@ -111,7 +111,7 @@ int openSubdiv_finishEvaluatorDescr(OpenSubdiv_EvaluatorDescr *evaluator_descr,
 
 
 int openSubdiv_setEvaluatorCoarsePositions(
-    struct OpenSubdiv_EvaluatorDescr *evaluator_descr,
+    OpenSubdiv_EvaluatorDescr *evaluator_descr,
     const float *positions, int numVertices)
 {
     std::string errorMessage;
@@ -135,7 +135,7 @@ int openSubdiv_setEvaluatorCoarsePositions(
 
 
 void openSubdiv_evaluateLimit(
-    struct OpenSubdiv_EvaluatorDescr *evaluation_descr,
+    OpenSubdiv_EvaluatorDescr *evaluation_descr,
     int face_id, float u, float v,
     float P[3], float dPdu[3], float dPdv[3])
 {
@@ -148,7 +148,7 @@ void openSubdiv_evaluateLimit(
 }
 
 void openSubdiv_getEvaluatorTopology(
-    struct OpenSubdiv_EvaluatorDescr *evaluation_descr,
+    OpenSubdiv_EvaluatorDescr *evaluation_descr,
     int *numVertices,
     int *refinementLevel,
     int *numIndices,
@@ -167,9 +167,9 @@ void openSubdiv_getEvaluatorTopology(
     *nverts =  &evaluation_descr->topology.nverts[0];
 }
 
-struct OpenSubdiv_EvaluatorDescr *openSubdiv_getEvaluatorTopologyDescr(
-    struct OpenSubdiv_EvaluatorDescr *evaluator_descr)
+OpenSubdiv_EvaluatorDescr *openSubdiv_getEvaluatorTopologyDescr(
+    OpenSubdiv_EvaluatorDescr *evaluator_descr)
 {
-    return (struct OpenSubdiv_EvaluatorDescr *) &evaluator_descr->topology;
+    return (OpenSubdiv_EvaluatorDescr *) &evaluator_descr->topology;
 }
 

--- a/opensubdiv/osdutil/evaluator_capi.h
+++ b/opensubdiv/osdutil/evaluator_capi.h
@@ -29,7 +29,6 @@ extern "C" {
  *   KIND, either express or implied. See the Apache License for the specific
  *   language governing permissions and limitations under the Apache License.
  */
-    
 
 /* Types declaration. */
 struct OpenSubdiv_EvaluatorDescr;
@@ -47,7 +46,7 @@ int openSubdiv_finishEvaluatorDescr(struct OpenSubdiv_EvaluatorDescr *evaluator_
 int openSubdiv_setEvaluatorCoarsePositions(
     struct OpenSubdiv_EvaluatorDescr *evaluator_descr,
     const float *positions, int numVertices);
-    
+
 /* Evaluate the subdivision limit surface at the given ptex face and u/v,    */
 /* return position and derivative information.  Derivative pointers can be   */
 /* NULL.  Note that face index here is the ptex index, or the index into     */
@@ -56,8 +55,6 @@ void openSubdiv_evaluateLimit(
     struct OpenSubdiv_EvaluatorDescr *evaluation_descr,
     int face_id, float u, float v,
     float P[3], float dPdu[3], float dPdv[3]);
-    
-    
 
 /* Get topology stored in the evaluator descriptor in order to be able */
 /* to check whether it still matches the mesh topology one is going to */


### PR DESCRIPTION
This way external application might check whether it need to
re-create evaluator from scratch or it might re-use existing
one without storing extra data from it's side.

TODO: Tags are still not accessible via C-API, it's marked as
to be solved later when it becomes more clear what is the best
way to expose them and when there'll be a real application to
test the tags.
