### PR TITLE
Fix compilation error with CLEW enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,7 +429,7 @@ if(OPENCL_FOUND)
             -DOPENSUBDIV_HAS_CLEW
         )
         set(OPENCL_INCLUDE_DIRS ${CLEW_INCLUDE_DIR})
-        set(OPENCL_LIBRARIES ${CLEW_LIBRARY})
+        set(OPENCL_LIBRARIES ${CLEW_LIBRARY} ${CMAKE_DL_LIBS})
     else()
         if (NOT NO_CLEW)
             message(WARNING


### PR DESCRIPTION
For some reason it compiled fine on the desktop but
compilation on laptop requires explicit linking against
dl library.
