### PR TITLE
Remove #pragma once

### DIFF
--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.h
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_END_CAP_BSPLINE_BASIS_PATCH_FACTORY_H
 #define OPENSUBDIV3_FAR_END_CAP_BSPLINE_BASIS_PATCH_FACTORY_H
 

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.h
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_END_CAP_GREGORY_BASIS_PATCH_FACTORY_H
 #define OPENSUBDIV3_FAR_END_CAP_GREGORY_BASIS_PATCH_FACTORY_H
 

--- a/opensubdiv/far/endCapLegacyGregoryPatchFactory.h
+++ b/opensubdiv/far/endCapLegacyGregoryPatchFactory.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_END_CAP_LEGACY_GREGORY_PATCH_FACTORY_H
 #define OPENSUBDIV3_FAR_END_CAP_LEGACY_GREGORY_PATCH_FACTORY_H
 

--- a/opensubdiv/far/error.h
+++ b/opensubdiv/far/error.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_ERROR_H
 #define OPENSUBDIV3_FAR_ERROR_H
 

--- a/opensubdiv/far/gregoryBasis.h
+++ b/opensubdiv/far/gregoryBasis.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_GREGORY_BASIS_H
 #define OPENSUBDIV3_FAR_GREGORY_BASIS_H
 

--- a/opensubdiv/far/interpolate.h
+++ b/opensubdiv/far/interpolate.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_INTERPOLATE_H
 #define OPENSUBDIV3_FAR_INTERPOLATE_H
 

--- a/opensubdiv/far/patchDescriptor.h
+++ b/opensubdiv/far/patchDescriptor.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_PATCH_DESCRIPTOR_H
 #define OPENSUBDIV3_FAR_PATCH_DESCRIPTOR_H
 

--- a/opensubdiv/far/patchMap.h
+++ b/opensubdiv/far/patchMap.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_PATCH_MAP_H
 #define OPENSUBDIV3_FAR_PATCH_MAP_H
 

--- a/opensubdiv/far/patchParam.h
+++ b/opensubdiv/far/patchParam.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_PATCH_PARAM_H
 #define OPENSUBDIV3_FAR_PATCH_PARAM_H
 

--- a/opensubdiv/far/patchTables.h
+++ b/opensubdiv/far/patchTables.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_PATCH_TABLES_H
 #define OPENSUBDIV3_FAR_PATCH_TABLES_H
 

--- a/opensubdiv/far/patchTablesFactory.h
+++ b/opensubdiv/far/patchTablesFactory.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_PATCH_TABLES_FACTORY_H
 #define OPENSUBDIV3_FAR_PATCH_TABLES_FACTORY_H
 

--- a/opensubdiv/far/protoStencil.h
+++ b/opensubdiv/far/protoStencil.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_PROTOSTENCIL_H
 #define OPENSUBDIV3_FAR_PROTOSTENCIL_H
 

--- a/opensubdiv/far/ptexIndices.h
+++ b/opensubdiv/far/ptexIndices.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_FAR_PTEX_INDICES_H
 #define OPENSUBDIV3_FAR_PTEX_INDICES_H
 

--- a/opensubdiv/far/stencilTables.h
+++ b/opensubdiv/far/stencilTables.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_STENCILTABLES_H
 #define OPENSUBDIV3_FAR_STENCILTABLES_H
 

--- a/opensubdiv/far/stencilTablesFactory.h
+++ b/opensubdiv/far/stencilTablesFactory.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_STENCILTABLE_FACTORY_H
 #define OPENSUBDIV3_FAR_STENCILTABLE_FACTORY_H
 

--- a/opensubdiv/far/topologyLevel.h
+++ b/opensubdiv/far/topologyLevel.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_FAR_TOPOLOGY_LEVEL_H
 #define OPENSUBDIV3_FAR_TOPOLOGY_LEVEL_H
 

--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_FAR_TOPOLOGY_REFINER_H
 #define OPENSUBDIV3_FAR_TOPOLOGY_REFINER_H
 

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_FAR_TOPOLOGY_REFINER_FACTORY_H
 #define OPENSUBDIV3_FAR_TOPOLOGY_REFINER_FACTORY_H
 

