### PR TITLE
Minor performance improvements to Sdc limit masks for the regular case:

### DIFF
--- a/opensubdiv/sdc/catmarkScheme.h
+++ b/opensubdiv/sdc/catmarkScheme.h
@@ -261,20 +261,32 @@ Scheme<SCHEME_CATMARK>::assignSmoothLimitMask(VERTEX const& vertex, MASK& posMas
     posMask.SetFaceWeightsForFaceCenters(false);
 
     //  Specialize for the regular case:
-    Weight fWeight = 1.0f / 36.0f;
-    Weight eWeight = 1.0f /  9.0f;
-    Weight vWeight = 4.0f /  9.0f;
+    if (valence == 4) {
+        Weight fWeight = 1.0f / 36.0f;
+        Weight eWeight = 1.0f /  9.0f;
+        Weight vWeight = 4.0f /  9.0f;
 
-    if (valence != 4) {
-        fWeight = 1.0f / (Weight)(valence * (valence + 5.0f));
-        eWeight = 4.0f * fWeight;
-        vWeight = (Weight)(1.0f - valence * (eWeight + fWeight));
-    }
+        posMask.VertexWeight(0) = vWeight;
 
-    posMask.VertexWeight(0) = vWeight;
-    for (int i = 0; i < valence; ++i) {
-        posMask.EdgeWeight(i) = eWeight;
-        posMask.FaceWeight(i) = fWeight;
+        posMask.EdgeWeight(0) = eWeight;
+        posMask.EdgeWeight(1) = eWeight;
+        posMask.EdgeWeight(2) = eWeight;
+        posMask.EdgeWeight(3) = eWeight;
+
+        posMask.FaceWeight(0) = fWeight;
+        posMask.FaceWeight(1) = fWeight;
+        posMask.FaceWeight(2) = fWeight;
+        posMask.FaceWeight(3) = fWeight;
+    } else {
+        Weight fWeight = 1.0f / (Weight)(valence * (valence + 5.0f));
+        Weight eWeight = 4.0f * fWeight;
+        Weight vWeight = (Weight)(1.0f - valence * (eWeight + fWeight));
+
+        posMask.VertexWeight(0) = vWeight;
+        for (int i = 0; i < valence; ++i) {
+            posMask.EdgeWeight(i) = eWeight;
+            posMask.FaceWeight(i) = fWeight;
+        }
     }
 }
 
@@ -494,12 +506,23 @@ Scheme<SCHEME_CATMARK>::assignSmoothLimitTangentMasks(VERTEX const& vertex,
     tan2Mask.SetFaceWeightsForFaceCenters(false);
 
     tan2Mask.VertexWeight(0) = 0.0f;
+    if (valence == 4) {
+        tan2Mask.EdgeWeight(0) =  0.0f;
+        tan2Mask.EdgeWeight(1) =  4.0f;
+        tan2Mask.EdgeWeight(2) =  0.0f;
+        tan2Mask.EdgeWeight(3) = -4.0f;
 
-    tan2Mask.EdgeWeight(0) = tan1Mask.EdgeWeight(valence-1);
-    tan2Mask.FaceWeight(0) = tan1Mask.FaceWeight(valence-1);
-    for (int i = 1; i < valence; ++i) {
-        tan2Mask.EdgeWeight(i) = tan1Mask.EdgeWeight(i-1);
-        tan2Mask.FaceWeight(i) = tan1Mask.FaceWeight(i-1);
+        tan2Mask.FaceWeight(0) =  1.0f;
+        tan2Mask.FaceWeight(1) =  1.0f;
+        tan2Mask.FaceWeight(2) = -1.0f;
+        tan2Mask.FaceWeight(3) = -1.0f;
+    } else {
+        tan2Mask.EdgeWeight(0) = tan1Mask.EdgeWeight(valence-1);
+        tan2Mask.FaceWeight(0) = tan1Mask.FaceWeight(valence-1);
+        for (int i = 1; i < valence; ++i) {
+            tan2Mask.EdgeWeight(i) = tan1Mask.EdgeWeight(i-1);
+            tan2Mask.FaceWeight(i) = tan1Mask.FaceWeight(i-1);
+        }
     }
 }
 

--- a/opensubdiv/sdc/loopScheme.h
+++ b/opensubdiv/sdc/loopScheme.h
@@ -280,22 +280,32 @@ Scheme<SCHEME_LOOP>::assignSmoothLimitMask(VERTEX const& vertex, MASK& posMask) 
     posMask.SetFaceWeightsForFaceCenters(false);
 
     //  Specialize for the regular case:  1/12 per edge-vert, 1/2 for the vert itself:
-    Weight eWeight = 1.0f / 12.0f;
-    Weight vWeight = 0.5f;
+    if (valence == 6) {
+        Weight eWeight = 1.0f / 12.0f;
+        Weight vWeight = 0.5f;
 
-    if (valence != 6) {
+        posMask.VertexWeight(0) = vWeight;
+
+        posMask.EdgeWeight(0) = eWeight;
+        posMask.EdgeWeight(1) = eWeight;
+        posMask.EdgeWeight(2) = eWeight;
+        posMask.EdgeWeight(3) = eWeight;
+        posMask.EdgeWeight(4) = eWeight;
+        posMask.EdgeWeight(5) = eWeight;
+
+    } else {
         Weight invValence = 1.0f / valence;
 
         Weight beta = 0.25f * cosf((Weight)M_PI * 2.0f * invValence) + 0.375f;
         beta = (0.625f - (beta * beta)) * invValence;;
 
-        eWeight = 1.0f / (valence + 3.0f / (8.0f * beta));
-        vWeight = (Weight)(1.0f - (eWeight * valence));
-    }
+        Weight eWeight = 1.0f / (valence + 3.0f / (8.0f * beta));
+        Weight vWeight = (Weight)(1.0f - (eWeight * valence));
 
-    posMask.VertexWeight(0) = vWeight;
-    for (int i = 0; i < valence; ++i) {
-        posMask.EdgeWeight(i) = eWeight;
+        posMask.VertexWeight(0) = vWeight;
+        for (int i = 0; i < valence; ++i) {
+            posMask.EdgeWeight(i) = eWeight;
+        }
     }
 }
 


### PR DESCRIPTION
 Just a little more simple loop unrolling and branch reduction for the regular limit masks for Catmark and Loop.  Gathering the limit masks does show up high enough on the profiling radar, so every little bit helps.