### PR TITLE
osd refactor: split the vertex buffer argument into src and dst

### DIFF
--- a/opensubdiv/osd/clKernel.cl
+++ b/opensubdiv/osd/clKernel.cl
@@ -36,7 +36,7 @@ static void addWithWeight(struct Vertex *dst,
                           __global float *srcOrigin,
                           int index, float weight) {
 
-    __global float *src = srcOrigin + index * STRIDE;
+    __global float *src = srcOrigin + index * SRC_STRIDE;
     for (int i = 0; i < LENGTH; ++i) {
         dst->v[i] += src[i] * weight;
     }
@@ -46,40 +46,42 @@ static void writeVertex(__global float *dstOrigin,
                         int index,
                         struct Vertex *src) {
 
-    __global float *dst = dstOrigin + index * STRIDE;
+    __global float *dst = dstOrigin + index * DST_STRIDE;
     for (int i = 0; i < LENGTH; ++i) {
         dst[i] = src->v[i];
     }
 }
 
 
-__kernel void computeStencils( __global float * vertexBuffer,
-                               __global unsigned char * sizes,
-                               __global int * offsets,
-                               __global int * indices,
-                               __global float * weights,
-                               int batchStart,
-                               int batchEnd,
-                               int primvarOffset,
-                               int numCVs ) {
+__kernel void computeStencils(__global float * src,
+                              int srcOffset,
+                              __global float * dst,
+                              int dstOffset,
+                              __global unsigned char * sizes,
+                              __global int * offsets,
+                              __global int * indices,
+                              __global float * weights,
+                              int batchStart,
+                              int batchEnd) {
 
     int current = get_global_id(0) + batchStart;
 
-	if (current>=batchEnd) {
-	    return;
-	}
-	
-    struct Vertex dst;
-    clear(&dst);
+    if (current>=batchEnd) {
+        return;
+    }
+
+    struct Vertex v;
+    clear(&v);
 
     int size = (int)sizes[current],
         offset = offsets[current];
 
-    vertexBuffer += primvarOffset;
+    src += srcOffset;
+    dst += dstOffset;
 
     for (int i=0; i<size; ++i) {
-        addWithWeight(&dst, vertexBuffer, indices[offset+i], weights[offset+i]);
+        addWithWeight(&v, src, indices[offset+i], weights[offset+i]);
     }
 
-    writeVertex(vertexBuffer, numCVs+current, &dst);
+    writeVertex(dst, current, &v);
 }

--- a/opensubdiv/osd/cpuComputeController.cpp
+++ b/opensubdiv/osd/cpuComputeController.cpp
@@ -53,20 +53,18 @@ CpuComputeController::ApplyStencilTableKernel(
     Far::StencilTables const * vertexStencils = context->GetVertexStencilTables();
 
     if (vertexStencils and _currentBindState.vertexBuffer) {
-
-        VertexBufferDescriptor const & desc = _currentBindState.vertexDesc;
-
-        float const * srcBuffer = _currentBindState.vertexBuffer + desc.offset;
-
-        float * destBuffer = _currentBindState.vertexBuffer + desc.offset +
-            vertexStencils->GetNumControlVertices() * desc.stride;
+        VertexBufferDescriptor srcDesc = _currentBindState.vertexDesc;
+        VertexBufferDescriptor dstDesc(srcDesc);
+        dstDesc.offset += vertexStencils->GetNumControlVertices() * dstDesc.stride;
 
         int start = 0;
         int end = vertexStencils->GetNumStencils();
 
         if (end > start) {
-            CpuComputeStencils(_currentBindState.vertexDesc,
-                               srcBuffer, destBuffer,
+            CpuComputeStencils(_currentBindState.vertexBuffer,
+                               srcDesc,
+                               _currentBindState.vertexBuffer,
+                               dstDesc,
                                &vertexStencils->GetSizes().at(0),
                                &vertexStencils->GetOffsets().at(0),
                                &vertexStencils->GetControlIndices().at(0),
@@ -79,20 +77,18 @@ CpuComputeController::ApplyStencilTableKernel(
     Far::StencilTables const * varyingStencils = context->GetVaryingStencilTables();
 
     if (varyingStencils and _currentBindState.varyingBuffer) {
-
-        VertexBufferDescriptor const & desc = _currentBindState.varyingDesc;
-
-        float const * srcBuffer = _currentBindState.varyingBuffer + desc.offset;
-
-        float * destBuffer = _currentBindState.varyingBuffer + desc.offset +
-            varyingStencils->GetNumControlVertices() * desc.stride;
+        VertexBufferDescriptor srcDesc = _currentBindState.varyingDesc;
+        VertexBufferDescriptor dstDesc(srcDesc);
+        dstDesc.offset += varyingStencils->GetNumControlVertices() * dstDesc.stride;
 
         int start = 0;
         int end = varyingStencils->GetNumStencils();
 
         if (end > start) {
-            CpuComputeStencils(_currentBindState.varyingDesc,
-                               srcBuffer, destBuffer,
+            CpuComputeStencils(_currentBindState.varyingBuffer,
+                               srcDesc,
+                               _currentBindState.varyingBuffer,
+                               dstDesc,
                                &varyingStencils->GetSizes().at(0),
                                &varyingStencils->GetOffsets().at(0),
                                &varyingStencils->GetControlIndices().at(0),

--- a/opensubdiv/osd/cpuKernel.h
+++ b/opensubdiv/osd/cpuKernel.h
@@ -26,26 +26,41 @@
 #define OSD_CPU_KERNEL_H
 
 #include "../version.h"
-
-#include "../osd/vertexDescriptor.h"
+#include <cstring>
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Osd {
 
-struct VertexDescriptor;
-
-
+struct VertexBufferDescriptor;
 
 void
-CpuComputeStencils(VertexBufferDescriptor const &vertexDesc,
-                   float const * vertexSrc,
-                   float * vertexDst,
+CpuComputeStencils(float const * src,
+                   VertexBufferDescriptor const &srcDesc,
+                   float * dst,
+                   VertexBufferDescriptor const &dstDesc,
                    unsigned char const * sizes,
                    int const * offsets,
                    int const * indices,
                    float const * weights,
+                   int start, int end);
+
+void
+CpuComputeStencils(float const * src,
+                   VertexBufferDescriptor const &srcDesc,
+                   float * dst,
+                   VertexBufferDescriptor const &dstDesc,
+                   float * dstDu,
+                   VertexBufferDescriptor const &dstDuDesc,
+                   float * dstDv,
+                   VertexBufferDescriptor const &dstDvDesc,
+                   unsigned char const * sizes,
+                   int const * offsets,
+                   int const * indices,
+                   float const * weights,
+                   float const * duWeights,
+                   float const * dvWeights,
                    int start, int end);
 
 //

--- a/opensubdiv/osd/cudaComputeController.h
+++ b/opensubdiv/osd/cudaComputeController.h
@@ -160,14 +160,6 @@ private:
             varyingDesc.Reset();
         }
 
-        float *GetVertexBufferAtOffset() const {
-            return vertexBuffer ? vertexBuffer + vertexDesc.offset : 0;
-        }
-
-        float *GetVaryingBufferAtOffset() const {
-            return varyingBuffer ? varyingBuffer + varyingDesc.offset : 0;
-        }
-
         float * vertexBuffer,   // cuda buffers
               * varyingBuffer;
 

--- a/opensubdiv/osd/glslComputeContext.cpp
+++ b/opensubdiv/osd/glslComputeContext.cpp
@@ -110,17 +110,17 @@ public:
     }
 
     void Bind() const {
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, _sizes);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, _offsets);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, _indices);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 4, _weights);
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, _sizes);
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, _offsets);
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 4, _indices);
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 5, _weights);
     }
 
     static void Unbind() {
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, 0);
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, 0);
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, 0);
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 4, 0);
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 5, 0);
 
         glUseProgram(0);
     }

