### PR TITLE
Fixing ProtoStencil mem leak

### DIFF
--- a/opensubdiv/far/protoStencil.h
+++ b/opensubdiv/far/protoStencil.h
@@ -52,8 +52,7 @@ public:
     Allocator(int maxSize, bool interpolateVarying=false) :
         _maxsize(maxSize), _interpolateVarying(interpolateVarying) { }
 
-	~Allocator()
-	{
+	~Allocator() {
 		clearBigStencils();
 	}
 


### PR DESCRIPTION
ProtoStencil pool allocator BigStencils memory was not released when destroying stenciltables.
