### PR TITLE
Integrate CLEW into osd library and examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,7 @@ option(NO_OMP "Disable OpenMP backend" OFF)
 option(NO_TBB "Disable TBB backend" OFF)
 option(NO_CUDA "Disable CUDA backend" OFF)
 option(NO_OPENCL "Disable OpenCL backend" OFF)
+option(NO_CLEW "Disable CLEW wrapper library" OFF)
 option(NO_NO_GCD "Disable GrandCentralDispatch backend" OFF)
 
 # Check for dependencies
@@ -296,7 +297,14 @@ endif()
 find_package(OpenGL)
 find_package(OpenGLES)
 if(NOT NO_OPENCL)
-    find_package(OpenCL 1.1)
+    if(NOT NO_CLEW)
+        find_package(CLEW)
+    endif()
+    if(NOT CLEW_FOUND)
+        find_package(OpenCL 1.1)
+    else()
+        set(OPENCL_FOUND TRUE)
+    endif()
 endif()
 if(NOT NO_CUDA)
     find_package(CUDA 4.0)
@@ -416,6 +424,20 @@ if(OPENCL_FOUND)
     add_definitions(
         -DOPENSUBDIV_HAS_OPENCL
     )
+    if(CLEW_FOUND)
+        add_definitions(
+            -DOPENSUBDIV_HAS_CLEW
+        )
+        set(OPENCL_INCLUDE_DIRS ${CLEW_INCLUDE_DIR})
+        set(OPENCL_LIBRARIES ${CLEW_LIBRARY})
+    else()
+        if (NOT NO_CLEW)
+            message(WARNING
+                "OpenCL was not found, but CLEW was not. "
+                "Building with OpenCL support enabled, but the build "
+                "wouldn't be portable on systems without OpenCL installed.")
+        endif()
+    endif()
 else()
     if (NOT NO_OPENCL)
         message(WARNING

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Optional:
 -DNO_OMP=1        // disable OpenMP
 -DNO_CUDA=1       // disable CUDA
 -DNO_OPENCL=1     // disable OpenCL
+-DNO_CLEW=1       // disable CLEW wrapper library
 -DNO_GCD=1        // disable GrandCentralDispatch on OSX
 ````
 

--- a/cmake/FindCLEW.cmake
+++ b/cmake/FindCLEW.cmake
@@ -30,61 +30,46 @@
 # CLEW_LIBRARY
 #
 
-include(FindPackageHandleStandardArgs)
+include (FindPackageHandleStandardArgs)
 
-if (WIN32)
-    find_path( CLEW_INCLUDE_DIR
-        NAMES
-            clew.h
-        PATHS
-            "${CLEW_LOCATION}/include"
-            "$ENV{CLEW_LOCATION}/include"
-            "$ENV{PROGRAMFILES}/CLEW/include"
-            "${PROJECT_SOURCE_DIR}/extern/clew/include"
-            DOC "The directory where clew.h resides" )
+if(WIN32)
+  set(_clew_SEARCH_DIRS
+    "${CLEW_LOCATION}/include"
+    "$ENV{CLEW_LOCATION}/include"
+    "$ENV{PROGRAMFILES}/CLEW/include"
+    "${PROJECT_SOURCE_DIR}/extern/clew/include"
+  )
+else()
+  set(_clew_SEARCH_DIRS
+      "${CLEW_LOCATION}"
+      "$ENV{CLEW_LOCATION}"
+      /usr
+      /usr/local
+      /sw
+      /opt/local
+      /opt/lib/clew
+  )
+endif()
 
-    find_library( CLEW_LIBRARY
-        NAMES
-            clew CLEW clew32s clew32
-        PATHS
-            "${CLEW_LOCATION}/lib"
-            "$ENV{CLEW_LOCATION}/lib"
-            "$ENV{PROGRAMFILES}/CLEW/lib"
-            "${PROJECT_SOURCE_DIR}/extern/clew/bin"
-            "${PROJECT_SOURCE_DIR}/extern/clew/lib"
-            DOC "The CLEW library")
-endif ()
+find_path(CLEW_INCLUDE_DIR
+  NAMES
+    clew.h
+  HINTS
+    ${_clew_SEARCH_DIRS}
+  PATH_SUFFIXES
+    include
+  NO_DEFAULT_PATH
+  DOC "The directory where clew.h resides")
 
-if (${CMAKE_HOST_UNIX})
-    find_path( CLEW_INCLUDE_DIR
-        NAMES
-            clew.h
-        PATHS
-            "${CLEW_LOCATION}/include"
-            "$ENV{CLEW_LOCATION}/include"
-            /usr/include
-            /usr/local/include
-            /sw/include
-            /opt/local/include
-            NO_DEFAULT_PATH
-            DOC "The directory where clew.h resides"
-    )
-    find_library( CLEW_LIBRARY
-        NAMES
-            CLEW clew
-        PATHS
-            "${CLEW_LOCATION}/lib"
-            "$ENV{CLEW_LOCATION}/lib"
-            /usr/lib64
-            /usr/lib
-            /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
-            /usr/local/lib64
-            /usr/local/lib
-            /sw/lib
-            /opt/local/lib
-            NO_DEFAULT_PATH
-            DOC "The CLEW library")
-endif ()
+find_library(CLEW_LIBRARY
+  NAMES
+    CLEW clew
+  PATHS
+    ${_clew_SEARCH_DIRS}
+  PATH_SUFFIXES
+    lib lib64
+  NO_DEFAULT_PATH
+  DOC "The CLEW library")
 
 find_package_handle_standard_args(CLEW
     REQUIRED_VARS

--- a/documentation/cmake_build.rst
+++ b/documentation/cmake_build.rst
@@ -125,6 +125,7 @@ The following configuration arguments can be passed to the cmake command line.
    -DNO_TBB=1        // disable TBB
    -DNO_CUDA=1       // disable CUDA
    -DNO_OPENCL=1     // disable OpenCL
+   -DNO_CLEW=1       // disable CLEW wrapper library
    -DNO_GCD=1        // disable GrandCentralDispatch on OSX
 
 Environment Variables

--- a/examples/common/clInit.h
+++ b/examples/common/clInit.h
@@ -27,17 +27,35 @@
 
 #if defined(_WIN32)
     #include <windows.h>
-    #include <CL/opencl.h>
 #elif defined(__APPLE__)
     #include <OpenGL/OpenGL.h>
-    #include <OpenCL/opencl.h>
 #else
     #include <GL/glx.h>
-    #include <CL/opencl.h>
 #endif
+
+#include "osd/opencl.h"
 
 #include <cstdio>
 
+static bool HAS_CL_VERSION_1_1 () {
+#ifdef OPENSUBDIV_HAS_OPENCL
+     #ifdef OPENSUBDIV_HAS_CLEW
+        static bool clewInitialized = false;
+        static bool clewLoadSuccess;
+        if (not clewInitialized) {
+            clewInitialized = true;
+            clewLoadSuccess = clewInit() == CLEW_SUCCESS;
+            if (not clewLoadSuccess) {
+                fprintf(stderr, "Loading OpenCL failed.\n");
+            }
+        }
+        return clewLoadSuccess;
+    #endif
+    return true;
+#else
+    return false;
+#endif
+}
 static bool initCL(cl_context *clContext, cl_command_queue *clQueue)
 {
     cl_int ciErrNum;

--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -1266,7 +1266,9 @@ initHUD()
     g_hud->AddRadioButton(0, "CUDA",   false, 10, 50, callbackKernel, kCUDA, 'K');
 #endif
 #ifdef OPENSUBDIV_HAS_OPENCL
-    g_hud->AddRadioButton(0, "OPENCL", false, 10, 70, callbackKernel, kCL, 'K');
+    if (HAS_CL_VERSION_1_1()) {
+        g_hud->AddRadioButton(0, "OPENCL", false, 10, 70, callbackKernel, kCL, 'K');
+    }
 #endif
     g_hud->AddRadioButton(0, "DirectCompute", false, 10, 90, callbackKernel, kDirectCompute, 'K');
 

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -1168,7 +1168,9 @@ initHUD()
     g_hud->AddRadioButton(0, "CUDA",   false, 10, 50, callbackKernel, kCUDA, 'K');
 #endif
 #ifdef OPENSUBDIV_HAS_OPENCL
-    g_hud->AddRadioButton(0, "OPENCL", false, 10, 70, callbackKernel, kCL, 'K');
+    if (HAS_CL_VERSION_1_1()) {
+        g_hud->AddRadioButton(0, "OPENCL", false, 10, 70, callbackKernel, kCL, 'K');
+    }
 #endif
     g_hud->AddRadioButton(0, "DirectCompute", false, 10, 90, callbackKernel, kDirectCompute, 'K');
 

--- a/examples/glBatchViewer/viewer.cpp
+++ b/examples/glBatchViewer/viewer.cpp
@@ -877,7 +877,9 @@ initHUD()
     g_hud.AddPullDownButton(compute_pulldown, "CUDA", kCUDA);
 #endif
 #ifdef OPENSUBDIV_HAS_OPENCL
-    g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    if (HAS_CL_VERSION_1_1()) {
+        g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    }
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
     g_hud.AddPullDownButton(compute_pulldown, "GLSL TransformFeedback", kGLSL);

--- a/examples/glViewer/viewer.cpp
+++ b/examples/glViewer/viewer.cpp
@@ -1772,7 +1772,9 @@ initHUD()
     g_hud.AddPullDownButton(compute_pulldown, "CUDA", kCUDA);
 #endif
 #ifdef OPENSUBDIV_HAS_OPENCL
-    g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    if (HAS_CL_VERSION_1_1()) {
+        g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    }
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
     g_hud.AddPullDownButton(compute_pulldown, "GLSL TransformFeedback", kGLSL);

--- a/examples/mayaPtexViewer/OpenSubdivPtexShaderOverride.cpp
+++ b/examples/mayaPtexViewer/OpenSubdivPtexShaderOverride.cpp
@@ -437,6 +437,11 @@ initializePlugin(MObject obj)
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL
+    if (loadCL() == false) {
+        // XXX
+        printf("Error in loading OpenCL libraries\n");
+        exit(1);
+    }
     if (initCL(&g_clContext, &g_clQueue) == false) {
         // XXX
         printf("Error in initializing OpenCL\n");

--- a/examples/mayaViewer/OpenSubdivShaderOverride.cpp
+++ b/examples/mayaViewer/OpenSubdivShaderOverride.cpp
@@ -454,6 +454,11 @@ initializePlugin(MObject obj)
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL
+    if (loadCL() == false) {
+        MGlobal::displayError("Cannot load OpenCL libraries");
+        status.perror("OpenCL initialization");
+        return MS::kFailure;
+    }
     if (initCL(&g_clContext, &g_clQueue) == false) {
         MGlobal::displayError("Cannot initialize OpenCL");
         status.perror("OpenCL initialization");

--- a/examples/ptexViewer/viewer.cpp
+++ b/examples/ptexViewer/viewer.cpp
@@ -2606,7 +2606,9 @@ int main(int argc, char ** argv)
     g_hud.AddPullDownButton(compute_pulldown, "CUDA", kCUDA);
 #endif
 #ifdef OPENSUBDIV_HAS_OPENCL
-    g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    if (HAS_CL_VERSION_1_1()) {
+        g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    }
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
     g_hud.AddPullDownButton(compute_pulldown, "GLSL TransformFeedback", kGLSL);

--- a/examples/topologySharing/viewer.cpp
+++ b/examples/topologySharing/viewer.cpp
@@ -1454,7 +1454,9 @@ initHUD()
     g_hud.AddPullDownButton(compute_pulldown, "CUDA", kCUDA);
 #endif
 #ifdef OPENSUBDIV_HAS_OPENCL
-    g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    if (HAS_CL_VERSION_1_1()) {
+        g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    }
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
     g_hud.AddPullDownButton(compute_pulldown, "GLSL TransformFeedback", kGLSL);

--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -355,6 +355,7 @@ set(OPENCL_PUBLIC_HEADERS
     clComputeContext.h
     clComputeController.h
     clVertexBuffer.h
+    opencl.h
 )
 if ( OPENCL_FOUND )
     list(APPEND GPU_SOURCE_FILES

--- a/opensubdiv/osd/clComputeContext.h
+++ b/opensubdiv/osd/clComputeContext.h
@@ -31,12 +31,7 @@
 #include "../far/vertexEditTables.h"
 #include "../osd/vertex.h"
 #include "../osd/nonCopyable.h"
-
-#if defined(__APPLE__)
-    #include <OpenCL/opencl.h>
-#else
-    #include <CL/opencl.h>
-#endif
+#include "../osd/opencl.h"
 
 #include <vector>
 

--- a/opensubdiv/osd/clComputeController.cpp
+++ b/opensubdiv/osd/clComputeController.cpp
@@ -26,13 +26,10 @@
 #include "../osd/clComputeContext.h"
 #include "../osd/clKernelBundle.h"
 #include "../osd/error.h"
+#include "../osd/opencl.h"
 
 #if defined(_WIN32)
     #include <windows.h>
-#elif defined(__APPLE__)
-    #include <OpenCL/opencl.h>
-#else
-    #include <CL/opencl.h>
 #endif
 
 #include <string.h>

--- a/opensubdiv/osd/clComputeController.h
+++ b/opensubdiv/osd/clComputeController.h
@@ -30,12 +30,7 @@
 #include "../far/dispatcher.h"
 #include "../osd/clComputeContext.h"
 #include "../osd/vertexDescriptor.h"
-
-#if defined(__APPLE__)
-    #include <OpenCL/opencl.h>
-#else
-    #include <CL/opencl.h>
-#endif
+#include "../osd/opencl.h"
 
 #include <vector>
 

--- a/opensubdiv/osd/clD3D11VertexBuffer.h
+++ b/opensubdiv/osd/clD3D11VertexBuffer.h
@@ -26,12 +26,7 @@
 #define OSD_CL_D3D11_VERTEX_BUFFER_H
 
 #include "../version.h"
-
-#if defined(__APPLE__)
-    #include <OpenCL/opencl.h>
-#else
-    #include <CL/opencl.h>
-#endif
+#include "../osd/opencl.h"
 
 struct ID3D11VertexShader;
 struct ID3D11HullShader;

--- a/opensubdiv/osd/clGLVertexBuffer.h
+++ b/opensubdiv/osd/clGLVertexBuffer.h
@@ -27,13 +27,8 @@
 
 #include "../version.h"
 
+#include "../osd/opencl.h"
 #include "../osd/opengl.h"
-
-#if defined(__APPLE__)
-    #include <OpenCL/opencl.h>
-#else
-    #include <CL/opencl.h>
-#endif
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {

--- a/opensubdiv/osd/clKernelBundle.h
+++ b/opensubdiv/osd/clKernelBundle.h
@@ -28,14 +28,8 @@
 #include "../version.h"
 
 #include "../osd/nonCopyable.h"
+#include "../osd/opencl.h"
 #include "../osd/vertexDescriptor.h"
-
-#if defined(__APPLE__)
-    #include <OpenCL/opencl.h>
-#else
-    #include <CL/opencl.h>
-#endif
-
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {

--- a/opensubdiv/osd/clVertexBuffer.h
+++ b/opensubdiv/osd/clVertexBuffer.h
@@ -26,12 +26,7 @@
 #define OSD_CL_VERTEX_BUFFER_H
 
 #include "../version.h"
-
-#if defined(__APPLE__)
-    #include <OpenCL/opencl.h>
-#else
-    #include <CL/opencl.h>
-#endif
+#include "../osd/opencl.h"
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {

--- a/opensubdiv/osd/d3d11Mesh.h
+++ b/opensubdiv/osd/d3d11Mesh.h
@@ -337,11 +337,7 @@ private:
 
 #ifdef OPENSUBDIV_HAS_OPENCL
 
-#if defined(__APPLE__)
-    #include <OpenCL/opencl.h>
-#else
-    #include <CL/opencl.h>
-#endif
+#include "../osd/opencl.h"
 
 class OsdCLComputeController;
 

--- a/opensubdiv/osd/glMesh.h
+++ b/opensubdiv/osd/glMesh.h
@@ -32,12 +32,8 @@
 #include "../osd/vertexDescriptor.h"
 
 #ifdef OPENSUBDIV_HAS_OPENCL
-#if defined(__APPLE__)
-    #include <OpenCL/opencl.h>
-#else
-    #include <CL/opencl.h>
-#endif
-#include "../osd/clComputeController.h"
+#  include "../osd/clComputeController.h"
+#  include "../osd/opencl.h"
 #endif
 
 namespace OpenSubdiv {

--- a/opensubdiv/osd/opencl.h
+++ b/opensubdiv/osd/opencl.h
@@ -1,0 +1,38 @@
+//
+//   Copyright 2014 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OSD_OPENCL_H
+#define OSD_OPENCL_H
+
+#if defined(OPENSUBDIV_HAS_CLEW)
+#  include <clew.h>
+#else
+#  if defined(__APPLE__)
+#    include <OpenCL/opencl.h>
+#  else
+#    include <CL/opencl.h>
+#  endif
+#endif
+
+#endif  // OSD_CL_UTIL_H


### PR DESCRIPTION
If the system has CLEW installed (which is detected by recently
added FindCLEW routines) then OpenSubduv would be compiled against
this library.

It makes binaries and libraries more portable across the systems,
so it's possible to run the same binary on systems with and without
OpenCL SDk installed.

The most annoying part of the change is updating examples to load
OpenCL libraries, but ideally code around controllers and interface
creation is to be de-duplicated anyway.

Based on the pull request #303 from Martijn Berger