--- a/opensubdiv/osd/glslComputeKernel.glsl
+++ b/opensubdiv/osd/glslComputeKernel.glsl
@@ -26,15 +26,15 @@
 
 uniform int batchStart = 0;
 uniform int batchEnd = 0;
+uniform int srcOffset = 0;
+uniform int dstOffset = 0;
 
-uniform int primvarOffset = 0;
-uniform int numCVs = 0;
-
-layout(binding=0) buffer vertex_buffer    { float         vertexBuffer[]; };
-layout(binding=1) buffer sterncilSizes    { unsigned char _sizes[];   };
-layout(binding=2) buffer sterncilOffsets  { int           _offsets[]; };
-layout(binding=3) buffer sterncilIndices  { int           _indices[]; };
-layout(binding=4) buffer sterncilWeights  { float         _weights[]; };
+layout(binding=0) buffer src_buffer      { float         srcVertexBuffer[]; };
+layout(binding=1) buffer dst_buffer      { float         dstVertexBuffer[]; };
+layout(binding=2) buffer stencilSizes    { unsigned char _sizes[];   };
+layout(binding=3) buffer stencilOffsets  { int           _offsets[]; };
+layout(binding=4) buffer stencilIndices  { int           _indices[]; };
+layout(binding=5) buffer stencilWeights  { float         _weights[]; };
 
 layout(local_size_x=WORK_GROUP_SIZE, local_size_y=1, local_size_z=1) in;
 
