### PR TITLE
Copy past error for colorMap variable

### DIFF
--- a/examples/common/gl_framebuffer.cpp
+++ b/examples/common/gl_framebuffer.cpp
@@ -188,7 +188,7 @@ GLFrameBuffer::compileProgram(char const * src, char const * defines) {
     if (colorMap != -1)
         glUniform1i(colorMap, 0);  // GL_TEXTURE0
 
-    GLint colorMap = glGetUniformLocation(program, "normalMap");
+    GLint normalMap = glGetUniformLocation(program, "normalMap");
     if (normalMap != -1)
         glUniform1i(normalMap, 1);  // GL_TEXTURE1
 


### PR DESCRIPTION
Small copy-past error which redefines colorMap instead of declaring normalMap variable.