### PR TITLE
Temporary fix for GL version detection in glViewer (issue #358)

### DIFF
--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -1723,18 +1723,23 @@ setGLCoreProfile() {
     #define GLFW_OPENGL_VERSION_MINOR GLFW_CONTEXT_VERSION_MINOR
 
     glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
 #if not defined(__APPLE__)
+
     glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 4);
-#ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 3);
-#else
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
-#endif
+    if (GLEW_VERSION_4_3) {
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 3);
+    } else {
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
+    }
 
 #else
+
     glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 3);
     glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
+
 #endif
+    
     glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 }
 


### PR DESCRIPTION
The way we ask for a GL version leaves room for improvement.  In this change I only changed it so that we test for the minor version at runtime rather than what we can grep out of the glew headers at compile time.  The full desired solution described in issue #358 provides a more complete solution.

This change makes glViewer work on machines that only support OpenGL 4.2 but
does not provide a nicer fix than that.