@@ -52,17 +52,17 @@ void clear(out Vertex v) {
 
 Vertex readVertex(int index) {
     Vertex v;
-    int vertexIndex = primvarOffset + index * STRIDE;
+    int vertexIndex = srcOffset + index * SRC_STRIDE;
     for (int i = 0; i < LENGTH; ++i) {
-        v.vertexData[i] = vertexBuffer[vertexIndex + i];
+        v.vertexData[i] = srcVertexBuffer[vertexIndex + i];
     }
     return v;
 }
 
 void writeVertex(int index, Vertex v) {
-    int vertexIndex = primvarOffset + index * STRIDE;
+    int vertexIndex = dstOffset + index * DST_STRIDE;
     for (int i = 0; i < LENGTH; ++i) {
-        vertexBuffer[vertexIndex + i] = v.vertexData[i];
+        dstVertexBuffer[vertexIndex + i] = v.vertexData[i];
     }
 }
 
@@ -91,9 +91,7 @@ void main() {
         addWithWeight(dst, readVertex( _indices[offset+i] ), _weights[offset+i]);
     }
 
-    // the vertex buffer contains our control vertices at the beginning: don't
-    // stomp on those !
-    writeVertex(numCVs+current, dst);
+    writeVertex(current, dst);
 }
 
 //------------------------------------------------------------------------------

--- a/opensubdiv/osd/glslTransformFeedbackKernel.glsl
+++ b/opensubdiv/osd/glslTransformFeedbackKernel.glsl
@@ -36,7 +36,7 @@ uniform samplerBuffer  weights;
 uniform int batchStart = 0;
 uniform int batchEnd = 0;
 
-uniform int primvarOffset = 0;
+uniform int srcOffset = 0;
 
 //------------------------------------------------------------------------------
 
