### PR TITLE
cleanup remaining ptex specific code in osd layer

### DIFF
--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -909,10 +909,13 @@ bindProgram(Effect effect, OpenSubdiv::Osd::DrawContext::PatchArray const & patc
     if (g_mesh->GetDrawContext()->quadOffsetBufferSRV) {
         g_pd3dDeviceContext->HSSetShaderResources(2, 1, &g_mesh->GetDrawContext()->quadOffsetBufferSRV);
     }
-    if (g_mesh->GetDrawContext()->ptexCoordinateBufferSRV) {
-        g_pd3dDeviceContext->HSSetShaderResources(3, 1, &g_mesh->GetDrawContext()->ptexCoordinateBufferSRV);
-        g_pd3dDeviceContext->DSSetShaderResources(3, 1, &g_mesh->GetDrawContext()->ptexCoordinateBufferSRV);
-        g_pd3dDeviceContext->GSSetShaderResources(3, 1, &g_mesh->GetDrawContext()->ptexCoordinateBufferSRV);
+    if (g_mesh->GetDrawContext()->patchParamBufferSRV) {
+        g_pd3dDeviceContext->HSSetShaderResources(
+            3, 1, &g_mesh->GetDrawContext()->patchParamBufferSRV);
+        g_pd3dDeviceContext->DSSetShaderResources(
+            3, 1, &g_mesh->GetDrawContext()->patchParamBufferSRV);
+        g_pd3dDeviceContext->GSSetShaderResources(
+            3, 1, &g_mesh->GetDrawContext()->patchParamBufferSRV);
     }
 
     g_pd3dDeviceContext->PSSetShaderResources(4, 1, g_osdPTexImage->GetTexelsSRV());

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -762,9 +762,11 @@ bindProgram(Effect effect, OpenSubdiv::Osd::DrawContext::PatchArray const & patc
     if (g_mesh->GetDrawContext()->quadOffsetBufferSRV) {
         g_pd3dDeviceContext->HSSetShaderResources(2, 1, &g_mesh->GetDrawContext()->quadOffsetBufferSRV);
     }
-    if (g_mesh->GetDrawContext()->ptexCoordinateBufferSRV) {
-        g_pd3dDeviceContext->HSSetShaderResources(3, 1, &g_mesh->GetDrawContext()->ptexCoordinateBufferSRV);
-        g_pd3dDeviceContext->DSSetShaderResources(3, 1, &g_mesh->GetDrawContext()->ptexCoordinateBufferSRV);
+    if (g_mesh->GetDrawContext()->patchParamBufferSRV) {
+        g_pd3dDeviceContext->HSSetShaderResources(
+            3, 1, &g_mesh->GetDrawContext()->patchParamBufferSRV);
+        g_pd3dDeviceContext->DSSetShaderResources(
+            3, 1, &g_mesh->GetDrawContext()->patchParamBufferSRV);
     }
 }
 

--- a/examples/glPaintTest/glPaintTest.cpp
+++ b/examples/glPaintTest/glPaintTest.cpp
@@ -236,7 +236,6 @@ createOsdMesh() {
     bool doAdaptive = true;
     OpenSubdiv::Osd::MeshBitset bits;
     bits.set(OpenSubdiv::Osd::MeshAdaptive, doAdaptive);
-    bits.set(OpenSubdiv::Osd::MeshPtexData, true);
 
     g_mesh = new OpenSubdiv::Osd::Mesh<OpenSubdiv::Osd::CpuGLVertexBuffer,
                                        OpenSubdiv::Far::StencilTables,

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -1005,7 +1005,6 @@ createOsdMesh(int level, int kernel) {
 
     OpenSubdiv::Osd::MeshBitset bits;
     bits.set(OpenSubdiv::Osd::MeshAdaptive, doAdaptive);
-    bits.set(OpenSubdiv::Osd::MeshPtexData, true);
     bits.set(OpenSubdiv::Osd::MeshEndCapGregoryBasis, true);
 
     int numVertexElements = g_adaptive ? 3 : 6;

--- a/opensubdiv/osd/d3d11DrawContext.h
+++ b/opensubdiv/osd/d3d11DrawContext.h
@@ -108,8 +108,8 @@ public:
 
     ID3D11Buffer             *patchIndexBuffer;
 
-    ID3D11Buffer             *ptexCoordinateBuffer;
-    ID3D11ShaderResourceView *ptexCoordinateBufferSRV;
+    ID3D11Buffer             *patchParamBuffer;
+    ID3D11ShaderResourceView *patchParamBufferSRV;
 
     ID3D11Buffer             *fvarDataBuffer;
     ID3D11ShaderResourceView *fvarDataBufferSRV;

--- a/opensubdiv/osd/d3d11DrawRegistry.h
+++ b/opensubdiv/osd/d3d11DrawRegistry.h
@@ -84,17 +84,9 @@ public:
     typedef D3D11DrawConfig ConfigType;
     typedef D3D11DrawSourceConfig SourceConfigType;
 
-    D3D11DrawRegistryBase(bool enablePtex=false) : _enablePtex(enablePtex) { }
+    D3D11DrawRegistryBase() { }
 
     virtual ~D3D11DrawRegistryBase();
-
-    bool IsPtexEnabled() const {
-        return _enablePtex;
-    }
-
-    void SetPtexEnabled(bool b) {
-        _enablePtex=b;
-    }
 
 protected:
     virtual ConfigType * _NewDrawConfig() { return new ConfigType(); }
@@ -109,9 +101,6 @@ protected:
     virtual SourceConfigType * _NewDrawSourceConfig() { return new SourceConfigType(); }
     virtual SourceConfigType *
     _CreateDrawSourceConfig(DescType const & desc, ID3D11Device * pd3dDevice);
-
-private:
-    bool _enablePtex;
 };
 
 //------------------------------------------------------------------------------

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -49,13 +49,12 @@ namespace Osd {
 enum MeshBits {
     MeshAdaptive             = 0,
     MeshInterleaveVarying    = 1,
-    MeshPtexData             = 2,
-    MeshFVarData             = 3,
-    MeshUseSingleCreasePatch = 4,
-    MeshEndCapBSplineBasis   = 5,  // exclusive
-    MeshEndCapGregoryBasis   = 6,  // exclusive
-    MeshEndCapLegacyGregory  = 7,  // exclusive
-    NUM_MESH_BITS            = 8,
+    MeshFVarData             = 2,
+    MeshUseSingleCreasePatch = 3,
+    MeshEndCapBSplineBasis   = 4,  // exclusive
+    MeshEndCapGregoryBasis   = 5,  // exclusive
+    MeshEndCapLegacyGregory  = 6,  // exclusive
+    NUM_MESH_BITS            = 7,
 };
 typedef std::bitset<NUM_MESH_BITS> MeshBitset;
 


### PR DESCRIPTION
- Remove MeshPtexData bit from Osd::MeshBits. It's not used any more
- Rename ptexIndexBuffer in D3D11DrawContext to paramParamBuffer
- Remove Is/SetPtexEnabled from D3D11DrawRegistry