### PR TITLE
Removed an unused local var from interpolate.cpp

### DIFF
--- a/opensubdiv/far/interpolate.cpp
+++ b/opensubdiv/far/interpolate.cpp
@@ -230,8 +230,6 @@ void Spline<BASIS>::GetPatchWeights(PatchParam::BitField bits,
     Spline<BASIS>::GetWeights(s, point ? sWeights : 0, derivS ? dsWeights : 0);
     Spline<BASIS>::GetWeights(t, point ? tWeights : 0, derivT ? dtWeights : 0);
 
-    int boundary = bits.GetBoundary();
-
     if (point) {
         // Compute the tensor product weight of the (s,t) basis function
         // corresponding to each control vertex:


### PR DESCRIPTION
Fixes a build warning from clang on OS X.