### PR TITLE
Refactor Osd::DrawContext

### DIFF
--- a/examples/common/patchColors.cpp
+++ b/examples/common/patchColors.cpp
@@ -40,9 +40,3 @@ getAdaptivePatchColor(Descriptor const & desc) {
     return _colors[(int)(desc.GetType()-Descriptor::REGULAR)];
 }
 
-float const *
-getAdaptivePatchColor(OpenSubdiv::Osd::DrawContext::PatchDescriptor const & desc) {
-
-    return _colors[(int)(desc.GetType()-Descriptor::REGULAR)];
-}
-

--- a/examples/common/patchColors.h
+++ b/examples/common/patchColors.h
@@ -30,8 +30,6 @@
 #include <far/patchTables.h>
 
 // returns a unique color for each type of feature-adaptive patches
-float const * getAdaptivePatchColor(OpenSubdiv::Osd::DrawContext::PatchDescriptor const & desc);
-
 float const * getAdaptivePatchColor(OpenSubdiv::Far::PatchDescriptor const & desc);
 
 

--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -425,7 +425,7 @@ void runTest(ShapeDesc const &shapeDesc, std::string const &kernel,
 
     for (int i=0; i<(int)patches.size(); ++i) {
         Osd::DrawContext::PatchArray const & patch = patches[i];
-        Osd::DrawContext::PatchDescriptor desc = patch.GetDescriptor();
+        Far::PatchDescriptor desc = patch.GetDescriptor();
         Far::PatchDescriptor::Type patchType = desc.GetType();
 
         GLenum primType;

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -803,27 +803,42 @@ union Effect {
     }
 };
 
-typedef std::pair<OpenSubdiv::Osd::DrawContext::PatchDescriptor, Effect> EffectDesc;
+struct EffectDesc {
+    EffectDesc(OpenSubdiv::Far::PatchDescriptor desc,
+               Effect effect) : desc(desc), effect(effect),
+                                maxValence(0), numElements(0) { }
+
+    OpenSubdiv::Far::PatchDescriptor desc;
+    Effect effect;
+    int maxValence;
+    int numElements;
+
+    bool operator < (const EffectDesc &e) const {
+        return desc < e.desc || (desc == e.desc &&
+              (maxValence < e.maxValence || ((maxValence == e.maxValence) &&
+              (effect < e.effect))));
+    }
+};
 
 class EffectDrawRegistry : public OpenSubdiv::Osd::GLDrawRegistry<EffectDesc> {
 
 protected:
     virtual ConfigType *
-    _CreateDrawConfig(DescType const & desc, SourceConfigType const * sconfig);
+    _CreateDrawConfig(EffectDesc const & desc, SourceConfigType const * sconfig);
 
     virtual SourceConfigType *
-    _CreateDrawSourceConfig(DescType const & desc);
+    _CreateDrawSourceConfig(EffectDesc const & desc);
 };
 
 EffectDrawRegistry::SourceConfigType *
-EffectDrawRegistry::_CreateDrawSourceConfig(DescType const & desc)
+EffectDrawRegistry::_CreateDrawSourceConfig(EffectDesc const & effectDesc)
 {
     typedef OpenSubdiv::Far::PatchDescriptor Descriptor;
 
-    Effect effect = desc.second;
+    Effect effect = effectDesc.effect;
 
     SourceConfigType * sconfig =
-        BaseRegistry::_CreateDrawSourceConfig(desc.first);
+        BaseRegistry::_CreateDrawSourceConfig(effectDesc.desc);
 
     assert(sconfig);
 
@@ -833,8 +848,20 @@ EffectDrawRegistry::_CreateDrawSourceConfig(DescType const & desc)
     const char *glslVersion = "#version 330\n";
 #endif
 
-    if (desc.first.GetType() == Descriptor::QUADS or
-        desc.first.GetType() == Descriptor::TRIANGLES) {
+    // legacy gregory patch requires OSD_MAX_VALENCE and OSD_NUM_ELEMENTS defined
+    if (effectDesc.desc.GetType() == Descriptor::GREGORY or
+        effectDesc.desc.GetType() == Descriptor::GREGORY_BOUNDARY) {
+        std::ostringstream ss;
+        ss << effectDesc.maxValence;
+        sconfig->commonShader.AddDefine("OSD_MAX_VALENCE", ss.str());
+        ss.str("");
+
+        ss << effectDesc.numElements;
+        sconfig->commonShader.AddDefine("OSD_NUM_ELEMENTS", ss.str());
+    }
+
+    if (effectDesc.desc.GetType() == Descriptor::QUADS or
+        effectDesc.desc.GetType() == Descriptor::TRIANGLES) {
         sconfig->vertexShader.source = shaderSource;
         sconfig->vertexShader.version = glslVersion;
         sconfig->vertexShader.AddDefine("VERTEX_SHADER");
@@ -850,12 +877,12 @@ EffectDrawRegistry::_CreateDrawSourceConfig(DescType const & desc)
     sconfig->fragmentShader.version = glslVersion;
     sconfig->fragmentShader.AddDefine("FRAGMENT_SHADER");
 
-    if (desc.first.GetType() == Descriptor::QUADS) {
+    if (effectDesc.desc.GetType() == Descriptor::QUADS) {
         // uniform catmark, bilinear
         sconfig->geometryShader.AddDefine("PRIM_QUAD");
         sconfig->fragmentShader.AddDefine("PRIM_QUAD");
         sconfig->commonShader.AddDefine("UNIFORM_SUBDIVISION");
-    } else if (desc.first.GetType() == Descriptor::TRIANGLES) {
+    } else if (effectDesc.desc.GetType() == Descriptor::TRIANGLES) {
         // uniform loop
         sconfig->geometryShader.AddDefine("PRIM_TRI");
         sconfig->fragmentShader.AddDefine("PRIM_TRI");
@@ -915,7 +942,7 @@ EffectDrawRegistry::_CreateDrawConfig(
         DescType const & desc,
         SourceConfigType const * sconfig)
 {
-    ConfigType * config = BaseRegistry::_CreateDrawConfig(desc.first, sconfig);
+    ConfigType * config = BaseRegistry::_CreateDrawConfig(desc.desc, sconfig);
     assert(config);
 
     GLuint uboIndex;
@@ -988,6 +1015,18 @@ static GLuint
 bindProgram(Effect effect, OpenSubdiv::Osd::DrawContext::PatchArray const & patch)
 {
     EffectDesc effectDesc(patch.GetDescriptor(), effect);
+
+    // only legacy gregory needs maxValence and numElements
+    int maxValence = g_mesh->GetDrawContext()->GetMaxValence();
+    int numElements = (g_displayStyle == kInterleavedVaryingColor ? 7 : 3);
+
+    typedef OpenSubdiv::Far::PatchDescriptor Descriptor;
+    if (patch.GetDescriptor().GetType() == Descriptor::GREGORY or
+        patch.GetDescriptor().GetType() == Descriptor::GREGORY_BOUNDARY) {
+        effectDesc.maxValence = maxValence;
+        effectDesc.numElements = numElements;
+    }
+
     EffectDrawRegistry::ConfigType *
         config = effectRegistry.GetDrawConfig(effectDesc);
 
@@ -1148,7 +1187,7 @@ display() {
     for (int i=0; i<(int)patches.size(); ++i) {
         OpenSubdiv::Osd::DrawContext::PatchArray const & patch = patches[i];
 
-        OpenSubdiv::Osd::DrawContext::PatchDescriptor desc = patch.GetDescriptor();
+        OpenSubdiv::Far::PatchDescriptor desc = patch.GetDescriptor();
         OpenSubdiv::Far::PatchDescriptor::Type patchType = desc.GetType();
 
         patchCount[patchType] += patch.GetNumPatches();

--- a/opensubdiv/osd/d3d11DrawContext.cpp
+++ b/opensubdiv/osd/d3d11DrawContext.cpp
@@ -33,7 +33,8 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Osd {
 
-D3D11DrawContext::D3D11DrawContext() :
+D3D11DrawContext::D3D11DrawContext(int maxValence) :
+    DrawContext(maxValence),
     patchIndexBuffer(NULL),
     patchParamBuffer(NULL),
     patchParamBufferSRV(NULL),
@@ -63,11 +64,11 @@ D3D11DrawContext::~D3D11DrawContext()
 
 D3D11DrawContext *
 D3D11DrawContext::Create(Far::PatchTables const *patchTables,
-                         int numVertexElements,
                          ID3D11DeviceContext *pd3d11DeviceContext)
 {
-    D3D11DrawContext * result = new D3D11DrawContext();
-    if (result->create(*patchTables, numVertexElements, pd3d11DeviceContext))
+    int maxValence = patchTables->GetMaxValence();
+    D3D11DrawContext * result = new D3D11DrawContext(maxValence);
+    if (result->create(*patchTables, pd3d11DeviceContext))
         return result;
 
     delete result;
@@ -76,7 +77,6 @@ D3D11DrawContext::Create(Far::PatchTables const *patchTables,
 
 bool
 D3D11DrawContext::create(Far::PatchTables const &patchTables,
-                         int numVertexElements,
                          ID3D11DeviceContext *pd3d11DeviceContext)
 {
     // adaptive patches
@@ -111,8 +111,7 @@ D3D11DrawContext::create(Far::PatchTables const &patchTables,
 
     pd3d11DeviceContext->Unmap(patchIndexBuffer, 0);
 
-    DrawContext::ConvertPatchArrays(patchTables, _patchArrays,
-        patchTables.GetMaxValence(), numVertexElements);
+    DrawContext::ConvertPatchArrays(patchTables, _patchArrays);
 
     // allocate and initialize additional buffer data
 
@@ -278,9 +277,9 @@ D3D11DrawContext::SetFVarDataTexture(Far::PatchTables const & patchTables,
 
 void
 D3D11DrawContext::updateVertexTexture(ID3D11Buffer *vbo,
-                                         ID3D11DeviceContext *pd3d11DeviceContext,
-                                         int numVertices,
-                                         int numVertexElements)
+                                      ID3D11DeviceContext *pd3d11DeviceContext,
+                                      int numVertices,
+                                      int numVertexElements)
 {
     ID3D11Device *pd3d11Device = NULL;
     pd3d11DeviceContext->GetDevice(&pd3d11Device);

--- a/opensubdiv/osd/d3d11DrawContext.h
+++ b/opensubdiv/osd/d3d11DrawContext.h
@@ -71,18 +71,14 @@ public:
     ///
     /// @param pd3d11DeviceContext  A device context
     ///
-    /// @param numVertexElements    The number of vertex elements
-    ///
     static D3D11DrawContext *Create(Far::PatchTables const *patchTables,
-                                    int numVertexElements,
                                     ID3D11DeviceContext *pd3d11DeviceContext);
 
     /// template version for custom context (OpenCL) used by OsdMesh
     template<typename DEVICE_CONTEXT>
     static D3D11DrawContext *Create(Far::PatchTables const *patchtables,
-                                    int numVertexElements,
                                     DEVICE_CONTEXT context) {
-        return Create(patchtables, numVertexElements, context->GetDeviceContext());
+        return Create(patchtables, context->GetDeviceContext());
     }
 
     /// Set vbo as a vertex texture (for gregory patch drawing)
@@ -146,12 +142,11 @@ public:
     }
 
 private:
-    D3D11DrawContext();
+    D3D11DrawContext(int maxValence);
 
 
     // allocate buffers from patchTables
     bool create(Far::PatchTables const &patchTables,
-                int numVertexElements,
                 ID3D11DeviceContext *pd3d11DeviceContext);
 
     void updateVertexTexture(ID3D11Buffer *vbo,

--- a/opensubdiv/osd/d3d11DrawRegistry.cpp
+++ b/opensubdiv/osd/d3d11DrawRegistry.cpp
@@ -58,20 +58,11 @@ D3D11DrawRegistryBase::~D3D11DrawRegistryBase() {}
 
 D3D11DrawSourceConfig *
 D3D11DrawRegistryBase::_CreateDrawSourceConfig(
-    DrawContext::PatchDescriptor const & desc, ID3D11Device * pd3dDevice)
+    Far::PatchDescriptor const & desc, ID3D11Device * pd3dDevice)
 {
     D3D11DrawSourceConfig * sconfig = _NewDrawSourceConfig();
 
     sconfig->commonShader.source = commonShaderSource;
-
-    {
-        std::ostringstream ss;
-        ss << (int)desc.GetMaxValence();
-        sconfig->commonShader.AddDefine("OSD_MAX_VALENCE", ss.str());
-        ss.str("");
-        ss << (int)desc.GetNumElements();
-        sconfig->commonShader.AddDefine("OSD_NUM_ELEMENTS", ss.str());
-    }
 
     switch (desc.GetType()) {
     case Far::PatchDescriptor::REGULAR:

--- a/opensubdiv/osd/d3d11DrawRegistry.h
+++ b/opensubdiv/osd/d3d11DrawRegistry.h
@@ -80,7 +80,7 @@ struct D3D11DrawSourceConfig {
 class D3D11DrawRegistryBase {
 
 public:
-    typedef DrawContext::PatchDescriptor DescType;
+    typedef Far::PatchDescriptor DescType;
     typedef D3D11DrawConfig ConfigType;
     typedef D3D11DrawSourceConfig SourceConfigType;
 
@@ -105,7 +105,7 @@ protected:
 
 //------------------------------------------------------------------------------
 
-template <class DESC_TYPE = DrawContext::PatchDescriptor,
+template <class DESC_TYPE = Far::PatchDescriptor,
           class CONFIG_TYPE = D3D11DrawConfig,
           class SOURCE_CONFIG_TYPE = D3D11DrawSourceConfig>
 class D3D11DrawRegistry : public D3D11DrawRegistryBase {

--- a/opensubdiv/osd/drawContext.cpp
+++ b/opensubdiv/osd/drawContext.cpp
@@ -37,7 +37,7 @@ DrawContext::~DrawContext() {}
 
 void
 DrawContext::ConvertPatchArrays(Far::PatchTables const &patchTables,
-    PatchArrayVector &osdPatchArrays, int maxValence, int numElements) {
+                                PatchArrayVector &osdPatchArrays) {
 
     int narrays = patchTables.GetNumPatchArrays();
 
@@ -47,17 +47,16 @@ DrawContext::ConvertPatchArrays(Far::PatchTables const &patchTables,
 
     for (int array=0, pidx=0, vidx=0, qidx=0; array<narrays; ++array) {
 
-        Far::PatchDescriptor srcDesc = patchTables.GetPatchArrayDescriptor(array);
+        Far::PatchDescriptor desc = patchTables.GetPatchArrayDescriptor(array);
 
         int npatches = patchTables.GetNumPatches(array),
-            nverts = srcDesc.GetNumControlVertices();
+            nverts = desc.GetNumControlVertices();
 
-        PatchDescriptor desc(srcDesc, maxValence, numElements);
         osdPatchArrays.push_back(PatchArray(desc, npatches, vidx, pidx, qidx));
 
         vidx += npatches * nverts;
         pidx += npatches;
-        qidx += (srcDesc.GetType() == Far::PatchDescriptor::GREGORY) ? npatches*nverts  : 0;
+        qidx += (desc.GetType() == Far::PatchDescriptor::GREGORY) ? npatches*nverts  : 0;
     }
 }
 

--- a/opensubdiv/osd/drawContext.h
+++ b/opensubdiv/osd/drawContext.h
@@ -59,60 +59,6 @@ namespace Osd {
 class DrawContext {
 
 public:
-
-    class PatchDescriptor {
-    public:
-        /// Constructor
-        ///
-        /// @param farDesc      Patch type descriptor
-        ///
-        /// @param maxValence   Highest vertex valence in the primitive
-        ///
-        /// @param numElements  The size of the vertex and varying data per-vertex
-        ///                     (in floats)
-        ///
-        PatchDescriptor(Far::PatchDescriptor farDesc, unsigned char maxValence, unsigned char numElements) :
-            _farDesc(farDesc), _maxValence(maxValence), _numElements(numElements) { }
-
-
-        /// Returns the type of the patch
-        Far::PatchDescriptor::Type GetType() const {
-            return _farDesc.GetType();
-        }
-
-        /// Returns the number of control vertices expected for a patch of the
-        /// type described
-        int GetNumControlVertices() const {
-            return _farDesc.GetNumControlVertices();
-        }
-
-        /// Returns the max valence
-        int GetMaxValence() const {
-            return _maxValence;
-        }
-
-        /// Returns the number of vertex elements
-        int GetNumElements() const {
-            return _numElements;
-        }
-
-        /// Set the number of vertex elements
-        void SetNumElements(int numElements) {
-            _numElements = (unsigned char)numElements;
-        }
-
-        /// Allows ordering of patches by type
-        bool operator < ( PatchDescriptor const other ) const;
-
-        /// True if the descriptors are identical
-        bool operator == ( PatchDescriptor const other ) const;
-
-    private:
-        Far::PatchDescriptor _farDesc;
-        unsigned char _maxValence;
-        unsigned char _numElements;
-    };
-
     typedef Far::Index Index;
 
     class PatchArray {
@@ -130,18 +76,18 @@ public:
         ///
         /// @param qoIndex    Index of the first quad-offset entry
         ///
-        PatchArray(PatchDescriptor desc, int npatches,
+        PatchArray(Far::PatchDescriptor desc, int npatches,
             Index vertIndex, Index patchIndex, Index qoIndex) :
                 _desc(desc), _npatches(npatches),
                     _vertIndex(vertIndex), _patchIndex(patchIndex), _quadOffsetIndex(qoIndex) { }
 
         /// Returns a patch descriptor defining the type of patches in the array
-        PatchDescriptor GetDescriptor() const {
+        Far::PatchDescriptor GetDescriptor() const {
             return _desc;
         }
 
         /// Update a patch descriptor
-        void SetDescriptor(PatchDescriptor desc) {
+        void SetDescriptor(Far::PatchDescriptor desc) {
             _desc = desc;
         }
 
@@ -178,7 +124,7 @@ public:
         }
 
     private:
-        PatchDescriptor _desc;
+        Far::PatchDescriptor _desc;
         int _npatches;
         Index _vertIndex,
               _patchIndex,
@@ -186,7 +132,7 @@ public:
     };
 
     /// Constructor
-    DrawContext() : _isAdaptive(false) {}
+    DrawContext(int maxValence) : _isAdaptive(false), _maxValence(maxValence) {}
 
     /// Descrtuctor
     virtual ~DrawContext();
@@ -212,10 +158,15 @@ public:
     // processes FarPatchArrays and inserts requisite sub-patches for the arrays
     // containing transition patches
     static void ConvertPatchArrays(Far::PatchTables const &patchTables,
-        DrawContext::PatchArrayVector &osdPatchArrays, int maxValence, int numElements);
+                                   DrawContext::PatchArrayVector &osdPatchArrays);
 
+    // maxValence is needed for legacy gregorypatch drawing
+    int GetMaxValence() const {
+        return _maxValence;
+    }
 
     typedef std::vector<float> FVarData;
+
 
 protected:
 
@@ -232,27 +183,9 @@ protected:
     PatchArrayVector _patchArrays;
 
     bool _isAdaptive;
+
+    int _maxValence;
 };
-
-// Allows ordering of patches by type
-inline bool
-DrawContext::PatchDescriptor::operator < ( PatchDescriptor const other ) const
-{
-    return _farDesc < other._farDesc or (_farDesc == other._farDesc and
-          (_maxValence < other._maxValence or ((_maxValence == other._maxValence) and
-          (_numElements < other._numElements))));
-}
-
-// True if the descriptors are identical
-inline bool
-DrawContext::PatchDescriptor::operator == ( PatchDescriptor const other ) const
-{
-    return _farDesc == other._farDesc and
-           _maxValence == other._maxValence and
-           _numElements == other._numElements;
-}
-
-
 
 }  // end namespace Osd
 

--- a/opensubdiv/osd/glDrawContext.cpp
+++ b/opensubdiv/osd/glDrawContext.cpp
@@ -32,7 +32,8 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Osd {
 
-GLDrawContext::GLDrawContext() :
+GLDrawContext::GLDrawContext(int maxValence) :
+    DrawContext(maxValence),
     _patchIndexBuffer(0), _patchParamTextureBuffer(0), _fvarDataTextureBuffer(0),
     _vertexTextureBuffer(0), _vertexValenceTextureBuffer(0), _quadOffsetsTextureBuffer(0)
 {
@@ -98,14 +99,14 @@ createTextureBuffer(T const &data, GLint format, int offset=0)
 }
 
 GLDrawContext *
-GLDrawContext::Create(Far::PatchTables const * patchTables,
-                      int numVertexElements, void * /*deviceContext*/) {
+GLDrawContext::Create(Far::PatchTables const * patchTables, void * /*deviceContext*/) {
 
     if (patchTables) {
 
-        GLDrawContext * result = new GLDrawContext();
+        int maxValence = patchTables->GetMaxValence();
+        GLDrawContext * result = new GLDrawContext(maxValence);
 
-        if (result->create(*patchTables, numVertexElements)) {
+        if (result->create(*patchTables)) {
             return result;
         } else {
             delete result;
@@ -115,7 +116,7 @@ GLDrawContext::Create(Far::PatchTables const * patchTables,
 }
 
 bool
-GLDrawContext::create(Far::PatchTables const & patchTables, int numVertexElements) {
+GLDrawContext::create(Far::PatchTables const & patchTables) {
 
     _isAdaptive = patchTables.IsFeatureAdaptive();
 
@@ -138,8 +139,7 @@ GLDrawContext::create(Far::PatchTables const & patchTables, int numVertexElement
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     }
 
-    DrawContext::ConvertPatchArrays(patchTables, _patchArrays,
-        patchTables.GetMaxValence(), numVertexElements);
+    DrawContext::ConvertPatchArrays(patchTables, _patchArrays);
 
     // allocate and initialize additional buffer data
 

--- a/opensubdiv/osd/glDrawContext.h
+++ b/opensubdiv/osd/glDrawContext.h
@@ -58,10 +58,9 @@ public:
     ///
     /// @param patchTables          a valid set of Far::PatchTables
     ///
-    /// @param numVertexElements    the number of vertex elements
+    /// @param deviceContext        not used in GLDrawContext
     ///
     static GLDrawContext * Create(Far::PatchTables const * patchTables,
-                                  int numVertexElements,
                                   void *deviceContext = NULL);
 
     /// Set vbo as a vertex texture (for gregory patch drawing)
@@ -137,10 +136,10 @@ protected:
     GLuint _vertexValenceTextureBuffer;
     GLuint _quadOffsetsTextureBuffer;
 
-    GLDrawContext();
+    GLDrawContext(int maxValence);
 
     // allocate buffers from patchTables
-    bool create(Far::PatchTables const & patchTables, int numElements);
+    bool create(Far::PatchTables const & patchTables);
 
     void updateVertexTexture(GLuint vbo);
 };

--- a/opensubdiv/osd/glDrawRegistry.cpp
+++ b/opensubdiv/osd/glDrawRegistry.cpp
@@ -58,21 +58,11 @@ GLDrawRegistryBase::~GLDrawRegistryBase() {}
 
 #if defined(GL_ARB_tessellation_shader) || defined(GL_VERSION_4_0)
 GLDrawSourceConfig *
-GLDrawRegistryBase::_CreateDrawSourceConfig(
-    DrawContext::PatchDescriptor const & desc)
+GLDrawRegistryBase::_CreateDrawSourceConfig(Far::PatchDescriptor const & desc)
 {
     GLDrawSourceConfig * sconfig = _NewDrawSourceConfig();
 
     sconfig->commonShader.source = commonShaderSource;
-
-    {
-        std::ostringstream ss;
-        ss << (int)desc.GetMaxValence();
-        sconfig->commonShader.AddDefine("OSD_MAX_VALENCE", ss.str());
-        ss.str("");
-        ss << (int)desc.GetNumElements();
-        sconfig->commonShader.AddDefine("OSD_NUM_ELEMENTS", ss.str());
-    }
 
     switch (desc.GetType()) {
     case Far::PatchDescriptor::REGULAR:
@@ -136,8 +126,7 @@ GLDrawRegistryBase::_CreateDrawSourceConfig(
 }
 #else
 GLDrawSourceConfig *
-GLDrawRegistryBase::_CreateDrawSourceConfig(
-    DrawContext::PatchDescriptor const &)
+GLDrawRegistryBase::_CreateDrawSourceConfig(Far::PatchDescriptor const &)
 {
     return _NewDrawSourceConfig();
 }
@@ -190,7 +179,7 @@ _CompileShader(
 
 GLDrawConfig *
 GLDrawRegistryBase::_CreateDrawConfig(
-        DrawContext::PatchDescriptor const & /* desc */,
+        Far::PatchDescriptor const & /* desc */,
         GLDrawSourceConfig const * sconfig)
 {
     assert(sconfig);

--- a/opensubdiv/osd/glDrawRegistry.h
+++ b/opensubdiv/osd/glDrawRegistry.h
@@ -63,7 +63,7 @@ struct GLDrawSourceConfig : public DrawSourceConfig {
 class GLDrawRegistryBase {
 
 public:
-    typedef DrawContext::PatchDescriptor DescType;
+    typedef Far::PatchDescriptor DescType;
     typedef GLDrawConfig ConfigType;
     typedef GLDrawSourceConfig SourceConfigType;
 
@@ -88,7 +88,7 @@ protected:
 
 //------------------------------------------------------------------------------
 
-template <class DESC_TYPE = DrawContext::PatchDescriptor,
+template <class DESC_TYPE = Far::PatchDescriptor,
           class CONFIG_TYPE = GLDrawConfig,
           class SOURCE_CONFIG_TYPE = GLDrawSourceConfig >
 

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -277,7 +277,7 @@ public:
 
         initializeContext(numVertexElements,
                           numVaryingElements,
-                          vertexBufferStride, level, bits);
+                          level, bits);
 
         initializeVertexBuffers(_numVertices,
                                 vertexBufferStride,
@@ -413,7 +413,7 @@ public:
 private:
     void initializeContext(int numVertexElements,
                            int numVaryingElements,
-                           int numElements, int level, MeshBitset bits) {
+                           int level, MeshBitset bits) {
         assert(_refiner);
 
         Far::StencilTablesFactory::Options options;
@@ -482,8 +482,7 @@ private:
             }
         }
 
-        _drawContext = DrawContext::Create(_patchTables, numElements,
-                                           _deviceContext);
+        _drawContext = DrawContext::Create(_patchTables, _deviceContext);
 
         // numvertices = coarse verts + refined verts + gregory basis verts
         _numVertices = vertexStencils->GetNumControlVertices()

--- a/opensubdiv/osd/tbbKernel.h
+++ b/opensubdiv/osd/tbbKernel.h
@@ -23,7 +23,7 @@
 //
 
 #ifndef OPENSUBDIV_OSD_TBB_KERNEL_H
-#define OPENSUBIDV_OSD_TBB_KERNEL_H
+#define OPENSUBDIV_OSD_TBB_KERNEL_H
 
 #include "../version.h"
 


### PR DESCRIPTION
Since unified shading work already removed subPatch info from
Osd::PatchDescriptor, the remaining difference between Far::PatchDescriptor and
Osd::PatchDescriptor is just maxValence and numElements. They are used
for legacy gregory patch drawing.

Both maxValence and numElements are actually constant within a topology
(drawContext). This change moves maxValence to DrawContext and let client
manage numElements, then we can eliminate Osd::PatchDescriptor and simply
use Far::PatchDescriptor instead.

This is still an intermediate step toward further DrawRegistry refactoring.
For the time being, adding EffectDesc struct to include maxValence and
numValence to be maintained by the clients. They will be cleaned up later.

The side benefit of this change is we no longer need to recompile regular b-spline
shaders for the different max-valences.