### PR TITLE
Fixing invalid memory read error in glEvalLimit.

### DIFF
--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -426,7 +426,8 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level) {
         delete g_varyingData; g_varyingData = 0;
         if (g_drawMode==kVARYING) {
             g_varyingData = Osd::CpuVertexBuffer::Create(3, nverts);
-            g_varyingData->UpdateData( &g_varyingColors[0], 0, nverts);
+            g_varyingData->UpdateData( 
+                &g_varyingColors[0], 0, g_varyingColors.size()/3 );
         }
 
         // Create output buffers for the limit samples (position & tangents)


### PR DESCRIPTION
We were erroneously using the number of vertices of the refined mesh to copy
data only allocated for the coarse mesh's number of vertices.