### PR TITLE
Fixed evaluation of boundary and corner patches

### DIFF
--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -137,7 +137,7 @@ int g_nparticles=0,
     g_nsamples=101,
     g_nsamplesFound=0;
 
-bool g_randomStart=true;
+bool g_randomStart=false;
 
 GLuint g_cageEdgeVAO = 0,
        g_cageEdgeVBO = 0,
@@ -337,7 +337,7 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level) {
     // location samples (ptex face index, (s,t) and updates them between frames.
     // Note: the number of limit locations can be entirely arbitrary
     delete g_particles;
-    g_particles = new STParticles(*g_topologyRefiner, g_nsamples, g_randomStart);
+    g_particles = new STParticles(*g_topologyRefiner, g_nsamples, !g_randomStart);
     g_nparticles = g_particles->GetNumParticles();
     g_particles->SetSpeed(speed);
 
@@ -896,7 +896,7 @@ callbackFreeze(bool checked, int /* f */) {
 //------------------------------------------------------------------------------
 static void
 callbackCentered(bool checked, int /* f */) {
-    g_randomStart = !checked;
+    g_randomStart = checked;
     createOsdMesh(g_defaultShapes[g_currentShape], g_level);
 }
 
@@ -939,7 +939,7 @@ initHUD() {
     g_hud.AddCheckBox("Animate vertices (M)", g_moveScale != 0, 10, 50, callbackAnimate, 0, 'm');
     g_hud.AddCheckBox("Freeze (spc)", false, 10, 70, callbackFreeze, 0, ' ');
 
-    g_hud.AddCheckBox("Random Start", false, 10, 120, callbackCentered, 0);
+    g_hud.AddCheckBox("Random Start", false, 10, 120, callbackCentered, g_randomStart);
 
     int shading_pulldown = g_hud.AddPullDown("Shading (W)", 250, 10, 250, callbackDisplayVaryingColors, 'w');
     g_hud.AddPullDownButton(shading_pulldown, "Random", kRANDOM, g_drawMode==kRANDOM);

--- a/opensubdiv/far/patchParam.h
+++ b/opensubdiv/far/patchParam.h
@@ -90,9 +90,6 @@ struct PatchParam {
         /// \brief Returns the boundary edge encoding for the patch.
         unsigned short GetBoundary() const { return (unsigned short)((field >> 4) & 0xf); }
 
-        /// \brief Deprecated XXXdyu-patch-drawing (patches rotated when gathered from refiner)
-        unsigned char GetRotation() const { return 0; }
-
         /// \brief True if the parent coarse face is a non-quad
         bool NonQuadRoot() const { return (field >> 3) & 0x1; }
 

--- a/opensubdiv/far/patchTables.h
+++ b/opensubdiv/far/patchTables.h
@@ -470,14 +470,10 @@ PatchTables::Evaluate(PatchHandle const & handle, float s, float t,
 
     if (ptype==PatchDescriptor::REGULAR) {
 
-        GetBSplineWeights(bits, s, t, Q, Qd1, Qd2);
-
         ConstIndexArray cvs = GetPatchVertices(handle);
 
+        GetBSplineWeights(bits, s, t, Q, Qd1, Qd2);
         InterpolateRegularPatch(cvs.begin(), Q, Qd1, Qd2, src, dst);
-        // XXXdyu bits InterpolateBoundaryPatch(cvs.begin(), Q, Qd1, Qd2, src, dst);
-        // XXXdyu bits InterpolateCornerPatch(cvs.begin(), Q, Qd1, Qd2, src, dst);
-
 
     } else if (ptype==PatchDescriptor::GREGORY_BASIS) {
 
@@ -526,8 +522,6 @@ PatchTables::EvaluateFaceVarying(int channel, PatchHandle const & handle,
         case PatchDescriptor::REGULAR:
             GetBSplineWeights(bits, s, t, Q, Qd1, Qd2);
             InterpolateRegularPatch(cvs.begin(), Q, Qd1, Qd2, src, dst);
-            // XXXdyu bits InterpolateBoundaryPatch(cvs.begin(), Q, Qd1, Qd2, src, dst);
-            // XXXdyu bits InterpolateCornerPatch(cvs.begin(), Q, Qd1, Qd2, src, dst);
             break;
         default:
             assert(0);


### PR DESCRIPTION
My earlier change which simplified the categorization of
patch types broke evaluation for boundary and corner patches.

Previously, boundary and corner patches were always rotated
into a canoncial orientation by permuting the point indices
of the patch. This was convenient in some cases, but generally
made things unnecessarily complicated, since the parameterization
of the patch had to be counter-rotated to compensate.

Now patches always remain correctly oriented with respect
to the underlying surface topology and evaluation of boundary
and corner patches is accommodated by simply adjusting the
spline weights to account for the missing/invalid patch
points along boundary and corner edges.

There is more to clean up and optimize, but this restores
correct behavior.