### PR TITLE
Fix DX-OpenCL/CUDA interop.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,15 +355,6 @@ if (OPENGL_FOUND AND NOT IOS)
     endif()
 endif()
 
-if (WIN32 AND NOT NO_DX)
-    find_package(DXSDK)
-    if(DXSDK_FOUND)
-        add_definitions(
-            -DOPENSUBDIV_HAS_DX
-        )
-    endif()
-endif()
-
 if (NOT NO_MAYA)
 find_package(Maya 201200)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,9 @@ if(NOT NO_PTEX)
    find_package(PTex 2.0)
 endif()
 if (OPENGL_FOUND AND NOT IOS)
+    add_definitions(
+        -DOPENSUBDIV_HAS_OPENGL
+    )
     if (APPLE)
         find_package(GLEW)
     else()
@@ -353,7 +356,12 @@ if (OPENGL_FOUND AND NOT IOS)
 endif()
 
 if (WIN32 AND NOT NO_DX)
-   find_package(DXSDK)
+    find_package(DXSDK)
+    if(DXSDK_FOUND)
+        add_definitions(
+            -DOPENSUBDIV_HAS_DX
+        )
+    endif()
 endif()
 
 if (NOT NO_MAYA)

--- a/examples/common/clDeviceContext.cpp
+++ b/examples/common/clDeviceContext.cpp
@@ -36,6 +36,98 @@
 #include <cstring>
 #include <string>
 
