### PR TITLE
cleanup examples to use common/clDeviceContext.h, cudaInit.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,8 @@ endif()
 
 add_subdirectory(opensubdiv)
 
+add_subdirectory(common)
+
 if (NOT ANDROID AND NOT IOS) # XXXdyu
     add_subdirectory(regression)
 endif()

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013 Pixar
+#   Copyright 2015 Pixar
 #
 #   Licensed under the Apache License, Version 2.0 (the "Apache License")
 #   with the following modification; you may not use this file except in
@@ -22,50 +22,32 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-# *** glViewer ***
+if (OPENCL_FOUND)
+    list (APPEND COMMON_SOURCE_FILES
+        clDeviceContext.cpp
+    )
 
-set(SHADER_FILES
-     shader.glsl
-     shader_gl3.glsl
-)
-
-include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
-    "${GLFW_INCLUDE_DIR}"
-)
-
-list(APPEND PLATFORM_LIBRARIES
-    "${OSD_LINK_TARGET}"
-    "${OPENGL_LIBRARY}"
-    "${GLFW_LIBRARIES}"
-)
-
-if ( GLEW_FOUND )
-    include_directories("${GLEW_INCLUDE_DIR}")
-    list(APPEND PLATFORM_LIBRARIES "${GLEW_LIBRARY}")
-endif()
-
-if( OPENCL_FOUND )
+    list (APPEND COMMON_HEADER_FILES
+        clDeviceContext.h
+    )
     include_directories("${OPENCL_INCLUDE_DIRS}")
 endif()
 
-_stringify("${SHADER_FILES}" INC_FILES)
+if (CUDA_FOUND)
+    list (APPEND COMMON_SOURCE_FILES
+    )
+    list (APPEND COMMON_HEADER_FILES
+        cudaInit.h
+    )
+endif()
 
