### PR TITLE
Alternative fix to clInit.h for cross-platform.

### DIFF
--- a/examples/common/clInit.h
+++ b/examples/common/clInit.h
@@ -57,16 +57,20 @@ static inline bool HAS_CL_VERSION_1_1 () {
     return false;
 #endif
 
+#ifndef _WIN32
     // Suppress unused function compiler warning.
     (void)HAS_CL_VERSION_1_1;
+#endif
 }
 
 static bool initCL(cl_context *clContext, cl_command_queue *clQueue)
 {
-    if (!&clGetPlatformIDs) {
+#ifdef _WIN32
+    if (!clGetPlatformIDs) {
         printf("Error clGetPlatformIDs call not bound.\n");
         return false;
     }
+#endif
 
     cl_int ciErrNum;
 


### PR DESCRIPTION
An alternative fix to clInit.h that should allow the Windows build to conitnue working.