+#if defined(OPENSUBDIV_HAS_DX)
+#include <D3D11.h>
+#include <CL/cl_d3d11.h>
+#endif
+
+#define message(...)    // fprintf(stderr, __VA_ARGS__)
+#define error(...)  fprintf(stderr, __VA_ARGS__)
+
+// returns the first found platform.
+//
+static cl_platform_id
+findPlatform() {
+    cl_uint numPlatforms;
+    cl_int ciErrNum = clGetPlatformIDs(0, NULL, &numPlatforms);
+
+    if (ciErrNum != CL_SUCCESS) {
+        error("Error %d in clGetPlatformIDs call.\n", ciErrNum);
+        return NULL;
+    }
+    if (numPlatforms == 0) {
+        error("No OpenCL platform found.\n");
+        return NULL;
+    }
+
+    cl_platform_id *clPlatformIDs = new cl_platform_id[numPlatforms];
+    ciErrNum = clGetPlatformIDs(numPlatforms, clPlatformIDs, NULL);
+    char chBuffer[1024];
+    for (cl_uint i = 0; i < numPlatforms; ++i) {
+        ciErrNum = clGetPlatformInfo(clPlatformIDs[i], CL_PLATFORM_NAME,
+                                     1024, chBuffer,NULL);
+        if (ciErrNum == CL_SUCCESS) {
+            cl_platform_id platformId = clPlatformIDs[i];
+            delete[] clPlatformIDs;
+            return platformId;
+        }
+    }
+    delete[] clPlatformIDs;
+    return NULL;
+}
+
+
+// returns the device in clDevices which supports the extension.
+//
+static int
+findExtensionSupportedDevice(cl_device_id *clDevices,
+                             int numDevices,
+                             const char *extensionName) {
+    // find a device that supports sharing with GL/D3D11
+    // (SLI / X-fire configurations)
+    cl_int ciErrNum;
+
+    for (int i = 0; i < numDevices; ++i) {
+        // get extensions string size
+        size_t extensionSize;
+        ciErrNum = clGetDeviceInfo(clDevices[i],
+                                   CL_DEVICE_EXTENSIONS, 0, NULL,
+                                   &extensionSize );
+
+        if (ciErrNum != CL_SUCCESS) {
+            error("Error %d in clGetDeviceInfo\n", ciErrNum);
+            return -1;
+        }
+
+        if (extensionSize>0) {
+            // get extensions string
+            char *extensions = new char[extensionSize];
+            ciErrNum = clGetDeviceInfo(clDevices[i], CL_DEVICE_EXTENSIONS,
+                                       extensionSize, extensions,
+                                       &extensionSize);
+            if (ciErrNum != CL_SUCCESS) {
+                error("Error %d in clGetDeviceInfo\n", ciErrNum);
+                delete[] extensions;
+                continue;
+            }
+            std::string extString(extensions);
+            delete[] extensions;
+
+            // parse string. This is bit deficient since the extentions
+            // is space separated.
+            //
+            // The actual string would be "cl_khr_d3d11_sharing"
+            //                         or "cl_nv_d3d11_sharing"
+            if (extString.find(extensionName) != std::string::npos) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
+// --------------------------------------------------------------------------
+
 CLDeviceContext::CLDeviceContext() :
     _clContext(NULL), _clCommandQueue(NULL) {
 }
@@ -59,7 +151,7 @@ CLDeviceContext::HAS_CL_VERSION_1_1 () {
         clewInitialized = true;
         clewLoadSuccess = clewInit() == CLEW_SUCCESS;
         if (not clewLoadSuccess) {
-            fprintf(stderr, "Loading OpenCL failed.\n");
+            error(stderr, "Loading OpenCL failed.\n");
         }
     }
     return clewLoadSuccess;
@@ -72,33 +164,13 @@ CLDeviceContext::Initialize() {
 
 #ifdef OPENSUBDIV_HAS_CLEW
     if (!clGetPlatformIDs) {
-        printf("Error clGetPlatformIDs function not bound.\n");
+        error("Error clGetPlatformIDs function not bound.\n");
         return false;
     }
 #endif
 
     cl_int ciErrNum;
-
-    cl_platform_id cpPlatform = 0;
-    cl_uint num_platforms;
-    ciErrNum = clGetPlatformIDs(0, NULL, &num_platforms);
-    if (ciErrNum != CL_SUCCESS) {
-        printf("Error %d in clGetPlatformIDs call.\n", ciErrNum);
-        return false;
-    }
-    if (num_platforms == 0) {
-        printf("No OpenCL platform found.\n");
-        return false;
-    }
-    cl_platform_id *clPlatformIDs = new cl_platform_id[num_platforms];
-    ciErrNum = clGetPlatformIDs(num_platforms, clPlatformIDs, NULL);
-    char chBuffer[1024];
-    for (cl_uint i = 0; i < num_platforms; ++i) {
-        ciErrNum = clGetPlatformInfo(clPlatformIDs[i], CL_PLATFORM_NAME, 1024, chBuffer,NULL);
-        if (ciErrNum == CL_SUCCESS) {
-            cpPlatform = clPlatformIDs[i];
-        }
-    }
+    cl_platform_id cpPlatform = findPlatform();
 
 #if defined(_WIN32)
     cl_context_properties props[] = {
@@ -122,33 +194,36 @@ CLDeviceContext::Initialize() {
         0
     };
 #endif
-    delete[] clPlatformIDs;
-
-    int clDeviceUsed = 0;
 
 #if defined(__APPLE__)
-    _clContext = clCreateContext(props, 0, NULL, clLogMessagesToStdoutAPPLE, NULL, &ciErrNum);
+    _clContext = clCreateContext(props, 0, NULL, clLogMessagesToStdoutAPPLE,
+                                 NULL, &ciErrNum);
     if (ciErrNum != CL_SUCCESS) {
-        printf("Error %d in clCreateContext\n", ciErrNum);
+        error("Error %d in clCreateContext\n", ciErrNum);
         return false;
     }
 
     size_t devicesSize = 0;
-    clGetGLContextInfoAPPLE(_clContext, kCGLContext, CL_CGL_DEVICES_FOR_SUPPORTED_VIRTUAL_SCREENS_APPLE, 0, NULL, &devicesSize);
+    clGetGLContextInfoAPPLE(_clContext, kCGLContext,
+                            CL_CGL_DEVICES_FOR_SUPPORTED_VIRTUAL_SCREENS_APPLE,
+                            0, NULL, &devicesSize);
     int numDevices = int(devicesSize / sizeof(cl_device_id));
     if (numDevices == 0) {
-        printf("No sharable devices.\n");
+        error("No sharable devices.\n");
         return false;
     }
     cl_device_id *clDevices = new cl_device_id[numDevices];
-    clGetGLContextInfoAPPLE(_clContext, kCGLContext, CL_CGL_DEVICES_FOR_SUPPORTED_VIRTUAL_SCREENS_APPLE, numDevices * sizeof(cl_device_id), clDevices, NULL);
-#else
+    clGetGLContextInfoAPPLE(_clContext, kCGLContext,
+                            CL_CGL_DEVICES_FOR_SUPPORTED_VIRTUAL_SCREENS_APPLE,
+                            numDevices * sizeof(cl_device_id), clDevices, NULL);
+
+#else   // not __APPLE__
 
     // get the number of GPU devices available to the platform
     cl_uint numDevices = 0;
     clGetDeviceIDs(cpPlatform, CL_DEVICE_TYPE_GPU, 0, NULL, &numDevices);
     if (numDevices == 0) {
-        printf("No CL GPU device found.\n");
+        error("No CL GPU device found.\n");
         return false;
     }
 
@@ -156,46 +231,77 @@ CLDeviceContext::Initialize() {
     cl_device_id *clDevices = new cl_device_id[numDevices];
     clGetDeviceIDs(cpPlatform, CL_DEVICE_TYPE_GPU, numDevices, clDevices, NULL);
 
-#define GL_SHARING_EXTENSION "cl_khr_gl_sharing"
+    const char *extension = "cl_khr_gl_sharing";
+    int clDeviceUsed = findExtensionSupportedDevice(clDevices, numDevices,
+                                                    extension);
 
-    // find a device that supports sharing with GL (SLI / X-fire configurations)
-    bool sharingSupported=false;
-    for (int i=0; i<(int)numDevices; ++i) {
-
-        size_t extensionSize;
-        ciErrNum = clGetDeviceInfo(clDevices[i], CL_DEVICE_EXTENSIONS, 0, NULL, &extensionSize );
-        if (ciErrNum != CL_SUCCESS) {
-            printf("Error %d in clGetDeviceInfo\n", ciErrNum);
-            return false;
-        }
-        
-        if (extensionSize>0) {
-            char* extensions = (char*)malloc(extensionSize);
-            ciErrNum = clGetDeviceInfo(clDevices[i], CL_DEVICE_EXTENSIONS, extensionSize, extensions, &extensionSize);
-            if (ciErrNum != CL_SUCCESS) {
-                printf("Error %d in clGetDeviceInfo\n", ciErrNum);
-                return false;
-            }
-            std::string stdDevString(extensions);
-            free(extensions);
-            size_t szOldPos = 0, szSpacePos = stdDevString.find(' ', szOldPos); // extensions string is space delimited
-            while (szSpacePos != stdDevString.npos) {
-                if (strcmp(GL_SHARING_EXTENSION, 
-                    stdDevString.substr(szOldPos, szSpacePos - szOldPos).c_str())==0) {
-                    clDeviceUsed = i;
-                    sharingSupported = true;
-                    break;
-                }
-                do {
-                    szOldPos = szSpacePos + 1;
-                    szSpacePos = stdDevString.find(' ', szOldPos);
-                } while (szSpacePos == szOldPos);
-            }
-        }
+    if (clDeviceUsed < 0) {
+        error("No device found that supports CL/GL context sharing\n");
+        delete[] clDevices;
+        return false;
     }
 
-    if (not sharingSupported) {
-        printf("No device found that supports CL/GL context sharing\n");
+    _clContext = clCreateContext(props, 1, &clDevices[clDeviceUsed],
+                                 NULL, NULL, &ciErrNum);
+
+#endif   // not __APPLE__
+
+    if (ciErrNum != CL_SUCCESS) {
+        error("Error %d in clCreateContext\n", ciErrNum);
+        delete[] clDevices;
+        return false;
+    }
+
+    _clCommandQueue = clCreateCommandQueue(_clContext, clDevices[clDeviceUsed],
+                                    0, &ciErrNum);
+    delete[] clDevices;
+    if (ciErrNum != CL_SUCCESS) {
+        error("Error %d in clCreateCommandQueue\n", ciErrNum);
+        return false;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+
+bool
+CLD3D11DeviceContext::Initialize(ID3D11DeviceContext *d3dDeviceContext) {
+
+#if defined(OPENSUBDIV_HAS_DX)
+    _d3dDeviceContext = d3dDeviceContext;
+
+    cl_int ciErrNum;
+    cl_platform_id cpPlatform = findPlatform();
+
+    ID3D11Device *device;
+    d3dDeviceContext->GetDevice(&device);
+
+    cl_context_properties props[] = {
+        CL_CONTEXT_D3D11_DEVICE_KHR, (cl_context_properties)device,
+        CL_CONTEXT_PLATFORM, (cl_context_properties)cpPlatform,
+        0
+    };
+
+    // get the number of GPU devices available to the platform
+    cl_uint numDevices = 0;
+    clGetDeviceIDs(cpPlatform, CL_DEVICE_TYPE_GPU, 0, NULL, &numDevices);
+    if (numDevices == 0) {
+        error("No CL GPU device found.\n");
+        return false;
+    }
+
+    // create the device list
+    cl_device_id *clDevices = new cl_device_id[numDevices];
+    clGetDeviceIDs(cpPlatform, CL_DEVICE_TYPE_GPU, numDevices, clDevices, NULL);
+
+    // we're cheating a little bit.
+    // try to find both cl_khr_d3d11_sharing and cl_nv_d3d11_sharing.
+    const char *extension = "_d3d11_sharing";
+    int clDeviceUsed = findExtensionSupportedDevice(clDevices, numDevices,
+                                                    extension);
+
+    if (clDeviceUsed < 0) {
+        error("No device found that supports CL/D3D11 context sharing\n");
         delete[] clDevices;
         return false;
     }
@@ -203,19 +309,21 @@ CLDeviceContext::Initialize() {
     _clContext = clCreateContext(props, 1, &clDevices[clDeviceUsed],
                                  NULL, NULL, &ciErrNum);
     if (ciErrNum != CL_SUCCESS) {
-        printf("Error %d in clCreateContext\n", ciErrNum);
+        error("Error %d in clCreateContext\n", ciErrNum);
         delete[] clDevices;
         return false;
     }
-#endif
 
     _clCommandQueue = clCreateCommandQueue(_clContext, clDevices[clDeviceUsed],
                                     0, &ciErrNum);
     delete[] clDevices;
     if (ciErrNum != CL_SUCCESS) {
-        printf("Error %d in clCreateCommandQueue\n", ciErrNum);
+        error("Error %d in clCreateCommandQueue\n", ciErrNum);
         return false;
     }
     return true;
+#else
+    (void)d3dDeviceContext;  // unused
+    return false;
+#endif
 }
-

--- a/examples/common/clDeviceContext.cpp
+++ b/examples/common/clDeviceContext.cpp
@@ -216,6 +216,7 @@ CLDeviceContext::Initialize() {
     clGetGLContextInfoAPPLE(_clContext, kCGLContext,
                             CL_CGL_DEVICES_FOR_SUPPORTED_VIRTUAL_SCREENS_APPLE,
                             numDevices * sizeof(cl_device_id), clDevices, NULL);
+    int clDeviceUsed = 0;
 
 #else   // not __APPLE__
 

--- a/examples/common/clDeviceContext.cpp
+++ b/examples/common/clDeviceContext.cpp
@@ -36,7 +36,7 @@
 #include <cstring>
 #include <string>
 
-#if defined(OPENSUBDIV_HAS_DX)
+#if defined(OPENSUBDIV_HAS_DX11SDK)
 #include <D3D11.h>
 #include <CL/cl_d3d11.h>
 #endif
@@ -268,7 +268,7 @@ CLDeviceContext::Initialize() {
 bool
 CLD3D11DeviceContext::Initialize(ID3D11DeviceContext *d3dDeviceContext) {
 
-#if defined(OPENSUBDIV_HAS_DX)
+#if defined(OPENSUBDIV_HAS_DX11SDK)
     _d3dDeviceContext = d3dDeviceContext;
 
     cl_int ciErrNum;

--- a/examples/common/clDeviceContext.h
+++ b/examples/common/clDeviceContext.h
@@ -47,11 +47,24 @@ public:
         return _clCommandQueue;
     }
 
-private:
+protected:
     cl_context _clContext;
     cl_command_queue _clCommandQueue;
 };
 
+struct ID3D11DeviceContext;
+
+class CLD3D11DeviceContext : public CLDeviceContext {
+public:
+    bool Initialize(ID3D11DeviceContext *deviceContext);
+
+    ID3D11DeviceContext *GetDeviceContext() const {
+        return _d3dDeviceContext;
+    }
+
+private:
+    ID3D11DeviceContext *_d3dDeviceContext;
+};
 
 
 #endif  // OSD_EXAMPLES_COMMON_CL_DEVICE_CONTEXT_H

--- a/examples/common/cudaDeviceContext.cpp
+++ b/examples/common/cudaDeviceContext.cpp
@@ -38,6 +38,10 @@
 #include <cuda_runtime_api.h>
 #include <cuda_gl_interop.h>
 
+#if defined(OPENSUBDIV_HAS_DX)
+#include <cuda_d3d11_interop.h>
+#endif
+
 #define message(fmt, ...)
 //#define message(fmt, ...)  fprintf(stderr, fmt, __VA_ARGS__)
 #define error(fmt, ...)  fprintf(stderr, fmt, __VA_ARGS__)
@@ -134,4 +138,16 @@ CudaDeviceContext::Initialize() {
     cudaGLSetGLDevice(_GetCudaDeviceForCurrentGLContext());
     _initialized = true;
     return true;
+}
+
+bool
+CudaDeviceContext::Initialize(ID3D11Device *device) {
+
+#if defined(OPENSUBDIV_HAS_DX)
+    cudaD3D11SetDirect3DDevice(device);
+    return true;
+#else
+    (void)device;  // unused
+    return false;
+#endif
 }

--- a/examples/common/cudaDeviceContext.cpp
+++ b/examples/common/cudaDeviceContext.cpp
@@ -38,7 +38,7 @@
 #include <cuda_runtime_api.h>
 #include <cuda_gl_interop.h>
 
-#if defined(OPENSUBDIV_HAS_DX)
+#if defined(OPENSUBDIV_HAS_DX11SDK)
 #include <cuda_d3d11_interop.h>
 #endif
 
@@ -143,7 +143,7 @@ CudaDeviceContext::Initialize() {
 bool
 CudaDeviceContext::Initialize(ID3D11Device *device) {
 
-#if defined(OPENSUBDIV_HAS_DX)
+#if defined(OPENSUBDIV_HAS_DX11SDK)
     cudaD3D11SetDirect3DDevice(device);
     return true;
 #else

--- a/examples/common/cudaDeviceContext.h
+++ b/examples/common/cudaDeviceContext.h
@@ -25,13 +25,20 @@
 #ifndef OSD_EXAMPLES_COMMON_CUDA_DEVICE_CONTEXT_H
 #define OSD_EXAMPLES_COMMON_CUDA_DEVICE_CONTEXT_H
 
+struct ID3D11Device;
+
 class CudaDeviceContext {
 public:
     CudaDeviceContext();
     ~CudaDeviceContext();
 
+    /// Initialze cuda device from the current GL context
     bool Initialize();
 
+    /// Initialze cuda device from the ID3D11Device
+    bool Initialize(ID3D11Device *device);
+
+    /// Returns true if the cuda device has already been initialized
     bool IsInitialized() const {
         return _initialized;
     }

--- a/examples/dxPtexViewer/CMakeLists.txt
+++ b/examples/dxPtexViewer/CMakeLists.txt
@@ -51,7 +51,6 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 _add_possibly_cuda_executable(dxPtexViewer WIN32
     "${SOURCE_FILES}"
-    "${SHADER_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:regression_vtr_utils_obj>

--- a/examples/glImaging/CMakeLists.txt
+++ b/examples/glImaging/CMakeLists.txt
@@ -77,8 +77,6 @@ _add_glfw_executable(glImaging
     $<TARGET_OBJECTS:examples_common_obj>
 )
 
-add_dependencies(glImaging blarg )
-
 target_link_libraries(glImaging
     ${PLATFORM_LIBRARIES}
 )

--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -322,15 +322,14 @@ if ( OPENCL_FOUND )
         list(APPEND PUBLIC_HEADER_FILES clGLVertexBuffer.h)
     endif()
 
-    # OpenCL D3D11 interop needs work...
-    #if ( DXSDK_FOUND )
-    #    list(APPEND GPU_SOURCE_FILES
-    #         clD3D11VertexBuffer.cpp
-    #    )
-    #    list(APPEND PUBLIC_HEADER_FILES
-    #         clD3D11VertexBuffer.h)
-    #    )
-    #endif()
+    if ( DXSDK_FOUND )
+        list(APPEND GPU_SOURCE_FILES
+             clD3D11VertexBuffer.cpp
+        )
+        list(APPEND PUBLIC_HEADER_FILES
+             clD3D11VertexBuffer.h
+        )
+    endif()
 endif()
 
 list(APPEND DOXY_HEADER_FILES ${OPENCL_PUBLIC_HEADERS})

--- a/regression/osd_regression/CMakeLists.txt
+++ b/regression/osd_regression/CMakeLists.txt
@@ -47,8 +47,6 @@ _add_executable(osd_regression
     $<TARGET_OBJECTS:regression_common_obj>
 )
 
-add_dependencies(osd_regression blarg )
-
 target_link_libraries(osd_regression
     ${PLATFORM_LIBRARIES}
 )


### PR DESCRIPTION
- resolves DX-CL interop functions in Osd::ClD3D11VertexBuffer.
- enable CL kernels in DX build.
- more cleanup in test harnesses, adding D3D11 initializations into DeviceContext.
- add new defines OPENSUBDIV_HAS_OPENGL for convenience.