### PR TITLE
Limit position screen-space tessellation level metric

### DIFF
--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -170,7 +170,7 @@ float TessAdaptive(vec3 p0, vec3 p1)
     // length of the projected edge itself to avoid problems near silhouettes.
     vec3 center = (p0 + p1) / 2.0;
     float diameter = distance(p0, p1);
-    return max(1.0, OsdTessLevel() * GetPostProjectionSphereExtent(center, diameter));
+    return round(max(1.0, OsdTessLevel() * GetPostProjectionSphereExtent(center, diameter)));
 }
 
 #ifndef OSD_DISPLACEMENT_CALLBACK
@@ -405,3 +405,32 @@ Univar4x4(in float u, out float B[4], out float D[4], out float C[4])
     C[2] = A1 - A2;
     C[3] = A2;
 }
+
+// ----------------------------------------------------------------------------
+
+vec3
+EvalBezier(vec3 cp[16], vec2 uv)
+{
+    vec3 BUCP[4] = vec3[4](vec3(0,0,0), vec3(0,0,0), vec3(0,0,0), vec3(0,0,0));
+
+    float B[4], D[4];
+
+    Univar4x4(uv.x, B, D);
+    for (int i=0; i<4; ++i) {
+        for (int j=0; j<4; ++j) {
+            vec3 A = cp[4*i + j];
+            BUCP[i] += A * B[j];
+        }
+    }
+
+    vec3 position = vec3(0);
+
+    Univar4x4(uv.y, B, D);
+    for (int k=0; k<4; ++k) {
+        position  += B[k] * BUCP[k];
+    }
+
+    return position;
+}
+
+// ----------------------------------------------------------------------------

--- a/opensubdiv/osd/hlslPatchBSpline.hlsl
+++ b/opensubdiv/osd/hlslPatchBSpline.hlsl
@@ -62,7 +62,7 @@ static float4x4 Mi = {
 };
 
 void
