### PR TITLE
Fix mismatch in declaration and usage of OsdCudaComputeRestrictedVertexA

### DIFF
--- a/opensubdiv/osd/cudaKernel.cu
+++ b/opensubdiv/osd/cudaKernel.cu
@@ -1149,7 +1149,7 @@ void OsdCudaComputeVertexB(float *vertex, float *varying,
 void OsdCudaComputeRestrictedVertexA(float *vertex, float *varying,
                                      int vertexLength, int vertexStride,
                                      int varyingLength, int varyingStride,
-                                     int *V_ITa, int offset, int tableOffset, int start, int end, int pass)
+                                     int *V_ITa, int offset, int tableOffset, int start, int end)
 {
 //    computeRestrictedVertexA<0, 3><<<512,32>>>(vertex, varying, V_ITa, offset, start, end);
     OPT_KERNEL(0, 0, computeRestrictedVertexA, 512, 32, (vertex, varying, V_ITa, offset, tableOffset, start, end));


### PR DESCRIPTION
Unused argument `pass` was defined in the CUDA kernel and it was never
passed to this function from the C++ code. This argument is also wasn't
used by the function itself.
