### PR TITLE
Fix invalid gregory patch tesslevel computation / enable backface culling in DX examples

### DIFF
--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -1493,7 +1493,7 @@ initD3D11(HWND hWnd) {
     D3D11_RASTERIZER_DESC rasterDesc;
     ZeroMemory(&rasterDesc, sizeof(rasterDesc));
     rasterDesc.AntialiasedLineEnable = false;
-    rasterDesc.CullMode = D3D11_CULL_NONE; // XXX
+    rasterDesc.CullMode = D3D11_CULL_BACK;
     rasterDesc.DepthBias = 0;
     rasterDesc.DepthBiasClamp = 0.0f;
     rasterDesc.DepthClipEnable = true;

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -1259,8 +1259,7 @@ initD3D11(HWND hWnd) {
     D3D11_RASTERIZER_DESC rasterDesc;
     ZeroMemory(&rasterDesc, sizeof(rasterDesc));
     rasterDesc.AntialiasedLineEnable = false;
-    //rasterDesc.CullMode = D3D11_CULL_NONE; // XXX
-    rasterDesc.CullMode = D3D11_CULL_BACK; // XXX
+    rasterDesc.CullMode = D3D11_CULL_BACK;
     rasterDesc.DepthBias = 0;
     rasterDesc.DepthBiasClamp = 0.0f;
     rasterDesc.DepthClipEnable = true;

--- a/opensubdiv/osd/glslPatchGregory.glsl
+++ b/opensubdiv/osd/glslPatchGregory.glsl
@@ -401,16 +401,30 @@ void main()
 
     outpt[ID].v.patchCoord = OsdGetPatchCoord(patchParam);
 
+#if defined OSD_ENABLE_SCREENSPACE_TESSELLATION
+    // Wait for all basis conversion to be finished
+    barrier();
+#endif
     if (ID == 0) {
         OSD_PATCH_CULL(4);
 
         vec4 tessLevelOuter = vec4(0);
         vec2 tessLevelInner = vec2(0);
 
-        OsdGetTessLevels(
-                    inpt[0].v.hullPosition.xyz, inpt[1].v.hullPosition.xyz,
-                    inpt[2].v.hullPosition.xyz, inpt[3].v.hullPosition.xyz,
-                    patchParam, tessLevelOuter, tessLevelInner);
+        vec3 p[4];
+#if defined OSD_ENABLE_SCREENSPACE_TESSELLATION
+        p[0] = (OsdModelViewMatrix() * vec4(inpt[0].v.position, 1)).xyz;
+        p[1] = (OsdModelViewMatrix() * vec4(inpt[1].v.position, 1)).xyz;
+        p[2] = (OsdModelViewMatrix() * vec4(inpt[2].v.position, 1)).xyz;
+        p[3] = (OsdModelViewMatrix() * vec4(inpt[3].v.position, 1)).xyz;
+#else
+        p[0] = inpt[0].v.position.xyz;
+        p[1] = inpt[1].v.position.xyz;
+        p[2] = inpt[2].v.position.xyz;
+        p[3] = inpt[3].v.position.xyz;
+#endif
+        OsdGetTessLevels(p[0], p[3], p[2], p[1],
+                         patchParam, tessLevelOuter, tessLevelInner);
 
         gl_TessLevelOuter[0] = tessLevelOuter[0];
         gl_TessLevelOuter[1] = tessLevelOuter[1];

--- a/opensubdiv/osd/glslPatchGregoryBasis.glsl
+++ b/opensubdiv/osd/glslPatchGregoryBasis.glsl
@@ -79,8 +79,8 @@ void main()
         vec4 tessLevelOuter = vec4(0);
         vec2 tessLevelInner = vec2(0);
 
-        OsdGetTessLevels(inpt[0].v.position.xyz, inpt[5].v.position.xyz,
-                         inpt[10].v.position.xyz, inpt[15].v.position.xyz,
+        OsdGetTessLevels(inpt[0].v.position.xyz, inpt[15].v.position.xyz,
+                         inpt[10].v.position.xyz, inpt[5].v.position.xyz,
                          patchParam, tessLevelOuter, tessLevelInner);
 
         gl_TessLevelOuter[0] = tessLevelOuter[0];

--- a/opensubdiv/osd/hlslPatchGregory.hlsl
+++ b/opensubdiv/osd/hlslPatchGregory.hlsl
@@ -275,8 +275,19 @@ HS_CONSTANT_FUNC_OUT HSConstFunc(
     float4 tessLevelOuter = float4(0,0,0,0);
     float4 tessLevelInner = float4(0,0,0,0);
 
-    OsdGetTessLevels(patch[0].hullPosition.xyz, patch[1].hullPosition.xyz,
-                     patch[2].hullPosition.xyz, patch[3].hullPosition.xyz,
+    float3 p[4];
+#if defined OSD_ENABLE_SCREENSPACE_TESSELLATION
+    p[0] = mul(OsdModelViewMatrix() * float4(patch[0].position, 1)).xyz;
+    p[1] = mul(OsdModelViewMatrix() * float4(patch[1].position, 1)).xyz;
+    p[2] = mul(OsdModelViewMatrix() * float4(patch[2].position, 1)).xyz;
+    p[3] = mul(OsdModelViewMatrix() * float4(patch[3].position, 1)).xyz;
+#else
+    p[0] = patch[0].position.xyz;
+    p[1] = patch[1].position.xyz;
+    p[2] = patch[2].position.xyz;
+    p[3] = patch[3].position.xyz;
+#endif
+    OsdGetTessLevels(p[0], p[3], p[2], p[1],
                      patchParam, tessLevelOuter, tessLevelInner);
 
     output.tessLevelOuter[0] = tessLevelOuter[0];

--- a/opensubdiv/osd/hlslPatchGregoryBasis.hlsl
+++ b/opensubdiv/osd/hlslPatchGregoryBasis.hlsl
@@ -61,8 +61,8 @@ HSConstFunc(
     float4 tessOuterLo = float4(0,0,0,0);
     float4 tessOuterHi = float4(0,0,0,0);
 
-    OsdGetTessLevels(patch[0].position.xyz, patch[5].position.xyz,
-                     patch[10].position.xyz, patch[15].position.xyz,
+    OsdGetTessLevels(patch[0].position.xyz, patch[15].position.xyz,
+                     patch[10].position.xyz, patch[5].position.xyz,
                      patchParam, tessLevelOuter, tessLevelInner);
 
     output.tessLevelOuter[0] = tessLevelOuter[0];


### PR DESCRIPTION
Fix gregory patch tesslevel computation
- flipping UV
- using limit position in legacy gregory shader.

dxViwer/dxPtexViewer enable back-face culling
since we fixed gregory patch rotation/orientation issues.