--- a/opensubdiv/far/types.h
+++ b/opensubdiv/far/types.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_FAR_TYPES_H
 #define OPENSUBDIV3_FAR_TYPES_H
 

--- a/opensubdiv/hbr/allocator.h
+++ b/opensubdiv/hbr/allocator.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRALLOCATOR_H
 #define OPENSUBDIV3_HBRALLOCATOR_H
 

--- a/opensubdiv/hbr/bilinear.h
+++ b/opensubdiv/hbr/bilinear.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRBILINEAR_H
 #define OPENSUBDIV3_HBRBILINEAR_H
 

--- a/opensubdiv/hbr/catmark.h
+++ b/opensubdiv/hbr/catmark.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRCATMARK_H
 #define OPENSUBDIV3_HBRCATMARK_H
 

--- a/opensubdiv/hbr/cornerEdit.h
+++ b/opensubdiv/hbr/cornerEdit.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRCORNEREDIT_H
 #define OPENSUBDIV3_HBRCORNEREDIT_H
 

--- a/opensubdiv/hbr/creaseEdit.h
+++ b/opensubdiv/hbr/creaseEdit.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRCREASEEDIT_H
 #define OPENSUBDIV3_HBRCREASEEDIT_H
 

--- a/opensubdiv/hbr/face.h
+++ b/opensubdiv/hbr/face.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRFACE_H
 #define OPENSUBDIV3_HBRFACE_H
 

--- a/opensubdiv/hbr/faceEdit.h
+++ b/opensubdiv/hbr/faceEdit.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRFACEEDIT_H
 #define OPENSUBDIV3_HBRFACEEDIT_H
 

--- a/opensubdiv/hbr/fvarData.h
+++ b/opensubdiv/hbr/fvarData.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRFVARDATA_H
 #define OPENSUBDIV3_HBRFVARDATA_H
 

--- a/opensubdiv/hbr/fvarEdit.h
+++ b/opensubdiv/hbr/fvarEdit.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRFVAREDIT_H
 #define OPENSUBDIV3_HBRFVAREDIT_H
 

--- a/opensubdiv/hbr/halfedge.h
+++ b/opensubdiv/hbr/halfedge.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRHALFEDGE_H
 #define OPENSUBDIV3_HBRHALFEDGE_H
 

--- a/opensubdiv/hbr/hierarchicalEdit.h
+++ b/opensubdiv/hbr/hierarchicalEdit.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRHIERARCHICALEDIT_H
 #define OPENSUBDIV3_HBRHIERARCHICALEDIT_H
 

--- a/opensubdiv/hbr/holeEdit.h
+++ b/opensubdiv/hbr/holeEdit.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRHOLEEDIT_H
 #define OPENSUBDIV3_HBRHOLEEDIT_H
 

--- a/opensubdiv/hbr/loop.h
+++ b/opensubdiv/hbr/loop.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRLOOP_H
 #define OPENSUBDIV3_HBRLOOP_H
 

--- a/opensubdiv/hbr/mesh.h
+++ b/opensubdiv/hbr/mesh.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRMESH_H
 #define OPENSUBDIV3_HBRMESH_H
 

--- a/opensubdiv/hbr/subdivision.h
+++ b/opensubdiv/hbr/subdivision.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRSUBDIVISION_H
 #define OPENSUBDIV3_HBRSUBDIVISION_H
 

--- a/opensubdiv/hbr/vertex.h
+++ b/opensubdiv/hbr/vertex.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRVERTEX_H
 #define OPENSUBDIV3_HBRVERTEX_H
 

--- a/opensubdiv/hbr/vertexEdit.h
+++ b/opensubdiv/hbr/vertexEdit.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_HBRVERTEXEDIT_H
 #define OPENSUBDIV3_HBRVERTEXEDIT_H
 

--- a/opensubdiv/osd/clD3D11VertexBuffer.h
+++ b/opensubdiv/osd/clD3D11VertexBuffer.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CL_D3D11_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_CL_D3D11_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/clEvaluator.h
+++ b/opensubdiv/osd/clEvaluator.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV_OPENSUBDIV3_OSD_CL_EVALUATOR_H
 #define OPENSUBDIV_OPENSUBDIV3_OSD_CL_EVALUATOR_H
 

