### PR TITLE
Break friendship between GegoryBasis and Factory

### DIFF
--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
@@ -83,23 +83,10 @@ EndCapGregoryBasisPatchFactory::Create(TopologyRefiner const & refiner,
     }
 
     GregoryBasis::ProtoBasis basis(level, faceIndex, fvarChannel);
-
-    int nelems= basis.GetNumElements();
-
     GregoryBasis * result = new GregoryBasis;
-
-    result->_indices.resize(nelems);
-    result->_weights.resize(nelems);
-
-    basis.Copy(result->_sizes, &result->_indices[0], &result->_weights[0]);
+    basis.Copy(result);
 
     // note: this function doesn't create varying stencils.
-
-    for (int i=0, offset=0; i<20; ++i) {
-        result->_offsets[i] = offset;
-        offset += result->_sizes[i];
-    }
-
     return result;
 }
 

--- a/opensubdiv/far/gregoryBasis.cpp
+++ b/opensubdiv/far/gregoryBasis.cpp
@@ -111,6 +111,16 @@ GregoryBasis::ProtoBasis::Copy(int * sizes, Index * indices, float * weights) co
     }
 }
 
+void
+GregoryBasis::ProtoBasis::Copy(GregoryBasis * dest) const {
+    int nelems = GetNumElements();
+
+    dest->_indices.resize(nelems);
+    dest->_weights.resize(nelems);
+
+    Copy(dest->_sizes, &dest->_indices[0], &dest->_weights[0]);
+}
+
 inline float csf(Index n, Index j) {
     if (j%2 == 0) {
         return cosf((2.0f * float(M_PI) * float(float(j-0)/2.0f))/(float(n)+3.0f));

--- a/opensubdiv/far/gregoryBasis.h
+++ b/opensubdiv/far/gregoryBasis.h
@@ -194,8 +194,8 @@ public:
 
         int _size;
         // XXXX this would really be better with VLA where we only allocate
-        // space based on the max vertex valence in the mesh, not the
-        // absolute maximum supported by the closed-form tangents table.
+        // space based on the max vertex valence in the mesh, not the absolute
+        // maximum supported by the closed-form tangents table.
         Index _indices[MAX_ELEMS];
         float _weights[MAX_ELEMS];
     };
@@ -203,8 +203,8 @@ public:
     //
     // ProtoBasis
     //
-    // Given a Vtr::Level and a face index, gathers all the influences of the 1-ring
-    // that supports the 20 CVs of a Gregory patch basis.
+    // Given a Vtr::Level and a face index, gathers all the influences of the
+    // 1-ring that supports the 20 CVs of a Gregory patch basis.
     //
     struct ProtoBasis {
 
@@ -213,10 +213,12 @@ public:
         int GetNumElements() const;
 
         void Copy(int * sizes, Index * indices, float * weights) const;
+        void Copy(GregoryBasis* dest) const;
 
         // Control Vertices based on :
-        // "Approximating Subdivision Surfaces with Gregory Patches for Hardware Tessellation"
-        // Loop, Schaefer, Ni, Castafio (ACM ToG Siggraph Asia 2009)
+        // "Approximating Subdivision Surfaces with Gregory Patches for Hardware
+        // Tessellation" Loop, Schaefer, Ni, Castafio (ACM ToG Siggraph Asia
+        // 2009)
         //
         //  P3         e3-      e2+         P2
         //     O--------O--------O--------O
@@ -250,10 +252,7 @@ public:
 
 private:
 
-    friend class EndCapGregoryBasisPatchFactory;
-
-    int _sizes[20],
-        _offsets[20];
+    int _sizes[20];
 
     std::vector<Index> _indices;
     std::vector<float> _weights;


### PR DESCRIPTION
In addition to breaking the friend ship, there was also an unused variable (_offsets) which I removed.

I also wrapped a few lines that looked like they were intended to be 80 chars long, but were slightly longer.