### PR TITLE
Optimize GL/DX compute dispatches.

### DIFF
--- a/opensubdiv/osd/d3d11ComputeController.cpp
+++ b/opensubdiv/osd/d3d11ComputeController.cpp
@@ -213,7 +213,7 @@ private:
         deviceContext->CSSetConstantBuffers(0, 1, &_uniformArgs); // b0
 
         deviceContext->CSSetShader(_computeShader, &kernel, 1);
-        deviceContext->Dispatch(count/_workGroupSize + 1, 1, 1);
+		deviceContext->Dispatch((count + _workGroupSize - 1) / _workGroupSize, 1, 1);
     }
 
 

--- a/opensubdiv/osd/glslComputeController.cpp
+++ b/opensubdiv/osd/glslComputeController.cpp
@@ -174,7 +174,7 @@ protected:
         glUniform1i(_uniformOffset, offset);
         glUniform1i(_uniformNumCVs, numCVs);
 
-        glDispatchCompute(count/_workGroupSize + 1, 1, 1);
+		glDispatchCompute((count + _workGroupSize - 1) / _workGroupSize, 1, 1);
 
         // sync for later reading.
         // XXX: in theory, just SHADER_STORAGE_BARRIER is needed here. However


### PR DESCRIPTION
Minor optimization to match the number of needed workgroups to the batch size.

Example: 
```
int workgroupsize = 64; 
int batchSize = 64;

//old:
numDispatches = batchSize/workgroupSize +1;
// = 64/64+1 = 2;
// will start 2 workgroups - 64 threads that have to be setup but will imediately exit

//new:
int numDispatches = (batchSize+workgroupSize-1)/workgroupSize;
// = (64+63)/64 = int(1.98);
// will do what we want and start 1 workgroup
```