--- a/opensubdiv/osd/clGLVertexBuffer.h
+++ b/opensubdiv/osd/clGLVertexBuffer.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CL_GL_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_CL_GL_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/clVertexBuffer.h
+++ b/opensubdiv/osd/clVertexBuffer.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CL_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_CL_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/cpuD3D11VertexBuffer.h
+++ b/opensubdiv/osd/cpuD3D11VertexBuffer.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CPU_D3D11_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_CPU_D3D11_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/cpuEvaluator.h
+++ b/opensubdiv/osd/cpuEvaluator.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CPU_EVALUATOR_H
 #define OPENSUBDIV3_OSD_CPU_EVALUATOR_H
 

--- a/opensubdiv/osd/cpuGLVertexBuffer.h
+++ b/opensubdiv/osd/cpuGLVertexBuffer.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CPU_GL_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_CPU_GL_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/cpuKernel.h
+++ b/opensubdiv/osd/cpuKernel.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CPU_KERNEL_H
 #define OPENSUBDIV3_OSD_CPU_KERNEL_H
 

--- a/opensubdiv/osd/cpuSmoothNormalContext.h
+++ b/opensubdiv/osd/cpuSmoothNormalContext.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CPU_SMOOTHNORMAL_CONTEXT_H
 #define OPENSUBDIV3_OSD_CPU_SMOOTHNORMAL_CONTEXT_H
 

--- a/opensubdiv/osd/cpuSmoothNormalController.h
+++ b/opensubdiv/osd/cpuSmoothNormalController.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CPU_SMOOTHNORMAL_CONTROLLER_H
 #define OPENSUBDIV3_OSD_CPU_SMOOTHNORMAL_CONTROLLER_H
 

--- a/opensubdiv/osd/cpuVertexBuffer.h
+++ b/opensubdiv/osd/cpuVertexBuffer.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CPU_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_CPU_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/cudaD3D11VertexBuffer.h
+++ b/opensubdiv/osd/cudaD3D11VertexBuffer.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CUDA_D3D11_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_CUDA_D3D11_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/cudaEvaluator.h
+++ b/opensubdiv/osd/cudaEvaluator.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CUDA_EVALUATOR_H
 #define OPENSUBDIV3_OSD_CUDA_EVALUATOR_H
 

--- a/opensubdiv/osd/cudaGLVertexBuffer.h
+++ b/opensubdiv/osd/cudaGLVertexBuffer.h
@@ -23,7 +23,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CUDA_GL_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_CUDA_GL_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/cudaVertexBuffer.h
+++ b/opensubdiv/osd/cudaVertexBuffer.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CUDA_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_CUDA_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/d3d11ComputeEvaluator.h
+++ b/opensubdiv/osd/d3d11ComputeEvaluator.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_D3D11_COMPUTE_EVALUATOR_H
 #define OPENSUBDIV3_OSD_D3D11_COMPUTE_EVALUATOR_H
 

--- a/opensubdiv/osd/d3d11DrawContext.h
+++ b/opensubdiv/osd/d3d11DrawContext.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_D3D11L_DRAW_CONTEXT_H
 #define OPENSUBDIV3_OSD_D3D11L_DRAW_CONTEXT_H
 

--- a/opensubdiv/osd/d3d11Mesh.h
+++ b/opensubdiv/osd/d3d11Mesh.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_D3D11MESH_H
 #define OPENSUBDIV3_OSD_D3D11MESH_H
 

--- a/opensubdiv/osd/d3d11VertexBuffer.h
+++ b/opensubdiv/osd/d3d11VertexBuffer.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_D3D11_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_D3D11_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/debug.h
+++ b/opensubdiv/osd/debug.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_DEBUG_H
 #define OPENSUBDIV3_OSD_DEBUG_H
 

--- a/opensubdiv/osd/drawContext.h
+++ b/opensubdiv/osd/drawContext.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_DRAW_CONTEXT_H
 #define OPENSUBDIV3_OSD_DRAW_CONTEXT_H
 

--- a/opensubdiv/osd/glComputeEvaluator.h
+++ b/opensubdiv/osd/glComputeEvaluator.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_GL_COMPUTE_EVALUATOR_H
 #define OPENSUBDIV3_OSD_GL_COMPUTE_EVALUATOR_H
 

