### PR TITLE
Fix for GLTransformFeedback crash in computeStencil

### DIFF
--- a/opensubdiv/osd/glslTransformFeedbackKernel.glsl
+++ b/opensubdiv/osd/glslTransformFeedbackKernel.glsl
@@ -31,7 +31,7 @@ uniform samplerBuffer vertexBuffer;
 
 out float outVertexBuffer[LENGTH];
 
-uniform isamplerBuffer sizes;
+uniform usamplerBuffer sizes;
 uniform isamplerBuffer offsets;
 uniform isamplerBuffer indices;
 uniform samplerBuffer  weights;
@@ -54,16 +54,16 @@ void clear(out Vertex v) {
 }
 
 void addWithWeight(inout Vertex v, Vertex src, float weight) {
-    for(int i = 0; i < LENGTH; i++) {
-        v.vertexData[i] += weight * src.vertexData[i];
+    for(int j = 0; j < LENGTH; j++) {
+        v.vertexData[j] += weight * src.vertexData[j];
     }
 }
 
 Vertex readVertex(int index) {
     Vertex v;
     int vertexIndex = primvarOffset + index * STRIDE;
-    for(int i = 0; i < LENGTH; i++) {
-        v.vertexData[i] = texelFetch(vertexBuffer, vertexIndex+i).x;
+    for(int j = 0; j < LENGTH; j++) {
+        v.vertexData[j] = texelFetch(vertexBuffer, vertexIndex+j).x;
     }
     return v;
 }
@@ -93,8 +93,8 @@ void computeStencil() {
     Vertex dst;
     clear(dst);
 
-    int offset = texelFetch(offsets, current).x,
-        size = texelFetch(sizes, current).x;
+    int offset = texelFetch(offsets, current).x;
+    uint size = texelFetch(sizes, current).x;
 
     for (int i=0; i<size; ++i) {
         int index = texelFetch(indices, offset+i).x;


### PR DESCRIPTION
- changed loop counter names in addWithWeight and readVertex that have overwritten the outer loop counter due to unrolling
- changed sizes sampler type to match GL_R8UI internal format

The crash occured on an NVidia 780, driver version 347.09, Windows. On Ati everything was fine.
