### PR TITLE
remove SupportsAdaptiveTessellation from OsdDrawContext (and example cleanups)

### DIFF
--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -52,17 +52,16 @@ set(EXAMPLES_COMMON_HEADER_FILES
 if( OPENGL_FOUND AND (GLEW_FOUND AND GLFW_FOUND) OR (APPLE AND GLFW_FOUND))
 
     list(APPEND EXAMPLES_COMMON_SOURCE_FILES
-      # we will rename gl_xxx to glXxx
-        gl_common.cpp
-        gl_framebuffer.cpp
-        gl_hud.cpp
+        glFramebuffer.cpp
+        glHud.cpp
+        glUtils.cpp
         glShaderCache.cpp
     )
 
     list(APPEND EXAMPLES_COMMON_HEADER_FILES
-        gl_common.h
-        gl_framebuffer.h
-        gl_hud.h
+        glFramebuffer.h
+        glHud.h
+        glUtils.h
         glShaderCache.h
     )
 
@@ -80,12 +79,14 @@ endif()
 if(DXSDK_FOUND)
 
     list(APPEND EXAMPLES_COMMON_SOURCE_FILES
-        d3d11_hud.cpp
+        d3d11Hud.cpp
+        d3d11Utils.cpp
         d3d11ShaderCache.cpp
     )
 
     list(APPEND EXAMPLES_COMMON_HEADER_FILES
-        d3d11_hud.h
+        d3d11Hud.h
+        d3d11Utils.h
         d3d11ShaderCache.h
     )
 

--- a/examples/common/d3d11Hud.cpp
+++ b/examples/common/d3d11Hud.cpp
@@ -26,8 +26,8 @@
 #include <string.h>
 #include <stdio.h>
 #include <cassert>
-#include "d3d11_hud.h"
-#include "d3d11_compile.h"
+#include "d3d11Hud.h"
+#include "d3d11Utils.h"
 #include "font_image.h"
 #include "../common/simple_math.h"
 
@@ -137,8 +137,8 @@ D3D11hud::Init(int width, int height, int frameBufferWidth, int frameBufferHeigh
 
     ID3DBlob* pVSBlob;
     ID3DBlob* pPSBlob;
-    pVSBlob = d3d11CompileShader(s_VS, "vs_main", "vs_4_0");
-    pPSBlob = d3d11CompileShader(s_PS, "ps_main", "ps_4_0");
+    pVSBlob = D3D11Utils::CompileShader(s_VS, "vs_main", "vs_4_0");
+    pPSBlob = D3D11Utils::CompileShader(s_PS, "ps_main", "ps_4_0");
     assert(pVSBlob);
     assert(pPSBlob);
 

--- a/examples/common/d3d11Hud.h
+++ b/examples/common/d3d11Hud.h
@@ -22,20 +22,25 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#ifndef GL_HUD_H
-#define GL_HUD_H
+#ifndef OPENSUBDIV_EXAMPLES_D3D11_HUD_H
+#define OPENSUBDIV_EXAMPLES_D3D11_HUD_H
 
+#include <D3D11.h>
 #include "hud.h"
 
-#include <osd/opengl.h>
-
-#include "gl_framebuffer.h"
-
-class GLhud : public Hud {
-
+class D3D11hud : public Hud
+{
 public:
-    GLhud();
-    ~GLhud();
+    D3D11hud(ID3D11DeviceContext *deviceContext);
+    ~D3D11hud();
+
+    void Init(int width, int height) {
+        Init(width, height, width, height);
+    }
+
+    void Rebuild(int width, int height) {
+        Rebuild(width, height, width, height);
+    }
 
     virtual void Init(int width, int height, int framebufferWidth, int framebufferHeight);
 
@@ -44,35 +49,19 @@ public:
 
     virtual bool Flush();
 
-    void SetFrameBuffer(GLFrameBuffer * frameBuffer) {
-        if (not _frameBuffer) {
-            _frameBuffer = frameBuffer;
-            _frameBuffer->Init(GetWidth(), GetHeight());
-            _frameBuffer->BuildUI(this, 10, 600);
-        }
-    }
-
-    GLFrameBuffer * GetFrameBuffer() {
-        return _frameBuffer;
-    }
-
-    GLuint GetFontTexture() const {
-        return _fontTexture;
-    }
-
 private:
-
-
-    GLFrameBuffer * _frameBuffer;
-
-    GLuint _fontTexture;
-    GLuint _vbo, _staticVbo;
-    GLuint _vao, _staticVao;
-    int _staticVboSize;
-
-    GLint _program;
-    GLint _mvpMatrix;
-    GLint _aPosition, _aColor, _aUV;
+    ID3D11DeviceContext *_deviceContext;
+    ID3D11Buffer *_vbo;
+    ID3D11Buffer *_staticVbo;
+    ID3D11Texture2D *_fontTexture;
+    ID3D11InputLayout *_inputLayout;
+    ID3D11ShaderResourceView *_shaderResourceView;
+    ID3D11SamplerState *_samplerState;
+    ID3D11VertexShader *_vertexShader;
+    ID3D11PixelShader *_pixelShader;
+    ID3D11RasterizerState *_rasterizerState;
+    ID3D11Buffer* _constantBuffer;
+    int _staticVboCount;
 };
 
-#endif // GL_HUD_H
+#endif  // OPENSUBDIV_EXAMPLES_D3D11_HUD_H

--- a/examples/common/d3d11Utils.cpp
+++ b/examples/common/d3d11Utils.cpp
@@ -22,46 +22,33 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#ifndef D3D11_HUD_H
-#define D3D11_HUD_H
+#include "d3d11Utils.h"
+#include <D3DCompiler.h>
 
-#include <D3D11.h>
-#include "hud.h"
+namespace D3D11Utils {
 
-class D3D11hud : public Hud
-{
-public:
-    D3D11hud(ID3D11DeviceContext *deviceContext);
-    ~D3D11hud();
+ID3DBlob *
+CompileShader(const char *src, const char *entry, const char *spec) {
+    DWORD dwShaderFlags = D3DCOMPILE_ENABLE_STRICTNESS;
+#if defined(DEBUG) || defined(_DEBUG)
+      dwShaderFlags |= D3DCOMPILE_DEBUG;
+#endif
 
-    void Init(int width, int height) {
-        Init(width, height, width, height);
+    ID3DBlob *pErrorBlob;
+    ID3DBlob *pBlob;
+    HRESULT hr = D3DCompile(src, strlen(src),
+                            NULL,NULL,NULL, entry, spec,
+                            dwShaderFlags, 0, &pBlob, &pErrorBlob);
+    if (FAILED(hr)) {
+        if (pErrorBlob) {
+            OutputDebugStringA((char*)pErrorBlob->GetBufferPointer());
+            pErrorBlob->Release();
+        }
+        return NULL;
     }
+    if (pErrorBlob)
+        pErrorBlob->Release();
+    return pBlob;
+}
 
-    void Rebuild(int width, int height) {
-        Rebuild(width, height, width, height);
-    }
-
-    virtual void Init(int width, int height, int framebufferWidth, int framebufferHeight);
-
-    virtual void Rebuild(int width, int height,
-                         int framebufferWidth, int framebufferHeight);
-
-    virtual bool Flush();
-
-private:
-    ID3D11DeviceContext *_deviceContext;
-    ID3D11Buffer *_vbo;
-    ID3D11Buffer *_staticVbo;
-    ID3D11Texture2D *_fontTexture;
-    ID3D11InputLayout *_inputLayout;
-    ID3D11ShaderResourceView *_shaderResourceView;
-    ID3D11SamplerState *_samplerState;
-    ID3D11VertexShader *_vertexShader;
-    ID3D11PixelShader *_pixelShader;
-    ID3D11RasterizerState *_rasterizerState;
-    ID3D11Buffer* _constantBuffer;
-    int _staticVboCount;
-};
-
-#endif // D3D11_HUD_H
+}   // D3D11Utils

--- a/examples/common/d3d11Utils.h
+++ b/examples/common/d3d11Utils.h
@@ -22,36 +22,15 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include "gl_common.h"
+#ifndef OPENSUBDIV_EXAMPLES_D3D11_COMPILE_H
+#define OPENSUBDIV_EXAMPLES_D3D11_COMPILE_H
 
-void
-checkGLErrors(std::string const & where) {
+#include <D3DCompiler.h>
 
-    GLuint err;
-    while ((err = glGetError()) != GL_NO_ERROR) {
-        std::cerr << "GL error: "
-                  << (where.empty() ? "" : where + " ")
-                  << err << "\n";
-    }
+namespace D3D11Utils {
+
+ID3DBlob *CompileShader(const char *src, const char *entry, const char *spec);
+
 }
 
-GLuint
-compileShader(GLenum shaderType, const char *source) {
-
-    GLuint shader = glCreateShader(shaderType);
-    glShaderSource(shader, 1, &source, NULL);
-    glCompileShader(shader);
-
-    GLint status;
-    glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
-    if (status == GL_FALSE) {
-        GLchar emsg[40960];
-        glGetShaderInfoLog(shader, sizeof(emsg), 0, emsg);
-        fprintf(stderr, "Error compiling GLSL shader: %s\n", emsg);
-        return 0;
-    }
-
-    return shader;
-}
-
-
+#endif  // OPENSUBDIV_EXAMPLES_D3D11_COMPILE_H

--- a/examples/common/glFramebuffer.cpp
+++ b/examples/common/glFramebuffer.cpp
@@ -22,9 +22,9 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include "gl_framebuffer.h"
-#include "gl_common.h"
-#include "gl_hud.h"
+#include "glFramebuffer.h"
+#include "glUtils.h"
+#include "glHud.h"
 
 #include <cstdlib>
 #include <cassert>
@@ -111,7 +111,7 @@ GLFrameBuffer::Init(int width, int height) {
     }
 
     glBindTexture(GL_TEXTURE_2D, 0);
-    checkGLErrors("FrameBuffer::Init");
+    GLUtils::CheckGLErrors("FrameBuffer::Init");
 }
 
 void
@@ -133,7 +133,7 @@ GLFrameBuffer::allocateTexture() {
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    checkGLErrors("FrameBuffer::allocateTexture");
+    GLUtils::CheckGLErrors("FrameBuffer::allocateTexture");
     
     return texture;
 }
@@ -148,10 +148,10 @@ GLFrameBuffer::compileProgram(char const * src, char const * defines) {
                       fragDefineStr[] = "#define IMAGE_FRAGMENT_SHADER\n";
 
     std::string vertexSrc = std::string(versionStr) + vtxDefineStr + (defines ? defines : "") + src;
-    GLuint vs = compileShader(GL_VERTEX_SHADER, vertexSrc.c_str());
+    GLuint vs = GLUtils::CompileShader(GL_VERTEX_SHADER, vertexSrc.c_str());
 
     std::string fragmentSrc = std::string(versionStr) + fragDefineStr + (defines ? defines : "") + src;
-    GLuint fs = compileShader(GL_FRAGMENT_SHADER, fragmentSrc.c_str());
+    GLuint fs = GLUtils::CompileShader(GL_FRAGMENT_SHADER, fragmentSrc.c_str());
 
     glAttachShader(program, vs);
     glAttachShader(program, fs);
@@ -383,7 +383,7 @@ SSAOGLFrameBuffer::Init(int width, int height) {
         SetGamma(1.0f);
     }
 
-    checkGLErrors("SSAOGLFrameBuffer::Init");
+    GLUtils::CheckGLErrors("SSAOGLFrameBuffer::Init");
 }
 
 void

--- a/examples/common/glFramebuffer.h
+++ b/examples/common/glFramebuffer.h
@@ -22,8 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#ifndef GL_FRAMEBUFFER_H
-#define GL_FRAMEBUFFER_H
+#ifndef OPENSUBDIV_EXAMPLES_GL_FRAMEBUFFER_H
+#define OPENSUBDIV_EXAMPLES_GL_FRAMEBUFFER_H
 
 #include <osd/opengl.h>
 
@@ -131,4 +131,4 @@ private:
           _contrast;
 };
 
-#endif // GL_FRAMEBUFFER_H
+#endif  // OPENSUBDIV_EXAMPLES_GL_FRAMEBUFFER_H

--- a/examples/common/glHud.cpp
+++ b/examples/common/glHud.cpp
@@ -22,8 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include "gl_hud.h"
-#include "gl_common.h"
+#include "glHud.h"
+#include "glUtils.h"
 
 #include "font_image.h"
 #include "simple_math.h"
@@ -135,8 +135,8 @@ GLhud::Init(int width, int height, int frameBufferWidth, int frameBufferHeight)
     glGenVertexArrays(1, &_vao);
     glGenVertexArrays(1, &_staticVao);
 
-    GLuint vertexShader = compileShader(GL_VERTEX_SHADER, s_VS);
-    GLuint fragmentShader = compileShader(GL_FRAGMENT_SHADER, s_FS);
+    GLuint vertexShader = GLUtils::CompileShader(GL_VERTEX_SHADER, s_VS);
+    GLuint fragmentShader = GLUtils::CompileShader(GL_FRAGMENT_SHADER, s_FS);
 
     _program = glCreateProgram();
     glAttachShader(_program, vertexShader);
@@ -191,7 +191,7 @@ GLhud::Init(int width, int height, int frameBufferWidth, int frameBufferHeight)
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-    checkGLErrors("GLhud::Init");
+    GLUtils::CheckGLErrors("GLhud::Init");
 }
 
 void

--- a/examples/common/glHud.h
+++ b/examples/common/glHud.h
@@ -22,57 +22,57 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#ifndef GL_FONT_UTILS_H
-#define GL_FONT_UTILS_H
+#ifndef OPENSUBDIV_EXAMPLES_GL_HUD_H
+#define OPENSUBDIV_EXAMPLES_GL_HUD_H
 
-#include "../common/glUtils.h"
+#include "hud.h"
 
-#include <vector>
+#include <osd/opengl.h>
 
-class GLFont {
+#include "glFramebuffer.h"
+
+class GLhud : public Hud {
+
 public:
+    GLhud();
+    ~GLhud();
 
-    GLFont(GLuint fontTexture);
+    virtual void Init(int width, int height, int framebufferWidth, int framebufferHeight);
 
-    ~GLFont();
+    virtual void Rebuild(int width, int height,
+                         int framebufferWidth, int framebufferHeight);
 
-    void Draw(GLuint transforUB);
+    virtual bool Flush();
 
-    void Clear();
-
-    void Print3D(float const pos[3], const char * str, int color=0);
-    
-    void SetFontScale(float scale);
-
-    struct Char {
-        float pos[3];
-        float ofs[2];
-        float alpha;
-        float color;
-    };
-    
-    std::vector<Char> & GetChars() {
-        _dirty=true;
-        return _chars;
+    void SetFrameBuffer(GLFrameBuffer * frameBuffer) {
+        if (not _frameBuffer) {
+            _frameBuffer = frameBuffer;
+            _frameBuffer->Init(GetWidth(), GetHeight());
+            _frameBuffer->BuildUI(this, 10, 600);
+        }
     }
-    
-    
+
+    GLFrameBuffer * GetFrameBuffer() {
+        return _frameBuffer;
+    }
+
+    GLuint GetFontTexture() const {
+        return _fontTexture;
+    }
+
 private:
 
-    void bindProgram();
 
-    std::vector<Char> _chars;
-    bool _dirty;
+    GLFrameBuffer * _frameBuffer;
 
-    GLuint _program,
-           _transformBinding,
-           _attrPosition,
-           _attrData,
-           _fontTexture,
-           _scale,
-           _VAO,
-           _EAO,
-           _VBO;
+    GLuint _fontTexture;
+    GLuint _vbo, _staticVbo;
+    GLuint _vao, _staticVao;
+    int _staticVboSize;
+
+    GLint _program;
+    GLint _mvpMatrix;
+    GLint _aPosition, _aColor, _aUV;
 };
 
-#endif // GL_FONT_UTILS_H
+#endif  // OPENSUBDIV_EXAMPLES_GL_HUD_H

--- a/examples/common/glUtils.h
+++ b/examples/common/glUtils.h
@@ -1,5 +1,5 @@
 //
-//   Copyright 2013 Pixar
+//   Copyright 2015 Pixar
 //
 //   Licensed under the Apache License, Version 2.0 (the "Apache License")
 //   with the following modification; you may not use this file except in
@@ -22,8 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#ifndef GL_COMMON_H
-#define GL_COMMON_H
+#ifndef OPENSUBDIV_EXAMPLES_GL_UTILS_H
+#define OPENSUBDIV_EXAMPLES_GL_UTILS_H
 
 #include <osd/opengl.h>
 
@@ -31,8 +31,16 @@
 #include <string>
 #include <iostream>
 
-void checkGLErrors(std::string const & where = "");
+namespace GLUtils {
 
-GLuint compileShader(GLenum shaderType, const char *source);
+void CheckGLErrors(std::string const & where = "");
 
-#endif // GL_FRAMEBUFFER_H
+GLuint CompileShader(GLenum shaderType, const char *source);
+
+bool SupportsAdaptiveTessellation();
+
+};
+
+#endif  // OPENSUBDIV_EXAMPLES_GL_UTILS_H
+
+

--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -61,7 +61,7 @@ OpenSubdiv::Osd::D3D11MeshInterface *g_mesh;
 #include <common/vtr_utils.h>
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/d3d11_hud.h"
+#include "../common/d3d11Hud.h"
 #include "../common/d3d11PtexMipmapTexture.h"
 #include "../common/d3d11ShaderCache.h"
 

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -62,7 +62,8 @@ OpenSubdiv::Osd::D3D11MeshInterface *g_mesh;
 #include <common/vtr_utils.h>
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/d3d11_hud.h"
+#include "../common/d3d11Hud.h"
+#include "../common/d3d11Utils.h"
 #include "../common/d3d11ShaderCache.h"
 
 #include <osd/hlslPatchShaderSource.h>

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -61,8 +61,8 @@ GLFWmonitor* g_primary=0;
 
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/gl_common.h"
-#include "../common/gl_hud.h"
+#include "../common/glUtils.h"
+#include "../common/glHud.h"
 
 #include "init_shapes.h"
 #include "gl_mesh.h"
@@ -1610,7 +1610,7 @@ int main(int argc, char ** argv)
     initHUD();
     rebuildOsdMeshes();
 
-    checkGLErrors("before loop");
+    GLUtils::CheckGLErrors("before loop");
     while (g_running) {
         idle();
         display();

--- a/examples/farViewer/gl_fontutils.cpp
+++ b/examples/farViewer/gl_fontutils.cpp
@@ -78,9 +78,12 @@ void GLFont::bindProgram() {
                     gsSrc = std::string(versionStr) + geoDefineStr + shaderSource,
                     fsSrc = std::string(versionStr) + fragDefineStr + shaderSource;
 
-        GLuint vertexShader = compileShader(GL_VERTEX_SHADER, vsSrc.c_str()),
-               geometryShader = compileShader(GL_GEOMETRY_SHADER, gsSrc.c_str()),
-               fragmentShader = compileShader(GL_FRAGMENT_SHADER, fsSrc.c_str());
+        GLuint vertexShader =
+            GLUtils::CompileShader(GL_VERTEX_SHADER, vsSrc.c_str()),
+               geometryShader =
+            GLUtils::CompileShader(GL_GEOMETRY_SHADER, gsSrc.c_str()),
+               fragmentShader =
+            GLUtils::CompileShader(GL_FRAGMENT_SHADER, fsSrc.c_str());
 
         glAttachShader(_program, vertexShader);
         glAttachShader(_program, geometryShader);

--- a/examples/farViewer/gl_mesh.cpp
+++ b/examples/farViewer/gl_mesh.cpp
@@ -744,7 +744,7 @@ createTextureBuffer(T const &data, GLint format, int offset=0) {
     glBindTexture(GL_TEXTURE_BUFFER, 0);
     glDeleteBuffers(1, &buffer);
 
-    checkGLErrors("createTextureBuffer");
+    GLUtils::CheckGLErrors("createTextureBuffer");
     return texture;
 }
 
@@ -791,7 +791,7 @@ GLMesh::InitializeDeviceBuffers() {
             glBufferData(GL_ELEMENT_ARRAY_BUFFER, _eao[i].size()*sizeof(int), &_eao[i][0], GL_STATIC_DRAW);
         }
 
-        checkGLErrors("init");
+        GLUtils::CheckGLErrors("init");
     }
 
     if (not _faceColors.empty()) {
@@ -856,9 +856,12 @@ bindProgram( char const * shaderSource,
                     gsSrc = std::string(versionStr) + geoDefineStr + shaderSource,
                     fsSrc = std::string(versionStr) + fragDefineStr + shaderSource;
 
-        GLuint vertexShader = compileShader(GL_VERTEX_SHADER, vsSrc.c_str()),
-               geometryShader = geometry ? compileShader(GL_GEOMETRY_SHADER, gsSrc.c_str()) : 0,
-               fragmentShader = compileShader(GL_FRAGMENT_SHADER, fsSrc.c_str());
+        GLuint vertexShader =
+            GLUtils::CompileShader(GL_VERTEX_SHADER, vsSrc.c_str()),
+               geometryShader = geometry ?
+            GLUtils::CompileShader(GL_GEOMETRY_SHADER, gsSrc.c_str()) : 0,
+               fragmentShader =
+            GLUtils::CompileShader(GL_FRAGMENT_SHADER, fsSrc.c_str());
 
         glAttachShader(*program, vertexShader);
         if (geometry) {

--- a/examples/farViewer/gl_mesh.h
+++ b/examples/farViewer/gl_mesh.h
@@ -29,7 +29,7 @@
 #include <common/hbr_utils.h>
 #include <far/patchTables.h>
 
-#include "../common/gl_common.h"
+#include "../common/glUtils.h"
 
 #include <algorithm>
 

--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -60,7 +60,7 @@ GLFWmonitor* g_primary=0;
 #include <common/vtr_utils.h>
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/gl_hud.h"
+#include "../common/glHud.h"
 
 #include "init_shapes.h"
 #include "particles.h"

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -54,7 +54,8 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh = NULL;
 #include <common/vtr_utils.h>
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/gl_hud.h"
+#include "../common/glHud.h"
+#include "../common/glUtils.h"
 #include "../common/glShaderCache.h"
 
 #include <osd/glslPatchShaderSource.h>
@@ -1061,7 +1062,7 @@ callbackModel(int m) {
 static void
 callbackAdaptive(bool checked, int /* a */) {
 
-    if (OpenSubdiv::Osd::GLDrawContext::SupportsAdaptiveTessellation()) {
+    if (GLUtils::SupportsAdaptiveTessellation()) {
         g_adaptive = checked;
         rebuildOsdMesh();
     }
@@ -1114,7 +1115,7 @@ initHUD() {
     g_hud.AddPullDownButton(shading_pulldown, "Shaded", kShaded, g_displayStyle==kShaded);
     g_hud.AddPullDownButton(shading_pulldown, "Wire+Shaded", kWireShaded, g_displayStyle==kWireShaded);
 
-    if (OpenSubdiv::Osd::GLDrawContext::SupportsAdaptiveTessellation())
+    if (GLUtils::SupportsAdaptiveTessellation())
         g_hud.AddCheckBox("Adaptive (`)", g_adaptive != 0, 10, 250, callbackAdaptive, 0, '`');
 
     for (int i = 1; i < 11; ++i) {

--- a/examples/glPaintTest/glPaintTest.cpp
+++ b/examples/glPaintTest/glPaintTest.cpp
@@ -55,7 +55,7 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 #include <common/vtr_utils.h>
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/gl_hud.h"
+#include "../common/glHud.h"
 #include "../common/glShaderCache.h"
 
 #include "init_shapes.h"

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -97,7 +97,8 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 #include <common/vtr_utils.h>
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/gl_hud.h"
+#include "../common/glHud.h"
+#include "../common/glUtils.h"
 #include "../common/hdr_reader.h"
 #include "../common/glPtexMipmapTexture.h"
 #include "../common/glShaderCache.h"
@@ -1662,7 +1663,7 @@ callbackCheckBox(bool checked, int button) {
 
     switch (button) {
     case HUD_CB_ADAPTIVE:
-        if (OpenSubdiv::Osd::GLDrawContext::SupportsAdaptiveTessellation()) {
+        if (GLUtils::SupportsAdaptiveTessellation()) {
             g_adaptive = checked;
             rebuild = true;
         }
@@ -1976,7 +1977,7 @@ int main(int argc, char ** argv) {
     reshape();
 
     // activate feature adaptive tessellation if OSD supports it
-    g_adaptive = OpenSubdiv::Osd::GLDrawContext::SupportsAdaptiveTessellation();
+    g_adaptive = GLUtils::SupportsAdaptiveTessellation();
 
     int windowWidth = g_width, windowHeight = g_height;
 
@@ -2018,7 +2019,7 @@ int main(int argc, char ** argv) {
     g_hud.AddRadioButton(HUD_RB_SCHEME, "CATMARK", true, 10, 190, callbackScheme, 0);
     g_hud.AddRadioButton(HUD_RB_SCHEME, "BILINEAR", false, 10, 210, callbackScheme, 1);
 
-    if (OpenSubdiv::Osd::GLDrawContext::SupportsAdaptiveTessellation())
+    if (GLUtils::SupportsAdaptiveTessellation())
         g_hud.AddCheckBox("Adaptive (`)", g_adaptive,
                           10, 300, callbackCheckBox, HUD_CB_ADAPTIVE, '`');
 

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -87,7 +87,7 @@ GLFWmonitor* g_primary=0;
 
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/gl_hud.h"
+#include "../common/glHud.h"
 #include "../common/glShaderCache.h"
 
 #include <osd/glslPatchShaderSource.h>

--- a/examples/glShareTopology/sceneBase.cpp
+++ b/examples/glShareTopology/sceneBase.cpp
@@ -40,7 +40,7 @@ SceneBase::~SceneBase() {
     if (_indexBuffer) glDeleteBuffers(1, &_indexBuffer);
     if (_patchParamTexture) glDeleteTextures(1, &_patchParamTexture);
 
-    for (int i = 0; i < _patchTables.size(); ++i) {
+    for (int i = 0; i < (int)_patchTables.size(); ++i) {
         delete _patchTables[i];
     }
 }

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -45,8 +45,8 @@ GLFWmonitor* g_primary=0;
 #include <common/vtr_utils.h>
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/gl_common.h"
-#include "../common/gl_hud.h"
+#include "../common/glUtils.h"
+#include "../common/glHud.h"
 
 #include <far/patchTablesFactory.h>
 #include <far/ptexIndices.h>
@@ -418,8 +418,10 @@ public:
 
             _program = glCreateProgram();
 
-            GLuint vertexShader = compileShader(GL_VERTEX_SHADER, _vtxSrc);
-            GLuint fragmentShader = compileShader(GL_FRAGMENT_SHADER, _frgSrc);
+            GLuint vertexShader =
+                GLUtils::CompileShader(GL_VERTEX_SHADER, _vtxSrc);
+            GLuint fragmentShader =
+                GLUtils::CompileShader(GL_FRAGMENT_SHADER, _frgSrc);
 
             glAttachShader(_program, vertexShader);
             glAttachShader(_program, fragmentShader);

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -88,7 +88,8 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 #include <common/vtr_utils.h>
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/gl_hud.h"
+#include "../common/glHud.h"
+#include "../common/glUtils.h"
 #include "../common/objAnim.h"
 #include "../common/glShaderCache.h"
 
@@ -1511,7 +1512,7 @@ callbackModel(int m) {
 static void
 callbackCheckBox(bool checked, int button) {
 
-    if (OpenSubdiv::Osd::GLDrawContext::SupportsAdaptiveTessellation()) {
+    if (GLUtils::SupportsAdaptiveTessellation()) {
         switch(button) {
         case kHUD_CB_ADAPTIVE:
             g_adaptive = checked;
@@ -1620,7 +1621,7 @@ initHUD() {
         g_hud.AddPullDownButton(compute_pulldown, "GLSL Compute", kGLSLCompute);
     }
 #endif
-    if (OpenSubdiv::Osd::GLDrawContext::SupportsAdaptiveTessellation()) {
+    if (GLUtils::SupportsAdaptiveTessellation()) {
         g_hud.AddCheckBox("Adaptive (`)", g_adaptive!=0,
                           10, 190, callbackCheckBox, kHUD_CB_ADAPTIVE, '`');
         g_hud.AddCheckBox("Single Crease Patch (S)", g_singleCreasePatch!=0,
@@ -1834,7 +1835,7 @@ int main(int argc, char ** argv) {
 #endif
 
     // activate feature adaptive tessellation if OSD supports it
-    g_adaptive = OpenSubdiv::Osd::GLDrawContext::SupportsAdaptiveTessellation();
+    g_adaptive = GLUtils::SupportsAdaptiveTessellation();
 
     initGL();
     linkDefaultProgram();

--- a/opensubdiv/osd/glDrawContext.cpp
+++ b/opensubdiv/osd/glDrawContext.cpp
@@ -48,21 +48,6 @@ GLDrawContext::~GLDrawContext()
     glDeleteTextures(1, &_fvarDataTextureBuffer);
 }
 
-bool
-GLDrawContext::SupportsAdaptiveTessellation()
-{
-#ifdef OSD_USES_GLEW
-    // XXX: uncomment here to try tessellation on OSX
-    // if (GLEW_ARB_tessellation_shader)
-    //    return true;
-#endif
-    static const GLubyte *version = glGetString(GL_VERSION);
-    if (version and version[0] == '4')
-        return true;
-
-    return false;
-}
-
 template <typename T> static GLuint
 createTextureBuffer(T const &data, GLint format, int offset=0)
 {

--- a/opensubdiv/osd/glDrawContext.h
+++ b/opensubdiv/osd/glDrawContext.h
@@ -74,9 +74,6 @@ public:
             updateVertexTexture(vbo->BindVBO());
     }
 
-    /// true if the GL version detected supports shader tessellation
-    static bool SupportsAdaptiveTessellation();
-
     /// Returns the GL texture buffer containing the patch control vertices array
     GLuint GetPatchIndexBuffer() const {
         return _patchIndexBuffer;


### PR DESCRIPTION
As a preparation for retiring DrawContext, move SupportsAdaptiveTessellation
method to examples/common/glUtils, which is renamed and namespaced
from gl_common.{cpp,h} to be consistent to other files.
Same renamings applied to other example files too.