--- a/opensubdiv/osd/glDrawContext.h
+++ b/opensubdiv/osd/glDrawContext.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_GL_DRAW_CONTEXT_H
 #define OPENSUBDIV3_OSD_GL_DRAW_CONTEXT_H
 

--- a/opensubdiv/osd/glMesh.h
+++ b/opensubdiv/osd/glMesh.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_GL_MESH_H
 #define OPENSUBDIV3_OSD_GL_MESH_H
 

--- a/opensubdiv/osd/glVertexBuffer.h
+++ b/opensubdiv/osd/glVertexBuffer.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_GL_VERTEX_BUFFER_H
 #define OPENSUBDIV3_OSD_GL_VERTEX_BUFFER_H
 

--- a/opensubdiv/osd/glXFBEvaluator.h
+++ b/opensubdiv/osd/glXFBEvaluator.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_GL_XFB_EVALUATOR_H
 #define OPENSUBDIV3_OSD_GL_XFB_EVALUATOR_H
 

--- a/opensubdiv/osd/glslPatchShaderSource.h
+++ b/opensubdiv/osd/glslPatchShaderSource.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_GLSL_PATCH_SHADER_SOURCE_H
 #define OPENSUBDIV3_OSD_GLSL_PATCH_SHADER_SOURCE_H
 

--- a/opensubdiv/osd/hlslPatchShaderSource.h
+++ b/opensubdiv/osd/hlslPatchShaderSource.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_HLSL_PATCH_SHADER_SOURCE_H
 #define OPENSUBDIV3_OSD_HLSL_PATCH_SHADER_SOURCE_H
 

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_MESH_H
 #define OPENSUBDIV3_OSD_MESH_H
 

--- a/opensubdiv/osd/nonCopyable.h
+++ b/opensubdiv/osd/nonCopyable.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_NON_COPYABLE_H
 #define OPENSUBDIV3_OSD_NON_COPYABLE_H
 

--- a/opensubdiv/osd/ompEvaluator.h
+++ b/opensubdiv/osd/ompEvaluator.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_OMP_EVALUATOR_H
 #define OPENSUBDIV3_OSD_OMP_EVALUATOR_H
 

--- a/opensubdiv/osd/ompKernel.h
+++ b/opensubdiv/osd/ompKernel.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_OMP_KERNEL_H
 #define OPENSUBDIV3_OSD_OMP_KERNEL_H
 

--- a/opensubdiv/osd/opencl.h
+++ b/opensubdiv/osd/opencl.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_OPENCL_H
 #define OPENSUBDIV3_OSD_OPENCL_H
 

--- a/opensubdiv/osd/opengl.h
+++ b/opensubdiv/osd/opengl.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_OPENGL_H
 #define OPENSUBDIV3_OSD_OPENGL_H
 

--- a/opensubdiv/osd/tbbEvaluator.h
+++ b/opensubdiv/osd/tbbEvaluator.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_TBB_EVALUATOR_H
 #define OPENSUBDIV3_OSD_TBB_EVALUATOR_H
 

--- a/opensubdiv/osd/tbbKernel.h
+++ b/opensubdiv/osd/tbbKernel.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_TBB_KERNEL_H
 #define OPENSUBDIV3_OSD_TBB_KERNEL_H
 

--- a/opensubdiv/osd/tbbSmoothNormalController.h
+++ b/opensubdiv/osd/tbbSmoothNormalController.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_TBB_SMOOTHNORMAL_CONTROLLER_H
 #define OPENSUBDIV3_OSD_TBB_SMOOTHNORMAL_CONTROLLER_H
 

--- a/opensubdiv/osd/vertexDescriptor.h
+++ b/opensubdiv/osd/vertexDescriptor.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_OSD_CPU_VERTEX_DESCRIPTOR_H
 #define OPENSUBDIV3_OSD_CPU_VERTEX_DESCRIPTOR_H
 

--- a/opensubdiv/sdc/bilinearScheme.h
+++ b/opensubdiv/sdc/bilinearScheme.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_SDC_BILINEAR_SCHEME_H
 #define OPENSUBDIV3_SDC_BILINEAR_SCHEME_H
 

--- a/opensubdiv/sdc/catmarkScheme.h
+++ b/opensubdiv/sdc/catmarkScheme.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_SDC_CATMARK_SCHEME_H
 #define OPENSUBDIV3_SDC_CATMARK_SCHEME_H
 

