### PR TITLE
Fixed FindDXSDK to prefer more recent D3DCompile

### DIFF
--- a/cmake/FindDXSDK.cmake
+++ b/cmake/FindDXSDK.cmake
@@ -42,9 +42,9 @@ if (WIN32)
             "$ENV{DXSDK_LOCATION}/Include"
             "${DXSDK_ROOT}/Include"
             "$ENV{DXSDK_ROOT}/Include"
+            "C:/Program Files (x86)/Windows Kits/8.1/Include/um"
             "C:/Program Files (x86)/Microsoft DirectX SDK*/Include"
             "C:/Program Files/Microsoft DirectX SDK*/Include"
-            "C:/Program Files (x86)/Windows Kits/8.1/Include/um"
     )
 
     if ("${CMAKE_GENERATOR}" MATCHES "[Ww]in64")
@@ -60,9 +60,9 @@ if (WIN32)
             "$ENV{DXSDK_LOCATION}/Lib/${ARCH}"
             "${DXSDK_ROOT}/Lib/${ARCH}"
             "$ENV{DXSDK_ROOT}/Lib/${ARCH}"
+            "C:/Program Files (x86)/Windows Kits/8.1/Lib/winv6.3/um/${ARCH}"
             "C:/Program Files (x86)/Microsoft DirectX SDK*/Lib/${ARCH}"
             "C:/Program Files/Microsoft DirectX SDK*/Lib/${ARCH}"
-            "C:/Program Files (x86)/Windows Kits/8.1/Lib/winv6.3/um/${ARCH}"
     )
 
     set(DXSDK_LIBRARY_DIR ${LIBRARY_DIR})


### PR DESCRIPTION
The most up-to-date version of the HLSL compiler is now shipped as part
of the Windows SDK. Previously, the HLSL compiler was included with
the DirectX SDK.

There is more that we can do to improve this cmake module, but this
makes it more likely to find the correct tool.