-include_directories("${CMAKE_CURRENT_BINARY_DIR}")
-
-_add_glfw_executable(glViewer
-    glViewer.cpp
-    "${SHADER_FILES}"
-    "${INC_FILES}"
-    $<TARGET_OBJECTS:common_obj>
-    $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:regression_vtr_utils_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+include_directories(
+    "${PROJECT_SOURCE_DIR}/opensubdiv"
 )
 
-target_link_libraries(glViewer
-    ${PLATFORM_LIBRARIES}
+add_library(common_obj
+    OBJECT
+        ${COMMON_SOURCE_FILES}
+        ${COMMON_HEADER_FILES}
 )
 
-install(TARGETS glViewer DESTINATION "${CMAKE_BINDIR_BASE}")

--- a/common/clDeviceContext.cpp
+++ b/common/clDeviceContext.cpp
@@ -1,5 +1,5 @@
 //
-//   Copyright 2013 Pixar
+//   Copyright 2015 Pixar
 //
 //   Licensed under the Apache License, Version 2.0 (the "Apache License")
 //   with the following modification; you may not use this file except in
@@ -22,8 +22,7 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#ifndef OSD_EXAMPLE_CL_INIT_H
-#define OSD_EXAMPLE_CL_INIT_H
+#include "clDeviceContext.h"
 
 #if defined(_WIN32)
     #include <windows.h>
@@ -33,33 +32,44 @@
     #include <GL/glx.h>
 #endif
 
-#include "osd/opencl.h"
-
 #include <cstdio>
+#include <cstring>
 #include <string>
 
-static inline bool HAS_CL_VERSION_1_1 () {
-#ifdef OPENSUBDIV_HAS_OPENCL
-     #ifdef OPENSUBDIV_HAS_CLEW
-        static bool clewInitialized = false;
-        static bool clewLoadSuccess;
-        if (not clewInitialized) {
-            clewInitialized = true;
-            clewLoadSuccess = clewInit() == CLEW_SUCCESS;
-            if (not clewLoadSuccess) {
-                fprintf(stderr, "Loading OpenCL failed.\n");
-            }
-        }
-        return clewLoadSuccess;
-    #endif
-    return true;
-#else
-    return false;
-#endif
+CLDeviceContext::CLDeviceContext() :
+    _clContext(NULL), _clCommandQueue(NULL) {
 }
 
-static bool initCL(cl_context *clContext, cl_command_queue *clQueue)
-{
+CLDeviceContext::~CLDeviceContext() {
+
+    if (_clCommandQueue)
+        clReleaseCommandQueue(_clCommandQueue);
+    if (_clContext)
+        clReleaseContext(_clContext);
+}
+
+/*static*/
+bool
+CLDeviceContext::HAS_CL_VERSION_1_1 () {
+
+#ifdef OPENSUBDIV_HAS_CLEW
+    static bool clewInitialized = false;
+    static bool clewLoadSuccess;
+    if (not clewInitialized) {
+        clewInitialized = true;
+        clewLoadSuccess = clewInit() == CLEW_SUCCESS;
+        if (not clewLoadSuccess) {
+            fprintf(stderr, "Loading OpenCL failed.\n");
+        }
+    }
+    return clewLoadSuccess;
+#endif
+    return true;
+}
+
+bool
+CLDeviceContext::Initialize() {
+
 #ifdef OPENSUBDIV_HAS_CLEW
     if (!clGetPlatformIDs) {
         printf("Error clGetPlatformIDs function not bound.\n");
@@ -190,7 +200,8 @@ static bool initCL(cl_context *clContext, cl_command_queue *clQueue)
         return false;
     }
 
-    *clContext = clCreateContext(props, 1, &clDevices[clDeviceUsed], NULL, NULL, &ciErrNum);
+    _clContext = clCreateContext(props, 1, &clDevices[clDeviceUsed],
+                                 NULL, NULL, &ciErrNum);
     if (ciErrNum != CL_SUCCESS) {
         printf("Error %d in clCreateContext\n", ciErrNum);
         delete[] clDevices;
@@ -198,7 +209,8 @@ static bool initCL(cl_context *clContext, cl_command_queue *clQueue)
     }
 #endif
 
-    *clQueue = clCreateCommandQueue(*clContext, clDevices[clDeviceUsed], 0, &ciErrNum);
+    _clCommandQueue = clCreateCommandQueue(_clContext, clDevices[clDeviceUsed],
+                                    0, &ciErrNum);
     delete[] clDevices;
     if (ciErrNum != CL_SUCCESS) {
         printf("Error %d in clCreateCommandQueue\n", ciErrNum);
@@ -207,10 +219,3 @@ static bool initCL(cl_context *clContext, cl_command_queue *clQueue)
     return true;
 }
 
-static void uninitCL(cl_context clContext, cl_command_queue clQueue)
-{
-    clReleaseCommandQueue(clQueue);
-    clReleaseContext(clContext);
-}
-
-#endif // OSD_EXAMPLE_CL_INIT_H

--- a/common/clDeviceContext.h
+++ b/common/clDeviceContext.h
@@ -1,0 +1,57 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OSD_COMMON_CL_DEVICE_CONTEXT_H
+#define OSD_COMMON_CL_DEVICE_CONTEXT_H
+
+#include "osd/opencl.h"
+
+class CLDeviceContext {
+public:
+    CLDeviceContext();
+    ~CLDeviceContext();
+
+    static bool HAS_CL_VERSION_1_1 ();
+
+    bool Initialize();
+
+    bool IsInitialized() const {
+        return (_clContext != NULL);
+    }
+
+    cl_context GetContext() const {
+        return _clContext;
+    }
+    cl_command_queue GetCommandQueue() const {
+        return _clCommandQueue;
+    }
+
+private:
+    cl_context _clContext;
+    cl_command_queue _clCommandQueue;
+};
+
+
+
+#endif  // OSD_COMMON_CL_DEVICE_CONTEXT_H

--- a/common/cudaInit.h
+++ b/common/cudaInit.h
@@ -22,8 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#ifndef OSD_CUDA_INIT_H
-#define OSD_CUDA_INIT_H
+#ifndef OSD_COMMON_CUDA_INIT_H
+#define OSD_COMMON_CUDA_INIT_H
 
 #include <algorithm>
 #include <cstdio>
@@ -108,4 +108,4 @@ inline int cutGetMaxGflopsDeviceId()
     return max_perf_device;
 }
 
-#endif //OSD_CUDA_INIT_H
+#endif  // OSD_COMMON_CUDA_INIT_H

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -36,8 +36,6 @@ set(EXAMPLES_COMMON_SOURCE_FILES
 )
 
 set(EXAMPLES_COMMON_HEADER_FILES
-    clInit.h
-    cudaInit.h
     font_image.h
     hdr_reader.h
     hud.h
@@ -84,10 +82,6 @@ if(DXSDK_FOUND)
 
     include_directories("${DXSDK_INCLUDE_DIR}")
 
-endif()
-
-if( OPENCL_FOUND )
-    include_directories("${OPENCL_INCLUDE_DIRS}")
 endif()
 
 include_directories(

--- a/examples/glImaging/CMakeLists.txt
+++ b/examples/glImaging/CMakeLists.txt
@@ -63,6 +63,7 @@ _add_possibly_cuda_executable(glImaging
     "${SOURCE_FILES}"
     "${SHADER_FILES}"
     "${INC_FILES}"
+    $<TARGET_OBJECTS:common_obj>
     $<TARGET_OBJECTS:regression_common_obj>
 )
 

--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -66,15 +66,9 @@
     #include <osd/clComputeContext.h>
     #include <osd/clComputeController.h>
 
-    #include "../common/clInit.h"
+    #include "../../common/clDeviceContext.h"
 
-    struct CLContext {
-        cl_context GetContext() const { return clContext; }
-        cl_command_queue GetCommandQueue() const { return clQueue; }
-        cl_context clContext;
-        cl_command_queue clQueue;
-    };
-    CLContext g_clContext;
+    CLDeviceContext g_clDeviceContext;
     OpenSubdiv::Osd::CLComputeController *g_clComputeController = NULL;
 #endif
 
@@ -86,7 +80,7 @@
     #include <cuda_runtime_api.h>
     #include <cuda_gl_interop.h>
 
-    #include "../common/cudaInit.h"
+    #include "../../common/cudaInit.h"
 
     OpenSubdiv::Osd::CudaComputeController *g_cudaComputeController = NULL;
 #endif
@@ -297,17 +291,18 @@ createOsdMesh(std::string const &kernel,
     } else if(kernel == "CL") {
         if (not g_clComputeController) {
             g_clComputeController = new Osd::CLComputeController(
-                g_clContext.clContext, g_clContext.clQueue);
+                g_clDeviceContext.GetContext(),
+                g_clDeviceContext.GetCommandQueue());
         }
         return new Osd::Mesh<Osd::CLGLVertexBuffer,
             Osd::CLComputeController,
             Osd::GLDrawContext,
-            CLContext>(
+            CLDeviceContext>(
                 g_clComputeController,
                 refiner,
                 numVertexElements,
                 numVaryingElements,
-                level, bits, &g_clContext);
+                level, bits, &g_clDeviceContext);
 #endif
 #ifdef OPENSUBDIV_HAS_CUDA
     } else if(kernel == "CUDA") {
@@ -726,9 +721,11 @@ int main(int argc, char ** argv) {
         // prep GPU kernel
 #ifdef OPENSUBDIV_HAS_OPENCL
         if (kernel == "CL") {
-            if (initCL(&g_clContext.clContext, &g_clContext.clQueue) == false) {
-                std::cout << "Error in initializing OpenCL\n";
-                exit(1);
+            if (g_clDeviceContext.IsInitialized() == false) {
+                if (g_clDeviceContext.Initialize() == false) {
+                    std::cout << "Error in initializing OpenCL\n";
+                    exit(1);
+                }
             }
         }
 #endif
@@ -754,12 +751,6 @@ int main(int argc, char ** argv) {
 
             glfwSwapBuffers(window);
         }
-
-#ifdef OPENSUBDIV_HAS_OPENCL
-        if (kernel == "CL") {
-            uninitCL(g_clContext.clContext, g_clContext.clQueue);
-        }
-#endif
     }
 
     return 0;

--- a/examples/glPtexViewer/CMakeLists.txt
+++ b/examples/glPtexViewer/CMakeLists.txt
@@ -77,6 +77,7 @@ _add_glfw_executable(glPtexViewer
     glPtexViewer.cpp
     "${SHADER_FILES}"
     "${INC_FILES}"
+    $<TARGET_OBJECTS:common_obj>
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:examples_common_obj>
 )

--- a/examples/glShareTopology/CMakeLists.txt
+++ b/examples/glShareTopology/CMakeLists.txt
@@ -59,6 +59,7 @@ _add_glfw_executable(glShareTopology
     glShareTopology.cpp
     "${SHADER_FILES}"
     "${INC_FILES}"
+    $<TARGET_OBJECTS:common_obj>
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:examples_common_obj>
 )

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -52,30 +52,33 @@ GLFWmonitor* g_primary=0;
 #include <osd/cpuGLVertexBuffer.h>
 #include <osd/cpuComputeContext.h>
 #include <osd/cpuComputeController.h>
+OpenSubdiv::Osd::CpuComputeController *g_cpuComputeController = NULL;
 
 #ifdef OPENSUBDIV_HAS_OPENMP
     #include <osd/ompComputeController.h>
+    OpenSubdiv::Osd::OmpComputeController *g_ompComputeController = NULL;
 #endif
 
 #ifdef OPENSUBDIV_HAS_TBB
     #include <osd/tbbComputeController.h>
+    OpenSubdiv::Osd::TbbComputeController *g_tbbComputeController = NULL;
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL
     #include <osd/clGLVertexBuffer.h>
     #include <osd/clComputeContext.h>
     #include <osd/clComputeController.h>
+    OpenSubdiv::Osd::CLComputeController *g_clComputeController = NULL;
 
-    #include "../common/clInit.h"
-
-    cl_context g_clContext;
-    cl_command_queue g_clQueue;
+    #include "../../common/clDeviceContext.h"
+    CLDeviceContext g_clDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_CUDA
     #include <osd/cudaGLVertexBuffer.h>
     #include <osd/cudaComputeContext.h>
     #include <osd/cudaComputeController.h>
+    OpenSubdiv::Osd::CudaComputeController *g_cudaComputeController = NULL;
 
     #include <cuda_runtime_api.h>
     #include <cuda_gl_interop.h>
@@ -88,12 +91,14 @@ GLFWmonitor* g_primary=0;
     #include <osd/glslTransformFeedbackComputeContext.h>
     #include <osd/glslTransformFeedbackComputeController.h>
     #include <osd/glVertexBuffer.h>
+    OpenSubdiv::Osd::GLSLTransformFeedbackComputeController *g_glslXFBComputeController = NULL;
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
     #include <osd/glslComputeContext.h>
     #include <osd/glslComputeController.h>
     #include <osd/glVertexBuffer.h>
+    OpenSubdiv::Osd::GLSLComputeController *g_glslComputeController = NULL;
 #endif
 
 
@@ -155,16 +160,18 @@ private:
     int _numVertices;                // # of vertices of single instance
 };
 
-template <class VERTEX_BUFFER>
+template <class VERTEX_BUFFER, class DEVICE_CONTEXT>
 class Instances : public InstancesBase {
 public:
     Instances(int numInstances,
               Osd::VertexBufferDescriptor const &vertexDesc,
               Osd::VertexBufferDescriptor const &varyingDesc,
               bool interleaved,
-              int numVertices) :
+              int numVertices,
+              DEVICE_CONTEXT *deviceContext) :
         InstancesBase(vertexDesc, varyingDesc, numVertices),
-        _vertexBuffer(NULL), _varyingBuffer(NULL), _interleaved(interleaved) {
+        _vertexBuffer(NULL), _varyingBuffer(NULL), _interleaved(interleaved),
+        _deviceContext(deviceContext) {
 
         if (interleaved) {
             assert(vertexDesc.stride == varyingDesc.stride);
@@ -206,11 +213,12 @@ public:
     }
 
     VERTEX_BUFFER *createVertexBuffer(int numElements, int numVertices) {
-        return VERTEX_BUFFER::Create(numElements, numVertices);
+        return VERTEX_BUFFER::Create(numElements, numVertices, _deviceContext);
     }
-    void updateVertexBuffer(VERTEX_BUFFER *vertexBuffer, const float *src, int startVertex,
+    void updateVertexBuffer(VERTEX_BUFFER *vertexBuffer,
+                            const float *src, int startVertex,
                             int numVertices) {
-        vertexBuffer->UpdateData(src, startVertex, numVertices);
+        vertexBuffer->UpdateData(src, startVertex, numVertices, _deviceContext);
     }
 
     VERTEX_BUFFER *GetVertexBuffer() const { return _vertexBuffer; }
@@ -220,6 +228,7 @@ private:
     VERTEX_BUFFER *_vertexBuffer;
     VERTEX_BUFFER *_varyingBuffer;
     bool _interleaved;
+    DEVICE_CONTEXT *_deviceContext;
 };
 
 // ---------------------------------------------------------------------------
@@ -282,19 +291,27 @@ private:
     std::vector<float> _restPosition;
 };
 
-template <class COMPUTE_CONTROLLER, class VERTEX_BUFFER>
+template <class COMPUTE_CONTROLLER, class VERTEX_BUFFER,
+          class DEVICE_CONTEXT=void>
 class Topology : public TopologyBase {
 
 public:
 
+    typedef COMPUTE_CONTROLLER ComputeController;
     typedef typename COMPUTE_CONTROLLER::ComputeContext ComputeContext;
+    typedef DEVICE_CONTEXT DeviceContext;
 
-    Topology(Far::PatchTables const * patchTables,
-        Far::StencilTables const * vertexStencils,
-            Far::StencilTables const * varyingStencils)
-                : TopologyBase(patchTables) {
+    Topology(ComputeController * computeController,
+             Far::PatchTables const * patchTables,
+             Far::StencilTables const * vertexStencils,
+             Far::StencilTables const * varyingStencils,
+             DeviceContext * deviceContext = NULL)
+        : TopologyBase(patchTables),
+          _computeController(computeController),
+          _deviceContext(deviceContext) {
 
-        _computeContext = ComputeContext::Create(vertexStencils, varyingStencils);
+        _computeContext = ComputeContext::Create(
+            vertexStencils, varyingStencils, deviceContext);
 
         _numVertices = vertexStencils->GetNumStencils() +
             vertexStencils->GetNumControlVertices();
@@ -311,8 +328,8 @@ public:
         Osd::VertexBufferDescriptor const &globalVaryingDesc =
             instance->GetVaryingDesc();
 
-        Instances<VERTEX_BUFFER> *typedInstance =
-            static_cast<Instances<VERTEX_BUFFER> *>(instance);
+        Instances<VERTEX_BUFFER, DEVICE_CONTEXT> *typedInstance =
+            static_cast<Instances<VERTEX_BUFFER, DEVICE_CONTEXT> *>(instance);
 
         for (int i = 0; i < numInstances; ++i) {
 
@@ -326,11 +343,11 @@ public:
                 globalVaryingDesc.length,
                 globalVaryingDesc.stride);
 
-            _computeController.Compute(_computeContext,
-                                      typedInstance->GetVertexBuffer(),
-                                      typedInstance->GetVaryingBuffer(),
-                                      &vertexDesc,
-                                      &varyingDesc);
+            _computeController->Compute(_computeContext,
+                                        typedInstance->GetVertexBuffer(),
+                                        typedInstance->GetVaryingBuffer(),
+                                        &vertexDesc,
+                                        &varyingDesc);
         }
     }
 
@@ -340,64 +357,28 @@ public:
         Osd::VertexBufferDescriptor const &varyingDesc,
         bool interleaved) {
 
-        return new Instances<VERTEX_BUFFER>(numInstances,
-                                            vertexDesc,
-                                            varyingDesc,
-                                            interleaved,
-                                            _numVertices);
+        return new Instances<VERTEX_BUFFER, DEVICE_CONTEXT>(
+            numInstances, vertexDesc, varyingDesc,
+            interleaved, _numVertices, _deviceContext);
     }
 
     virtual void Synchronize() {
-        _computeController.Synchronize();
+        _computeController->Synchronize();
     }
 
     virtual void UpdateVertexTexture(InstancesBase *instances) {
-        Instances<VERTEX_BUFFER> *typedInstance =
-            static_cast<Instances<VERTEX_BUFFER> *>(instances);
+        Instances<VERTEX_BUFFER, DEVICE_CONTEXT> *typedInstance =
+            static_cast<Instances<VERTEX_BUFFER, DEVICE_CONTEXT> *>(instances);
         GetDrawContext()->UpdateVertexTexture(typedInstance->GetVertexBuffer());
 
         updateVertexBufferStride(typedInstance->GetVertexBuffer()->GetNumElements());
     }
 
 private:
-    COMPUTE_CONTROLLER _computeController;
+    ComputeController *_computeController;
     ComputeContext *_computeContext;
+    DeviceContext *_deviceContext;
 };
-
-// ---------------------------------------------------------------------------
-
-// CL specializations
-#ifdef OPENSUBDIV_HAS_OPENCL
-
-template<> Osd::CLGLVertexBuffer *
-Instances<Osd::CLGLVertexBuffer>::createVertexBuffer(
-    int numElements, int numVertices) {
-    return Osd::CLGLVertexBuffer::Create(
-        numElements, numVertices, g_clContext);
-}
-
-template<> void
-Instances<Osd::CLGLVertexBuffer>::updateVertexBuffer(
-    Osd::CLGLVertexBuffer *vertexBuffer,
-    const float *src, int startVertex, int numVertices) {
-    vertexBuffer->UpdateData(src, startVertex, numVertices, g_clQueue);
-}
-
-template<>
-Topology<Osd::CLComputeController, Osd::CLGLVertexBuffer>::
-Topology(Far::PatchTables const * patchTables,
-    Far::StencilTables const * vertexStencils, Far::StencilTables const * varyingStencils) :
-        TopologyBase(patchTables), _computeController(g_clContext, g_clQueue) {
-
-    _computeContext = ComputeContext::Create(vertexStencils, varyingStencils, g_clContext);
-
-    _numVertices = vertexStencils->GetNumStencils() +
-        vertexStencils->GetNumControlVertices();
-}
-#endif
-
-// ---------------------------------------------------------------------------
-
 
 TopologyBase *g_topology = NULL;
 InstancesBase *g_instances = NULL;
@@ -616,7 +597,8 @@ createOsdMesh( const std::string &shapeStr, int level, Scheme scheme=kCatmark ) 
     bool doAdaptive = (g_adaptive!=0 and scheme==kCatmark);
 
     if (doAdaptive) {
-        refiner->RefineAdaptive(Far::TopologyRefiner::AdaptiveOptions(level));
+        Far::TopologyRefiner::AdaptiveOptions options(level);
+        refiner->RefineAdaptive(options);
     } else {
         Far::TopologyRefiner::UniformOptions options(level);
         options.fullTopologyInLastLevel = true;
@@ -638,45 +620,82 @@ createOsdMesh( const std::string &shapeStr, int level, Scheme scheme=kCatmark ) 
         assert(vertexStencils);
     }
 
-    Far::PatchTables const * patchTables =
-        Far::PatchTablesFactory::Create(*refiner);
+    Far::PatchTables const * patchTables = NULL;
+    {
+        Far::PatchTablesFactory::Options poptions(level);
+        poptions.SetEndCapType(
+            Far::PatchTablesFactory::Options::ENDCAP_LEGACY_GREGORY);
+        patchTables = Far::PatchTablesFactory::Create(*refiner, poptions);
+    }
 
 
     // create partitioned patcharray
     TopologyBase *topology = NULL;
 
     if (g_kernel == kCPU) {
+        if (not g_cpuComputeController)
+            g_cpuComputeController = new Osd::CpuComputeController();
         topology = new Topology<Osd::CpuComputeController,
-            Osd::CpuGLVertexBuffer>(patchTables, vertexStencils, varyingStencils);
+            Osd::CpuGLVertexBuffer>(g_cpuComputeController,
+                                    patchTables,
+                                    vertexStencils, varyingStencils);
 #ifdef OPENSUBDIV_HAS_OPENMP
     } else if (g_kernel == kOPENMP) {
+        if (not g_ompComputeController)
+            g_ompComputeController = new Osd::OmpComputeController();
         topology = new Topology<Osd::OmpComputeController,
-            Osd::CpuGLVertexBuffer>(patchTables, vertexStencils, varyingStencils);
+            Osd::CpuGLVertexBuffer>(g_ompComputeController,
+                                    patchTables,
+                                    vertexStencils, varyingStencils);
 #endif
 #ifdef OPENSUBDIV_HAS_TBB
     } else if (g_kernel == kTBB) {
+        if (not g_tbbComputeController)
+            g_tbbComputeController = new Osd::TbbComputeController();
         topology = new Topology<Osd::TbbComputeController,
-            Osd::CpuGLVertexBuffer>(patchTables, vertexStencils, varyingStencils);
+            Osd::CpuGLVertexBuffer>(g_tbbComputeController,
+                                    patchTables,
+                                    vertexStencils, varyingStencils);
 #endif
 #ifdef OPENSUBDIV_HAS_CUDA
     } else if (g_kernel == kCUDA) {
+        if (not g_cudaComputeController)
+            g_cudaComputeController = new Osd::CudaComputeController();
         topology = new Topology<Osd::CudaComputeController,
-            Osd::CudaGLVertexBuffer>(patchTables, vertexStencils, varyingStencils);
+            Osd::CudaGLVertexBuffer>(g_cudaComputeController,
+                                     patchTables,
+                                     vertexStencils, varyingStencils);
 #endif
 #ifdef OPENSUBDIV_HAS_OPENCL
     } else if (g_kernel == kCL) {
+        if (not g_clComputeController)
+            g_clComputeController = new Osd::CLComputeController(
+                g_clDeviceContext.GetContext(),
+                g_clDeviceContext.GetCommandQueue());
         topology = new Topology<Osd::CLComputeController,
-            Osd::CLGLVertexBuffer>(patchTables, vertexStencils, varyingStencils);
+            Osd::CLGLVertexBuffer,
+            CLDeviceContext>(g_clComputeController,
+                             patchTables,
+                             vertexStencils, varyingStencils,
+                             &g_clDeviceContext);
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
     } else if (g_kernel == kGLSL) {
+        if (not g_glslXFBComputeController)
+            g_glslXFBComputeController = new Osd::GLSLTransformFeedbackComputeController();
         topology = new Topology<Osd::GLSLTransformFeedbackComputeController,
-            Osd::GLVertexBuffer>(patchTables, vertexStencils, varyingStencils);
+            Osd::GLVertexBuffer>(g_glslXFBComputeController,
+                                 patchTables,
+                                 vertexStencils, varyingStencils);
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
     } else if (g_kernel == kGLSLCompute) {
+        if (not g_glslComputeController)
+            g_glslComputeController = new Osd::GLSLComputeController();
         topology = new Topology<Osd::GLSLComputeController,
-            Osd::GLVertexBuffer>(patchTables, vertexStencils, varyingStencils);
+            Osd::GLVertexBuffer>(g_glslComputeController,
+                                 patchTables,
+                                 vertexStencils, varyingStencils);
 #endif
     } else {
     }
@@ -1257,10 +1276,28 @@ uninitGL() {
     if (g_topology)
         delete g_topology;
 
-#ifdef OPENSUBDIV_HAS_OPENCL
-    uninitCL(g_clContext, g_clQueue);
+    delete g_cpuComputeController;
+
+#ifdef OPENSUBDIV_HAS_OPENMP
+    delete g_ompComputeController;
 #endif
 
+#ifdef OPENSUBDIV_HAS_TBB
+    delete g_tbbComputeController;
+#endif
+#ifdef OPENSUBDIV_HAS_OPENCL
+    delete g_clComputeController;
+#endif
+#ifdef OPENSUBDIV_HAS_CUDA
+    delete g_cudaComputeController;
+    cudaDeviceReset();
+#endif
+#ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
+    delete g_glslXFBComputeController;
+#endif
+#ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
+    delete g_glslComputeController;
+#endif
 }
 
 //------------------------------------------------------------------------------
@@ -1363,8 +1400,8 @@ callbackKernel(int k) {
     g_kernel = k;
 
 #ifdef OPENSUBDIV_HAS_OPENCL
-    if (g_kernel == kCL and g_clContext == NULL) {
-        if (initCL(&g_clContext, &g_clQueue) == false) {
+    if (g_kernel == kCL and (not g_clDeviceContext.IsInitialized())) {
+        if (g_clDeviceContext.Initialize() == false) {
             printf("Error in initializing OpenCL\n");
             exit(1);
         }
@@ -1457,7 +1494,7 @@ initHUD() {
     g_hud.AddPullDownButton(compute_pulldown, "CUDA", kCUDA);
 #endif
 #ifdef OPENSUBDIV_HAS_OPENCL
-    if (HAS_CL_VERSION_1_1()) {
+    if (CLDeviceContext::HAS_CL_VERSION_1_1()) {
         g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
     }
 #endif

--- a/regression/osd_regression/CMakeLists.txt
+++ b/regression/osd_regression/CMakeLists.txt
@@ -52,6 +52,7 @@ endif()
 
 _add_possibly_cuda_executable(osd_regression
     "${SOURCE_FILES}"
+    $<TARGET_OBJECTS:common_obj>
     $<TARGET_OBJECTS:regression_common_obj>
 )
 


### PR DESCRIPTION
move CL/CUDA specific initialization stuffs into
common/clDeviceContext.{h,cpp} and common/cudaInit.h
so that they can be referred from both examples and regression tests.

update examples to use same CLDeviceContext struct.
fix glShareTopology drawing bug.
(still something strange with XFB kernels)

Note that topdir/common is meant to be used just for examples and regression tests,
so don't include a file in common from opensubdiv lib sources.
(do we like to rename /common to /utils or something?)