### PR TITLE
osd_regression test ported over to new API and small bug fix in vtr

### DIFF
--- a/examples/common/clInit.h
+++ b/examples/common/clInit.h
@@ -36,6 +36,7 @@
 #include "osd/opencl.h"
 
 #include <cstdio>
+#include <string>
 
 static bool HAS_CL_VERSION_1_1 () {
 #ifdef OPENSUBDIV_HAS_OPENCL

--- a/examples/common/clInit.h
+++ b/examples/common/clInit.h
@@ -59,6 +59,11 @@ static bool HAS_CL_VERSION_1_1 () {
 }
 static bool initCL(cl_context *clContext, cl_command_queue *clQueue)
 {
+    if (!clGetPlatformIDs) {
+        printf("Error clGetPlatformIDs call not bound.\n");
+        return false;
+    }
+
     cl_int ciErrNum;
 
     cl_platform_id cpPlatform = 0;

--- a/opensubdiv/vtr/quadRefinement.cpp
+++ b/opensubdiv/vtr/quadRefinement.cpp
@@ -373,6 +373,11 @@ QuadRefinement::populateEdgeFaceRelation() {
     child._edgeFaceIndices.resize(     childEdgeFaceIndexSizeEstimate);
     child._edgeFaceLocalIndices.resize(childEdgeFaceIndexSizeEstimate);
 
+    // Update _maxEdgeFaces from the parent level before calling the 
+    // populateEdgeFacesFromParent methods below, as these may further
+    // update _maxEdgeFaces.
+    child._maxEdgeFaces = parent._maxEdgeFaces;
+
     populateEdgeFacesFromParentFaces();
     populateEdgeFacesFromParentEdges();
 
@@ -382,8 +387,6 @@ QuadRefinement::populateEdgeFaceRelation() {
                                      child.getOffsetOfEdgeFaces(child.getNumEdges()-1);
     child._edgeFaceIndices.resize(     childEdgeFaceIndexSizeEstimate);
     child._edgeFaceLocalIndices.resize(childEdgeFaceIndexSizeEstimate);
-
-    child._maxEdgeFaces = parent._maxEdgeFaces;
 }
 
 void

--- a/opensubdiv/vtr/triRefinement.cpp
+++ b/opensubdiv/vtr/triRefinement.cpp
@@ -366,6 +366,11 @@ TriRefinement::populateEdgeFaceRelation() {
     _child->_edgeFaceIndices.resize(childEdgeFaceIndexSizeEstimate);
     _child->_edgeFaceLocalIndices.resize(childEdgeFaceIndexSizeEstimate);
 
+    // Update _maxEdgeFaces from the parent level before calling the 
+    // populateEdgeFacesFromParent methods below, as these may further
+    // update _maxEdgeFaces.
+    _child->_maxEdgeFaces = _parent->_maxEdgeFaces;
+
     populateEdgeFacesFromParentFaces();
     populateEdgeFacesFromParentEdges();
 
@@ -375,8 +380,6 @@ TriRefinement::populateEdgeFaceRelation() {
                                      _child->getOffsetOfEdgeFaces(_child->getNumEdges()-1);
     _child->_edgeFaceIndices.resize(childEdgeFaceIndexSizeEstimate);
     _child->_edgeFaceLocalIndices.resize(childEdgeFaceIndexSizeEstimate);
-
-    _child->_maxEdgeFaces = _parent->_maxEdgeFaces;
 }
 
 void

--- a/regression/common/CMakeLists.txt
+++ b/regression/common/CMakeLists.txt
@@ -27,6 +27,7 @@ set(REGRESSION_COMMON_SOURCE_FILES
 )
 
 set(REGRESSION_COMMON_HEADER_FILES
+    cmp_utils.h
     hbr_utils.h
     shape_utils.h
     vtr_utils.h

--- a/regression/common/cmp_utils.h
+++ b/regression/common/cmp_utils.h
@@ -47,7 +47,6 @@ GetReorderedHbrVertexData(
     typedef OpenSubdiv::HbrFace<T>     Hface;
     typedef OpenSubdiv::HbrHalfedge<T> Hhalfedge;
 
-
     struct Mapper {
 
         struct LevelMap {
@@ -179,7 +178,7 @@ GetReorderedHbrVertexData(
 
     for (int level=0, ofs=0; level<(refiner.GetMaxLevel()+1); ++level) {
 
-       Mapper::LevelMap & map = mapper.maps[level];
+       typename Mapper::LevelMap & map = mapper.maps[level];
        for (int i=0; i<(int)map.verts.size(); ++i) {
             Hvertex * v = map.verts[i];
             if (hbrVertexOnBoundaryData) {

--- a/regression/common/cmp_utils.h
+++ b/regression/common/cmp_utils.h
@@ -1,0 +1,196 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef CMP_UTILS_H
+#define CMP_UTILS_H
+
+#include <far/topologyRefinerFactory.h>
+
+#include "../../regression/common/hbr_utils.h"
+
+//------------------------------------------------------------------------------
+
+
+// Copies vertex data from hmesh into hbrVertexData reordered to match
+// the given refiner and subdivision level.  This is used for later easy 
+// comparison between the two.
+template<class T>
+void
+GetReorderedHbrVertexData(
+    const OpenSubdiv::Far::TopologyRefiner &refiner,
+    const OpenSubdiv::HbrMesh<T> &hmesh,
+    std::vector<T> *hbrVertexData,
+    std::vector<bool> *hbrVertexOnBoundaryData = NULL)
+{
+    typedef OpenSubdiv::HbrVertex<T>   Hvertex;
+    typedef OpenSubdiv::HbrFace<T>     Hface;
+    typedef OpenSubdiv::HbrHalfedge<T> Hhalfedge;
+
+
+    struct Mapper {
+
+        struct LevelMap {
+            std::vector<Hface *>     faces;
+            std::vector<Hhalfedge *> edges;
+            std::vector<Hvertex *>   verts;
+        };
+
+        std::vector<LevelMap> maps;
+
+        Mapper(const OpenSubdiv::Far::TopologyRefiner &refiner, 
+               const OpenSubdiv::HbrMesh<T> &hmesh) {
+
+            maps.resize(refiner.GetMaxLevel()+1);
+
+            typedef OpenSubdiv::Far::Index Index;
+            typedef OpenSubdiv::Far::ConstIndexArray ConstIndexArray;
+
+            {   // Populate base level
+                // note : topological ordering is identical between Hbr and Vtr
+                // for the base level
+
+                int nfaces = refiner.GetNumFaces(0),
+                    nedges = refiner.GetNumEdges(0),
+                    nverts = refiner.GetNumVertices(0);
+
+                maps[0].faces.resize(nfaces, 0);
+                maps[0].edges.resize(nedges, 0);
+                maps[0].verts.resize(nverts, 0);
+
+                for (int face=0; face<nfaces; ++face) {
+                    maps[0].faces[face] = hmesh.GetFace(face);
+                }
+
+                for (int edge = 0; edge <nedges; ++edge) {
+
+                    ConstIndexArray vtrVerts = refiner.GetEdgeVertices(0, edge);
+
+                    Hvertex const * v0 = hmesh.GetVertex(vtrVerts[0]),
+                                  * v1 = hmesh.GetVertex(vtrVerts[1]);
+
+                    Hhalfedge * e = v0->GetEdge(v1);
+                    if (not e) {
+                        e = v1->GetEdge(v0);
+                    }
+                    assert(e);
+
+                    maps[0].edges[edge] = e;
+                }
+
+                for (int vert = 0; vert<nverts; ++vert) {
+                    maps[0].verts[vert] = hmesh.GetVertex(vert);
+                }
+            }
+
+            // Populate refined levels
+            for (int level=1, ecount=0; level<=refiner.GetMaxLevel(); ++level) {
+
+                LevelMap & previous = maps[level-1],
+                         & current = maps[level];
+
+                current.faces.resize(refiner.GetNumFaces(level), 0);
+                current.edges.resize(refiner.GetNumEdges(level), 0);
+                current.verts.resize(refiner.GetNumVertices(level), 0);
+
+                for (int face=0; face < refiner.GetNumFaces(level-1); ++face) {
+
+                    // populate child faces
+                    Hface * f = previous.faces[face];
+
+                    ConstIndexArray childFaces = refiner.GetFaceChildFaces(level-1, face);
+                    assert(childFaces.size()==f->GetNumVertices());
+
+                    for (int i=0; i<childFaces.size(); ++i) {
+                        current.faces[childFaces[i]] = f->GetChild(i);
+                    }
+
+                    // populate child face-verts
+                    Index childVert = refiner.GetFaceChildVertex(level-1, face);
+                    Hvertex * v = f->Subdivide();
+                    assert(v->GetParentFace());
+                    current.verts[childVert] = v;
+                }
+
+                for (int edge=0; edge < refiner.GetNumEdges(level-1); ++edge) {
+                    // populate child edge-verts
+                    Index childVert = refiner.GetEdgeChildVertex(level-1,edge);
+                    Hhalfedge * e = previous.edges[edge];
+                    Hvertex * v = e->Subdivide();
+                    assert(v->GetParentEdge());
+                    current.verts[childVert] = v;
+                }
+
+                for (int vert = 0; vert < refiner.GetNumVertices(level-1); ++vert) {
+                    // populate child vert-verts
+                    Index childVert = refiner.GetVertexChildVertex(level-1, vert);
+                    Hvertex * v = previous.verts[vert]->Subdivide();
+                    current.verts[childVert] = v;
+                    assert(v->GetParentVertex());
+                }
+
+                // populate child edges
+                for (int edge=0; edge < refiner.GetNumEdges(level); ++edge) {
+
+                    ConstIndexArray vtrVerts = refiner.GetEdgeVertices(level, edge);
+
+                    Hvertex const * v0 = current.verts[vtrVerts[0]],
+                                  * v1 = current.verts[vtrVerts[1]];
+                    assert(v0 and v1);
+
+                    Hhalfedge * e= v0->GetEdge(v1);
+                    if (not e) {
+                        e = v1->GetEdge(v0);
+                    }
+                    assert(e);
+                    current.edges[edge] = e;
+                }
+                ecount += refiner.GetNumEdges(level-1);
+            }
+        }
+    };
+
+    Mapper mapper(refiner, hmesh);
+
+    int nverts = hmesh.GetNumVertices();
+    assert( nverts==refiner.GetNumVerticesTotal() );
+
+    hbrVertexData->resize(nverts);
+
+    for (int level=0, ofs=0; level<(refiner.GetMaxLevel()+1); ++level) {
+
+       Mapper::LevelMap & map = mapper.maps[level];
+       for (int i=0; i<(int)map.verts.size(); ++i) {
+            Hvertex * v = map.verts[i];
+            if (hbrVertexOnBoundaryData) {
+                (*hbrVertexOnBoundaryData)[ofs] = hbrVertexOnBoundary(v);
+            }
+            (*hbrVertexData)[ofs++] = v->GetData();
+       }
+    }
+
+}
+
+//------------------------------------------------------------------------------
+
+#endif /* CMP_UTILS_H */

--- a/regression/common/hbr_utils.h
+++ b/regression/common/hbr_utils.h
@@ -625,4 +625,70 @@ simpleHbr(char const * Shapestr, Scheme scheme, std::vector<float> & verts, bool
     return mesh;
 }
 
+//------------------------------------------------------------------------------
+template <class T>
+OpenSubdiv::HbrMesh<T> *
+interpolateHbrVertexData(char const * Shapestr, Scheme scheme, int maxlevel) {
+
+    // Hbr interpolation
+    OpenSubdiv::HbrMesh<T> *hmesh = simpleHbr<T>(Shapestr, scheme,
+            /* verts vector */ 0, /* fvar */ false);
+    assert(hmesh);
+
+    for (int level=0, firstface=0; level<maxlevel; ++level ) {
+        int nfaces = hmesh->GetNumFaces();
+        for (int i=firstface; i<nfaces; ++i) {
+
+            OpenSubdiv::HbrFace<T> * f = hmesh->GetFace(i);
+            assert(f->GetDepth()==level);
+            if (not f->IsHole()) {
+                f->Refine();
+            }
+        }
+        // Hbr allocates faces sequentially, skip faces that have already been
+        // refined.
+        firstface = nfaces;
+    }
+
+    return hmesh;
+
+}
+
+//------------------------------------------------------------------------------
+// Returns true if a vertex or any of its parents is on a boundary
+template <class T>
+bool
+hbrVertexOnBoundary(const OpenSubdiv::HbrVertex<T> *v)
+{
+    if (not v)
+        return false;
+
+    if (v->OnBoundary())
+        return true;
+
+    OpenSubdiv::HbrVertex<T> const * pv = v->GetParentVertex();
+    if (pv)
+        return hbrVertexOnBoundary(pv);
+    else {
+        OpenSubdiv::HbrHalfedge<T> const * pe = v->GetParentEdge();
+        if (pe) {
+              return hbrVertexOnBoundary(pe->GetOrgVertex()) or
+                     hbrVertexOnBoundary(pe->GetDestVertex());
+        } else {
+            OpenSubdiv::HbrFace<T> const * pf = v->GetParentFace(), * rootf = pf;
+            while (pf) {
+                pf = pf->GetParent();
+                if (pf)
+                    rootf=pf;
+            }
+            if (rootf)
+                for (int i=0; i<rootf->GetNumVertices(); ++i)
+                    if (rootf->GetVertex(i)->OnBoundary())
+                        return true;
+        }
+    }
+    return false;
+}
+
+
 #endif /* HBR_UTILS_H */

--- a/regression/common/vtr_utils.h
+++ b/regression/common/vtr_utils.h
@@ -161,7 +161,7 @@ InterpolateVtrVertexData(const char *shapeStr, Scheme scheme, int maxlevel,
                             shape->verts[i*3+2]);
     }
 
-    xyzVV * verts = &data[0];
+    T * verts = &data[0];
     refiner->Interpolate(verts, verts+refiner->GetNumVertices(0));
 
     delete shape;

--- a/regression/common/vtr_utils.h
+++ b/regression/common/vtr_utils.h
@@ -124,9 +124,51 @@ GetSdcOptions(Shape const & shape) {
     return result;
 }
 
+//------------------------------------------------------------------------------
+
 void
 InterpolateFVarData(OpenSubdiv::Far::TopologyRefiner & refiner,
     Shape const & shape, std::vector<float> & fvarData);
+
+//------------------------------------------------------------------------------
+
+template <class T>
+OpenSubdiv::Far::TopologyRefiner *
+InterpolateVtrVertexData(const char *shapeStr, Scheme scheme, int maxlevel,
+    std::vector<T> &data) {
+
+    typedef OpenSubdiv::Far::TopologyRefiner FarTopologyRefiner;
+    typedef OpenSubdiv::Far::TopologyRefinerFactory<Shape> FarTopologyRefinerFactory;
+
+    // Vtr interpolation
+    Shape * shape = Shape::parseObj(shapeStr, scheme);
+
+    FarTopologyRefiner * refiner =
+        FarTopologyRefinerFactory::Create(*shape,
+            FarTopologyRefinerFactory::Options(
+                GetSdcType(*shape), GetSdcOptions(*shape)));
+    assert(refiner);
+
+    FarTopologyRefiner::UniformOptions options(maxlevel);
+    options.fullTopologyInLastLevel=true;
+    refiner->RefineUniform(options);
+
+    // populate coarse mesh positions
+    data.resize(refiner->GetNumVerticesTotal());
+    for (int i=0; i<refiner->GetNumVertices(0); i++) {
+        data[i].SetPosition(shape->verts[i*3+0],
+                            shape->verts[i*3+1],
+                            shape->verts[i*3+2]);
+    }
+
+    xyzVV * verts = &data[0];
+    refiner->Interpolate(verts, verts+refiner->GetNumVertices(0));
+
+    delete shape;
+    return refiner;
+}
+
+
 //------------------------------------------------------------------------------
 
 namespace OpenSubdiv {

--- a/regression/osd_regression/main.cpp
+++ b/regression/osd_regression/main.cpp
@@ -202,8 +202,6 @@ checkVertexBuffer(
 
     for (int i=0; i<nverts; ++i) {
 
-        xyzvertex * hv = hmesh->GetVertex(i);
-
         const float * ov = & vbData[ i * numElements ];
 
         // boundary interpolation rules set to "none" produce "undefined" 
@@ -288,7 +286,7 @@ checkMeshCPU( FarTopologyRefiner *refiner,
                 vertexStencils, varyingStencils);
 
 
-    assert(coarseverts.size() == refiner.GetNumVerticesTotal());
+    assert(coarseverts.size() == refiner->GetNumVerticesTotal());
     
     Osd::CpuVertexBuffer * vb = 
         Osd::CpuVertexBuffer::Create(3, refiner->GetNumVerticesTotal());


### PR DESCRIPTION
vtr:

- Fixed a potential stack corruption issue with _maxEdgeFaces.

osd_regression:

- I had to disable the loop tests

- I had to disable the hedit tests

- Otherwise everything passes on Linux and Windows with all the existing tested backends (CPU, CPUGL, CL) -- we should add the rest.  (I couldn't test CL on Windows).

- The top-level CMakeLists.txt file still has osd_regression disabled because I haven't yet verified that it compiles on the Mac (it compiles on Windows and Linux).

- I think we should delete far_regression.  It's very outdated and the functionality is covered by vtr_regression.