### PR TITLE
remove maximum valence limitation in gregory basis and bspline basis end caps.

### DIFF
--- a/examples/glViewer/init_shapes.h
+++ b/examples/glViewer/init_shapes.h
@@ -77,6 +77,12 @@ static std::vector<ShapeDesc> g_defaultShapes;
 #include <shapes/catmark_hole_test4.h>
 #include <shapes/catmark_lefthanded.h>
 #include <shapes/catmark_righthanded.h>
+#include <shapes/catmark_pole8.h>
+#include <shapes/catmark_pole64.h>
+#include <shapes/catmark_pole360.h>
+#include <shapes/catmark_nonman_quadpole8.h>
+#include <shapes/catmark_nonman_quadpole64.h>
+#include <shapes/catmark_nonman_quadpole360.h>
 #include <shapes/catmark_pawn.h>
 #include <shapes/catmark_pyramid_creases0.h>
 #include <shapes/catmark_pyramid_creases1.h>
@@ -106,6 +112,9 @@ static std::vector<ShapeDesc> g_defaultShapes;
 #include <shapes/loop_triangle_edgeonly.h>
 #include <shapes/loop_chaikin0.h>
 #include <shapes/loop_chaikin1.h>
+#include <shapes/loop_pole8.h>
+#include <shapes/loop_pole64.h>
+#include <shapes/loop_pole360.h>
 
 //------------------------------------------------------------------------------
 static void initShapes() {
@@ -145,6 +154,12 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_hole_test4",       catmark_hole_test4,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_lefthanded",       catmark_lefthanded,       kCatmark, true /*isLeftHanded*/ ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_righthanded",      catmark_righthanded,      kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_pole8",            catmark_pole8,            kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_pole64",           catmark_pole64,           kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_pole360",          catmark_pole360,          kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_nonman_quadpole8",   catmark_nonman_quadpole8,   kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_nonman_quadpole64",  catmark_nonman_quadpole64,  kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_nonman_quadpole360", catmark_nonman_quadpole360, kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pyramid_creases0", catmark_pyramid_creases0, kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pyramid_creases1", catmark_pyramid_creases1, kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pyramid",          catmark_pyramid,          kCatmark ) );
@@ -177,5 +192,8 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_chaikin0",            loop_chaikin0,            kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_chaikin1",            loop_chaikin1,            kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_pole8",               loop_pole8,               kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_pole64",              loop_pole64,              kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_pole360",             loop_pole360,             kLoop ) );
 }
 //------------------------------------------------------------------------------

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
@@ -37,19 +37,6 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Far {
 
-
-static inline bool
-checkMaxValence(Vtr::Level const & level) {
-    if (level.getMaxValence()>EndCapGregoryBasisPatchFactory::GetMaxValence()) {
-        // The proto-basis closed-form table limits valence to 'MAX_VALENCE'
-        Error(FAR_RUNTIME_ERROR,
-            "Vertex valence %d exceeds maximum %d supported",
-                level.getMaxValence(), EndCapGregoryBasisPatchFactory::GetMaxValence());
-        return false;
-    }
-    return true;
-}
-
 //
 // EndCapGregoryBasisPatchFactory for Vertex StencilTables
 //
@@ -62,12 +49,6 @@ EndCapGregoryBasisPatchFactory::EndCapGregoryBasisPatchFactory(
     assert(not refiner.IsUniform());
 }
 
-int
-EndCapGregoryBasisPatchFactory::GetMaxValence() {
-
-    return GregoryBasis::MAX_VALENCE;
-}
-
 //
 // Stateless EndCapGregoryBasisPatchFactory
 //
@@ -77,10 +58,6 @@ EndCapGregoryBasisPatchFactory::Create(TopologyRefiner const & refiner,
 
     // Gregory patches are end-caps: they only exist on max-level
     Vtr::Level const & level = refiner.getLevel(refiner.GetMaxLevel());
-
-    if (not checkMaxValence(level)) {
-        return 0;
-    }
 
     GregoryBasis::ProtoBasis basis(level, faceIndex, fvarChannel);
     GregoryBasis * result = new GregoryBasis;
@@ -96,10 +73,6 @@ EndCapGregoryBasisPatchFactory::addPatchBasis(Index faceIndex,
 
     // Gregory patches only exist on the hight
     Vtr::Level const & level = _refiner->getLevel(_refiner->GetMaxLevel());
-
-    if (not checkMaxValence(level)) {
-        return false;
-    }
 
     // Gather the CVs that influence the Gregory patch and their relative
     // weights in a basis

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.h
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.h
@@ -62,10 +62,6 @@ public:
     static GregoryBasis const * Create(TopologyRefiner const & refiner,
         Index faceIndex, int fvarChannel=-1);
 
-    /// \brief Returns the maximum valence of a vertex in the mesh that the
-    ///        Gregory patches can handle
-    static int GetMaxValence();
-
 public:
 
     ///

--- a/opensubdiv/far/gregoryBasis.cpp
+++ b/opensubdiv/far/gregoryBasis.cpp
@@ -129,10 +129,10 @@ inline float csf(Index n, Index j) {
     }
 }
 
-GregoryBasis::ProtoBasis::ProtoBasis(
-    Vtr::Level const & level, Index faceIndex, int fvarChannel) {
-
-    static float ef[MAX_VALENCE-3] = {
+inline float computeCoefficient(int valence) {
+    // precomputed coefficient table up to valence 29
+    static float efTable[] = {
+        0, 0, 0,
         0.812816f, 0.500000f, 0.363644f, 0.287514f,
         0.238688f, 0.204544f, 0.179229f, 0.159657f,
         0.144042f, 0.131276f, 0.120632f, 0.111614f,
@@ -141,6 +141,16 @@ GregoryBasis::ProtoBasis::ProtoBasis(
         0.0669851f, 0.0641504f, 0.0615475f, 0.0591488f,
         0.0569311f, 0.0548745f, 0.0529621f
     };
+    assert(valence > 0);
+    if (valence < 30) return efTable[valence];
+
+    float t = 2.0f * float(M_PI) / float(valence);
+    return 1.0f / (valence * (cosf(t) + 5.0f +
+                              sqrtf((cosf(t) + 9) * (cosf(t) + 1)))/16.0f);
+}
+
+GregoryBasis::ProtoBasis::ProtoBasis(
+    Vtr::Level const & level, Index faceIndex, int fvarChannel) {
 
     Vtr::ConstIndexArray facePoints = (fvarChannel<0) ?
         level.getFaceVertices(faceIndex) :
@@ -248,8 +258,9 @@ GregoryBasis::ProtoBasis::ProtoBasis(
             e1[vid] += e * csf(ivalence-3, 2*i+1);
         }
 
-        e0[vid] *= ef[ivalence-3];
-        e1[vid] *= ef[ivalence-3];
+        float ef = computeCoefficient(ivalence);
+        e0[vid] *= ef;
+        e1[vid] *= ef;
 
         if (valence<0) {
 


### PR DESCRIPTION
Add a non table-based version of end cap tangent computation in gregory basis, and remove MAX_ELEM and MAX_VALENCE limitations.

Also add high-valence regression shapes into glViewer.

note 1: LegacyGregory patch drawing is still under the limitation of maximum valence 29, mostly due to GLSL interstage parameter data width.
note 2: Creating end cap stencils for high-valence shape can be very slow.