### PR TITLE
Removed BOUNDARY and CORNER patch types

### DIFF
--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -920,10 +920,6 @@ display() {
                              patchCount[Descriptor::QUADS]); y += 20;
             g_hud->DrawString(x, y, "Regular          : %d",
                              patchCount[Descriptor::REGULAR]); y+= 20;
-            g_hud->DrawString(x, y, "Boundary         : %d",
-                             patchCount[Descriptor::BOUNDARY]); y+= 20;
-            g_hud->DrawString(x, y, "Corner           : %d",
-                             patchCount[Descriptor::CORNER]); y+= 20;
             g_hud->DrawString(x, y, "Gregory          : %d",
                              patchCount[Descriptor::GREGORY]); y+= 20;
             g_hud->DrawString(x, y, "Boundary Gregory : %d",

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -1301,10 +1301,6 @@ display() {
                              patchCount[Descriptor::QUADS]); y += 20;
             g_hud.DrawString(x, y, "Regular          : %d",
                              patchCount[Descriptor::REGULAR]); y+= 20;
-            g_hud.DrawString(x, y, "Boundary         : %d",
-                             patchCount[Descriptor::BOUNDARY]); y+= 20;
-            g_hud.DrawString(x, y, "Corner           : %d",
-                             patchCount[Descriptor::CORNER]); y+= 20;
             g_hud.DrawString(x, y, "Gregory          : %d",
                              patchCount[Descriptor::GREGORY]); y+= 20;
             g_hud.DrawString(x, y, "Boundary Gregory : %d",

--- a/examples/vtrViewer/gl_mesh.cpp
+++ b/examples/vtrViewer/gl_mesh.cpp
@@ -708,16 +708,6 @@ GLMesh::initializeBuffers(Options options, TopologyRefiner const & refiner,
                     eao[face*4+1] = cvs[ 6];
                     eao[face*4+2] = cvs[10];
                     eao[face*4+3] = cvs[ 9];
-                } else if (desc.GetType()==Descriptor::BOUNDARY) {
-                    eao[face*4  ] = cvs[ 2];
-                    eao[face*4+1] = cvs[ 6];
-                    eao[face*4+2] = cvs[ 5];
-                    eao[face*4+3] = cvs[ 1];
-                } else if (desc.GetType()==Descriptor::CORNER) {
-                    eao[face*4  ] = cvs[ 1];
-                    eao[face*4+1] = cvs[ 2];
-                    eao[face*4+2] = cvs[ 5];
-                    eao[face*4+3] = cvs[ 4];
                 } else {
                     memcpy(&eao[face*4], cvs.begin(), 4*sizeof(OpenSubdiv::Far::Index));
                 }

--- a/examples/vtrViewer/hbr_refine.cpp
+++ b/examples/vtrViewer/hbr_refine.cpp
@@ -455,8 +455,6 @@ private:
     template<class TYPE> struct PatchTypes {
 
         TYPE R,    // regular patch
-             B,    // boundary patch (4 rotations)
-             C,    // corner patch (4 rotations)
              G,    // gregory patch
              GB,   // gregory boundary patch
              GP;   // gregory basis
@@ -484,8 +482,6 @@ Far::PatchTablesFactory::PatchTypes<TYPE>::getValue( Far::PatchDescriptor desc )
 
     switch (desc.GetType()) {
         case Far::PatchDescriptor::REGULAR          : return R;
-        case Far::PatchDescriptor::BOUNDARY         : return B;
-        case Far::PatchDescriptor::CORNER           : return C;
         case Far::PatchDescriptor::GREGORY          : return G;
         case Far::PatchDescriptor::GREGORY_BOUNDARY : return GB;
         case Far::PatchDescriptor::GREGORY_BASIS    : return GP;
@@ -500,10 +496,9 @@ Far::PatchTablesFactory::PatchTypes<TYPE>::getNumPatchArrays() const {
 
     int result=0;
     if (R) ++result;
-    if (B) ++result;
-    if (C) ++result;
     if (G) ++result;
     if (GB) ++result;
+    if (GP) ++result;
 
     return result;
 }
@@ -690,12 +685,12 @@ Far::PatchTablesFactory::Create(Hmesh & mesh, int maxvalence) {
 
                         case 2 : {   // Boundary patch
                                      f->_adaptiveFlags.rots=computeBoundaryPatchRotation(f);
-                                     patchCtr.B++;
+                                     patchCtr.R++;
                                  } break;
 
                         case 3 : {   // Corner patch
                                      f->_adaptiveFlags.rots=computeCornerPatchRotation(f);
-                                     patchCtr.C++;
+                                     patchCtr.R++;
                                  } break;
 
                         default : break;
@@ -784,7 +779,7 @@ Far::PatchTablesFactory::Create(Hmesh & mesh, int maxvalence) {
 
                                      f->_adaptiveFlags.rots=rot; // override the transition rotation
 
-                                     patchCtr.B++;
+                                     patchCtr.R++;
                                  } break;
 
                         case 3 : {   // corner patch
@@ -794,7 +789,7 @@ Far::PatchTablesFactory::Create(Hmesh & mesh, int maxvalence) {
 
                                      f->_adaptiveFlags.rots=rot; // override the transition rotation
 
-                                     patchCtr.C++;
+                                     patchCtr.R++;
                                  } break;
 
                         default : assert(0); break;
@@ -808,8 +803,8 @@ Far::PatchTablesFactory::Create(Hmesh & mesh, int maxvalence) {
 
 
     static const Far::Index remapRegular        [16] = {5,6,10,9,4,0,1,2,3,7,11,15,14,13,12,8};
-    static const Far::Index remapRegularBoundary[12] = {1,2,6,5,0,3,7,11,10,9,8,4};
-    static const Far::Index remapRegularCorner  [ 9] = {1,2,5,4,0,8,7,6,3};
+    static const Far::Index remapRegularBoundary[16] = {5,6,10,9,4,7,11,15,14,13,12,8,0,1,2,3};
+    static const Far::Index remapRegularCorner  [16] = {5,6,10,9,7,11,15,14,13,12,8,4,0,1,2,3};
 
     int fvarwidth=0;
 
@@ -878,16 +873,16 @@ Far::PatchTablesFactory::Create(Hmesh & mesh, int maxvalence) {
 
                         case 2 : {   // Boundary Patch (12 CVs)
                                      f->_adaptiveFlags.brots = (f->_adaptiveFlags.rots+1)%4;
-                                     iptrs.B = getOneRing(f, 12, remapRegularBoundary, iptrs.B);
-                                     pptrs.B = computePatchParam(f, pptrs.B);
-                                     //fptrs.B[pattern][rot] = computeFVarData(f, fvarwidth, fptrs.B[0][0], /*isAdaptive=*/true);
+                                     iptrs.R = getOneRing(f, 12, remapRegularBoundary, iptrs.R);
+                                     pptrs.R = computePatchParam(f, pptrs.R);
+                                     //fptrs.R[pattern][rot] = computeFVarData(f, fvarwidth, fptrs.R[0][0], /*isAdaptive=*/true);
                                  } break;
 
                         case 3 : {   // Corner Patch (9 CVs)
                                      f->_adaptiveFlags.brots = (f->_adaptiveFlags.rots+1)%4;
-                                     iptrs.C = getOneRing(f, 9, remapRegularCorner, iptrs.C);
-                                     pptrs.C = computePatchParam(f, pptrs.C);
-                                     //fptrs.C[pattern][rot] = computeFVarData(f, fvarwidth, fptrs.C[0][0], /*isAdaptive=*/true);
+                                     iptrs.R = getOneRing(f, 9, remapRegularCorner, iptrs.R);
+                                     pptrs.R = computePatchParam(f, pptrs.R);
+                                     //fptrs.R[pattern][rot] = computeFVarData(f, fvarwidth, fptrs.R[0][0], /*isAdaptive=*/true);
                                  } break;
 
                         default : assert(0);
@@ -938,16 +933,16 @@ Far::PatchTablesFactory::Create(Hmesh & mesh, int maxvalence) {
 
                     case 2 : {   // Boundary Transition Patch (12 CVs)
                                  //unsigned rot = f->_adaptiveFlags.brots;
-                                 iptrs.B = getOneRing(f, 12, remapRegularBoundary, iptrs.B);
-                                 pptrs.B = computePatchParam(f, pptrs.B);
-                                 //fptrs.B[pattern][rot] = computeFVarData(f, fvarwidth, fptrs.B[pattern][rot], /*isAdaptive=*/true);
+                                 iptrs.R = getOneRing(f, 12, remapRegularBoundary, iptrs.R);
+                                 pptrs.R = computePatchParam(f, pptrs.R);
+                                 //fptrs.R[pattern][rot] = computeFVarData(f, fvarwidth, fptrs.R[pattern][rot], /*isAdaptive=*/true);
                              } break;
 
                     case 3 : {   // Corner Transition Patch (9 CVs)
                                  //unsigned rot = f->_adaptiveFlags.brots;
-                                 iptrs.C = getOneRing(f, 9, remapRegularCorner, iptrs.C);
-                                 pptrs.C = computePatchParam(f, pptrs.C);
-                                 //fptrs.C[pattern][rot] = computeFVarData(f, fvarwidth, fptrs.C[pattern][rot], /*isAdaptive=*/true);
+                                 iptrs.R = getOneRing(f, 9, remapRegularCorner, iptrs.R);
+                                 pptrs.R = computePatchParam(f, pptrs.R);
+                                 //fptrs.R[pattern][rot] = computeFVarData(f, fvarwidth, fptrs.R[pattern][rot], /*isAdaptive=*/true);
                              } break;
                 }
             } else
@@ -1106,10 +1101,10 @@ Far::PatchTablesFactory::getOneRing(Hface const * f,
 
         // Boundary case
         //
-        //         4      0      3      5
+        //         4      0      1      5
         //  ---- o ---- o ---- o ---- o ----
         //       |      |      |      |
-        //       | 11   | 1    | 2    | 6
+        //       | 11   | 3    | 2    | 6
         //  ---- o ---- o ---- o ---- o ----
         //       |      |      |      |
         //       | 10   | 9    | 8    | 7
@@ -1141,7 +1136,10 @@ Far::PatchTablesFactory::getOneRing(Hface const * f,
             result[remap[idx++ % ringsize]] = e->GetOrgVertex()->GetID();
         }
 
-        result += 12;
+        for (int i=12; i<16; ++i) {
+            result[remap[idx++]] = result[0];
+        }
+        result += 16;
 
     } else if (ringsize==9) {
 
@@ -1176,10 +1174,13 @@ Far::PatchTablesFactory::getOneRing(Hface const * f,
             result[remap[idx++ % ringsize]] = e->GetOrgVertex()->GetID();
         }
 
-        result += 9;
+        for (int i=9; i<16; ++i) {
+            result[remap[idx++]] = result[0];
+        }
+        result += 16;
 
     }
-    assert(idx==ringsize);
+    assert(idx==16);
     return result;
 }
 

--- a/examples/vtrViewer/vtrViewer.cpp
+++ b/examples/vtrViewer/vtrViewer.cpp
@@ -709,8 +709,6 @@ createPtexNumbers(OpenSubdiv::Far::PatchTables const & patchTables,
     static char buf[16];
 
     static int regular[4]  = {5, 6, 9, 10},
-               boundary[4] = {1, 2, 5, 6},
-               corner[4]   = {1, 2, 4, 5},
                gregory[4]  = {0, 1, 2, 3};
 
     for (int array=0; array<(int)patchTables.GetNumPatchArrays(); ++array) {
@@ -723,8 +721,6 @@ createPtexNumbers(OpenSubdiv::Far::PatchTables const & patchTables,
             int * remap = 0;
             switch (patchTables.GetPatchArrayDescriptor(array).GetType()) {
                 case Descriptor::REGULAR:          remap = regular; break;
-                case Descriptor::BOUNDARY:         remap = boundary; break;
-                case Descriptor::CORNER:           remap = corner; break;
                 case Descriptor::GREGORY:
                 case Descriptor::GREGORY_BOUNDARY:
                 case Descriptor::GREGORY_BASIS:    remap = gregory; break;

--- a/opensubdiv/far/patchDescriptor.cpp
+++ b/opensubdiv/far/patchDescriptor.cpp
@@ -47,11 +47,7 @@ PatchDescriptor::GetAdaptivePatchDescriptors(Sdc::SchemeType type) {
     };
 
     static PatchDescriptor _catmarkDescriptors[] = {
-
-        // XXXdyu-patch-drawing 
         PatchDescriptor(REGULAR),
-        PatchDescriptor(BOUNDARY),
-        PatchDescriptor(CORNER),
         PatchDescriptor(GREGORY),
         PatchDescriptor(GREGORY_BOUNDARY),
         PatchDescriptor(GREGORY_BASIS),
@@ -75,9 +71,8 @@ PatchDescriptor::GetAdaptivePatchDescriptors(Sdc::SchemeType type) {
 void
 PatchDescriptor::print() const {
     static char const * types[13] = {
-        "NON_PATCH", "POINTS", "LINES", "QUADS", "TRIANGLES", "LOOP", "REGULAR",
-            "SINGLE_CREASE", "BOUNDARY", "CORNER", "GREGORY",
-                "GREGORY_BOUNDARY", "GREGORY_BASIS" };
+        "NON_PATCH", "POINTS", "LINES", "QUADS", "TRIANGLES", "LOOP",
+            "REGULAR", "GREGORY", "GREGORY_BOUNDARY", "GREGORY_BASIS" };
 
     printf("    type %s\n",
         types[_type]);

--- a/opensubdiv/far/patchDescriptor.h
+++ b/opensubdiv/far/patchDescriptor.h
@@ -45,7 +45,7 @@ namespace Far {
 ///   or TRIANGLES
 ///
 /// * Adaptively subdivided meshes contain bicubic patches of types REGULAR,
-///   BOUNDARY, CORNER, GREGORY, GREGORY_BOUNDARY, GREGOYR_BASIS.
+///   GREGORY, GREGORY_BOUNDARY, GREGORY_BASIS.
 ///   These bicubic patches are also further distinguished by a transition
 ///   pattern as well as a rotational orientation.
 ///
@@ -71,8 +71,6 @@ public:
         LOOP,              ///< Loop patch
 
         REGULAR,           ///< feature-adaptive bicubic patches
-        BOUNDARY,
-        CORNER,
         GREGORY,
         GREGORY_BOUNDARY,
         GREGORY_BASIS
@@ -128,12 +126,6 @@ public:
     /// \brief Number of control vertices of Regular Patches in table.
     static short GetRegularPatchSize() { return 16; }
 
-    /// \brief Number of control vertices of Boundary Patches in table.
-    static short GetBoundaryPatchSize() { return 16; }
-
-    /// \brief Number of control vertices of Boundary Patches in table.
-    static short GetCornerPatchSize() { return 16; }
-
     /// \brief Number of control vertices of Gregory (and Gregory Boundary) Patches in table.
     static short GetGregoryPatchSize() { return 4; }
 
@@ -169,8 +161,6 @@ PatchDescriptor::GetNumControlVertices( Type type ) {
         case GREGORY           :
         case GREGORY_BOUNDARY  : return GetGregoryPatchSize();
         case GREGORY_BASIS     : return GetGregoryBasisPatchSize();
-        case BOUNDARY          : return GetBoundaryPatchSize();
-        case CORNER            : return GetCornerPatchSize();
         case TRIANGLES         : return 3;
         case LINES             : return 2;
         case POINTS            : return 1;
@@ -185,8 +175,6 @@ PatchDescriptor::GetNumFVarControlVertices( Type type ) {
         case REGULAR           : return GetRegularPatchSize();
         case QUADS             : return 4;
         case TRIANGLES         : return 3;
-        case BOUNDARY          : return GetBoundaryPatchSize();
-        case CORNER            : return GetCornerPatchSize();
         case LINES             : return 2;
         case POINTS            : return 1;
         case GREGORY_BASIS     : assert(0); return GetGregoryBasisPatchSize();

--- a/opensubdiv/far/patchTablesFactory.cpp
+++ b/opensubdiv/far/patchTablesFactory.cpp
@@ -47,8 +47,6 @@ struct PatchTypes {
 
 
     TYPE R,    // regular patch
-         B,    // boundary patch (4 rotations)
-         C,    // corner patch (4 rotations)
          G,    // gregory patch
          GB,   // gregory boundary patch
          GP;   // gregory basis patch
@@ -59,8 +57,6 @@ struct PatchTypes {
     TYPE & getValue( Far::PatchDescriptor desc ) {
         switch (desc.GetType()) {
             case Far::PatchDescriptor::REGULAR          : return R;
-            case Far::PatchDescriptor::BOUNDARY         : return B;
-            case Far::PatchDescriptor::CORNER           : return C;
             case Far::PatchDescriptor::GREGORY          : return G;
             case Far::PatchDescriptor::GREGORY_BOUNDARY : return GB;
             case Far::PatchDescriptor::GREGORY_BASIS    : return GP;
@@ -75,8 +71,6 @@ struct PatchTypes {
     int getNumPatchArrays() const {
         int result=0;
         if (R) ++result;
-        if (B) ++result;
-        if (C) ++result;
         if (G) ++result;
         if (GB) ++result;
         if (GP) ++result;
@@ -573,10 +567,6 @@ PatchTablesFactory::gatherFVarData(AdaptiveContext & context, int level,
                 // compute the 20 cvs basis)
                 fvarPatchType = context.options.useFVarQuadEndCaps ?
                     PatchDescriptor::QUADS : PatchDescriptor::GREGORY_BASIS;
-            } else if (fvarPatchTag._boundaryCount > 1) {
-                fvarPatchType = PatchDescriptor::CORNER;
-            } else if (fvarPatchTag._boundaryCount == 1) {
-                fvarPatchType = PatchDescriptor::BOUNDARY;
             } else if (fvarPatchTag._isSingleCrease) {
                 fvarPatchType = PatchDescriptor::REGULAR;
             }
@@ -596,17 +586,31 @@ PatchTablesFactory::gatherFVarData(AdaptiveContext & context, int level,
             //     revisited...
             int orientationIndex = fvarPatchTag._boundaryIndex;
             if (fvarPatchType == PatchDescriptor::REGULAR) {
-                static int const permuteRegular[16] = { 5, 6, 7, 8, 4, 0, 1, 9, 15, 3, 2, 10, 14, 13, 12, 11 };
-                vtxLevel.gatherQuadRegularInteriorPatchPoints(faceIndex, patchVerts, orientationIndex, *fvc);
-                permutation = permuteRegular;
-            } else if (fvarPatchType == PatchDescriptor::CORNER) {
-                static int const permuteCorner[9] = { 8, 3, 0, 7, 2, 1, 6, 5, 4 };
-                vtxLevel.gatherQuadRegularCornerPatchPoints(faceIndex, patchVerts, orientationIndex, *fvc);
-                permutation = permuteCorner;
-            } else if (fvarPatchType == PatchDescriptor::BOUNDARY) {
-                static int const permuteBoundary[12] = { 11, 3, 0, 4, 10, 2, 1, 5, 9, 8, 7, 6 };
-                vtxLevel.gatherQuadRegularBoundaryPatchPoints(faceIndex, patchVerts, orientationIndex, *fvc);
-                permutation = permuteBoundary;
+                if (fvarPatchTag._boundaryCount == 0) {
+                    static int const permuteRegular[16] = { 5, 6, 7, 8, 4, 0, 1, 9, 15, 3, 2, 10, 14, 13, 12, 11 };
+                    permutation = permuteRegular;
+                    vtxLevel.gatherQuadRegularInteriorPatchPoints(faceIndex, patchVerts, orientationIndex, *fvc);
+                } else if (fvarPatchTag._boundaryCount == 1) {
+                    // Expand boundary patch vertices and rotate to restore correct orientation.
+                    static int const permuteBoundary[4][16] = {
+                        { -1, -1, -1, -1, 11, 3, 0, 4, 10, 2, 1, 5, 9, 8, 7, 6 },
+                        { 9, 10, 11, -1, 8, 2, 3, -1, 7, 1, 0, -1, 6, 5, 4, -1 },
+                        { 6, 7, 8, 9, 5, 1, 2, 10, 4, 0, 3, 11, -1, -1, -1, -1 },
+                        { -1, 4, 5, 6, -1, 0, 1, 7, -1, 3, 2, 8, -1, 11, 10, 9 } };
+                    permutation = permuteBoundary[orientationIndex];
+                    vtxLevel.gatherQuadRegularBoundaryPatchPoints(faceIndex, patchVerts, orientationIndex);
+                } else if (fvarPatchTag._boundaryCount == 2) {
+                    // Expand corner patch vertices and rotate to restore correct orientation.
+                    static int const permuteCorner[4][16] = {
+                        { -1, -1, -1, -1, -1, 0, 1, 4, -1, 3, 2, 5, -1, 8, 7, 6 },
+                        { -1, -1, -1, -1, 8, 3, 0, -1, 7, 2, 1, -1, 6, 5, 4, -1 },
+                        { 6, 7, 8, -1, 5, 2, 3, -1, 4, 1, 0, -1, -1, -1, -1, -1 },
+                        { -1, 4, 5, 6, -1, 1, 2, 7, -1, 0, 3, 8, -1, -1, -1, -1 } };
+                    permutation = permuteCorner[orientationIndex];
+                    vtxLevel.gatherQuadRegularCornerPatchPoints(faceIndex, patchVerts, orientationIndex, *fvc);
+                } else {
+                    assert(fvarPatchTag._boundaryCount >=0 && fvarPatchTag._boundaryCount <= 2);
+                }
             } else if (fvarPatchType == PatchDescriptor::QUADS) {
                 vtxLevel.gatherQuadLinearPatchPoints(faceIndex, patchVerts, orientationIndex, *fvc);
                 permutation = 0;

--- a/opensubdiv/osd/d3d11DrawRegistry.cpp
+++ b/opensubdiv/osd/d3d11DrawRegistry.cpp
@@ -66,8 +66,6 @@ D3D11DrawRegistryBase::_CreateDrawSourceConfig(
 
     switch (desc.GetType()) {
     case Far::PatchDescriptor::REGULAR:
-    case Far::PatchDescriptor::BOUNDARY:
-    case Far::PatchDescriptor::CORNER:
         sconfig->commonShader.AddDefine("OSD_PATCH_BSPLINE");
         sconfig->commonShader.AddDefine("OSD_PATCH_ENABLE_SINGLE_CREASE");
         sconfig->vertexShader.source = bsplineShaderSource;

--- a/opensubdiv/osd/glDrawRegistry.cpp
+++ b/opensubdiv/osd/glDrawRegistry.cpp
@@ -66,8 +66,6 @@ GLDrawRegistryBase::_CreateDrawSourceConfig(Far::PatchDescriptor const & desc)
 
     switch (desc.GetType()) {
     case Far::PatchDescriptor::REGULAR:
-    case Far::PatchDescriptor::BOUNDARY:
-    case Far::PatchDescriptor::CORNER:
         sconfig->commonShader.AddDefine("OSD_PATCH_BSPLINE");
         sconfig->commonShader.AddDefine("OSD_PATCH_ENABLE_SINGLE_CREASE");
         sconfig->vertexShader.source = bsplineShaderSource;


### PR DESCRIPTION
These are now redundant since all bspline patches are encoded in
the patch tables consistently using 16 point indices with boundary
and corner edges indicated in the boundary mask of the patch params.