### PR TITLE
Fix duplicate variables with identical name

### DIFF
--- a/examples/common/gl_framebuffer.cpp
+++ b/examples/common/gl_framebuffer.cpp
@@ -188,7 +188,7 @@ GLFrameBuffer::compileProgram(char const * src, char const * defines) {
     if (colorMap != -1)
         glUniform1i(colorMap, 0);  // GL_TEXTURE0
 
-    GLint colorMap = glGetUniformLocation(program, "normalMap");
+    GLint normalMap = glGetUniformLocation(program, "normalMap");
     if (normalMap != -1)
         glUniform1i(normalMap, 1);  // GL_TEXTURE1
 


### PR DESCRIPTION
Fix compilation error with two variables both named as colorMap but from the string, it should be normalMap.
