### PR TITLE
Fix for OsdUtilVertexSplit

### DIFF
--- a/opensubdiv/osdutil/vertexSplit.h
+++ b/opensubdiv/osdutil/vertexSplit.h
@@ -94,9 +94,9 @@ OsdUtilVertexSplit<T>::OsdUtilVertexSplit(FarMesh<T> * mesh)
             ++vertexRange.first, ++j)
         {
             int fvar = vertexRange.first->second;
-            if (std::equal(&fvarDataTable[i * fvarWidth],
-                &fvarDataTable[(i + 1) * fvarWidth],
-                &fvarDataTable[fvar * fvarWidth]))
+            const float* fvarData = &fvarDataTable[fvar * fvarWidth];
+            if (std::equal(fvarData, fvarData + fvarWidth,
+                &fvarDataTable[i * fvarWidth]))
             {
                 splitTable[i] = j;
                 goto split_vertex;


### PR DESCRIPTION
Fixes a bug in `OsdUtilVertexSplit` that occurs when getting the address of the end of a `std::vector`.
