### PR TITLE
Fixed "Osd" namespace closure

### DIFF
--- a/opensubdiv/osd/cudaD3D11VertexBuffer.cpp
+++ b/opensubdiv/osd/cudaD3D11VertexBuffer.cpp
@@ -141,6 +141,7 @@ CudaD3D11VertexBuffer::unmap() {
     _cudaBuffer = NULL;
 }
 
+} // end namespace Osd
 
 } // end namespace OPENSUBDIV_VERSION
 } // end namespace OpenSubdiv


### PR DESCRIPTION
The namespace "Osd" was not properly closed with a curly brace, causing
an error in Visual Studio 11.  Added closing curly brace and appropriate
comment.
