### PR TITLE
fix max valence issue for the case that only has one triangle face

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,8 +182,7 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANGCC OR CMAKE_COMPILER_IS_IC
                 NAMES
                     ${ICC_LIB}
                 PATHS
-                    ${ICC_LOCATION}/lib
-                    /opt/intel/lib/
+                    ${ICC_LIB_LOCATION}
                 PATH_SUFFIXES
                     ${ICC_LIB_ARCH}
             )

--- a/opensubdiv/far/patchTablesFactory.cpp
+++ b/opensubdiv/far/patchTablesFactory.cpp
@@ -696,6 +696,8 @@ PatchTablesFactory::createUniform( TopologyRefiner const & refiner, Options opti
         firstlevel = options.generateAllLevels ? 0 : maxlevel,
         nlevels = maxlevel-firstlevel+1;
 
+    if(maxvalence < 4) maxvalence = 4;
+    
     PatchDescriptor::Type ptype = PatchDescriptor::NON_PATCH;
     if (options.triangulateQuads) {
         ptype = PatchDescriptor::TRIANGLES;
@@ -843,7 +845,8 @@ PatchTablesFactory::createAdaptive( TopologyRefiner const & refiner, Options opt
     //  the inventory of patches determined above:
     //
     int maxValence = refiner.getLevel(0).getMaxValence();
-
+    if(maxValence < 4) maxValence = 4;
+    
     PatchTables * tables = new PatchTables(maxValence);
 
     // Populate the patch array descriptors
@@ -1188,7 +1191,8 @@ PatchTablesFactory::populateAdaptivePatches( TopologyRefiner const & refiner,
 
             int maxvalence = refiner.getLevel(0).getMaxValence(),
                 npatches = patchInventory.GP;
-
+            if(maxvalence < 4) maxvalence = 4;
+            
             gregoryStencilsFactory =
                 new GregoryBasisFactory(refiner, *adaptiveStencils, npatches, maxvalence);
 


### PR DESCRIPTION
When a mesh only has single triangle face, current code looks for the maximum valence in level 0, so max valence is 3. However, if the face is subdivided twice, the maximum valence is 4. This pull request is to fix this issue.

The directory layout for ICC library keeps changing in different releases. So I think it's much easier to use ICC_LIB_LOCATION, instead of ICC_LOCATION to find ICC related libraries.