### PR TITLE
Fixing iOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ You can then use CMake to configure and generate an Xcode project:
 ````
 mkdir build-ios
 cd build-ios
-cmake -DCMAKE_TOOLCHAIN_FILE=[path to iOS.cmake] -GXcode ..
+cmake -DNO_CUDA=1 -DCMAKE_TOOLCHAIN_FILE=[path to iOS.cmake] -GXcode ..
 
 xcodebuild -target install -configuration Debug
 ````

--- a/cmake/FindOpenGLES.cmake
+++ b/cmake/FindOpenGLES.cmake
@@ -43,6 +43,10 @@ if(ANDROID)
     )
 
 elseif(IOS)
+    FIND_PATH( OPENGLES_INCLUDE_DIR
+        OpenGLES/ES2/gl.h
+    )
+
     FIND_LIBRARY( OPENGLES_FRAMEWORKS OpenGLES )
 
     if(OPENGLES_FRAMEWORKS)


### PR DESCRIPTION
Configuring with cmake-ios toolchain fails with error:

```
CUDA_TOOLKIT_ROOT_DIR not found or specified
CMake Error at /usr/local/Cellar/cmake/3.0.2/share/cmake/Modules/FindCUDA.cmake:605 (if):
  if given arguments:

     "CUDA_VERSION" "VERSION_GREATER" "5.0" "AND" "CMAKE_CROSSCOMPILING" "AND" "MATCHES" "arm" "AND" "EXISTS" "CUDA_TOOLKIT_ROOT_DIR-NOTFOUND/targets/armv7-linux-gnueabihf"

   Unknown arguments specified
 Call Stack (most recent call first):
   CMakeLists.txt:334 (find_package)


-- Configuring incomplete, errors occurred!
```

Configuring with cmake-ios toolchian and -DNO_CUDA=1 fails with error:

```
CMake Error at opensubdiv/CMakeLists.txt:80 (include_directories):
  include_directories given empty-string as include directory.
```

because of empty OPENGLES_INCLUDE_DIR for iOS
