### PR TITLE
Minor fixes to building docs and doc links.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,7 +360,7 @@ endif()
 
 if (NOT NO_DOC)
     find_package(Doxygen 1.8.4)
-    find_package(Docutils 0.6)
+    find_package(Docutils 0.9)
 else()
     set(DOXYGEN_EXECUTABLE )
 endif()

--- a/documentation/cmake_build.rst
+++ b/documentation/cmake_build.rst
@@ -80,8 +80,8 @@ ________
     - `GLFW <https://github.com/glfw/glfw>`__ (required for standalone examples
       and some regression tests)
     - `Docutils <http://docutils.sourceforge.net/>`__ (required for reST-based documentation)
-    - `Python Pygments <http://www.pygments.org/>`__ (required for Docutils reST styling)
-    - `Doxygen <www.doxygen.org/>`__
+    - `Python Pygments <http://pygments.org/>`__ (required for Docutils reST styling)
+    - `Doxygen <http://www.doxygen.org/>`__
 
 ----
 


### PR DESCRIPTION
- Upped minimum required version of docutils from 0.6 to 0.9.
- Fixed link to pygments in build documentation
- Fixed link to doxygen in build documentation