### PR TITLE
Fixing FindGLFW cmake module

### DIFF
--- a/cmake/FindGLFW.cmake
+++ b/cmake/FindGLFW.cmake
@@ -32,8 +32,32 @@
 
 find_path( GLFW_INCLUDE_DIR 
     NAMES
-        GL/glfw.h
         GLFW/glfw3.h
+    HINTS
+        "${GLFW_LOCATION}/include"
+        "$ENV{GLFW_LOCATION}/include"
+    PATHS
+        "$ENV{PROGRAMFILES}/GLFW/include"
+        "${OPENGL_INCLUDE_DIR}"
+        /usr/openwin/share/include
+        /usr/openwin/include
+        /usr/X11R6/include
+        /usr/include/X11
+        /opt/graphics/OpenGL/include
+        /opt/graphics/OpenGL/contrib/libglfw
+        /usr/local/include
+        /usr/include/GL
+        /usr/include
+    DOC 
+        "The directory where GLFW/glfw3.h resides"
+)
+
+#
+# XXX: Do we still need to search for GL/glfw.h?
+#
+find_path( GLFW_INCLUDE_DIR 
+    NAMES
+        GL/glfw.h
     HINTS
         "${GLFW_LOCATION}/include"
         "$ENV{GLFW_LOCATION}/include"


### PR DESCRIPTION
Previously, FindGLFW would search for both GL/glfw.h and GLFW/glfw3.h, which
does not work when a system has both GLFW 2.0 and 3.0 installed.

The fix still probes for both files, but does so in two passes, preferring
glfw3.h.