### PR TITLE
dxPtexViewer fixes

### DIFF
--- a/examples/dxPtexViewer/shader.hlsl
+++ b/examples/dxPtexViewer/shader.hlsl
@@ -79,7 +79,7 @@ int OsdPrimitiveIdBase()
     || defined(NORMAL_BIQUADRATIC_WG)
 
 Texture2DArray textureDisplace_Data : register(t6);
-Buffer<int> textureDisplace_Packing : register(t7);
+Buffer<uint> textureDisplace_Packing : register(t7);
 #endif
 
 #if defined(DISPLACEMENT_HW_BILINEAR) \
@@ -358,22 +358,23 @@ edgeColor(float4 Cfill, float4 edgeDistance)
 //  Pixel Shader
 // ---------------------------------------------------------------------------
 
+
 #if defined(COLOR_PTEX_NEAREST) ||     \
     defined(COLOR_PTEX_HW_BILINEAR) || \
     defined(COLOR_PTEX_BILINEAR) ||    \
     defined(COLOR_PTEX_BIQUADRATIC)
 Texture2DArray textureImage_Data : register(t4);
-Buffer<int> textureImage_Packing : register(t5);
+Buffer<uint> textureImage_Packing : register(t5);
 #endif
 
 #ifdef USE_PTEX_OCCLUSION
 Texture2DArray textureOcclusion_Data : register(t8);
-Buffer<int> textureOcclusion_Packing : register(t9);
+Buffer<uint> textureOcclusion_Packing : register(t9);
 #endif
 
 #ifdef USE_PTEX_SPECULAR
 Texture2DArray textureSpecular_Data : register(t10);
-Buffer<int> textureSpecular_Packing : register(t11);
+Buffer<uint> textureSpecular_Packing : register(t11);
 #endif
 
 void