--- a/opensubdiv/sdc/crease.h
+++ b/opensubdiv/sdc/crease.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_SDC_CREASE_H
 #define OPENSUBDIV3_SDC_CREASE_H
 

--- a/opensubdiv/sdc/loopScheme.h
+++ b/opensubdiv/sdc/loopScheme.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_SDC_LOOP_SCHEME_H
 #define OPENSUBDIV3_SDC_LOOP_SCHEME_H
 

--- a/opensubdiv/sdc/options.h
+++ b/opensubdiv/sdc/options.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_SDC_OPTIONS_H
 #define OPENSUBDIV3_SDC_OPTIONS_H
 

--- a/opensubdiv/sdc/scheme.h
+++ b/opensubdiv/sdc/scheme.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_SDC_SCHEME_H
 #define OPENSUBDIV3_SDC_SCHEME_H
 

--- a/opensubdiv/sdc/types.h
+++ b/opensubdiv/sdc/types.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_SDC_TYPES_H
 #define OPENSUBDIV3_SDC_TYPES_H
 

--- a/opensubdiv/version.h
+++ b/opensubdiv/version.h
@@ -22,7 +22,6 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#pragma once
 #ifndef OPENSUBDIV3_VERSION_H
 #define OPENSUBDIV3_VERSION_H
 

--- a/opensubdiv/vtr/array.h
+++ b/opensubdiv/vtr/array.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_ARRAY_INTERFACE_H
 #define OPENSUBDIV3_VTR_ARRAY_INTERFACE_H
 

--- a/opensubdiv/vtr/fvarLevel.h
+++ b/opensubdiv/vtr/fvarLevel.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_FVAR_LEVEL_H
 #define OPENSUBDIV3_VTR_FVAR_LEVEL_H
 

--- a/opensubdiv/vtr/fvarRefinement.h
+++ b/opensubdiv/vtr/fvarRefinement.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_FVAR_REFINEMENT_H
 #define OPENSUBDIV3_VTR_FVAR_REFINEMENT_H
 

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_LEVEL_H
 #define OPENSUBDIV3_VTR_LEVEL_H
 

--- a/opensubdiv/vtr/maskInterfaces.h
+++ b/opensubdiv/vtr/maskInterfaces.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_INTERFACES_H
 #define OPENSUBDIV3_VTR_INTERFACES_H
 

--- a/opensubdiv/vtr/quadRefinement.h
+++ b/opensubdiv/vtr/quadRefinement.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_QUAD_REFINEMENT_H
 #define OPENSUBDIV3_VTR_QUAD_REFINEMENT_H
 

--- a/opensubdiv/vtr/refinement.h
+++ b/opensubdiv/vtr/refinement.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_REFINEMENT_H
 #define OPENSUBDIV3_VTR_REFINEMENT_H
 

--- a/opensubdiv/vtr/sparseSelector.h
+++ b/opensubdiv/vtr/sparseSelector.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_SPARSE_SELECTOR_H
 #define OPENSUBDIV3_VTR_SPARSE_SELECTOR_H
 

--- a/opensubdiv/vtr/stackBuffer.h
+++ b/opensubdiv/vtr/stackBuffer.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_STACK_BUFFER_H
 #define OPENSUBDIV3_VTR_STACK_BUFFER_H
 

--- a/opensubdiv/vtr/triRefinement.h
+++ b/opensubdiv/vtr/triRefinement.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_TRI_REFINEMENT_H
 #define OPENSUBDIV3_VTR_TRI_REFINEMENT_H
 

--- a/opensubdiv/vtr/types.h
+++ b/opensubdiv/vtr/types.h
@@ -21,7 +21,6 @@
 //   KIND, either express or implied. See the Apache License for the specific
 //   language governing permissions and limitations under the Apache License.
 //
-#pragma once
 #ifndef OPENSUBDIV3_VTR_TYPES_H
 #define OPENSUBDIV3_VTR_TYPES_H
 


### PR DESCRIPTION
While this may be worth revisiting, we should first quantify the benefits and
identify the compilers that support it. Ultimately, we may never use pragma
once in favor of strictly using standard C++.