### PR TITLE
Fix for CATMARK_QUAD_FACE_VERTEX kernel in FarCatmarkSubdivisionTablesFactory

### DIFF
--- a/opensubdiv/far/catmarkSubdivisionTablesFactory.h
+++ b/opensubdiv/far/catmarkSubdivisionTablesFactory.h
@@ -166,7 +166,7 @@ FarCatmarkSubdivisionTablesFactory<T,U>::Create( FarMeshFactory<T,U> * meshFacto
         } else {
             if (hasQuadFaceVertexKernel)
                 kernelType = FarKernelBatch::CATMARK_QUAD_FACE_VERTEX;
-            if (hasTriQuadFaceVertexKernel)
+            else if (hasTriQuadFaceVertexKernel)
                 kernelType = FarKernelBatch::CATMARK_TRI_QUAD_FACE_VERTEX;
         }
 


### PR DESCRIPTION
Fixes a bug in `FarCatmarkSubdivisionTablesFactory` that prevented the `CATMARK_QUAD_FACE_VERTEX` kernel from being selected for subdivision level 2 or greater.