--- a/opensubdiv/osd/d3d11PtexMipmapTexture.cpp
+++ b/opensubdiv/osd/d3d11PtexMipmapTexture.cpp
@@ -140,10 +140,10 @@ D3D11PtexMipmapTexture::Create(ID3D11DeviceContext *deviceContext,
             break;
         default:
             switch (numChannels) {
-                case 1: format = DXGI_FORMAT_R8_UINT; break;
-                case 2: format = DXGI_FORMAT_R8G8_UINT; break;
+                case 1: format = DXGI_FORMAT_R8_UNORM; break;
+                case 2: format = DXGI_FORMAT_R8G8_UNORM; break;
                 case 3: assert(false); break;
-                case 4: format = DXGI_FORMAT_R8G8B8A8_UINT; break;
+                case 4: format = DXGI_FORMAT_R8G8B8A8_UNORM; break;
             }
             bpp = numChannels;
             break;

--- a/opensubdiv/osd/hlslPatchBSpline.hlsl
+++ b/opensubdiv/osd/hlslPatchBSpline.hlsl
@@ -332,7 +332,7 @@ void ds_main_patches(
     OSD_COMPUTE_PTEX_COORD_DOMAIN_SHADER;
 
     OSD_DISPLACEMENT_CALLBACK;
-
+	output.edgeDistance = 0;
     output.positionOut = mul(OsdProjectionMatrix(),
                              float4(output.position.xyz, 1.0f));
 }

--- a/opensubdiv/osd/hlslPatchCommon.hlsl
+++ b/opensubdiv/osd/hlslPatchCommon.hlsl
@@ -136,7 +136,7 @@ float TessAdaptive(float3 p0, float3 p1)
 #define OSD_DISPLACEMENT_CALLBACK
 #endif
 
-Buffer<int2> OsdPatchParamBuffer : register( t3 );
+Buffer<uint2> OsdPatchParamBuffer : register( t3 );
 
 #define GetPatchLevel(primitiveID)                                      \
     (OsdPatchParamBuffer[GetPrimitiveID(primitiveID)].y & 0xf)

--- a/opensubdiv/osd/hlslPatchGregory.hlsl
+++ b/opensubdiv/osd/hlslPatchGregory.hlsl
@@ -637,6 +637,8 @@ void ds_main_patches(
 
     output.patchCoord = patch[0].patchCoord;
     output.patchCoord.xy = float2(v, u);
+	
+	output.edgeDistance = 0;
 
     OSD_COMPUTE_PTEX_COORD_DOMAIN_SHADER;
 

--- a/opensubdiv/osd/hlslPtexCommon.hlsl
+++ b/opensubdiv/osd/hlslPtexCommon.hlsl
@@ -36,7 +36,7 @@ struct PtexPacking {
     int height;
 };
 
-PtexPacking getPtexPacking(Buffer<int> packings, int faceID)
+PtexPacking getPtexPacking(Buffer<uint> packings, int faceID)
 {
     PtexPacking packing;
     packing.page    = packings[faceID*6+0].x;
@@ -72,7 +72,7 @@ int computeMipmapOffsetV(int h, int level)
     return (m & x) + (level&~1);
 }
 
-PtexPacking getPtexPacking(Buffer<int> packings, int faceID, int level)
+PtexPacking getPtexPacking(Buffer<uint> packings, int faceID, int level)
 {
     PtexPacking packing;
     packing.page    = packings[faceID*6+0].x;
@@ -112,7 +112,7 @@ void evalQuadraticBSpline(float u, out float B[3], out float BU[3])
 
 float4 PtexLookupNearest(float4 patchCoord,
                          Texture2DArray data,
-                         Buffer<int> packings)
+                         Buffer<uint> packings)
 {
     float2 uv = patchCoord.xy;
     int faceID = int(patchCoord.w);
@@ -125,7 +125,7 @@ float4 PtexLookupNearest(float4 patchCoord,
 float4 PtexLookupNearest(float4 patchCoord,
                          int level,
                          Texture2DArray data,
-                         Buffer<int> packings)
+                         Buffer<uint> packings)
 {
     float2 uv = patchCoord.xy;
     int faceID = int(patchCoord.w);
@@ -138,7 +138,7 @@ float4 PtexLookupNearest(float4 patchCoord,
 float4 PtexLookup(float4 patchCoord,
                   int level,
                   Texture2DArray data,
-                  Buffer<int> packings)
+                  Buffer<uint> packings)
 {
     float2 uv = patchCoord.xy;
     int faceID = int(patchCoord.w);
@@ -172,7 +172,7 @@ float4 PtexLookupQuadratic(out float4 du,
                            float4 patchCoord,
                            int level,
                            Texture2DArray data,
-                           Buffer<int> packings)
+                           Buffer<uint> packings)
 {
     float2 uv = patchCoord.xy;
     int faceID = int(patchCoord.w);
@@ -238,7 +238,7 @@ float4 PtexLookupQuadratic(out float4 du,
 float4 PtexMipmapLookupNearest(float4 patchCoord,
                                int level,
                                Texture2DArray data,
-                               Buffer<int> packings)
+                               Buffer<uint> packings)
 {
 #if defined(SEAMLESS_MIPMAP)
     // diff level
@@ -262,7 +262,7 @@ float4 PtexMipmapLookupNearest(float4 patchCoord,
 float4 PtexMipmapLookup(float4 patchCoord,
                         float level,
                         Texture2DArray data,
-                        Buffer<int> packings)
+                        Buffer<uint> packings)
 {
 #if defined(SEAMLESS_MIPMAP)
     // diff level
@@ -288,7 +288,7 @@ float4 PtexMipmapLookupQuadratic(out float4 du,
                                  float4 patchCoord,
                                  float level,
                                  Texture2DArray data,
-                                 Buffer<int> packings)
+                                 Buffer<uint> packings)
 {
 #if defined(SEAMLESS_MIPMAP)
     // diff level
@@ -318,7 +318,7 @@ float4 PtexMipmapLookupQuadratic(out float4 du,
 float4 PtexMipmapLookupQuadratic(float4 patchCoord,
                                  float level,
                                  Texture2DArray data,
-                                 Buffer<int> packings)
+                                 Buffer<uint> packings)
 {
     float4 du, dv;
     return PtexMipmapLookupQuadratic(du, dv, patchCoord, level, data, packings);


### PR DESCRIPTION
 - changed ptex layout data types in shaders to match srv format
 - changed ptex srv type to unorm format for uchar data
 - fixed hlsl compiler warning: initialized edgeDistance of OutputVertex struct in domain shader even if we are not in wireframe mode
 - added directx debug device and enabled automatic break points to easily spot dx errors


before:
![before_fixes](https://cloud.githubusercontent.com/assets/8351776/5674076/325d4238-97a5-11e4-92b6-e6066c0eb9b6.png)

after:
![after_fixes](https://cloud.githubusercontent.com/assets/8351776/5674082/3ee005ea-97a5-11e4-9d9e-e2b66106660c.png)



