### PR TITLE
Fix glPtexViewer backfacing bug: initialize handedness flag in Shape

### DIFF
--- a/regression/common/shape_utils.h
+++ b/regression/common/shape_utils.h
@@ -81,6 +81,8 @@ struct Shape {
 
     std::string genRIB() const;
 
+    Shape() : scheme(kCatmark), isLeftHanded(false) { }
+
     ~Shape();
 
     int GetNumVertices() const { return (int)verts.size()/3; }


### PR DESCRIPTION
Shape::isLeftHanded was left uninitialized when Shape is instantiated manually.