### PR TITLE
Fixed a bug in our obj parser

### DIFF
--- a/regression/common/shape_utils.cpp
+++ b/regression/common/shape_utils.cpp
@@ -105,8 +105,8 @@ Shape * Shape::parseObj(char const * shapestr, Scheme shapescheme,
                           while( (nitems=sscanf(cp, "%d/%d/%d", &vi, &ti, &ni))>0) {
                               nverts++;
                               s->faceverts.push_back(vi-1);
-                              if(nitems >= 1) s->faceuvs.push_back(ti-1);
-                              if(nitems >= 2) s->facenormals.push_back(ni-1);
+                              if(nitems > 1) s->faceuvs.push_back(ti-1);
+                              if(nitems > 2) s->facenormals.push_back(ni-1);
                               while (*cp && *cp != ' ') cp++;
                               while (*cp == ' ') cp++;
                           }


### PR DESCRIPTION
Fixed a case where we could erroneously fill in the texture or normal index for a vertex on a face when they are not actually specified in the obj.