-reflectBoundaryEdges(inout float3 cpt[24], int patchParam)
+reflectBoundaryEdges(inout float3 cpt[16], int patchParam)
 {
     if (((patchParam >> 4) & 1) != 0) {
         cpt[0] = 2*cpt[4] - cpt[8];
@@ -114,15 +114,16 @@ ComputeMatrixSimplified(float sharpness)
 HS_CONSTANT_FUNC_OUT
 HSConstFunc(
     InputPatch<HullVertex, OSD_PATCH_INPUT_SIZE> patch,
+    OutputPatch<HullVertex, 16> bezierPatch,
     uint primitiveID : SV_PrimitiveID)
 {
     HS_CONSTANT_FUNC_OUT output;
     int patchParam = GetPatchParam(primitiveID);
     int patchLevel = GetPatchLevel(primitiveID);
 
-    float3 position[24];
+    float3 position[16];
     for (int p=0; p<16; ++p) {
-        position[p] = patch[p].position.xyz;
+        position[p] = bezierPatch[p].position.xyz;
     }
 
     reflectBoundaryEdges(position, patchParam);
@@ -143,7 +144,7 @@ HSConstFunc(
     output.tessLevelOuter[3] = outerLevel[3];
 
     output.tessLevelInner[0] = innerLevel[0];
-    output.tessLevelInner[1] = innerLevel[0];
+    output.tessLevelInner[1] = innerLevel[1];
 
     output.tessOuterLo = tessOuterLo;
     output.tessOuterHi = tessOuterHi;
@@ -164,7 +165,7 @@ HullVertex hs_main_patches(
     int i = ID%4;
     int j = ID/4;
 
-    float3 position[24];
+    float3 position[16];
     for (int p=0; p<16; ++p) {
         position[p] = patch[p].position.xyz;
     }

--- a/opensubdiv/osd/hlslPatchCommon.hlsl
+++ b/opensubdiv/osd/hlslPatchCommon.hlsl
@@ -133,7 +133,7 @@ float TessAdaptive(float3 p0, float3 p1)
     // length of the projected edge itself to avoid problems near silhouettes.
     float3 center = (p0 + p1) / 2.0;
     float diameter = distance(p0, p1);
-    return max(1.0, OsdTessLevel() * GetPostProjectionSphereExtent(center, diameter));
+    return round(max(1.0, OsdTessLevel() * GetPostProjectionSphereExtent(center, diameter)));
 }
 
 #ifndef OSD_DISPLACEMENT_CALLBACK
@@ -271,3 +271,32 @@ Univar4x4(in float u, out float B[4], out float D[4], out float C[4])
     C[2] = A1 - A2;
     C[3] = A2;
 }
+
+// ----------------------------------------------------------------------------
+
+float3
+EvalBezier(float3 cp[16], float2 uv)
+{
+    float3 BUCP[4] = { float3(0,0,0), float3(0,0,0), float3(0,0,0), float3(0,0,0) };
+
+    float B[4], D[4];
+
+    Univar4x4(uv.x, B, D);
+    for (int i=0; i<4; ++i) {
+        for (int j=0; j<4; ++j) {
+            float3 A = cp[4*i + j];
+            BUCP[i] += A * B[j];
+        }
+    }
+
+    float3 position = float3(0,0,0);
+
+    Univar4x4(uv.y, B, D);
+    for (int k=0; k<4; ++k) {
+        position  += B[k] * BUCP[k];
+    }
+
+    return position;
+}
+
+// ----------------------------------------------------------------------------

--- a/opensubdiv/osd/hlslPatchTransition.hlsl
+++ b/opensubdiv/osd/hlslPatchTransition.hlsl
@@ -26,78 +26,188 @@
 // Patches.HullTransition
 //----------------------------------------------------------
 
-float
-TessAdaptiveRound(float3 p0, float3 p1)
+void
+GetTessLevelsUniform(float3 cp[16], int patchParam, int patchLevel,
+                     inout float4 tessOuterLo, inout float4 tessOuterHi)
 {
-    return round(TessAdaptive(p0, p1));
+    float tessAmount = GetTessLevel(patchLevel);
+
+    tessOuterLo = float4(tessAmount,tessAmount,tessAmount,tessAmount);
+    tessOuterHi = float4(0,0,0,0);
+}
+
+//
+// Organization of B-spline and Bezier control points.
+//
+// Each patch is defined by 16 control points (labeled 0-15).
+//
+// The patch will be evaluated across the domain from (0,0) at
+// the lower-left to (1,1) at the upper-right. When computing
+// adaptive tessellation metrics, we consider refined vertex-vertex
+// and edge-vertex points along the transition edges of the patch
+// (labeled vv* and ev* respectively).
+//
+// The two segments of each transition edge are labeled Lo and Hi,
+// with the Lo segment occuring before the Hi segment along the
+// transition edge's domain parameterization. These Lo and Hi segment
+// tessellation levels determine how domain evaluation coordinates
+// are remapped along transition edges. The Hi segment value will
+// be zero for a non-transition edge.
+//
+// (0,1)                                         (1,1)
+//
+//   vv3                  ev23                   vv2
+//        |       Lo3       |       Hi3       |
+//      --O-----------O-----+-----O-----------O--
+//        | 12        | 13     14 |        15 |
+//        |           |           |           |
+//        |           |           |           |
+//    Hi0 |           |           |           | Hi2
+//        |           |           |           |
+//        O-----------O-----------O-----------O
+//        | 8         | 9      10 |        11 |
+//        |           |           |           |
+// ev03 --+           |           |           +-- ev12
+//        |           |           |           |
+//        | 4         | 5       6 |         7 |
+//        O-----------O-----------O-----------O
+//        |           |           |           |
+//    Lo0 |           |           |           | Lo2
+//        |           |           |           |
+//        |           |           |           |
+//        | 0         | 1       2 |         3 |
+//      --O-----------O-----+-----O-----------O--
+//        |       Lo1       |       Hi1       |
+//   vv0                  ev01                   vv1
+//
+// (0,0)                                         (1,0)
+//
+
+void
+GetTessLevelsRefinedPoints(float3 cp[16], int patchParam,
+                           inout float4 tessOuterLo, inout float4 tessOuterHi)
+{
+    // Each edge of a transition patch is adjacent to one or two patches
+    // at the next refined level of subdivision. We compute the corresponding
+    // vertex-vertex and edge-vertex refined points along the edges of the
+    // patch using Catmull-Clark subdivision stencil weights.
+    // For simplicity, we let the optimizer discard unused computation.
+
+    float3 vv0 = (cp[0] + cp[2] + cp[8] + cp[10]) * 0.015625 +
+                 (cp[1] + cp[4] + cp[6] + cp[9]) * 0.09375 + cp[5] * 0.5625;
+    float3 ev01 = (cp[1] + cp[2] + cp[9] + cp[10]) * 0.0625 +
+                  (cp[5] + cp[6]) * 0.375;
+
+    float3 vv1 = (cp[1] + cp[3] + cp[9] + cp[11]) * 0.015625 +
+                 (cp[2] + cp[5] + cp[7] + cp[10]) * 0.09375 + cp[6] * 0.5625;
+    float3 ev12 = (cp[5] + cp[7] + cp[9] + cp[11]) * 0.0625 +
+                  (cp[6] + cp[10]) * 0.375;
+
+    float3 vv2 = (cp[5] + cp[7] + cp[13] + cp[15]) * 0.015625 +
+                 (cp[6] + cp[9] + cp[11] + cp[14]) * 0.09375 + cp[10] * 0.5625;
+    float3 ev23 = (cp[5] + cp[6] + cp[13] + cp[14]) * 0.0625 +
+                  (cp[9] + cp[10]) * 0.375;
+
+    float3 vv3 = (cp[4] + cp[6] + cp[12] + cp[14]) * 0.015625 +
+                 (cp[5] + cp[8] + cp[10] + cp[13]) * 0.09375 + cp[9] * 0.5625;
+    float3 ev03 = (cp[4] + cp[6] + cp[8] + cp[10]) * 0.0625 +
+                  (cp[5] + cp[9]) * 0.375;
+
+    tessOuterLo = float4(1,1,1,1);
+    tessOuterHi = float4(0,0,0,0);
+
+    if (((patchParam >> 11) & 1) != 0) {
+        tessOuterLo[0] = TessAdaptive(vv0, ev03);
+        tessOuterHi[0] = TessAdaptive(vv3, ev03);
+    } else {
+        tessOuterLo[0] = TessAdaptive(cp[5], cp[9]);
+    }
+    if (((patchParam >> 8) & 1) != 0) {
+        tessOuterLo[1] = TessAdaptive(vv0, ev01);
+        tessOuterHi[1] = TessAdaptive(vv1, ev01);
+    } else {
+        tessOuterLo[1] = TessAdaptive(cp[5], cp[6]);
+    }
+    if (((patchParam >> 9) & 1) != 0) {
+        tessOuterLo[2] = TessAdaptive(vv1, ev12);
+        tessOuterHi[2] = TessAdaptive(vv2, ev12);
+    } else {
+        tessOuterLo[2] = TessAdaptive(cp[6], cp[10]);
+    }
+    if (((patchParam >> 10) & 1) != 0) {
+        tessOuterLo[3] = TessAdaptive(vv3, ev23);
+        tessOuterHi[3] = TessAdaptive(vv2, ev23);
+    } else {
+        tessOuterLo[3] = TessAdaptive(cp[9], cp[10]);
+    }
+}
+
+void
+GetTessLevelsLimitPoints(float3 cpBezier[16], int patchParam,
+                         inout float4 tessOuterLo, inout float4 tessOuterHi)
+{
+    // Each edge of a transition patch is adjacent to one or two patches
+    // at the next refined level of subdivision. When the patch control
+    // points have been converted to the Bezier basis, the control points
+    // at the four corners are on the limit surface (since a Bezier patch
+    // interpolates its corner control points). We can compute an adaptive
+    // tessellation level for transition edges on the limit surface by
+    // evaluating a limit position at the mid point of each transition edge.
+
+    tessOuterLo = float4(1,1,1,1);
+    tessOuterHi = float4(0,0,0,0);
+
+    if (((patchParam >> 11) & 1) != 0) {
+        float3 ev03 = EvalBezier(cpBezier, float2(0.0, 0.5));
+        tessOuterLo[0] = TessAdaptive(cpBezier[0], ev03);
+        tessOuterHi[0] = TessAdaptive(cpBezier[12], ev03);
+    } else {
+        tessOuterLo[0] = TessAdaptive(cpBezier[0], cpBezier[12]);
+    }
+    if (((patchParam >> 8) & 1) != 0) {
+        float3 ev01 = EvalBezier(cpBezier, float2(0.5, 0.0));
+        tessOuterLo[1] = TessAdaptive(cpBezier[0], ev01);
+        tessOuterHi[1] = TessAdaptive(cpBezier[3], ev01);
+    } else {
+        tessOuterLo[1] = TessAdaptive(cpBezier[0], cpBezier[3]);
+    }
+    if (((patchParam >> 9) & 1) != 0) {
+        float3 ev12 = EvalBezier(cpBezier, float2(1.0, 0.5));
+        tessOuterLo[2] = TessAdaptive(cpBezier[3], ev12);
+        tessOuterHi[2] = TessAdaptive(cpBezier[15], ev12);
+    } else {
+        tessOuterLo[2] = TessAdaptive(cpBezier[3], cpBezier[15]);
+    }
+    if (((patchParam >> 10) & 1) != 0) {
+        float3 ev23 = EvalBezier(cpBezier, float2(0.5, 1.0));
+        tessOuterLo[3] = TessAdaptive(cpBezier[12], ev23);
+        tessOuterHi[3] = TessAdaptive(cpBezier[15], ev23);
+    } else {
+        tessOuterLo[3] = TessAdaptive(cpBezier[12], cpBezier[15]);
+    }
 }
 
 void
 GetTransitionTessLevels(
-        float3 cp[24], int patchParam, int patchLevel,
-        inout float4 outer, inout float4 inner,
+        float3 cp[16], int patchParam, int patchLevel,
+        inout float4 outerLevel, inout float4 innerLevel,
         inout float4 tessOuterLo, inout float4 tessOuterHi)
 {
-    // Each edge of a transition patch is adjacent to one or two patches
-    // at the next refined level of subdivision. We COmpute the corresponding
-    // vertex-vertex and edge-vertex refined points along the edges of the
-    // patch using Catmull-Clark subdivision stencil weights.
-    // For simplicity, we let the optimizer discard unused computation.
-    cp[16] = (cp[0] + cp[2] + cp[8] + cp[10]) * 0.015625 +
-             (cp[1] + cp[4] + cp[6] + cp[9]) * 0.09375 + cp[5] * 0.5625;
-    cp[17] = (cp[1] + cp[2] + cp[9] + cp[10]) * 0.0625 + (cp[5] + cp[6]) * 0.375;
-
-    cp[18] = (cp[1] + cp[3] + cp[9] + cp[11]) * 0.015625 +
-             (cp[2] + cp[5] + cp[7] + cp[10]) * 0.09375 + cp[6] * 0.5625;
-    cp[19] = (cp[5] + cp[7] + cp[9] + cp[11]) * 0.0625 + (cp[6] + cp[10]) * 0.375;
-
-    cp[20] = (cp[5] + cp[7] + cp[13] + cp[15]) * 0.015625 +
-             (cp[6] + cp[9] + cp[11] + cp[14]) * 0.09375 + cp[10] * 0.5625;
-    cp[21] = (cp[5] + cp[6] + cp[13] + cp[14]) * 0.0625 + (cp[9] + cp[10]) * 0.375;
-
-    cp[22] = (cp[4] + cp[6] + cp[12] + cp[14]) * 0.015625 +
-             (cp[5] + cp[8] + cp[10] + cp[13]) * 0.09375 + cp[9] * 0.5625;
-    cp[23] = (cp[4] + cp[6] + cp[8] + cp[10]) * 0.0625 + (cp[5] + cp[9]) * 0.375;
-    tessOuterLo = float4(1,1,1,1);
-    tessOuterHi = float4(0,0,0,0);
-
-#ifdef OSD_ENABLE_SCREENSPACE_TESSELLATION
-    if (((patchParam >> 11) & 1) != 0) {
-        tessOuterLo[0] = TessAdaptiveRound(cp[23], cp[16]);
-        tessOuterHi[0] = TessAdaptiveRound(cp[22], cp[23]);
-    } else {
-        tessOuterLo[0] = TessAdaptiveRound(cp[5], cp[9]);
-    }
-    if (((patchParam >> 8) & 1) != 0) {
-        tessOuterLo[1] = TessAdaptiveRound(cp[16], cp[17]);
-        tessOuterHi[1] = TessAdaptiveRound(cp[17], cp[18]);
-    } else {
-        tessOuterLo[1] = TessAdaptiveRound(cp[5], cp[6]);
-    }
-    if (((patchParam >> 9) & 1) != 0) {
-        tessOuterLo[2] = TessAdaptiveRound(cp[18], cp[19]);
-        tessOuterHi[2] = TessAdaptiveRound(cp[19], cp[20]);
-    } else {
-        tessOuterLo[2] = TessAdaptiveRound(cp[6], cp[10]);
-    }
-    if (((patchParam >> 10) & 1) != 0) {
-        tessOuterLo[3] = TessAdaptiveRound(cp[21], cp[22]);
-        tessOuterHi[3] = TessAdaptiveRound(cp[20], cp[21]);
-    } else {
-        tessOuterLo[3] = TessAdaptiveRound(cp[9], cp[10]);
-    }
+#if defined OSD_ENABLE_SCREENSPACE_TESSELLATION
+    GetTessLevelsLimitPoints(cp, patchParam, tessOuterLo, tessOuterHi);
+#elif defined OSD_ENABLE_SCREENSPACE_TESSELLATION_REFINED
+    GetTessLevelsRefinedPoints(cp, patchParam, tessOuterLo, tessOuterHi);
 #else
-    float tessAmount = GetTessLevel(patchLevel);
-
-    tessOuterLo[0] = tessAmount;
-    tessOuterLo[1] = tessAmount;
-    tessOuterLo[2] = tessAmount;
-    tessOuterLo[3] = tessAmount;
+    GetTessLevelsUniform(cp, patchParam, patchLevel, tessOuterLo, tessOuterHi);
 #endif
 
-    outer = tessOuterLo + tessOuterHi;
-    inner[0] = (outer[0] + outer[2]) * 0.5;
-    inner[1] = (outer[1] + outer[3]) * 0.5;
+    // Outer levels are the sum of the Lo and Hi segments where the Hi
+    // segments will have a length of zero for non-transition edges.
+    outerLevel = tessOuterLo + tessOuterHi;
+
+    // Inner levels are the average the corresponding outer levels.
+    innerLevel[0] = (outerLevel[1] + outerLevel[3]) * 0.5;
+    innerLevel[1] = (outerLevel[0] + outerLevel[2]) * 0.5;
 }
 
 //----------------------------------------------------------
@@ -107,8 +217,7 @@ GetTransitionTessLevels(
 float
 GetTransitionSplit(float t, float n0, float n1)
 {
-    float n = round(n0 + n1);
-    float ti = round(t * n);
+    float ti = round(t * (n0 + n1));
 
     if (ti <= n0) {
         return 0.5 * (ti / n0);


### PR DESCRIPTION
Added a new screen-space adaptive tessellation metric which
computes edge lengths using limit surface points. Made this
the default screen-space metric so that we avoid cracks when
using Gregory Basis or Regular B-spline end caps.

The alternative method which computes edge lengths using the
distance between B-spline control points is still available.

Added a diagram and comments to explain how the control
points and limit points are organized.