### PR TITLE
update glShareTopology example.

### DIFF
--- a/examples/glShareTopology/CMakeLists.txt
+++ b/examples/glShareTopology/CMakeLists.txt
@@ -57,6 +57,7 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 _add_glfw_executable(glShareTopology
     glShareTopology.cpp
+    sceneBase.cpp
     "${SHADER_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -42,8 +42,6 @@
 GLFWwindow* g_window=0;
 GLFWmonitor* g_primary=0;
 
-#include <osd/glDrawContext.h>
-#include <osd/glMesh.h>
 #include <far/error.h>
 #include <far/stencilTables.h>
 #include <far/ptexIndices.h>
@@ -85,10 +83,7 @@ GLFWmonitor* g_primary=0;
 
 
 #include <common/vtr_utils.h>
-#include <shapes/catmark_cube.h>
-#include <shapes/catmark_bishop.h>
-#include <shapes/catmark_pawn.h>
-#include <shapes/catmark_rook.h>
+#include "init_shapes.h"
 
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
@@ -105,302 +100,15 @@ static const char *shaderSource =
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <limits>
+
+#include "scene.h"
+
+SceneBase *g_scene = NULL;
 
 using namespace OpenSubdiv;
 
 // ---------------------------------------------------------------------------
-
-class InstancesBase {
-public:
-    virtual ~InstancesBase() {}
-
-    virtual void UpdateVertexBuffer(int instance, std::vector<float> const &src) = 0;
-    virtual void UpdateVaryingBuffer(int instance, std::vector<float> const &src) = 0;
-
-    virtual GLuint BindVertexBuffer() = 0;
-    virtual GLuint BindVaryingBuffer() = 0;
-
-    Osd::VertexBufferDescriptor const &GetVertexDesc() const {
-        return _vertexDesc;
-    }
-    Osd::VertexBufferDescriptor const &GetVaryingDesc() const {
-        return _varyingDesc;
-    }
-
-protected:
-    InstancesBase(Osd::VertexBufferDescriptor const &vertexDesc,
-                  Osd::VertexBufferDescriptor const &varyingDesc,
-                  int numVertices) :
-        _vertexDesc(vertexDesc),
-        _varyingDesc(varyingDesc),
-        _numVertices(numVertices) {
-    }
-
-    int getNumVertices() const { return _numVertices; }
-
-private:
-    Osd::VertexBufferDescriptor _vertexDesc;
-    Osd::VertexBufferDescriptor _varyingDesc;
-    int _numVertices;                // # of vertices of single instance
-};
-
-template <class VERTEX_BUFFER, class DEVICE_CONTEXT>
-class Instances : public InstancesBase {
-public:
-    Instances(int numInstances,
-              Osd::VertexBufferDescriptor const &vertexDesc,
-              Osd::VertexBufferDescriptor const &varyingDesc,
-              bool interleaved,
-              int numVertices,
-              DEVICE_CONTEXT *deviceContext) :
-        InstancesBase(vertexDesc, varyingDesc, numVertices),
-        _vertexBuffer(NULL), _varyingBuffer(NULL), _interleaved(interleaved),
-        _deviceContext(deviceContext) {
-
-        if (interleaved) {
-            assert(vertexDesc.stride == varyingDesc.stride);
-            _vertexBuffer = createVertexBuffer(
-                vertexDesc.stride, numInstances * numVertices);
-        } else {
-            if (vertexDesc.stride > 0) {
-                _vertexBuffer = createVertexBuffer(
-                    vertexDesc.stride, numInstances * numVertices);
-            }
-            if (varyingDesc.stride > 0) {
-                _varyingBuffer = createVertexBuffer(
-                    varyingDesc.stride, numInstances * numVertices);
-            }
-        }
-    }
-
-    virtual ~Instances() {
-        delete _vertexBuffer;
-        delete _varyingBuffer;
-    }
-
-    virtual void UpdateVertexBuffer(int instance, std::vector<float> const &src) {
-        updateVertexBuffer(_vertexBuffer, &src[0], instance * getNumVertices(),
-                           (int)src.size()/_vertexBuffer->GetNumElements());
-    }
-    virtual void UpdateVaryingBuffer(int instance, std::vector<float> const &src) {
-        updateVertexBuffer(_varyingBuffer, &src[0], instance * getNumVertices(),
-                           (int)src.size()/_varyingBuffer->GetNumElements());
-    }
-
-    virtual GLuint BindVertexBuffer() {
-        return _vertexBuffer->BindVBO();
-    }
-
-    virtual GLuint BindVaryingBuffer() {
-        return _varyingBuffer->BindVBO();
-    }
-
-    VERTEX_BUFFER *createVertexBuffer(int numElements, int numVertices) {
-        return VERTEX_BUFFER::Create(numElements, numVertices, _deviceContext);
-    }
-    void updateVertexBuffer(VERTEX_BUFFER *vertexBuffer,
-                            const float *src, int startVertex,
-                            int numVertices) {
-        vertexBuffer->UpdateData(src, startVertex, numVertices, _deviceContext);
-    }
-
-    VERTEX_BUFFER *GetVertexBuffer() const { return _vertexBuffer; }
-    VERTEX_BUFFER *GetVaryingBuffer() const { return _interleaved ? _vertexBuffer :_varyingBuffer; }
-
-private:
-    VERTEX_BUFFER *_vertexBuffer;
-    VERTEX_BUFFER *_varyingBuffer;
-    bool _interleaved;
-    DEVICE_CONTEXT *_deviceContext;
-};
-
-// ---------------------------------------------------------------------------
-
-class TopologyBase {
-public:
-    virtual ~TopologyBase() {
-        delete _drawContext;
-    }
-
-    virtual void Refine(InstancesBase *instance, int numInstances) = 0;
-
-    virtual InstancesBase *CreateInstances(
-        int numInstances,
-        Osd::VertexBufferDescriptor const &vertexDesc,
-        Osd::VertexBufferDescriptor const &varyingDesc,
-        bool interleaved) = 0;
-
-    virtual void UpdateVertexTexture(InstancesBase *instances) = 0;
-
-    virtual void Synchronize() = 0;
-
-    Osd::GLDrawContext *GetDrawContext() const {
-        return _drawContext;
-    }
-
-    void SetRestPosition(std::vector<float> const &restPosition) {
-        _restPosition = restPosition;
-    }
-
-    std::vector<float> const &GetRestPosition() const {
-        return _restPosition;
-    }
-
-    int GetNumVertices() const {  // total (control + refined)
-        return _numVertices;
-    }
-    int GetNumControlVertices() const {
-        return _numControlVertices;
-    }
-
-protected:
-
-    TopologyBase(Far::PatchTables const * patchTables) {
-        _drawContext = Osd::GLDrawContext::Create(patchTables);
-    }
-
-    int _numVertices;
-    int _numControlVertices;
-
-private:
-    Osd::GLDrawContext *_drawContext;
-    std::vector<float> _restPosition;
-};
-
-template <class EVALUATOR,
-          class VERTEX_BUFFER,
-          class STENCIL_TABLES,
-          class DEVICE_CONTEXT=void>
-class Topology : public TopologyBase {
-public:
-    typedef EVALUATOR Evaluator;
-    typedef STENCIL_TABLES StencilTables;
-    typedef DEVICE_CONTEXT DeviceContext;
-    typedef Osd::EvaluatorCacheT<Evaluator> EvaluatorCache;
-
-    Topology(Far::PatchTables const * patchTables,
-             Far::StencilTables const * vertexStencils, //XXX: takes ownership
-             Far::StencilTables const * varyingStencils,
-             int numControlVertices,
-             EvaluatorCache * evaluatorCache = NULL,
-             DeviceContext * deviceContext = NULL)
-        : TopologyBase(patchTables),
-          _evaluatorCache(evaluatorCache),
-          _deviceContext(deviceContext) {
-
-        _numControlVertices = numControlVertices;
-        _numVertices = numControlVertices + vertexStencils->GetNumStencils();
-
-        _vertexStencils = Osd::convertToCompatibleStencilTables<StencilTables>(
-            vertexStencils, deviceContext);
-        _varyingStencils = Osd::convertToCompatibleStencilTables<StencilTables>(
-            varyingStencils, deviceContext);
-
-    }
-
-    ~Topology() {
-        delete _vertexStencils;
-        delete _varyingStencils;
-    }
-
-    void Refine(InstancesBase *instance, int numInstances) {
-
-        Osd::VertexBufferDescriptor const &globalVertexDesc =
-            instance->GetVertexDesc();
-        Osd::VertexBufferDescriptor const &globalVaryingDesc =
-            instance->GetVaryingDesc();
-
-        Instances<VERTEX_BUFFER, DEVICE_CONTEXT> *typedInstance =
-            static_cast<Instances<VERTEX_BUFFER, DEVICE_CONTEXT> *>(instance);
-
-        for (int i = 0; i < numInstances; ++i) {
-
-            Osd::VertexBufferDescriptor vertexSrcDesc(
-                globalVertexDesc.offset + _numVertices*i*globalVertexDesc.stride,
-                globalVertexDesc.length,
-                globalVertexDesc.stride);
-
-            Osd::VertexBufferDescriptor vertexDstDesc(
-                globalVertexDesc.offset + (_numVertices*i + _numControlVertices)*globalVertexDesc.stride,
-                globalVertexDesc.length,
-                globalVertexDesc.stride);
-
-            // vertex
-            Evaluator const *evalInstance = Osd::GetEvaluator<Evaluator>(
-                _evaluatorCache, vertexSrcDesc, vertexDstDesc, _deviceContext);
-
-            Evaluator::EvalStencils(typedInstance->GetVertexBuffer(), vertexSrcDesc,
-                                    typedInstance->GetVertexBuffer(), vertexDstDesc,
-                                    _vertexStencils,
-                                    evalInstance,
-                                    _deviceContext);
-
-            // varying
-            if (_varyingStencils) {
-                Osd::VertexBufferDescriptor varyingSrcDesc(
-                    globalVaryingDesc.offset + _numVertices*i*globalVaryingDesc.stride,
-                    globalVaryingDesc.length,
-                    globalVaryingDesc.stride);
-
-                Osd::VertexBufferDescriptor varyingDstDesc(
-                    globalVaryingDesc.offset + (_numVertices*i + _numControlVertices)*globalVaryingDesc.stride,
-                    globalVaryingDesc.length,
-                    globalVaryingDesc.stride);
-
-                evalInstance = Osd::GetEvaluator<Evaluator>(
-                    _evaluatorCache, varyingSrcDesc, varyingDstDesc, _deviceContext);
-
-                if (typedInstance->GetVaryingBuffer()) {
-                    // non interleaved
-                    Evaluator::EvalStencils(
-                        typedInstance->GetVaryingBuffer(), varyingSrcDesc,
-                        typedInstance->GetVaryingBuffer(), varyingDstDesc,
-                        _varyingStencils,
-                        evalInstance,
-                        _deviceContext);
-                } else {
-                    // interleaved
-                    Evaluator::EvalStencils(
-                        typedInstance->GetVertexBuffer(), varyingSrcDesc,
-                        typedInstance->GetVertexBuffer(), varyingDstDesc,
-                        _varyingStencils,
-                        evalInstance,
-                        _deviceContext);
-                }
-            }
-        }
-    }
-
-    virtual InstancesBase *CreateInstances(
-        int numInstances,
-        Osd::VertexBufferDescriptor const &vertexDesc,
-        Osd::VertexBufferDescriptor const &varyingDesc,
-        bool interleaved) {
-
-        return new Instances<VERTEX_BUFFER, DEVICE_CONTEXT>(
-            numInstances, vertexDesc, varyingDesc,
-            interleaved, _numVertices, _deviceContext);
-    }
-
-    virtual void Synchronize() {
-        Evaluator::Synchronize(_deviceContext);
-    }
-
-    virtual void UpdateVertexTexture(InstancesBase *instances) {
-        Instances<VERTEX_BUFFER, DEVICE_CONTEXT> *typedInstance =
-            static_cast<Instances<VERTEX_BUFFER, DEVICE_CONTEXT> *>(instances);
-        GetDrawContext()->UpdateVertexTexture(typedInstance->GetVertexBuffer());
-    }
-
-private:
-    StencilTables const *_vertexStencils;
-    StencilTables const *_varyingStencils;
-    EvaluatorCache * _evaluatorCache;
-    DeviceContext *_deviceContext;
-};
-
-TopologyBase *g_topology = NULL;
-InstancesBase *g_instances = NULL;
 
 enum KernelType { kCPU = 0,
                   kOPENMP = 1,
@@ -416,14 +124,22 @@ enum DisplayStyle { kWire = 0,
                     kVarying,
                     kVaryingInterleaved };
 
-enum HudCheckBox { kHUD_CB_FREEZE };
+enum HudCheckBox { kHUD_CB_ADAPTIVE,
+                   kHUD_CB_MDI,
+                   kHUD_CB_FREEZE,
+                   kHUD_CB_VIEW_LOD,
+                   kHUD_CB_PATCH_CULL };
 
 // GUI variables
 int   g_displayStyle = kShaded,
-      g_adaptive = 0,
+      g_MDI = 0,
       g_mbutton[3] = {0, 0, 0},
       g_freeze = 0,
+      g_screenSpaceTess = 1,
+      g_patchCull = 1,
       g_running = 1;
+
+SceneBase::Options g_options;
 
 float g_rotate[2] = {0, 0},
       g_dolly = 5,
@@ -444,12 +160,14 @@ float g_cpuTime = 0;
 float g_gpuTime = 0;
 Stopwatch g_fpsTimer;
 
-int g_level = 2;
+int g_level = 1;
 int g_tessLevel = 1;
 int g_tessLevelMin = 1;
-int g_numInstances = 25;
 int g_frame = 0;
 int g_kernel = kCPU;
+int g_numObjects = 64;
+size_t g_vboSize = 0;
+size_t g_iboSize = 0;
 
 GLuint g_transformUB = 0,
        g_transformBinding = 0,
@@ -467,16 +185,6 @@ struct Transform {
 GLuint g_queries[2] = {0, 0};
 GLuint g_vao = 0;
 
-static void
-checkGLErrors(std::string const & where = "") {
-    GLuint err;
-    while ((err = glGetError()) != GL_NO_ERROR) {
-        std::cerr << "GL error: "
-                  << (where.empty() ? "" : where + " ")
-                  << err << "\n";
-    }
-}
-
 //------------------------------------------------------------------------------
 struct SimpleShape {
     std::string  name;
@@ -492,17 +200,19 @@ struct SimpleShape {
 static void
 updateGeom() {
 
-    std::vector<float> const &restPosition = g_topology->GetRestPosition();
+    int numObjects = g_scene->GetNumObjects();
+    int column = (int)ceil(sqrt((float)numObjects));
 
-    int nverts = (int)restPosition.size()/3;
-    int numVertexElements = (g_displayStyle == kVaryingInterleaved ? 7 : 3);
-    int numVaryingElements = (g_displayStyle == kVarying ? 4 : 0);
+    for (int i = 0; i < numObjects; ++i) {
+        std::vector<float> const &restPosition = g_scene->GetRestPosition(i);
 
-    std::vector<float> vertex(numVertexElements * nverts);
-    std::vector<float> varying(numVaryingElements * nverts);
+        int nverts = (int)restPosition.size()/3;
+        int numVertexElements = (g_displayStyle == kVaryingInterleaved ? 7 : 3);
+        int numVaryingElements = (g_displayStyle == kVarying ? 4 : 0);
 
-    int column = (int)ceil(sqrt((float)g_numInstances));
-    for (int i = 0; i < g_numInstances; ++i) {
+        std::vector<float> vertex(numVertexElements * nverts);
+        std::vector<float> varying(numVaryingElements * nverts);
+
         float *d = &vertex[0];
         const float *p = &restPosition[0];
 
@@ -519,7 +229,9 @@ updateGeom() {
                 *d++ = 1.0;
             }
         }
-        g_instances->UpdateVertexBuffer(i, vertex);
+
+        int vertsOffset = g_scene->GetVertsOffset(i);
+        g_scene->UpdateVertexBuffer(vertsOffset, vertex);
 
         if (g_displayStyle == kVarying) {
             float *d = &varying[0];
@@ -529,7 +241,7 @@ updateGeom() {
                 *d++ = 1;
                 *d++ = 1.0;
             }
-            g_instances->UpdateVaryingBuffer(i, varying);
+            g_scene->UpdateVaryingBuffer(vertsOffset, varying);
         }
     }
 }
@@ -540,13 +252,16 @@ refine() {
     Stopwatch s;
     s.Start();
 
-    g_topology->Refine(g_instances, g_numInstances);
+    int numObjects = g_scene->GetNumObjects();
+    for (int i = 0; i < numObjects; ++i) {
+        g_scene->Refine(i);
+    }
 
     s.Stop();
     g_cpuTime = float(s.GetElapsed() * 1000.0f);
     s.Start();
 
-    g_topology->Synchronize();
+    g_scene->Synchronize();
 
     s.Stop();
     g_gpuTime = float(s.GetElapsed() * 1000.0f);
@@ -556,222 +271,6 @@ refine() {
 }
 
 //------------------------------------------------------------------------------
-static TopologyBase *
-createOsdMesh( const std::string &shapeStr, int level, Scheme scheme=kCatmark ) {
-
-    checkGLErrors("create osd enter");
-
-    Shape * shape = Shape::parseObj(shapeStr.c_str(), scheme);
-
-    std::vector<float> restPosition(shape->verts);
-
-    Far::TopologyRefiner * refiner = 0;
-    {
-        Sdc::SchemeType type = GetSdcType(*shape);
-        Sdc::Options options = GetSdcOptions(*shape);
-
-        refiner = Far::TopologyRefinerFactory<Shape>::Create(*shape,
-                    Far::TopologyRefinerFactory<Shape>::Options(type, options));
-
-        assert(refiner);
-    }
-
-    // material assignment
-    std::vector<int> idsOnPtexFaces;
-    {
-        int numFaces = refiner->GetNumFaces(0);
-
-        // first, assign material ID to each coarse face
-        std::vector<int> idsOnCoarseFaces;
-        for (int i = 0; i < numFaces; ++i) {
-            int materialID = i%6;
-            idsOnCoarseFaces.push_back(materialID);
-        }
-
-        // create ptex index to coarse face index mapping
-        Far::PtexIndices ptexIndices(*refiner);
-        int numPtexFaces = ptexIndices.GetNumFaces();
-
-        // XXX: duped logic to simpleHbr
-        std::vector<int> ptexIndexToFaceMapping(numPtexFaces);
-        int ptexIndex = 0;
-        for (int face=0; face < numFaces; ++face) {
-
-            ptexIndexToFaceMapping[ptexIndex++] = face;
-            Far::ConstIndexArray fverts = refiner->GetFaceVertices(0, face);
-            if ( (scheme==kCatmark or scheme==kBilinear) and fverts.size() != 4 ) {
-                for (int j = 0; j < (fverts.size()-1); ++j) {
-                    ptexIndexToFaceMapping[ptexIndex++] = face;
-                }
-            }
-        }
-
-        // convert ID array from coarse face index space to ptex index space
-        for (int i = 0; i < numPtexFaces; ++i) {
-            idsOnPtexFaces.push_back(idsOnCoarseFaces[ptexIndexToFaceMapping[i]]);
-        }
-    }
-
-    // Adaptive refinement currently supported only for catmull-clark scheme
-    bool doAdaptive = (g_adaptive!=0 and scheme==kCatmark);
-
-    if (doAdaptive) {
-        Far::TopologyRefiner::AdaptiveOptions options(level);
-        refiner->RefineAdaptive(options);
-    } else {
-        Far::TopologyRefiner::UniformOptions options(level);
-        options.fullTopologyInLastLevel = true;
-        refiner->RefineUniform(options);
-    }
-
-    Far::StencilTables const * vertexStencils=0, * varyingStencils=0;
-    {
-        Far::StencilTablesFactory::Options options;
-        options.generateOffsets = true;
-        options.generateIntermediateLevels = doAdaptive ? true : false;
-
-        vertexStencils = Far::StencilTablesFactory::Create(*refiner, options);
-
-        if (g_displayStyle==kVarying or g_displayStyle==kVaryingInterleaved) {
-            varyingStencils = Far::StencilTablesFactory::Create(*refiner, options);
-        }
-
-        assert(vertexStencils);
-    }
-
-    Far::PatchTables const * patchTables = NULL;
-    {
-        Far::PatchTablesFactory::Options poptions(level);
-        patchTables = Far::PatchTablesFactory::Create(*refiner, poptions);
-    }
-
-    // append gregory vertices into stencils
-    {
-        if (Far::StencilTables const *vertexStencilsWithEndCap =
-            Far::StencilTablesFactory::AppendEndCapStencilTables(
-                *refiner,
-                vertexStencils,
-                patchTables->GetEndCapVertexStencilTables())) {
-            delete vertexStencils;
-            vertexStencils = vertexStencilsWithEndCap;
-        }
-        if (varyingStencils) {
-            if (Far::StencilTables const *varyingStencilsWithEndCap =
-                Far::StencilTablesFactory::AppendEndCapStencilTables(
-                    *refiner,
-                    varyingStencils,
-                    patchTables->GetEndCapVaryingStencilTables())) {
-                delete varyingStencils;
-                varyingStencils = varyingStencilsWithEndCap;
-            }
-        }
-    }
-
-    int numControlVertices = refiner->GetNumVertices(0);
-
-    // create partitioned patcharray
-    TopologyBase *topology = NULL;
-
-    if (g_kernel == kCPU) {
-        topology = new Topology<Osd::CpuEvaluator,
-                                Osd::CpuGLVertexBuffer,
-                                Far::StencilTables>(
-                                    patchTables,
-                                    vertexStencils, varyingStencils,
-                                    numControlVertices);
-#ifdef OPENSUBDIV_HAS_OPENMP
-    } else if (g_kernel == kOPENMP) {
-        topology = new Topology<Osd::OmpEvaluator,
-                                Osd::CpuGLVertexBuffer,
-                                Far::StencilTables>(
-                                    patchTables,
-                                    vertexStencils, varyingStencils,
-                                    numControlVertices);
-#endif
-#ifdef OPENSUBDIV_HAS_TBB
-    } else if (g_kernel == kTBB) {
-        topology = new Topology<Osd::TbbEvaluator,
-                                Osd::CpuGLVertexBuffer,
-                                Far::StencilTables>(
-                                    patchTables,
-                                    vertexStencils, varyingStencils,
-                                    numControlVertices);
-#endif
-#ifdef OPENSUBDIV_HAS_CUDA
-    } else if (g_kernel == kCUDA) {
-        topology = new Topology<Osd::CudaEvaluator,
-                                Osd::CudaGLVertexBuffer,
-                                Osd::CudaStencilTables>(
-                                     patchTables,
-                                     vertexStencils, varyingStencils,
-                                     numControlVertices);
-#endif
-#ifdef OPENSUBDIV_HAS_OPENCL
-    } else if (g_kernel == kCL) {
-        static Osd::EvaluatorCacheT<Osd::CLEvaluator> clEvaluatorCache;
-        topology = new Topology<Osd::CLEvaluator,
-                                Osd::CLGLVertexBuffer,
-                                Osd::CLStencilTables,
-                                CLDeviceContext>(
-                                    patchTables,
-                                    vertexStencils, varyingStencils,
-                                    numControlVertices,
-                                    &clEvaluatorCache,
-                                    &g_clDeviceContext);
-#endif
-#ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
-    } else if (g_kernel == kGLSL) {
-        static Osd::EvaluatorCacheT<Osd::GLXFBEvaluator> glXFBEvaluatorCache;
-        topology = new Topology<Osd::GLXFBEvaluator,
-                                Osd::GLVertexBuffer,
-                                Osd::GLStencilTablesTBO>(
-                                    patchTables,
-                                    vertexStencils, varyingStencils,
-                                    numControlVertices);
-#endif
-#ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    } else if (g_kernel == kGLSLCompute) {
-        static Osd::EvaluatorCacheT<Osd::GLComputeEvaluator> glComputeEvaluatorCache;
-        topology = new Topology<Osd::GLComputeEvaluator,
-                                Osd::GLVertexBuffer,
-                                Osd::GLStencilTablesSSBO>(
-                                    patchTables,
-                                    vertexStencils, varyingStencils,
-                                    numControlVertices);
-#endif
-    } else {
-    }
-
-    delete refiner;
-    // XXX: Weired API. think again..
-///    delete vertexStencils;
-///    delete varyingStencils;
-    delete patchTables;
-
-    // centering rest position
-    float min[3] = { FLT_MAX,  FLT_MAX,  FLT_MAX};
-    float max[3] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
-    float center[3];
-    for (size_t i=0; i < restPosition.size()/3; ++i) {
-        for (int j=0; j<3; ++j) {
-            float v = restPosition[i*3+j];
-            min[j] = std::min(min[j], v);
-            max[j] = std::max(max[j], v);
-        }
-    }
-    for (int j=0; j<3; ++j) center[j] = (min[j] + max[j]) * 0.5f;
-    for (size_t i=0; i < restPosition.size()/3; ++i) {
-        restPosition[i*3+0] -= center[0];
-        restPosition[i*3+1] -= center[1];
-        restPosition[i*3+2] -= min[2];
-    }
-
-    // save rest position
-    topology->SetRestPosition(restPosition);
-
-    return topology;
-}
-
 //------------------------------------------------------------------------------
 static void
 fitFrame() {
@@ -783,12 +282,18 @@ fitFrame() {
 //------------------------------------------------------------------------------
 
 union Effect {
-    Effect(int displayStyle_) : value(0) {
+    Effect(int displayStyle_,
+           int screenSpaceTess_,
+           int patchCull_) : value(0) {
         displayStyle = displayStyle_;
+        screenSpaceTess = screenSpaceTess_;
+        patchCull = patchCull_;
     }
 
     struct {
-        unsigned int displayStyle:3;
+        unsigned int displayStyle: 3;
+        unsigned int screenSpaceTess: 1;
+        unsigned int patchCull: 1;
     };
     int value;
 
@@ -800,7 +305,7 @@ union Effect {
 static Effect
 GetEffect() {
 
-    return Effect(g_displayStyle);
+    return Effect(g_displayStyle, g_screenSpaceTess, g_patchCull);
 }
 
 struct EffectDesc {
@@ -843,6 +348,13 @@ public:
         // common defines
         std::stringstream ss;
 
+        if (effectDesc.effect.screenSpaceTess) {
+            ss << "#define OSD_ENABLE_SCREENSPACE_TESSELLATION\n";
+        }
+        if (effectDesc.effect.patchCull) {
+            ss << "#define OSD_ENABLE_PATCH_CULL\n";
+        }
+
         // display styles
         switch (effectDesc.effect.displayStyle) {
         case kWire:
@@ -862,6 +374,18 @@ public:
             ss << "#define VARYING_COLOR\n";
             ss << "#define GEOMETRY_OUT_FILL\n";
             break;
+        }
+        if (effectDesc.desc.IsAdaptive()) {
+            ss << "#define SMOOTH_NORMALS\n";
+        }
+
+        // need for patch color-coding : we need these defines in the fragment shader
+        if (type == Far::PatchDescriptor::GREGORY) {
+            ss << "#define OSD_PATCH_GREGORY\n";
+        } else if (type == Far::PatchDescriptor::GREGORY_BOUNDARY) {
+            ss << "#define OSD_PATCH_GREGORY_BOUNDARY\n";
+        } else if (type == Far::PatchDescriptor::GREGORY_BASIS) {
+            ss << "#define OSD_PATCH_GREGORY_BASIS\n";
         }
 
         // for legacy gregory
@@ -884,6 +408,7 @@ public:
         if (effectDesc.desc.IsAdaptive()) {
             // tess control shader
             ss << common
+               << "#define OSD_PATCH_TESS_CONTROL_BSPLINE_SHADER\n"
                << shaderSource
                << Osd::GLSLPatchShaderSource::GetTessControlShaderSource(type);
             config->CompileAndAttachShader(GL_TESS_CONTROL_SHADER, ss.str());
@@ -939,16 +464,16 @@ public:
 
         // assign texture locations
         GLint loc;
-        if ((loc = glGetUniformLocation(program, "OsdVertexBuffer")) != -1) {
+        if ((loc = glGetUniformLocation(program, "OsdPatchParamBuffer")) != -1) {
             glProgramUniform1i(program, loc, 0); // GL_TEXTURE0
         }
-        if ((loc = glGetUniformLocation(program, "OsdValenceBuffer")) != -1) {
+        if ((loc = glGetUniformLocation(program, "OsdVertexBuffer")) != -1) {
             glProgramUniform1i(program, loc, 1); // GL_TEXTURE1
         }
-        if ((loc = glGetUniformLocation(program, "OsdQuadOffsetBuffer")) != -1) {
+        if ((loc = glGetUniformLocation(program, "OsdValenceBuffer")) != -1) {
             glProgramUniform1i(program, loc, 2); // GL_TEXTURE2
         }
-        if ((loc = glGetUniformLocation(program, "OsdPatchParamBuffer")) != -1) {
+        if ((loc = glGetUniformLocation(program, "OsdQuadOffsetBuffer")) != -1) {
             glProgramUniform1i(program, loc, 3); // GL_TEXTURE3
         }
         if ((loc = glGetUniformLocation(program, "OsdFVarDataBuffer")) != -1) {
@@ -1033,56 +558,22 @@ updateUniformBlocks() {
 
 static void
 bindTextures() {
-    Osd::GLDrawContext *drawContext = g_topology->GetDrawContext();
-
-    if (drawContext->GetVertexTextureBuffer()) {
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_BUFFER,
-            drawContext->GetVertexTextureBuffer());
-    }
-    if (drawContext->GetVertexValenceTextureBuffer()) {
-        glActiveTexture(GL_TEXTURE1);
-        glBindTexture(GL_TEXTURE_BUFFER,
-            drawContext->GetVertexValenceTextureBuffer());
-    }
-    if (drawContext->GetQuadOffsetsTextureBuffer()) {
-        glActiveTexture(GL_TEXTURE2);
-        glBindTexture(GL_TEXTURE_BUFFER,
-            drawContext->GetQuadOffsetsTextureBuffer());
-    }
-    if (drawContext->GetPatchParamTextureBuffer()) {
-        glActiveTexture(GL_TEXTURE3);
-        glBindTexture(GL_TEXTURE_BUFFER,
-            drawContext->GetPatchParamTextureBuffer());
-    }
-    if (drawContext->GetFvarDataTextureBuffer()) {
-        glActiveTexture(GL_TEXTURE4);
-        glBindTexture(GL_TEXTURE_BUFFER,
-            drawContext->GetFvarDataTextureBuffer());
-    }
 
     glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_BUFFER, g_scene->GetPatchParamTexture());
 
+    // XXX: LegacyGregory hasn't been supported.
+    glActiveTexture(GL_TEXTURE0);
 }
 
 static GLenum
 bindProgram(Effect effect,
-            Osd::DrawContext::PatchArray const & patch,
-            GLfloat const *color,
-            int baseVertex) {
+            Far::PatchDescriptor desc,
+            int basePrimitiveID) {
 
-    EffectDesc effectDesc(patch.GetDescriptor(), effect);
+    EffectDesc effectDesc(desc, effect);
 
     typedef OpenSubdiv::Far::PatchDescriptor Descriptor;
-    if (patch.GetDescriptor().GetType() == Descriptor::GREGORY or
-        patch.GetDescriptor().GetType() == Descriptor::GREGORY_BOUNDARY) {
-        // only legacy gregory needs maxValence and numElements
-        int maxValence = g_topology->GetDrawContext()->GetMaxValence();
-        int numElements = (g_displayStyle == kVaryingInterleaved ? 7 : 3);
-
-        effectDesc.maxValence = maxValence;
-        effectDesc.numElements = numElements;
-    }
 
     // lookup shader cache (compile the shader if needed)
     GLDrawConfig *config = g_shaderCache.GetDrawConfig(effectDesc);
@@ -1096,19 +587,7 @@ bindProgram(Effect effect,
     GLint uniformPrimitiveIdBase =
         glGetUniformLocation(program, "PrimitiveIdBase");
     if (uniformPrimitiveIdBase >=0)
-        glUniform1i(uniformPrimitiveIdBase, patch.GetPatchIndex());
-    GLint uniformColor = glGetUniformLocation(program, "diffuseColor");
-    if (uniformColor >= 0)
-        glUniform4f(uniformColor, color[0], color[1], color[2], 1);
-
-    // used by legacy gregory
-    GLint uniformBaseVertex = glGetUniformLocation(program, "BaseVertex");
-    if (uniformBaseVertex >= 0)
-        glUniform1i(uniformBaseVertex, baseVertex);
-    GLint uniformGregoryQuadOffsetBase =
-        glGetUniformLocation(program, "GregoryQuadOffsetBase");
-    if (uniformGregoryQuadOffsetBase >= 0)
-        glUniform1i(uniformGregoryQuadOffsetBase, patch.GetQuadOffsetIndex());
+        glUniform1i(uniformPrimitiveIdBase, basePrimitiveID);
 
     // return primtype
     GLenum primType;
@@ -1132,32 +611,17 @@ bindProgram(Effect effect,
     return primType;
 }
 
+
 //------------------------------------------------------------------------------
-static int
-drawPatches(Osd::DrawContext::PatchArrayVector const &patches,
-            int instanceIndex,
-            GLfloat const *color) {
 
-    int numDrawCalls = 0;
-    for (int i=0; i<(int)patches.size(); ++i) {
-
-        Osd::DrawContext::PatchArray const & patch = patches[i];
-
-        int baseVertex = g_topology->GetNumVertices() * instanceIndex;
-        GLvoid *indices = (void *)(patch.GetVertIndex() * sizeof(unsigned int));
-        GLenum primType = bindProgram(GetEffect(), patch, color, baseVertex);
-
-        glDrawElementsBaseVertex(primType,
-                                 patch.GetNumIndices(),
-                                 GL_UNSIGNED_INT,
-                                 indices,
-                                 baseVertex);
-        ++numDrawCalls;
-    }
-    return numDrawCalls;
+template <typename T>
+std::string formatWithCommas(T value) {
+    std::stringstream ss;
+    ss.imbue(std::locale(""));
+    ss << std::fixed << value;
+    return ss.str();
 }
 
-//------------------------------------------------------------------------------
 static void
 display() {
 
@@ -1188,28 +652,27 @@ display() {
     glEnable(GL_DEPTH_TEST);
 
     // make sure that the vertex buffer is interoped back as a GL resources.
-    g_instances->BindVertexBuffer();
+    g_scene->BindVertexBuffer();
 
     glBindVertexArray(g_vao);
 
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER,
-                 g_topology->GetDrawContext()->GetPatchIndexBuffer());
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, g_scene->GetIndexBuffer());
 
     if (g_displayStyle == kVarying) {
 
         glEnableVertexAttribArray(0);
-        glBindBuffer(GL_ARRAY_BUFFER, g_instances->BindVertexBuffer());
+        glBindBuffer(GL_ARRAY_BUFFER, g_scene->BindVertexBuffer());
         glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof (GLfloat) * 3, 0);
 
         glEnableVertexAttribArray(1);
-        glBindBuffer(GL_ARRAY_BUFFER, g_instances->BindVaryingBuffer());
+        glBindBuffer(GL_ARRAY_BUFFER, g_scene->BindVaryingBuffer());
         glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof (GLfloat) * 4, 0);
 
     } else if (g_displayStyle == kVaryingInterleaved) {
 
         glEnableVertexAttribArray(0);
         glEnableVertexAttribArray(1);
-        glBindBuffer(GL_ARRAY_BUFFER, g_instances->BindVertexBuffer());
+        glBindBuffer(GL_ARRAY_BUFFER, g_scene->BindVertexBuffer());
         glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof (GLfloat) * 7, 0);
         glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof (GLfloat) * 7,
                               (void*)(sizeof(GLfloat)*3));
@@ -1217,17 +680,14 @@ display() {
     } else {
 
         glEnableVertexAttribArray(0);
-        glBindBuffer(GL_ARRAY_BUFFER, g_instances->BindVertexBuffer());
+        glBindBuffer(GL_ARRAY_BUFFER, g_scene->BindVertexBuffer());
         glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof (GLfloat) * 3, 0);
         glDisableVertexAttribArray(1);
     }
 
-
     // update vertex buffer to texture for gregory patch drawing.
-    g_topology->UpdateVertexTexture(g_instances);
+    //    g_topology->UpdateVertexTexture(g_vbo);
 
-    Osd::DrawContext::PatchArrayVector const & patches =
-        g_topology->GetDrawContext()->GetPatchArrays();
     int numDrawCalls = 0;
     // primitive counting
     glBeginQuery(GL_PRIMITIVES_GENERATED, g_queries[0]);
@@ -1238,10 +698,43 @@ display() {
     updateUniformBlocks();
     bindTextures();
 
-    // draw instances with same topology
-    for (int i = 0; i < g_numInstances; ++i) {
-        GLfloat color[3] = {i/(float)g_numInstances, 0.5, 0.5};
-        numDrawCalls += drawPatches(patches, i, color);
+    if (g_MDI && glMultiDrawElementsIndirect) {
+        SceneBase::BatchVector const &batches = g_scene->GetBatches();
+        for (int i = 0; i < (int)batches.size(); ++i) {
+            glBindBuffer(GL_DRAW_INDIRECT_BUFFER, batches[i].dispatchBuffer);
+            GLenum primType = bindProgram(GetEffect(),
+                                          batches[i].desc,
+                                          /*primitiveIDBase=*/0);
+            glMultiDrawElementsIndirect(primType, GL_UNSIGNED_INT, 0,
+                                        batches[i].count,
+                                        batches[i].stride);
+            // XXX: currently MDI path is broken because of the bad plumbing
+            // of PrimitiveIdBase.
+            ++numDrawCalls;
+        }
+        glBindBuffer(GL_DRAW_INDIRECT_BUFFER, 0);
+    } else {
+        int numObjects = g_scene->GetNumObjects();
+        for (int i = 0; i < numObjects; ++i) {
+            SceneBase::PatchArrayVector const &patchArrays = g_scene->GetPatchArrays(i);
+            for (int j = 0; j < (int)patchArrays.size(); ++j) {
+                SceneBase::PatchArray const &patchArray = patchArrays[j];
+
+                int nPatch = patchArray.numPatches;
+                int baseVertex = g_scene->GetVertsOffset(i);
+                GLvoid *indices = (void *)(patchArray.indexOffset * sizeof(int));
+                GLenum primType = bindProgram(GetEffect(),
+                                              patchArray.desc,
+                                              patchArray.primitiveIDOffset);
+                glDrawElementsBaseVertex(
+                    primType,
+                    nPatch * patchArray.desc.GetNumControlVertices(),
+                    GL_UNSIGNED_INT,
+                    indices,
+                    baseVertex);
+                ++numDrawCalls;
+            }
+        }
     }
 
     glEndQuery(GL_PRIMITIVES_GENERATED);
@@ -1271,8 +764,15 @@ display() {
         double fps = 1.0/g_fpsTimer.GetElapsed();
         g_fpsTimer.Start();
 
+        g_hud.DrawString(230, -60, "Vertex + Varying Bufsize   : %s",
+                         formatWithCommas(g_vboSize).c_str());
+        g_hud.DrawString(230, -40, "Index + PatchParam Bufsize : %s",
+                         formatWithCommas(g_iboSize).c_str());
+        g_hud.DrawString(230, -20, "Stencil table size         : %s",
+                         formatWithCommas(g_scene->GetStencilTableSize()).c_str());
+
         g_hud.DrawString(10, -180, "Tess level  : %d", g_tessLevel);
-        g_hud.DrawString(10, -160, "Primitives  : %d", numPrimsGenerated);
+        g_hud.DrawString(10, -160, "Primitives  : %s", formatWithCommas(numPrimsGenerated).c_str());
         g_hud.DrawString(10, -140, "Draw calls  : %d", numDrawCalls);
         g_hud.DrawString(10, -100, "GPU Compute : %.3f ms", g_gpuTime);
         g_hud.DrawString(10, -80,  "CPU Compute : %.3f ms", g_cpuTime);
@@ -1282,8 +782,6 @@ display() {
 
         g_hud.Flush();
     }
-
-    glFinish();
 
     //checkGLErrors("display leave");
 }
@@ -1331,10 +829,8 @@ uninitGL() {
     glDeleteQueries(2, g_queries);
     glDeleteVertexArrays(1, &g_vao);
 
-    if (g_instances)
-        delete g_instances;
-    if (g_topology)
-        delete g_topology;
+    delete g_scene;
+    g_scene = NULL;
 }
 
 //------------------------------------------------------------------------------
@@ -1358,50 +854,102 @@ void windowClose(GLFWwindow*) {
 }
 
 static void
-rebuildInstances() {
+rebuildObjects() {
 
-    delete g_instances;
+    // create Objects
+
+    int numVerts = g_scene->AddObjects(g_numObjects);
+
+    Osd::VertexBufferDescriptor vertexDesc, varyingDesc;
+    bool interleaved = true;
+
     if (g_displayStyle == kVaryingInterleaved) {
-        g_instances = g_topology->CreateInstances(
-            g_numInstances,
-            Osd::VertexBufferDescriptor(0, 3, 7),
-            Osd::VertexBufferDescriptor(3, 4, 7),
-            true);
+        vertexDesc = Osd::VertexBufferDescriptor(0, 3, 7);
+        varyingDesc = Osd::VertexBufferDescriptor(3, 4, 7);
+        interleaved = true;
     } else if (g_displayStyle == kVarying) {
-        g_instances = g_topology->CreateInstances(
-            g_numInstances,
-            Osd::VertexBufferDescriptor(0, 3, 3),
-            Osd::VertexBufferDescriptor(0, 4, 4),
-            false);
+        vertexDesc = Osd::VertexBufferDescriptor(0, 3, 3);
+        varyingDesc = Osd::VertexBufferDescriptor(0, 4, 4);
+        interleaved = false;
     } else {
-        g_instances = g_topology->CreateInstances(
-            g_numInstances,
-            Osd::VertexBufferDescriptor(0, 3, 3),
-            Osd::VertexBufferDescriptor(0, 0, 0),
-            false);
+        vertexDesc = Osd::VertexBufferDescriptor(0, 3, 3);
+        varyingDesc = Osd::VertexBufferDescriptor(0, 0, 0);
+        interleaved = false;
     }
+
+    g_vboSize = g_scene->AllocateVBO(numVerts, vertexDesc, varyingDesc, interleaved);
 
     updateGeom();
     refine();
 }
 
 static void
-rebuildOsdMesh() {
+rebuildTopology() {
 
-    static SimpleShape g_modelCube =
-        SimpleShape(catmark_cube, "catmark_cube", kCatmark);
-    //static SimpleShape g_modelBishop =
-    // SimpleShape(catmark_bishop, "catmark_bishop", kCatmark);
-    static SimpleShape g_modelPawn =
-        SimpleShape(catmark_pawn, "catmark_pawn", kCatmark);
-    // static SimpleShape g_modelRook =
-    //     SimpleShape(catmark_rook, "catmark_rook", kCatmark);
+    if (g_scene) delete g_scene;
 
-    delete g_topology;
-    g_topology = createOsdMesh(g_modelPawn.data, g_level);
-    //g_topology = createOsdMesh(g_modelCube.data, g_level);
+    if (g_kernel == kCPU) {
+        g_scene = new Scene<Osd::CpuEvaluator,
+                            Osd::CpuGLVertexBuffer,
+                            Far::StencilTables>(g_options);
+#ifdef OPENSUBDIV_HAS_OPENMP
+    } else if (g_kernel == kOPENMP) {
+        g_scene = new Scene<Osd::OmpEvaluator,
+                            Osd::CpuGLVertexBuffer,
+                            Far::StencilTables>(g_options);
+#endif
+#ifdef OPENSUBDIV_HAS_TBB
+    } else if (g_kernel == kTBB) {
+        g_scene = new Scene<Osd::TbbEvaluator,
+                            Osd::CpuGLVertexBuffer,
+                            Far::StencilTables>(g_options);
+#endif
+#ifdef OPENSUBDIV_HAS_CUDA
+    } else if (g_kernel == kCUDA) {
+        g_scene = new Scene<Osd::CudaEvaluator,
+                            Osd::CudaGLVertexBuffer,
+                            Osd::CudaStencilTables>(g_options);
+#endif
+#ifdef OPENSUBDIV_HAS_OPENCL
+    } else if (g_kernel == kCL) {
+        static Osd::EvaluatorCacheT<Osd::CLEvaluator> clEvaluatorCache;
+        g_scene = new Scene<Osd::CLEvaluator,
+                            Osd::CLGLVertexBuffer,
+                            Osd::CLStencilTables,
+                            CLDeviceContext>(g_options, &clEvaluatorCache,
+                                             &g_clDeviceContext);
+#endif
+#ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
+    } else if (g_kernel == kGLSL) {
+        static Osd::EvaluatorCacheT<Osd::GLXFBEvaluator> glXFBEvaluatorCache;
+        g_scene = new Scene<Osd::GLXFBEvaluator,
+                            Osd::GLVertexBuffer,
+                            Osd::GLStencilTablesTBO>(g_options, &glXFBEvaluatorCache);
+#endif
+#ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
+    } else if (g_kernel == kGLSLCompute) {
+        static Osd::EvaluatorCacheT<Osd::GLComputeEvaluator> glComputeEvaluatorCache;
+        g_scene = new Scene<Osd::GLComputeEvaluator,
+                            Osd::GLVertexBuffer,
+                            Osd::GLStencilTablesSSBO>(g_options, &glComputeEvaluatorCache);
+#endif
+    }
 
-    rebuildInstances();
+    for (int i = 0; i < (int)g_defaultShapes.size(); ++i) {
+        Shape const * shape = Shape::parseObj(
+            g_defaultShapes[i].data.c_str(),
+            g_defaultShapes[i].scheme,
+            g_defaultShapes[i].isLeftHanded);
+
+        bool varying = (g_displayStyle==kVarying or g_displayStyle==kVaryingInterleaved);
+        g_scene->AddTopology(shape, g_level, varying);
+
+        delete shape;
+    }
+
+    g_iboSize = g_scene->CreateIndexBuffer();
+
+    rebuildObjects();
 }
 
 //------------------------------------------------------------------------------
@@ -1423,13 +971,19 @@ keyboard(GLFWwindow *, int key, int /* scancode */, int event, int /* mods */) {
         case '+':
         case '=': g_tessLevel++; break;
         case '-': g_tessLevel = std::max(g_tessLevelMin, g_tessLevel-1); break;
-        case '.': g_numInstances++; rebuildInstances(); break;
-        case ',': g_numInstances = std::max(1, g_numInstances-1); rebuildInstances(); break;
+        case '.': g_numObjects *= 2; rebuildObjects(); break;
+        case ',': g_numObjects = std::max(1, g_numObjects/2); rebuildObjects(); break;
         case GLFW_KEY_ESCAPE: g_hud.SetVisible(!g_hud.IsVisible()); break;
     }
 }
 
 //------------------------------------------------------------------------------
+
+static void
+callbackEndCap(int endCap) {
+    g_options.endCap = endCap;
+    rebuildTopology();
+}
 
 static void
 callbackKernel(int k) {
@@ -1454,43 +1008,47 @@ callbackKernel(int k) {
     }
 #endif
 
-    rebuildOsdMesh();
+    rebuildTopology();
 }
 
 static void
 callbackLevel(int l) {
 
     g_level = l;
-    rebuildOsdMesh();
+    rebuildTopology();
 }
 
 static void
 callbackSlider(float value, int /* data */) {
 
-    g_numInstances = (int)value;
-    rebuildInstances();
+    g_numObjects = (int)value;
+    rebuildObjects();
 }
 
 static void
 callbackDisplayStyle(int b) {
 
     g_displayStyle = b;
-    rebuildOsdMesh();
-}
-
-static void
-callbackAdaptive(bool checked, int /* a */) {
-
-    if (Osd::GLDrawContext::SupportsAdaptiveTessellation()) {
-        g_adaptive = checked;
-        rebuildOsdMesh();
-    }
+    rebuildTopology();
 }
 
 static void
 callbackCheckBox(bool checked, int button) {
 
     switch (button) {
+    case kHUD_CB_ADAPTIVE:
+        g_options.adaptive = checked;
+        rebuildTopology();
+        break;
+    case kHUD_CB_MDI:
+        g_MDI = checked;
+        break;
+    case kHUD_CB_VIEW_LOD:
+        g_screenSpaceTess = checked;
+        break;
+    case kHUD_CB_PATCH_CULL:
+        g_patchCull = checked;
+        break;
     case kHUD_CB_FREEZE:
         g_freeze = checked;
         break;
@@ -1518,6 +1076,10 @@ initHUD() {
     g_hud.AddPullDownButton(shading_pulldown, "Varying", kVarying, g_displayStyle==kVarying);
     g_hud.AddPullDownButton(shading_pulldown, "Varying(Interleaved)", kVaryingInterleaved, g_displayStyle==kVaryingInterleaved);
 
+    g_hud.AddCheckBox("Screen space LOD (V)",  g_screenSpaceTess != 0,
+                      10, 110, callbackCheckBox, kHUD_CB_VIEW_LOD, 'v');
+    g_hud.AddCheckBox("Frustum Patch Culling (B)",  g_patchCull != 0,
+                      10, 130, callbackCheckBox, kHUD_CB_PATCH_CULL, 'b');
     g_hud.AddCheckBox("Freeze (spc)", g_freeze != 0,
                       10, 150, callbackCheckBox, kHUD_CB_FREEZE, ' ');
 
@@ -1547,11 +1109,25 @@ initHUD() {
     }
 #endif
 
-    g_hud.AddSlider("Prim counts", 1, 100, 25,
-                    -200, 20, 20, false, callbackSlider, 0);
+    g_hud.AddSlider("Objects count", 1, 1000, 25,
+                    -200, 20, 20, true, callbackSlider, 0);
 
-    if (Osd::GLDrawContext::SupportsAdaptiveTessellation())
-        g_hud.AddCheckBox("Adaptive (`)", g_adaptive!=0, 10, 190, callbackAdaptive, 0, '`');
+    {
+        g_hud.AddCheckBox("Multi Draw Indirect (m)", g_MDI != 0,
+                          10, 170, callbackCheckBox, kHUD_CB_MDI, 'm');
+        g_hud.AddCheckBox("Adaptive (`)", g_options.adaptive != 0,
+                          10, 190, callbackCheckBox, kHUD_CB_ADAPTIVE, '`');
+
+        int endcap_pulldown = g_hud.AddPullDown(
+            "End cap (E)", 10, 210, 200, callbackEndCap, 'e');
+        g_hud.AddPullDownButton(endcap_pulldown, "BSpline",
+                                SceneBase::kEndCapBSplineBasis,
+                                g_options.endCap == SceneBase::kEndCapBSplineBasis);
+        g_hud.AddPullDownButton(endcap_pulldown, "GregoryBasis",
+                                SceneBase::kEndCapGregoryBasis,
+                                g_options.endCap == SceneBase::kEndCapGregoryBasis);
+    }
+
 
     for (int i = 1; i < 11; ++i) {
         char level[16];
@@ -1640,7 +1216,7 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    static const char windowTitle[] = "OpenSubdiv face partitioning example";
+    static const char windowTitle[] = "OpenSubdiv batching example " OPENSUBDIV_VERSION_STRING;
 
 #define CORE_PROFILE
 #ifdef CORE_PROFILE
@@ -1679,14 +1255,15 @@ int main(int argc, char ** argv) {
 #endif
 
     // activate feature adaptive tessellation if OSD supports it
-    g_adaptive = Osd::GLDrawContext::SupportsAdaptiveTessellation();
+    g_options.adaptive = true;
 
+    initShapes();
     initGL();
 
     glfwSwapInterval(0);
 
     initHUD();
-    rebuildOsdMesh();
+    rebuildTopology();
 
     while (g_running) {
         idle();
@@ -1694,8 +1271,6 @@ int main(int argc, char ** argv) {
 
         glfwPollEvents();
         glfwSwapBuffers(g_window);
-
-        glFinish();
     }
 
     uninitGL();

--- a/examples/glShareTopology/init_shapes.h
+++ b/examples/glShareTopology/init_shapes.h
@@ -1,0 +1,184 @@
+//
+//   Copyright 2013 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#include <common/shape_utils.h>
+
+struct ShapeDesc {
+
+    ShapeDesc(char const * iname, std::string const & idata, Scheme ischeme,
+        bool iIsLeftHanded=false) :
+        name(iname), data(idata), scheme(ischeme), isLeftHanded(iIsLeftHanded) { }
+
+    std::string name,
+                data;
+    Scheme      scheme;
+    bool        isLeftHanded;
+};
+
+static std::vector<ShapeDesc> g_defaultShapes;
+
+#include <shapes/catmark_bishop.h>
+#include <shapes/catmark_car.h>
+#include <shapes/catmark_chaikin0.h>
+#include <shapes/catmark_chaikin1.h>
+#include <shapes/catmark_chaikin2.h>
+#include <shapes/catmark_cube_corner0.h>
+#include <shapes/catmark_cube_corner1.h>
+#include <shapes/catmark_cube_corner2.h>
+#include <shapes/catmark_cube_corner3.h>
+#include <shapes/catmark_cube_corner4.h>
+#include <shapes/catmark_cube_creases0.h>
+#include <shapes/catmark_cube_creases1.h>
+#include <shapes/catmark_cube_creases2.h>
+#include <shapes/catmark_cube.h>
+#include <shapes/catmark_dart_edgecorner.h>
+#include <shapes/catmark_dart_edgeonly.h>
+#include <shapes/catmark_edgecorner.h>
+#include <shapes/catmark_edgeonly.h>
+#include <shapes/catmark_fan.h>
+#include <shapes/catmark_flap.h>
+#include <shapes/catmark_flap2.h>
+#include <shapes/catmark_fvar_bound0.h>
+#include <shapes/catmark_fvar_bound1.h>
+#include <shapes/catmark_fvar_bound2.h>
+#include <shapes/catmark_gregory_test0.h>
+#include <shapes/catmark_gregory_test1.h>
+#include <shapes/catmark_gregory_test2.h>
+#include <shapes/catmark_gregory_test3.h>
+#include <shapes/catmark_gregory_test4.h>
+#include <shapes/catmark_gregory_test5.h>
+#include <shapes/catmark_gregory_test6.h>
+#include <shapes/catmark_gregory_test7.h>
+#include <shapes/catmark_helmet.h>
+#include <shapes/catmark_hole_test1.h>
+#include <shapes/catmark_hole_test2.h>
+#include <shapes/catmark_hole_test3.h>
+#include <shapes/catmark_hole_test4.h>
+#include <shapes/catmark_lefthanded.h>
+#include <shapes/catmark_righthanded.h>
+#include <shapes/catmark_pawn.h>
+#include <shapes/catmark_pyramid_creases0.h>
+#include <shapes/catmark_pyramid_creases1.h>
+#include <shapes/catmark_pyramid.h>
+#include <shapes/catmark_rook.h>
+#include <shapes/catmark_smoothtris0.h>
+#include <shapes/catmark_smoothtris1.h>
+#include <shapes/catmark_square_hedit0.h>
+#include <shapes/catmark_square_hedit1.h>
+#include <shapes/catmark_square_hedit2.h>
+#include <shapes/catmark_square_hedit3.h>
+#include <shapes/catmark_tent_creases0.h>
+#include <shapes/catmark_tent_creases1.h>
+#include <shapes/catmark_tent.h>
+#include <shapes/catmark_torus.h>
+#include <shapes/catmark_torus_creases0.h>
+
+#include <shapes/bilinear_cube.h>
+
+#include <shapes/loop_cube_creases0.h>
+#include <shapes/loop_cube_creases1.h>
+#include <shapes/loop_cube.h>
+#include <shapes/loop_icosahedron.h>
+#include <shapes/loop_saddle_edgecorner.h>
+#include <shapes/loop_saddle_edgeonly.h>
+#include <shapes/loop_triangle_edgecorner.h>
+#include <shapes/loop_triangle_edgeonly.h>
+#include <shapes/loop_chaikin0.h>
+#include <shapes/loop_chaikin1.h>
+
+//------------------------------------------------------------------------------
+static void initShapes() {
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner0",     catmark_cube_corner0,     kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner1",     catmark_cube_corner1,     kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner2",     catmark_cube_corner2,     kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner3",     catmark_cube_corner3,     kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner4",     catmark_cube_corner4,     kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases2",    catmark_cube_creases2,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_edgecorner",       catmark_edgecorner,       kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_edgeonly",         catmark_edgeonly,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin0",         catmark_chaikin0,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin1",         catmark_chaikin1,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin2",         catmark_chaikin2,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_fan",              catmark_fan,              kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_flap",             catmark_flap,             kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_flap2",            catmark_flap2,            kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound0",      catmark_fvar_bound0,      kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound1",      catmark_fvar_bound1,      kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound2",      catmark_fvar_bound2,      kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test0",    catmark_gregory_test0,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test1",    catmark_gregory_test1,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test2",    catmark_gregory_test2,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test3",    catmark_gregory_test3,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test4",    catmark_gregory_test4,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test5",    catmark_gregory_test5,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test6",    catmark_gregory_test6,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test7",    catmark_gregory_test7,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_hole_test1",       catmark_hole_test1,       kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_hole_test2",       catmark_hole_test2,       kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_hole_test3",       catmark_hole_test3,       kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_hole_test4",       catmark_hole_test4,       kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_lefthanded",       catmark_lefthanded,       kCatmark, true /*isLeftHanded*/ ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_righthanded",      catmark_righthanded,      kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_pyramid_creases0", catmark_pyramid_creases0, kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_pyramid_creases1", catmark_pyramid_creases1, kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_pyramid",          catmark_pyramid,          kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_tent_creases0",    catmark_tent_creases0,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_tent_creases1",    catmark_tent_creases1 ,   kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_tent",             catmark_tent,             kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_torus",            catmark_torus,            kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_torus_creases0",   catmark_torus_creases0,   kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_smoothtris0",      catmark_smoothtris0,      kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_smoothtris1",      catmark_smoothtris1,      kCatmark ) );
+//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit0",    catmark_square_hedit0,    kCatmark ) );
+//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit1",    catmark_square_hedit1,    kCatmark ) );
+//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit2",    catmark_square_hedit2,    kCatmark ) );
+//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit3",    catmark_square_hedit3,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_bishop",           catmark_bishop,           kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_car",              catmark_car,              kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_helmet",           catmark_helmet,           kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_pawn",             catmark_pawn,             kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_rook",             catmark_rook,             kCatmark ) );
+
+#if 0
+    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
+
+
+    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases0",       loop_cube_creases0,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases1",       loop_cube_creases1,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cube",                loop_cube,                kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgecorner",   loop_saddle_edgecorner,   kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgeonly",     loop_saddle_edgeonly,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_chaikin0",            loop_chaikin0,            kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_chaikin1",            loop_chaikin1,            kLoop ) );
+#endif
+}
+//------------------------------------------------------------------------------

--- a/examples/glShareTopology/meshRefiner.h
+++ b/examples/glShareTopology/meshRefiner.h
@@ -1,0 +1,147 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_MESH_REFINER_H
+#define OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_MESH_REFINER_H
+
+#include <osd/mesh.h>   // for evaluator cache
+
+template <class EVALUATOR,
+          class VERTEX_BUFFER,
+          class STENCIL_TABLES,
+          class DEVICE_CONTEXT=void>
+class MeshRefiner {
+public:
+    typedef EVALUATOR Evaluator;
+    typedef STENCIL_TABLES StencilTables;
+    typedef DEVICE_CONTEXT DeviceContext;
+    typedef OpenSubdiv::Osd::EvaluatorCacheT<Evaluator> EvaluatorCache;
+
+    MeshRefiner(OpenSubdiv::Far::StencilTables const * vertexStencils, //XXX: takes ownership
+                OpenSubdiv::Far::StencilTables const * varyingStencils,
+                int numControlVertices,
+                EvaluatorCache * evaluatorCache = NULL,
+                DeviceContext * deviceContext = NULL)
+        : _evaluatorCache(evaluatorCache),
+          _deviceContext(deviceContext) {
+
+        _numControlVertices = numControlVertices;
+        _numVertices = numControlVertices + vertexStencils->GetNumStencils();
+
+        _vertexStencils = OpenSubdiv::Osd::convertToCompatibleStencilTables<StencilTables>(
+            vertexStencils, deviceContext);
+        _varyingStencils = OpenSubdiv::Osd::convertToCompatibleStencilTables<StencilTables>(
+            varyingStencils, deviceContext);
+    }
+
+    ~MeshRefiner() {
+        delete _vertexStencils;
+        delete _varyingStencils;
+    }
+
+    template <typename VBO>
+    void Refine(VBO *vbo, int vertsOffset) {
+        OpenSubdiv::Osd::VertexBufferDescriptor const &globalVertexDesc =
+            vbo->GetVertexDesc();
+        OpenSubdiv::Osd::VertexBufferDescriptor const &globalVaryingDesc =
+            vbo->GetVaryingDesc();
+
+        OpenSubdiv::Osd::VertexBufferDescriptor vertexSrcDesc(
+            globalVertexDesc.offset + vertsOffset * globalVertexDesc.stride,
+            globalVertexDesc.length,
+            globalVertexDesc.stride);
+        OpenSubdiv::Osd::VertexBufferDescriptor vertexDstDesc(
+            vertexSrcDesc.offset + (_numControlVertices * vertexSrcDesc.stride),
+            vertexSrcDesc.length,
+            vertexSrcDesc.stride);
+
+        // vertex
+        Evaluator const *evalInstance = OpenSubdiv::Osd::GetEvaluator<Evaluator>(
+            _evaluatorCache, vertexSrcDesc, vertexDstDesc, _deviceContext);
+
+        Evaluator::EvalStencils(
+            vbo->GetVertexBuffer(), vertexSrcDesc,
+            vbo->GetVertexBuffer(), vertexDstDesc,
+            _vertexStencils,
+            evalInstance,
+            _deviceContext);
+
+        // varying
+        if (_varyingStencils) {
+            OpenSubdiv::Osd::VertexBufferDescriptor varyingSrcDesc(
+                globalVaryingDesc.offset + vertsOffset * globalVaryingDesc.stride,
+                globalVaryingDesc.length,
+                globalVaryingDesc.stride);
+
+            OpenSubdiv::Osd::VertexBufferDescriptor varyingDstDesc(
+                varyingSrcDesc.offset + (_numControlVertices * varyingSrcDesc.stride),
+                varyingSrcDesc.length,
+                varyingSrcDesc.stride);
+
+            evalInstance = OpenSubdiv::Osd::GetEvaluator<Evaluator>(
+                _evaluatorCache, varyingSrcDesc, varyingDstDesc, _deviceContext);
+
+            if (vbo->GetVaryingBuffer()) {
+                // non interleaved
+                Evaluator::EvalStencils(
+                    vbo->GetVaryingBuffer(), varyingSrcDesc,
+                    vbo->GetVaryingBuffer(), varyingDstDesc,
+                    _varyingStencils,
+                    evalInstance,
+                    _deviceContext);
+            } else {
+                // interleaved
+                Evaluator::EvalStencils(
+                    vbo->GetVertexBuffer(), varyingSrcDesc,
+                    vbo->GetVertexBuffer(), varyingDstDesc,
+                    _varyingStencils,
+                    evalInstance,
+                    _deviceContext);
+            }
+        }
+    }
+
+    void Synchronize() {
+        Evaluator::Synchronize(_deviceContext);
+    }
+
+    int GetNumVertices() const {  // total (control + refined)
+        return _numVertices;
+    }
+    int GetNumControlVertices() const {
+        return _numControlVertices;
+    }
+
+private:
+    int _numVertices;
+    int _numControlVertices;
+
+    StencilTables const *_vertexStencils;
+    StencilTables const *_varyingStencils;
+    EvaluatorCache * _evaluatorCache;
+    DeviceContext *_deviceContext;
+};
+
+
+#endif   // OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_TOPOLOGY_H

--- a/examples/glShareTopology/scene.h
+++ b/examples/glShareTopology/scene.h
@@ -1,0 +1,141 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_SCENE_H
+#define OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_SCENE_H
+
+#include "meshRefiner.h"
+#include "vbo.h"
+#include "sceneBase.h"
+
+template <class EVALUATOR,
+          class VERTEX_BUFFER,
+          class STENCIL_TABLES,
+          class DEVICE_CONTEXT=void>
+class Scene : public SceneBase {
+public:
+    typedef EVALUATOR Evaluator;
+    typedef STENCIL_TABLES StencilTables;
+    typedef DEVICE_CONTEXT DeviceContext;
+    typedef OpenSubdiv::Osd::EvaluatorCacheT<Evaluator> EvaluatorCache;
+    typedef MeshRefiner<EVALUATOR, VERTEX_BUFFER,
+                        STENCIL_TABLES, DEVICE_CONTEXT> MeshRefinerType;
+    typedef VBO<VERTEX_BUFFER, DEVICE_CONTEXT> VBOType;
+
+    Scene(Options const &options,
+          EvaluatorCache * evaluatorCache = NULL,
+          DeviceContext * deviceContext = NULL)
+        : SceneBase(options),
+          _vbo(NULL),
+          _evaluatorCache(evaluatorCache),
+          _deviceContext(deviceContext) {
+    }
+
+    virtual ~Scene() {
+        Clear();
+    }
+
+    virtual void Refine(int object) {
+        int vertsOffset = GetVertsOffset(object);
+        _refiners[_objects[object].topologyIndex]->Refine(_vbo, vertsOffset);
+    }
+
+    virtual void Synchronize() {
+        Evaluator::Synchronize(_deviceContext);
+    }
+
+    virtual void UpdateVertexBuffer(int vertsOffset, std::vector<float> const &src) {
+        _vbo->UpdateVertexBuffer(vertsOffset, src);
+    }
+    virtual void UpdateVaryingBuffer(int vertsOffset, std::vector<float> const &src) {
+        _vbo->UpdateVaryingBuffer(vertsOffset, src);
+    }
+
+    virtual GLuint BindVertexBuffer() {
+        return _vbo->BindVertexBuffer();
+    }
+
+    virtual GLuint BindVaryingBuffer() {
+        return _vbo->BindVaryingBuffer();
+    }
+
+    virtual size_t AllocateVBO(int numVerts,
+                               OpenSubdiv::Osd::VertexBufferDescriptor const &vertexDesc,
+                               OpenSubdiv::Osd::VertexBufferDescriptor const &varyingDesc,
+                               bool interleaved) {
+
+        if (_vbo) delete _vbo;
+        _vbo = new VBOType(vertexDesc, varyingDesc, interleaved, numVerts, _deviceContext);
+        return _vbo->GetSize();
+    }
+
+    virtual size_t createMeshRefiner(
+        OpenSubdiv::Far::StencilTables const * vertexStencils,
+        OpenSubdiv::Far::StencilTables const * varyingStencils,
+        int numControlVertices) {
+
+        MeshRefinerType *meshRefiner =
+            new MeshRefinerType(vertexStencils, varyingStencils,
+                                numControlVertices,
+                                _evaluatorCache,
+                                _deviceContext);
+        _refiners.push_back(meshRefiner);
+
+        size_t size = 0;
+        if (vertexStencils) {
+            size += vertexStencils->GetSizes().size() * sizeof(vertexStencils->GetSizes()[0])
+            + vertexStencils->GetOffsets().size() * sizeof(vertexStencils->GetOffsets()[0])
+            + vertexStencils->GetControlIndices().size() * sizeof(vertexStencils->GetControlIndices()[0])
+            + vertexStencils->GetWeights().size() * sizeof(vertexStencils->GetWeights()[0]);
+        }
+        if (varyingStencils) {
+            size += varyingStencils->GetSizes().size() * sizeof(varyingStencils->GetSizes()[0])
+            + varyingStencils->GetOffsets().size() * sizeof(varyingStencils->GetOffsets()[0])
+            + varyingStencils->GetControlIndices().size() * sizeof(varyingStencils->GetControlIndices()[0])
+            + varyingStencils->GetWeights().size() * sizeof(varyingStencils->GetWeights()[0]);
+        }
+        return size;
+    }
+
+    void Clear() {
+        for (typename std::vector<MeshRefinerType*>::iterator it = _refiners.begin();
+             it != _refiners.end(); ++it) {
+            delete *it;
+        }
+
+        _refiners.clear();
+        _objects.clear();
+        delete _vbo;
+        _vbo = NULL;
+    }
+
+private:
+    std::vector<MeshRefinerType*> _refiners;
+    VBOType *_vbo;
+    EvaluatorCache * _evaluatorCache;
+    DeviceContext *_deviceContext;
+
+};
+
+#endif  // OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_SCENE_H

--- a/examples/glShareTopology/sceneBase.cpp
+++ b/examples/glShareTopology/sceneBase.cpp
@@ -1,0 +1,354 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#include <limits>
+#include <common/vtr_utils.h>
+#include <far/patchTablesFactory.h>
+#include <far/stencilTablesFactory.h>
+#include "sceneBase.h"
+
+using namespace OpenSubdiv;
+
+
+SceneBase::SceneBase(Options const &options)
+    : _options(options),
+      _indexBuffer(0), _patchParamTexture(0) {
+}
+
+SceneBase::~SceneBase() {
+    if (_indexBuffer) glDeleteBuffers(1, &_indexBuffer);
+    if (_patchParamTexture) glDeleteTextures(1, &_patchParamTexture);
+
+    for (int i = 0; i < _patchTables.size(); ++i) {
+        delete _patchTables[i];
+    }
+}
+
+void
+SceneBase::AddTopology(Shape const *shape, int level, bool varying) {
+    Far::PatchTables const * patchTable = NULL;
+    int numVerts = createStencilTable(shape, level, varying, &patchTable);
+
+    // centering rest position
+    float pmin[3] = { std::numeric_limits<float>::max(),
+                      std::numeric_limits<float>::max(),
+                      std::numeric_limits<float>::max() };
+    float pmax[3] = { -std::numeric_limits<float>::max(),
+                      -std::numeric_limits<float>::max(),
+                      -std::numeric_limits<float>::max() };
+    int nverts = shape->GetNumVertices();
+    for (int i = 0; i < nverts; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            float v = shape->verts[i*3+j];
+            pmin[j] = std::min(v, pmin[j]);
+            pmax[j] = std::max(v, pmax[j]);
+        }
+    }
+    float center[3] = { (pmax[0]+pmin[0])*0.5f,
+                        (pmax[1]+pmin[1])*0.5f,
+                        pmin[2] };
+    float radius = sqrt((pmax[0]-pmin[0])*(pmax[0]-pmin[0]) +
+                        (pmax[1]-pmin[1])*(pmax[1]-pmin[1]) +
+                        (pmax[2]-pmin[2])*(pmax[2]-pmin[2]));
+
+    std::vector<float> restPosition(shape->verts);
+    for (size_t i=0; i < restPosition.size()/3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            restPosition[i*3+j] = (shape->verts[i*3+j] - center[j])/radius;
+        }
+    }
+
+    // store topology
+    Topology topology;
+    topology.numVerts = numVerts;
+    topology.restPosition = restPosition;
+    _topologies.push_back(topology);
+
+    // store patch.
+    // PatchTables is used later to be spliced into the index buffer.
+    _patchTables.push_back(patchTable);
+}
+
+int
+SceneBase::createStencilTable(Shape const *shape, int level, bool varying,
+                              OpenSubdiv::Far::PatchTables const **patchTablesOut) {
+
+    Far::TopologyRefiner * refiner = 0;
+    {
+        Sdc::SchemeType type = GetSdcType(*shape);
+        Sdc::Options options = GetSdcOptions(*shape);
+
+        refiner = Far::TopologyRefinerFactory<Shape>::Create(
+            *shape, Far::TopologyRefinerFactory<Shape>::Options(type, options));
+        assert(refiner);
+    }
+
+    // Adaptive refinement currently supported only for catmull-clark scheme
+
+    if (_options.adaptive) {
+        Far::TopologyRefiner::AdaptiveOptions options(level);
+        refiner->RefineAdaptive(options);
+    } else {
+        Far::TopologyRefiner::UniformOptions options(level);
+        options.fullTopologyInLastLevel = true;
+        refiner->RefineUniform(options);
+    }
+
+    Far::StencilTables const * vertexStencils=0, * varyingStencils=0;
+    {
+        Far::StencilTablesFactory::Options options;
+        options.generateOffsets = true;
+        options.generateIntermediateLevels = _options.adaptive;
+
+        vertexStencils = Far::StencilTablesFactory::Create(*refiner, options);
+
+        if (varying) {
+            varyingStencils = Far::StencilTablesFactory::Create(*refiner, options);
+        }
+
+        assert(vertexStencils);
+    }
+
+    Far::PatchTables const * patchTables = NULL;
+    {
+        Far::PatchTablesFactory::Options poptions(level);
+        if (_options.endCap == kEndCapBSplineBasis) {
+            poptions.SetEndCapType(
+                Far::PatchTablesFactory::Options::ENDCAP_BSPLINE_BASIS);
+        } else {
+            poptions.SetEndCapType(
+                Far::PatchTablesFactory::Options::ENDCAP_GREGORY_BASIS);
+        }
+        patchTables = Far::PatchTablesFactory::Create(*refiner, poptions);
+    }
+    *patchTablesOut = patchTables;
+
+    // append gregory vertices into stencils
+    {
+        if (Far::StencilTables const *vertexStencilsWithEndCap =
+            Far::StencilTablesFactory::AppendEndCapStencilTables(
+                *refiner,
+                vertexStencils,
+                patchTables->GetEndCapVertexStencilTables())) {
+            delete vertexStencils;
+            vertexStencils = vertexStencilsWithEndCap;
+        }
+        if (varyingStencils) {
+            if (Far::StencilTables const *varyingStencilsWithEndCap =
+                Far::StencilTablesFactory::AppendEndCapStencilTables(
+                    *refiner,
+                    varyingStencils,
+                    patchTables->GetEndCapVaryingStencilTables())) {
+                delete varyingStencils;
+                varyingStencils = varyingStencilsWithEndCap;
+            }
+        }
+    }
+    int numControlVertices = refiner->GetNumVertices(0);
+
+    _stencilTableSize = createMeshRefiner(vertexStencils, varyingStencils,
+                                          numControlVertices);
+    // note: refiner takes ownerships of vertexStencils/ varyingStencils, patchTables
+
+    delete refiner;
+    return numControlVertices + vertexStencils->GetNumStencils();
+}
+
+int
+SceneBase::AddObjects(int numObjects) {
+
+    _objects.clear();
+
+    int numTopologies = (int)_topologies.size();
+    int vertsOffset = 0;
+
+    for (int i = 0; i < numObjects; ++i) {
+
+        Object obj;
+        obj.topologyIndex = i % numTopologies;
+        obj.vertsOffset = vertsOffset;
+        _objects.push_back(obj);
+
+        vertsOffset += _topologies[obj.topologyIndex].numVerts;
+    }
+
+    // invalidate batch
+    for (int i = 0; i < (int)_batches.size(); ++i) {
+        glDeleteBuffers(1, &_batches[i].dispatchBuffer);
+    }
+    _batches.clear();
+
+    return vertsOffset;
+}
+
+size_t
+SceneBase::CreateIndexBuffer() {
+    if (_indexBuffer == 0) {
+        glGenBuffers(1, &_indexBuffer);
+    }
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _indexBuffer);
+    std::vector<int> buffer;
+    std::vector<unsigned int> ppBuffer;
+
+    int numTopologies = (int)_topologies.size();
+    for (int i = 0; i < numTopologies; ++i) {
+        Far::PatchTables const *patchTables = _patchTables[i];
+
+        int nPatchArrays = patchTables->GetNumPatchArrays();
+
+        _topologies[i].patchArrays.clear();
+
+        // for each patchArray
+        for (int j = 0; j < nPatchArrays; ++j) {
+
+            SceneBase::PatchArray patchArray;
+            patchArray.desc = patchTables->GetPatchArrayDescriptor(j);
+            patchArray.numPatches = patchTables->GetNumPatches(j);
+            patchArray.indexOffset = (int)buffer.size();
+            patchArray.primitiveIDOffset = (int)ppBuffer.size()/3;
+
+            _topologies[i].patchArrays.push_back(patchArray);
+
+            // indices
+            Far::ConstIndexArray indices = patchTables->GetPatchArrayVertices(j);
+            for (int k = 0; k < indices.size(); ++k) {
+                buffer.push_back(indices[k]);
+            }
+
+            // patchParams
+            Far::ConstPatchParamArray patchParams = patchTables->GetPatchParams(j);
+            // XXX: needs sharpness interface for patcharray or put sharpness into patchParam.
+            for (int k = 0; k < patchParams.size(); ++k) {
+                float sharpness = 0.0;
+                ppBuffer.push_back(patchParams[k].faceIndex);
+                ppBuffer.push_back(patchParams[k].bitField.field);
+                ppBuffer.push_back(*((unsigned int *)&sharpness));
+            }
+        }
+#if 0
+        // XXX: we'll remove below APIs from Far::PatchTables.
+        //      use GetPatchParams(patchArray) instead as above.
+
+        // patch param (all in one)
+        Far::PatchParamTable const &patchParamTables =
+            patchTables->GetPatchParamTable();
+        std::vector<int> const &sharpnessIndexTable =
+            patchTables->GetSharpnessIndexTable();
+        std::vector<float> const &sharpnessValues =
+            patchTables->GetSharpnessValues();
+
+        int npatches = (int)patchParamTables.size();
+        for (int i = 0; i < npatches; ++i) {
+            float sharpness = 0.0;
+            if (i < (int)sharpnessIndexTable.size()) {
+                sharpness = sharpnessIndexTable[i] >= 0 ?
+                    sharpnessValues[sharpnessIndexTable[i]] : 0.0f;
+            }
+            ppBuffer.push_back(patchParamTables[i].faceIndex);
+            ppBuffer.push_back(patchParamTables[i].bitField.field);
+            ppBuffer.push_back(*((unsigned int *)&sharpness));
+        }
+#endif
+    }
+
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER,
+                 (int)buffer.size()*sizeof(int), &buffer[0], GL_STATIC_DRAW);
+
+    // patchParam is currently expected to be texture (it can be SSBO)
+    GLuint texBuffer = 0;
+    glGenBuffers(1, &texBuffer);
+    glBindBuffer(GL_ARRAY_BUFFER, texBuffer);
+    glBufferData(GL_ARRAY_BUFFER, ppBuffer.size()*sizeof(unsigned int),
+                 &ppBuffer[0], GL_STATIC_DRAW);
+
+    if (_patchParamTexture == 0) {
+        glGenTextures(1, &_patchParamTexture);
+    }
+    glBindTexture(GL_TEXTURE_BUFFER, _patchParamTexture);
+    glTexBuffer(GL_TEXTURE_BUFFER, GL_RGB32I, texBuffer);
+    glBindTexture(GL_TEXTURE_BUFFER, 0);
+
+    glDeleteBuffers(1, &texBuffer);
+
+    return buffer.size()*sizeof(int) + ppBuffer.size()*sizeof(int);
+}
+
+void
+SceneBase::buildBatches() {
+
+    int numObjects = (int)_objects.size();
+    for (int i = 0; i < (int)_batches.size(); ++i) {
+        glDeleteBuffers(1, &_batches[i].dispatchBuffer);
+    }
+    _batches.clear();
+
+    typedef std::map<Far::PatchDescriptor, std::vector<int> > StagingBatches;
+    StagingBatches stagingBatches;
+
+    for (int i = 0; i < numObjects; ++i) {
+        // get patchArrays from topology
+        SceneBase::PatchArrayVector const &patchArrays =
+            _topologies[_objects[i].topologyIndex].patchArrays;
+
+        // for each patchArray:
+        for (int j = 0; j < (int)patchArrays.size(); ++j) {
+            SceneBase::PatchArray const &patchArray = patchArrays[j];
+
+            // find batch for the descriptor
+            std::vector<int> &command = stagingBatches[patchArray.desc];
+
+            int nPatch = patchArray.numPatches;
+            int baseVertex = GetVertsOffset(i);
+
+            command.push_back(nPatch * patchArray.desc.GetNumControlVertices());
+            command.push_back(1);
+            command.push_back(patchArray.indexOffset);
+            command.push_back(baseVertex);
+            command.push_back(0);
+
+            command.push_back(patchArray.primitiveIDOffset);
+        }
+    }
+    int stride = sizeof(int)*6; // not 5, since we interleave primitiveIDOffset
+
+    for (StagingBatches::iterator it = stagingBatches.begin();
+         it != stagingBatches.end(); ++it) {
+
+        Batch batch;
+        glGenBuffers(1, &batch.dispatchBuffer);
+
+        glBindBuffer(GL_DRAW_INDIRECT_BUFFER, batch.dispatchBuffer);
+        glBufferData(GL_DRAW_INDIRECT_BUFFER,
+                     it->second.size()*sizeof(int),
+                     &it->second[0], GL_STATIC_DRAW);
+
+        batch.desc = it->first;
+        batch.count = (int)it->second.size()/6;
+        batch.stride = stride;
+
+        _batches.push_back(batch);
+    }
+    glBindBuffer(GL_DRAW_INDIRECT_BUFFER, 0);
+}

--- a/examples/glShareTopology/sceneBase.h
+++ b/examples/glShareTopology/sceneBase.h
@@ -1,0 +1,159 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_SCENE_BASE_H
+#define OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_SCENE_BASE_H
+
+#include <far/patchDescriptor.h>
+#include <far/patchTables.h>
+#include <osd/vertexDescriptor.h>
+#include <osd/opengl.h>
+
+struct Shape;
+
+class SceneBase {
+public:
+    enum EndCap      { kEndCapBSplineBasis,
+                       kEndCapGregoryBasis };
+
+    struct Options {
+        Options() : adaptive(true), endCap(kEndCapBSplineBasis) { }
+
+        bool adaptive;
+        int endCap;
+    };
+
+    struct Object {
+        int topologyIndex;
+        int vertsOffset;        // an offset within the VBO
+    };
+
+    struct PatchArray {
+        OpenSubdiv::Far::PatchDescriptor desc;
+        int numPatches;
+        int indexOffset;        // an offset within the index buffer
+        int primitiveIDOffset;  // an offset within the patch param buffer
+    };
+    typedef std::vector<PatchArray> PatchArrayVector;
+
+    struct Topology {
+        int numVerts;
+        PatchArrayVector patchArrays;
+        std::vector<float> restPosition;
+    };
+
+    struct Batch {
+        OpenSubdiv::Far::PatchDescriptor desc;
+        int count;
+        int stride;
+        GLuint dispatchBuffer;
+    };
+    typedef std::vector<Batch> BatchVector;
+
+    /// Constructor.
+    SceneBase(Options const &options);
+
+    /// Destructor.
+    virtual ~SceneBase();
+
+    /// trivial accessors
+    int GetNumObjects() const { return (int)_objects.size(); }
+
+    PatchArrayVector const &GetPatchArrays(int object) const {
+        return _topologies[_objects[object].topologyIndex].patchArrays;
+    }
+
+    BatchVector const &GetBatches() {
+        if (_batches.empty()) buildBatches();
+        return _batches;
+    }
+
+    int GetVertsOffset(int object) const {
+        return _objects[object].vertsOffset;
+    }
+
+    std::vector<float> const &GetRestPosition(int object) const {
+        return _topologies[_objects[object].topologyIndex].restPosition;
+    }
+
+    GLuint GetPatchParamTexture() const {
+        return _patchParamTexture;
+    }
+
+    GLuint GetIndexBuffer() const {
+        return _indexBuffer;
+    }
+
+    // allocate batched vbo
+    virtual size_t AllocateVBO(int numVerts,
+                               OpenSubdiv::Osd::VertexBufferDescriptor const &vertexDesc,
+                               OpenSubdiv::Osd::VertexBufferDescriptor const &varyingDesc,
+                               bool interleaved) = 0;
+
+    // refine an object
+    virtual void Refine(int object) =0;
+
+    virtual void Synchronize() = 0;
+
+    virtual void UpdateVertexBuffer(int vertsOffset, std::vector<float> const &src)=0;
+
+    virtual void UpdateVaryingBuffer(int vertsOffset, std::vector<float> const &src)=0;
+
+    virtual GLuint BindVertexBuffer() = 0;
+
+    virtual GLuint BindVaryingBuffer() = 0;
+
+    // build batched index buffer and patchparam texture buffer
+    size_t CreateIndexBuffer();
+
+    void AddTopology(Shape const *shape, int level, bool varying);
+
+    int AddObjects(int numObjects);
+
+    size_t GetStencilTableSize() const { return _stencilTableSize; }
+
+protected:
+    int createStencilTable(Shape const *shape, int level, bool varying,
+                           OpenSubdiv::Far::PatchTables const **patchTableOut);
+
+    void buildBatches();
+
+    virtual size_t createMeshRefiner(
+        OpenSubdiv::Far::StencilTables const * vertexStencils,
+        OpenSubdiv::Far::StencilTables const * varyingStencils,
+        int numControlVertices) = 0;
+
+    Options _options;
+
+    std::vector<Object> _objects;
+    std::vector<Topology> _topologies;
+    std::vector<OpenSubdiv::Far::PatchTables const *> _patchTables;
+    GLuint _indexBuffer;
+    GLuint _patchParamTexture;
+    BatchVector _batches;
+    size_t _stencilTableSize;
+
+};
+
+#endif  // OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_SCENE_BASE_H

--- a/examples/glShareTopology/vbo.h
+++ b/examples/glShareTopology/vbo.h
@@ -1,0 +1,126 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_VBO_H
+#define OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_VBO_H
+
+#include <vector>
+#include <osd/vertexDescriptor.h>
+#include <osd/opengl.h>
+
+template <class VERTEX_BUFFER, class DEVICE_CONTEXT>
+class VBO {
+public:
+    VBO(OpenSubdiv::Osd::VertexBufferDescriptor const &vertexDesc,
+        OpenSubdiv::Osd::VertexBufferDescriptor const &varyingDesc,
+        bool interleaved, int numVertices, DEVICE_CONTEXT *deviceContext) :
+        _vertexDesc(vertexDesc),
+        _varyingDesc(varyingDesc),
+        _numVertices(numVertices),
+        _vertexBuffer(NULL), _varyingBuffer(NULL), _interleaved(interleaved),
+        _deviceContext(deviceContext) {
+
+        if (interleaved) {
+            assert(vertexDesc.stride == varyingDesc.stride);
+            _vertexBuffer = createVertexBuffer(
+                vertexDesc.stride, numVertices);
+        } else {
+            if (vertexDesc.stride > 0) {
+                _vertexBuffer = createVertexBuffer(
+                    vertexDesc.stride, numVertices);
+            }
+            if (varyingDesc.stride > 0) {
+                _varyingBuffer = createVertexBuffer(
+                    varyingDesc.stride, numVertices);
+            }
+        }
+    }
+
+    ~VBO() {
+        delete _vertexBuffer;
+        delete _varyingBuffer;
+    }
+
+    OpenSubdiv::Osd::VertexBufferDescriptor const &GetVertexDesc() const {
+        return _vertexDesc;
+    }
+    OpenSubdiv::Osd::VertexBufferDescriptor const &GetVaryingDesc() const {
+        return _varyingDesc;
+    }
+
+    void UpdateVertexBuffer(int vertsOffset, std::vector<float> const &src) {
+        updateVertexBuffer(_vertexBuffer, &src[0], vertsOffset,
+                           (int)src.size()/_vertexBuffer->GetNumElements());
+    }
+    void UpdateVaryingBuffer(int vertsOffset, std::vector<float> const &src) {
+        updateVertexBuffer(_varyingBuffer, &src[0], vertsOffset,
+                           (int)src.size()/_varyingBuffer->GetNumElements());
+    }
+
+    GLuint BindVertexBuffer() {
+        return _vertexBuffer->BindVBO();
+    }
+
+    GLuint BindVaryingBuffer() {
+        return _varyingBuffer->BindVBO();
+    }
+
+    VERTEX_BUFFER *GetVertexBuffer() const {
+        return _vertexBuffer;
+    }
+
+    VERTEX_BUFFER *GetVaryingBuffer() const {
+        return _interleaved ? _vertexBuffer : _varyingBuffer;
+    }
+
+    size_t GetSize() const {
+        size_t size = _numVertices * _vertexDesc.stride;
+        if (_varyingBuffer) size += _numVertices * _varyingDesc.stride;
+        return size * sizeof(float);
+    }
+
+private:
+    VERTEX_BUFFER *createVertexBuffer(int numElements, int numVertices) {
+        return VERTEX_BUFFER::Create(numElements, numVertices, _deviceContext);
+    }
+
+    void updateVertexBuffer(VERTEX_BUFFER *vertexBuffer,
+                            const float *src, int startVertex,
+                            int numVertices) {
+        vertexBuffer->UpdateData(src, startVertex, numVertices, _deviceContext);
+    }
+
+    OpenSubdiv::Osd::VertexBufferDescriptor _vertexDesc;
+    OpenSubdiv::Osd::VertexBufferDescriptor _varyingDesc;
+
+    // # of vertices total, including both control verts and refined verts.
+    int _numVertices;
+
+    VERTEX_BUFFER *_vertexBuffer;
+    VERTEX_BUFFER *_varyingBuffer;
+    bool _interleaved;
+    DEVICE_CONTEXT *_deviceContext;
+};
+
+#endif  //  OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_VBO_H


### PR DESCRIPTION
This example is rewritten as a more comprehensive example
of Far and Osd APIs to generate batched index buffer and
vertex buffer, as well as sharing same topology and stencil
table among multiple objects.

Also this change includes an experimental code path of using
glMultiDrawElementsIndirect. It's currently incomplete due to
the missing interface of osd tessellation shader.