@@ -58,17 +58,11 @@ void addWithWeight(inout Vertex v, Vertex src, float weight) {
 
 Vertex readVertex(int index) {
     Vertex v;
-    int vertexIndex = primvarOffset + index * STRIDE;
+    int vertexIndex = srcOffset + index * SRC_STRIDE;
     for(int j = 0; j < LENGTH; j++) {
         v.vertexData[j] = texelFetch(vertexBuffer, vertexIndex+j).x;
     }
     return v;
-}
-
-void copyVertex(out Vertex dst, int index) {
-    for(int i = 0; i < LENGTH; i++) {
-        dst.vertexData[i] = texelFetch(vertexBuffer, index*STRIDE+i).x;
-    }
 }
 
 void writeVertex(Vertex v) {

--- a/opensubdiv/osd/hlslComputeKernel.hlsl
+++ b/opensubdiv/osd/hlslComputeKernel.hlsl
@@ -22,25 +22,21 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-interface IComputeKernel {
-    void runKernel( uint3 ID );
-};
-IComputeKernel kernel;
-
 cbuffer KernelUniformArgs : register( b0 ) {
-    int batchStart,
-        batchEnd,
-        primvarOffset,
-        numCVs;
+    int batchStart;
+    int batchEnd;
+    int srcOffset;
+    int dstOffset;
 };
 
 RWBuffer<float> vertexBuffer  : register( u0 );
+RWBuffer<float> dstVertexBuffer  : register( u1 );
 Buffer<int>    sizes   : register( t1 );
-Buffer<int>    offsets : register( t2 );      
-Buffer<int>    indices : register( t3 );      
-Buffer<float>  weights : register( t4 );      
+Buffer<int>    offsets : register( t2 );
+Buffer<int>    indices : register( t3 );
+Buffer<float>  weights : register( t4 );
 
-//--------------------------------------------------------------------------------
+//----------------------------------------------------------------------------
 
 struct Vertex {
     float vertexData[LENGTH];
@@ -54,7 +50,7 @@ void clear(out Vertex v) {
 
 Vertex readVertex(int index) {
     Vertex v;
-    int vertexIndex = primvarOffset + index * STRIDE;
+    int vertexIndex = srcOffset + index * SRC_STRIDE;
     for (int i = 0; i < LENGTH; ++i) {
         v.vertexData[i] = vertexBuffer[vertexIndex + i];
     }
@@ -62,9 +58,16 @@ Vertex readVertex(int index) {
 }
 
 void writeVertex(int index, Vertex v) {
-    int vertexIndex = primvarOffset + index * STRIDE;
+    int vertexIndex = dstOffset + index * DST_STRIDE;
     for (int i = 0; i < LENGTH; ++i) {
         vertexBuffer[vertexIndex + i] = v.vertexData[i];
+    }
+}
+
+void writeVertexSeparate(int index, Vertex v) {
+    int vertexIndex = dstOffset + index * DST_STRIDE;
+    for (int i = 0; i < LENGTH; ++i) {
+        dstVertexBuffer[vertexIndex + i] = v.vertexData[i];
     }
 }
 
@@ -74,15 +77,17 @@ void addWithWeight(inout Vertex v, const Vertex src, float weight) {
     }
 }
 
+// ---------------------------------------------------------------------------
 
-//--------------------------------------------------------------------------------
-// Stencil compute Kernel
-class ComputeStencil : IComputeKernel {
+interface IComputeKernel {
+    void runKernel( uint3 ID );
+};
+IComputeKernel kernel;
+
+class SingleBufferCompute : IComputeKernel {
 
     int placeholder;
-
-    void runKernel( uint3 ID ) {
-
+    void runKernel(uint3 ID) {
         int current = int(ID.x) + batchStart;
 
         if (current>=batchEnd) {
@@ -99,24 +104,43 @@ class ComputeStencil : IComputeKernel {
             addWithWeight(dst, readVertex( indices[offset+i] ), weights[offset+i]);
         }
 
-        // the vertex buffer contains our control vertices at the beginning: don't
-        // stomp on those !
-        writeVertex(numCVs+current, dst);
+        writeVertex(current, dst);
     }
 };
+class SeparateBufferCompute : IComputeKernel {
+
+    int placeholder;
+    void runKernel(uint3 ID) {
+        int current = int(ID.x) + batchStart;
+
+        if (current>=batchEnd) {
+            return;
+        }
+
+        Vertex dst;
+        clear(dst);
+
+        int offset = offsets[current],
+            size = sizes[current];
+
+        for (int i=0; i<size; ++i) {
+            addWithWeight(dst, readVertex( indices[offset+i] ), weights[offset+i]);
+        }
+
+        writeVertexSeparate(current, dst);
+    }
+};
+
+SingleBufferCompute singleBufferCompute;
+SeparateBufferCompute separateBufferCompute;
 
 // Add place-holder stencil kernel or D3D11ShaderReflection::GetInterfaceSlots()
 // returns 0
 class PlaceHolder : IComputeKernel {
     int placeholder;
-    
     void runKernel( uint3 ID ) {
     }
 };
-
-//--------------------------------------------------------------------------------
-
-ComputeStencil computeStencil;
 
 [numthreads(WORK_GROUP_SIZE, 1, 1)]
 void cs_main( uint3 ID : SV_DispatchThreadID )
@@ -125,4 +149,3 @@ void cs_main( uint3 ID : SV_DispatchThreadID )
     kernel.runKernel(ID);
 }
 
-//--------------------------------------------------------------------------------

--- a/opensubdiv/osd/ompComputeController.cpp
+++ b/opensubdiv/osd/ompComputeController.cpp
@@ -47,20 +47,18 @@ OmpComputeController::ApplyStencilTableKernel(
     Far::StencilTables const * vertexStencils = context->GetVertexStencilTables();
 
     if (vertexStencils and _currentBindState.vertexBuffer) {
+        VertexBufferDescriptor srcDesc = _currentBindState.vertexDesc;
+        VertexBufferDescriptor dstDesc(srcDesc);
+        dstDesc.offset += vertexStencils->GetNumControlVertices() * dstDesc.stride;
 
         int start = 0;
         int end = vertexStencils->GetNumStencils();
 
-        VertexBufferDescriptor const & desc = _currentBindState.vertexDesc;
-
-        float const * srcBuffer = _currentBindState.vertexBuffer + desc.offset;
-
-        float * destBuffer = _currentBindState.vertexBuffer + desc.offset +
-            vertexStencils->GetNumControlVertices() * desc.stride;
-
         if (end > start) {
-            OmpComputeStencils(_currentBindState.vertexDesc,
-                               srcBuffer, destBuffer,
+            OmpComputeStencils(_currentBindState.vertexBuffer,
+                               srcDesc,
+                               _currentBindState.vertexBuffer,
+                               dstDesc,
                                &vertexStencils->GetSizes().at(0),
                                &vertexStencils->GetOffsets().at(0),
                                &vertexStencils->GetControlIndices().at(0),
@@ -73,20 +71,18 @@ OmpComputeController::ApplyStencilTableKernel(
     Far::StencilTables const * varyingStencils = context->GetVaryingStencilTables();
 
     if (varyingStencils and _currentBindState.varyingBuffer) {
+        VertexBufferDescriptor srcDesc = _currentBindState.varyingDesc;
+        VertexBufferDescriptor dstDesc(srcDesc);
+        dstDesc.offset += varyingStencils->GetNumControlVertices() * dstDesc.stride;
 
         int start = 0;
         int end = varyingStencils->GetNumStencils();
 
-        VertexBufferDescriptor const & desc = _currentBindState.varyingDesc;
-
-        float const * srcBuffer = _currentBindState.varyingBuffer + desc.offset;
-
-        float * destBuffer = _currentBindState.varyingBuffer + desc.offset +
-            varyingStencils->GetNumControlVertices() * desc.stride;
-
         if (end > start) {
-            OmpComputeStencils(_currentBindState.varyingDesc,
-                               srcBuffer, destBuffer,
+            OmpComputeStencils(_currentBindState.varyingBuffer,
+                               srcDesc,
+                               _currentBindState.varyingBuffer,
+                               dstDesc,
                                &varyingStencils->GetSizes().at(0),
                                &varyingStencils->GetOffsets().at(0),
                                &varyingStencils->GetControlIndices().at(0),

--- a/opensubdiv/osd/ompKernel.cpp
+++ b/opensubdiv/osd/ompKernel.cpp
@@ -73,26 +73,33 @@ copy(float *dst, int dstIndex, const float *src,
 // XXXX manuelk this should be optimized further by using SIMD - considering
 //              OMP is somewhat obsolete - this is probably not worth it.
 void
-OmpComputeStencils(VertexBufferDescriptor const &vertexDesc,
-                      float const * vertexSrc,
-                      float * vertexDst,
-                      unsigned char const * sizes,
-                      int const * offsets,
-                      int const * indices,
-                      float const * weights,
-                      int start, int end) {
+OmpComputeStencils(float const * src,
+                   VertexBufferDescriptor const &srcDesc,
+                   float * dst,
+                   VertexBufferDescriptor const &dstDesc,
+                   unsigned char const * sizes,
+                   int const * offsets,
+                   int const * indices,
+                   float const * weights,
+                   int start, int end) {
 
-    assert(start>=0 and start<end);
+    if (start > 0) {
+        sizes += start;
+        indices += offsets[start];
+        weights += offsets[start];
+    }
+    src += srcDesc.offset;
+    dst += dstDesc.offset;
 
-    int numThreads = omp_get_max_threads(),
-        nstencils = end-start;
+    int numThreads = omp_get_max_threads();
+    int n = end - start;
 
-    float * result = (float*)alloca(vertexDesc.length*numThreads*sizeof(float));
+    float * result = (float*)alloca(srcDesc.length * numThreads * sizeof(float));
 
 #pragma omp parallel for
-    for (int i=0; i<nstencils; ++i) {
+    for (int i = 0; i < n; ++i) {
 
-        int index = i + (start>0 ? start : 0); // Stencil index
+        int index = i + (start > 0 ? start : 0); // Stencil index
 
         // Get thread-local pointers
         int const           * threadIndices = indices + offsets[index];
@@ -100,16 +107,16 @@ OmpComputeStencils(VertexBufferDescriptor const &vertexDesc,
 
         int threadId = omp_get_thread_num();
 
-        float * threadResult = result + threadId*vertexDesc.length;
+        float * threadResult = result + threadId*srcDesc.length;
 
-        clear(threadResult, vertexDesc);
+        clear(threadResult, dstDesc);
 
         for (int j=0; j<(int)sizes[index]; ++j) {
-            addWithWeight(threadResult, vertexSrc,
-                threadIndices[j], threadWeights[j], vertexDesc);
+            addWithWeight(threadResult, src,
+                threadIndices[j], threadWeights[j], srcDesc);
         }
 
-        copy(vertexDst, i, threadResult, vertexDesc);
+        copy(dst, i, threadResult, dstDesc);
     }
 
 }

--- a/opensubdiv/osd/ompKernel.h
+++ b/opensubdiv/osd/ompKernel.h
@@ -27,24 +27,23 @@
 
 #include "../version.h"
 
-#include "../osd/vertexDescriptor.h"
-
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Osd {
 
-struct VertexDescriptor;
+struct VertexBufferDescriptor;
 
 void
-OmpComputeStencils(VertexBufferDescriptor const &vertexDesc,
-                      float const * vertexSrc,
-                      float * vertexDst,
-                      unsigned char const * sizes,
-                      int const * offsets,
-                      int const * indices,
-                      float const * weights,
-                      int start, int end);
+OmpComputeStencils(float const * src,
+                   VertexBufferDescriptor const &srcDesc,
+                   float * dst,
+                   VertexBufferDescriptor const &dstDesc,
+                   unsigned char const * sizes,
+                   int const * offsets,
+                   int const * indices,
+                   float const * weights,
+                   int start, int end);
 
 } // end namespace Osd
 

--- a/opensubdiv/osd/tbbComputeController.cpp
+++ b/opensubdiv/osd/tbbComputeController.cpp
@@ -56,20 +56,18 @@ TbbComputeController::ApplyStencilTableKernel(
     Far::StencilTables const * vertexStencils = context->GetVertexStencilTables();
 
     if (vertexStencils and _currentBindState.vertexBuffer) {
+        VertexBufferDescriptor srcDesc = _currentBindState.vertexDesc;
+        VertexBufferDescriptor dstDesc(srcDesc);
+        dstDesc.offset += vertexStencils->GetNumControlVertices() * dstDesc.stride;
 
         int start = 0;
         int end = vertexStencils->GetNumStencils();
 
-        VertexBufferDescriptor const & desc = _currentBindState.vertexDesc;
-
-        float const * srcBuffer = _currentBindState.vertexBuffer + desc.offset;
-
-        float * destBuffer = _currentBindState.vertexBuffer + desc.offset +
-            vertexStencils->GetNumControlVertices() * desc.stride;
-
         if (end > start) {
-            TbbComputeStencils(_currentBindState.vertexDesc,
-                               srcBuffer, destBuffer,
+            TbbComputeStencils(_currentBindState.vertexBuffer,
+                               srcDesc,
+                               _currentBindState.vertexBuffer,
+                               dstDesc,
                                &vertexStencils->GetSizes().at(0),
                                &vertexStencils->GetOffsets().at(0),
                                &vertexStencils->GetControlIndices().at(0),
@@ -82,20 +80,18 @@ TbbComputeController::ApplyStencilTableKernel(
     Far::StencilTables const * varyingStencils = context->GetVaryingStencilTables();
 
     if (varyingStencils and _currentBindState.varyingBuffer) {
+        VertexBufferDescriptor srcDesc = _currentBindState.varyingDesc;
+        VertexBufferDescriptor dstDesc(srcDesc);
+        dstDesc.offset += varyingStencils->GetNumControlVertices() * dstDesc.stride;
 
         int start = 0;
         int end = varyingStencils->GetNumStencils();
 
-        VertexBufferDescriptor const & desc = _currentBindState.varyingDesc;
-
-        float const * srcBuffer = _currentBindState.varyingBuffer + desc.offset;
-
-        float * destBuffer = _currentBindState.varyingBuffer + desc.offset +
-            varyingStencils->GetNumControlVertices() * desc.stride;
-
         if (end > start) {
-            TbbComputeStencils(_currentBindState.varyingDesc,
-                               srcBuffer, destBuffer,
+            TbbComputeStencils(_currentBindState.varyingBuffer,
+                               srcDesc,
+                               _currentBindState.varyingBuffer,
+                               dstDesc,
                                &varyingStencils->GetSizes().at(0),
                                &varyingStencils->GetOffsets().at(0),
                                &varyingStencils->GetControlIndices().at(0),

--- a/opensubdiv/osd/tbbKernel.cpp
+++ b/opensubdiv/osd/tbbKernel.cpp
@@ -74,9 +74,9 @@ copy(float *dst, int dstIndex, const float *src,
 
 class TBBStencilKernel {
 
-    VertexBufferDescriptor _vertexDesc;
+    VertexBufferDescriptor _srcDesc;
+    VertexBufferDescriptor _dstDesc;
     float const * _vertexSrc;
-
     float * _vertexDst;
 
     unsigned char const * _sizes;
@@ -86,19 +86,24 @@ class TBBStencilKernel {
 
 
 public:
-    TBBStencilKernel(VertexBufferDescriptor vertexDesc, float const * vertexSrc,
-        float * vertexDst, unsigned char const * sizes, int const * offsets,
-            int const * indices, float const * weights ) :
-         _vertexDesc(vertexDesc),
-         _vertexSrc(vertexSrc),
-         _vertexDst(vertexDst),
+    TBBStencilKernel(float const *src,
+                     VertexBufferDescriptor srcDesc,
+                     float *dst,
+                     VertexBufferDescriptor dstDesc,
+                     unsigned char const * sizes, int const * offsets,
+                     int const * indices, float const * weights) :
+         _srcDesc(srcDesc),
+         _dstDesc(dstDesc),
+         _vertexSrc(src),
+         _vertexDst(dst),
          _sizes(sizes),
          _offsets(offsets),
          _indices(indices),
          _weights(weights) { }
 
     TBBStencilKernel(TBBStencilKernel const & other) {
-        _vertexDesc = other._vertexDesc;
+        _srcDesc    = other._srcDesc;
+        _dstDesc    = other._dstDesc;
         _sizes      = other._sizes;
         _offsets    = other._offsets;
         _indices    = other._indices;
@@ -110,14 +115,14 @@ public:
     void operator() (tbb::blocked_range<int> const &r) const {
 #define USE_SIMD
 #ifdef USE_SIMD
-        if (_vertexDesc.length==4 and _vertexDesc.stride==4) {
+        if (_srcDesc.length==4 and _srcDesc.stride==4 and _dstDesc.stride==4) {
 
             // SIMD fast path for aligned primvar data (4 floats)
             int offset = _offsets[r.begin()];
             ComputeStencilKernel<4>(_vertexSrc, _vertexDst,
                 _sizes, _indices+offset, _weights+offset, r.begin(), r.end());
 
-        } else if (_vertexDesc.length==8 and _vertexDesc.stride==4) {
+        } else if (_srcDesc.length==8 and _srcDesc.stride==4 and _dstDesc.stride==4) {
 
             // SIMD fast path for aligned primvar data (8 floats)
             int offset = _offsets[r.begin()];
@@ -127,7 +132,7 @@ public:
         } else {
 #else
         {
-#endif                
+#endif
             unsigned char const * sizes = _sizes;
             int const * indices = _indices;
             float const * weights = _weights;
@@ -139,36 +144,43 @@ public:
             }
 
             // Slow path for non-aligned data
-            float * result = (float*)alloca(_vertexDesc.length * sizeof(float));
+            float * result = (float*)alloca(_srcDesc.length * sizeof(float));
 
             for (int i=r.begin(); i<r.end(); ++i, ++sizes) {
 
-                clear(result, _vertexDesc);
+                clear(result, _dstDesc);
 
                 for (int j=0; j<*sizes; ++j) {
-                    addWithWeight(result, _vertexSrc, *indices++, *weights++, _vertexDesc);
+                    addWithWeight(result, _vertexSrc, *indices++, *weights++, _srcDesc);
                 }
 
-                copy(_vertexDst, i, result, _vertexDesc);
+                copy(_vertexDst, i, result, _dstDesc);
             }
         }
     }
 };
 
 void
-TbbComputeStencils(VertexBufferDescriptor const &vertexDesc,
-                      float const * vertexSrc,
-                      float * vertexDst,
-                      unsigned char const * sizes,
-                      int const * offsets,
-                      int const * indices,
-                      float const * weights,
-                      int start, int end) {
+TbbComputeStencils(float const * src,
+                   VertexBufferDescriptor const &srcDesc,
+                   float * dst,
+                   VertexBufferDescriptor const &dstDesc,
+                   unsigned char const * sizes,
+                   int const * offsets,
+                   int const * indices,
+                   float const * weights,
+                   int start, int end) {
 
-    assert(start>=0 and start<end);
+    if (start > 0) {
+        sizes += start;
+        indices += offsets[start];
+        weights += offsets[start];
+    }
+    src += srcDesc.offset;
+    dst += dstDesc.offset;
 
-    TBBStencilKernel kernel(vertexDesc, vertexSrc, vertexDst,
-        sizes, offsets, indices, weights);
+    TBBStencilKernel kernel(src, srcDesc, dst, dstDesc,
+                            sizes, offsets, indices, weights);
 
     tbb::blocked_range<int> range(start, end, grain_size);
 

--- a/opensubdiv/osd/tbbKernel.h
+++ b/opensubdiv/osd/tbbKernel.h
@@ -35,9 +35,10 @@ namespace Osd {
 struct VertexBufferDescriptor;
 
 void
-TbbComputeStencils(VertexBufferDescriptor const &vertexDesc,
-                   float const * vertexSrc,
-                   float * vertexDst,
+TbbComputeStencils(float const * src,
+                   VertexBufferDescriptor const &srcDesc,
+                   float * dst,
+                   VertexBufferDescriptor const &dstDesc,
                    unsigned char const * sizes,
                    int const * offsets,
                    int const * indices,


### PR DESCRIPTION
Changing all device kernels to take two buffer identifiers for
source and destination separately.
This change is an intermediate step toward upcoming context/controller
refactoring.

Previously we have a limitation that the source and destination
vertex buffer have to be a single buffer, since the subdivision
tables are iteratively applied level by level.
With stencil tables, we don't have such a limitation any more,
so we may want to apply stencils from a separate source buffer to
another.

To specify the stencil output location within the destination buffer,
we use VertexBufferDescriptor.offset. This allows us not only
configuring arbitrary batching scheme, but also relaxing the
limitation that source and destination buffers had to have a same
interleaved layout. For examples, with this change we could layout
derivatives only exist in the destination buffer, which doesn't need
to be allocated in the source buffer.