### PR TITLE
Satisfy compiler warnings about unused parameters.

### DIFF
--- a/opensubdiv/vtr/stackBuffer.h
+++ b/opensubdiv/vtr/stackBuffer.h
@@ -73,7 +73,7 @@ public:
 private:
     //  Non-copyable:
     StackBuffer(const StackBuffer<TYPE,SIZE> &) { }
-    StackBuffer& operator=(const StackBuffer<TYPE,SIZE> &) { }
+    StackBuffer& operator=(const StackBuffer<TYPE,SIZE> &) { return *this; }
 
     void allocate(size_type capacity);
     void deallocate();

--- a/opensubdiv/vtr/stackBuffer.h
+++ b/opensubdiv/vtr/stackBuffer.h
@@ -72,8 +72,8 @@ public:
 
 private:
     //  Non-copyable:
-    StackBuffer(const StackBuffer<TYPE,SIZE> & source) { }
-    StackBuffer& operator=(const StackBuffer<TYPE,SIZE> & source) { }
+    StackBuffer(const StackBuffer<TYPE,SIZE> &) { }
+    StackBuffer& operator=(const StackBuffer<TYPE,SIZE> &) { }
 
     void allocate(size_type capacity);
     void deallocate();


### PR DESCRIPTION
In vtr/stackBuffer.h, removed  unnecessary symbols for parameters to silence
compiler warnings about them not being used.