### PR TITLE
Fixed orientation of boundary and corner patches

### DIFF
--- a/opensubdiv/far/patchTablesFactory.h
+++ b/opensubdiv/far/patchTablesFactory.h
@@ -167,7 +167,7 @@ private:
 
     static PatchParam * computePatchParam(TopologyRefiner const & refiner,
         PtexIndices const & ptexIndices,
-        int level, int face, int rotation,
+        int level, int face,
         int boundaryMask, int transitionMask, PatchParam * coord);
 
     static int gatherFVarData(AdaptiveContext & state,

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -309,6 +309,9 @@ public:
     int gatherQuadLinearPatchPoints(Index fIndex, Index patchPoints[], int rotation = 0,
                                                                        int fvarChannel = -1) const;
 
+    int gatherQuadRegularPatchPoints(Index fIndex, Index patchPoints[], int boundaryMask = 0,
+                                                                        int rotation = 0,
+                                                                        int fvarChannel = -1) const;
     int gatherQuadRegularInteriorPatchPoints(Index fIndex, Index patchPoints[], int rotation = 0,
                                                                                 int fvarChannel = -1) const;
     int gatherQuadRegularBoundaryPatchPoints(Index fIndex, Index patchPoints[], int boundaryEdgeInFace,


### PR DESCRIPTION
Now a boundary and corner patch remains
aligned with its underlying parametric
orientation. This simplifies both the
gathering of patch vertices and downstream
evaluation of patches.

Added a method to Vtr::Level which gathers
the 16 patch points for a B-spline patch
even if the patch has boundary or corner
edges.  The undefined patch vertex index
values along boundary and corner edges are
assigned Vtr::INDEX_INVALID.

In order to simplifiy the process of drawing
B-spline patches with boundary or corner
edges, the Far::PatchTablesFactory will
replace any invalid vertex indices with
a known good value, i.e. the index of the
first patch face vertex.

Single-crease patches are still a slightly
special case, which will be resolved later.