### PR TITLE
implements Osd::CpuEvaluator::EvalPatches function.

### DIFF
--- a/opensubdiv/osd/cpuEvaluator.h
+++ b/opensubdiv/osd/cpuEvaluator.h
@@ -56,14 +56,17 @@ struct PatchCoord {
     float s, t;              ///< parametric location on patch
 };
 
-typedef std::vector<PatchCoord> PatchCoordArray;
-
-
 class CpuEvaluator {
 public:
+    /// ----------------------------------------------------------------------
+    ///
+    ///   Stencil evaluations with StencilTable
+    ///
+    /// ----------------------------------------------------------------------
+
     /// \brief Generic static eval stencils function. This function has a same
     ///        signature as other device kernels have so that it can be called
-    ///        transparently from OsdMesh template interface.
+    ///        in the same way from OsdMesh template interface.
     ///
     /// @param srcBuffer      Input primvar buffer.
     ///                       must have BindCpuBuffer() method returning a
@@ -108,7 +111,28 @@ public:
                             /*end   = */ stencilTable->GetNumStencils());
     }
 
-    /// stencil evaluate function.
+    /// \brief Static eval stencils function which takes raw CPU pointers for
+    ///        input and output.
+    ///
+    /// @param src            Input primvar pointer. An offset of srcDesc
+    ///                       will be applied internally (i.e. the pointer
+    ///                       should not include the offset)
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst            Output primvar pointer. An offset of dstDesc
+    ///                       will be applied internally.
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param stencilTable   stencil table to be applied.
+    ///
+    /// @param instance       not used in the cpu kernel
+    ///                       (declared as a typed pointer to prevent
+    ///                        undesirable template resolution)
+    ///
+    /// @param deviceContext  not used in the cpu kernel
+    ///
     static bool EvalStencils(const float *src,
                              VertexBufferDescriptor const &srcDesc,
                              float *dst,
@@ -120,15 +144,52 @@ public:
                              int start,
                              int end);
 
+    /// \brief Generic static eval stencils function with derivatives.
+    ///        This function has a same signature as other device kernels
+    ///        have so that it can be called in the same way from OsdMesh
+    ///        template interface.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       const float pointer for read
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param dstDsBuffer    Output s-derivative buffer
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dstDsDesc      vertex buffer descriptor for the output buffer
+    ///
+    /// @param dstDtBuffer    Output t-derivative buffer
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dstDtDesc      vertex buffer descriptor for the output buffer
+    ///
+    /// @param stencilTable   stencil table to be applied.
+    ///
+    /// @param instance       not used in the cpu kernel
+    ///                       (declared as a typed pointer to prevent
+    ///                        undesirable template resolution)
+    ///
+    /// @param deviceContext  not used in the cpu kernel
+    ///
     template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
     static bool EvalStencils(SRC_BUFFER *srcBuffer,
                              VertexBufferDescriptor const &srcDesc,
                              DST_BUFFER *dstBuffer,
                              VertexBufferDescriptor const &dstDesc,
-                             DST_BUFFER *dstDuBuffer,
-                             VertexBufferDescriptor const &dstDuDesc,
-                             DST_BUFFER *dstDvBuffer,
-                             VertexBufferDescriptor const &dstDvDesc,
+                             DST_BUFFER *dstDsBuffer,
+                             VertexBufferDescriptor const &dstDsDesc,
+                             DST_BUFFER *dstDtBuffer,
+                             VertexBufferDescriptor const &dstDtDesc,
                              STENCIL_TABLE const *stencilTable,
                              const CpuEvaluator *evaluator = NULL,
                              void * deviceContext = NULL) {
@@ -139,10 +200,10 @@ public:
                             srcDesc,
                             dstBuffer->BindCpuBuffer(),
                             dstDesc,
-                            dstDuBuffer->BindCpuBuffer(),
-                            dstDuDesc,
-                            dstDvBuffer->BindCpuBuffer(),
-                            dstDvDesc,
+                            dstDsBuffer->BindCpuBuffer(),
+                            dstDsDesc,
+                            dstDtBuffer->BindCpuBuffer(),
+                            dstDtDesc,
                             &stencilTable->GetSizes()[0],
                             &stencilTable->GetOffsets()[0],
                             &stencilTable->GetControlIndices()[0],
@@ -153,14 +214,46 @@ public:
                             /*end   = */ stencilTable->GetNumStencils());
     }
 
+    /// \brief Static eval stencils function with derivatives, which takes
+    ///        raw CPU pointers for input and output.
+    ///
+    /// @param src            Input primvar pointer. An offset of srcDesc
+    ///                       will be applied internally (i.e. the pointer
+    ///                       should not include the offset)
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst            Output primvar pointer. An offset of dstDesc
+    ///                       will be applied internally.
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param dstDs          Output s-derivatives pointer. An offset of
+    ///                       dstDsDesc will be applied internally.
+    ///
+    /// @param dstDsDesc      vertex buffer descriptor for the output buffer
+    ///
+    /// @param dstDt          Output t-derivatives pointer. An offset of
+    ///                       dstDtDesc will be applied internally.
+    ///
+    /// @param dstDtDesc      vertex buffer descriptor for the output buffer
+    ///
+    /// @param stencilTable   stencil table to be applied.
+    ///
+    /// @param instance       not used in the cpu kernel
+    ///                       (declared as a typed pointer to prevent
+    ///                        undesirable template resolution)
+    ///
+    /// @param deviceContext  not used in the cpu kernel
+    ///
     static bool EvalStencils(const float *src,
                              VertexBufferDescriptor const &srcDesc,
                              float *dst,
                              VertexBufferDescriptor const &dstDesc,
-                             float *dstDu,
-                             VertexBufferDescriptor const &dstDuDesc,
-                             float *dstDv,
-                             VertexBufferDescriptor const &dstDvDesc,
+                             float *dstDs,
+                             VertexBufferDescriptor const &dstDsDesc,
+                             float *dstDt,
+                             VertexBufferDescriptor const &dstDtDesc,
                              const int * sizes,
                              const int * offsets,
                              const int * indices,
@@ -170,11 +263,15 @@ public:
                              int start,
                              int end);
 
+    /// ----------------------------------------------------------------------
+    ///
+    ///   Limit evaluations with PatchTable
+    ///
+    /// ----------------------------------------------------------------------
+
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
-    ///        transparently.
-    ///
-    ///       XXX: This interface is still work in progress. XXX
+    ///        in the same way.
     ///
     /// @param srcBuffer        Input primvar buffer.
     ///                         must have BindCpuBuffer() method returning a
@@ -188,23 +285,26 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param patchCoord       array of locations to be evaluated.
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
     ///
     /// @param patchTable       Far::PatchTable
     ///
-    /// @param instanced        not used in the cpu evaluator
+    /// @param instance         not used in the cpu evaluator
     ///
     /// @param deviceContext    not used in the cpu evaluator
     ///
     template <typename SRC_BUFFER, typename DST_BUFFER>
-    static int EvalPatches(SRC_BUFFER *srcBuffer,
-                           VertexBufferDescriptor const &srcDesc,
-                           DST_BUFFER *dstBuffer,
-                           VertexBufferDescriptor const &dstDesc,
-                           PatchCoordArray const &patchCoords,
-                           Far::PatchTables const *patchTable,
-                           CpuEvaluator const *instance,
-                           void * deviceContext = NULL) {
+    static bool EvalPatches(SRC_BUFFER *srcBuffer,
+                            VertexBufferDescriptor const &srcDesc,
+                            DST_BUFFER *dstBuffer,
+                            VertexBufferDescriptor const &dstDesc,
+                            int numPatchCoords,
+                            PatchCoord const *patchCoords,
+                            Far::PatchTables const *patchTable,
+                            CpuEvaluator const *instance,
+                            void * deviceContext = NULL) {
         (void)instance;   // unused
         (void)deviceContext;   // unused
 
@@ -212,17 +312,158 @@ public:
                            srcDesc,
                            dstBuffer->BindCpuBuffer(),
                            dstDesc,
+                           numPatchCoords,
                            patchCoords,
                            patchTable);
     }
 
-    /// \brief limit eval function.
-    static int EvalPatches(const float *src,
-                           VertexBufferDescriptor const &srcDesc,
-                           float *dst,
-                           VertexBufferDescriptor const &dstDesc,
-                           PatchCoordArray const &patchCoords,
-                           Far::PatchTables const *patchTable);
+    /// \brief Generic limit eval function with derivatives. This function has
+    ///        a same signature as other device kernels have so that it can be
+    ///        called in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param dstDsBuffer      Output s-derivatives buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDsDesc        vertex buffer descriptor for the dstDsBuffer
+    ///
+    /// @param dstDtBuffer      Output t-derivatives buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDtDesc        vertex buffer descriptor for the dstDtBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       Far::PatchTable
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER>
+    static bool EvalPatches(SRC_BUFFER *srcBuffer,
+                            VertexBufferDescriptor const &srcDesc,
+                            DST_BUFFER *dstBuffer,
+                            VertexBufferDescriptor const &dstDesc,
+                            DST_BUFFER *dstDsBuffer,
+                            VertexBufferDescriptor const &dstDsDesc,
+                            DST_BUFFER *dstDtBuffer,
+                            VertexBufferDescriptor const &dstDtDesc,
+                            int numPatchCoords,
+                            PatchCoord const *patchCoords,
+                            Far::PatchTables const *patchTable,
+                            CpuEvaluator const *instance,
+                            void * deviceContext = NULL) {
+        (void)instance;   // unused
+        (void)deviceContext;   // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(),
+                           srcDesc,
+                           dstBuffer->BindCpuBuffer(),
+                           dstDesc,
+                           dstDsBuffer->BindCpuBuffer(),
+                           dstDsDesc,
+                           dstDtBuffer->BindCpuBuffer(),
+                           dstDtDesc,
+                           numPatchCoords,
+                           patchCoords,
+                           patchTable);
+    }
+
+    /// \brief Static limit eval function. It takes an array of PatchCoord
+    ///        and evaluate limit values on given PatchTable.
+    ///
+    /// @param src              Input primvar pointer. An offset of srcDesc
+    ///                         will be applied internally (i.e. the pointer
+    ///                         should not include the offset)
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst              Output primvar pointer. An offset of dstDesc
+    ///                         will be applied internally.
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       Far::PatchTable on which primvars are evaluated
+    ///                         for the patchCoords
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    static bool EvalPatches(const float *src,
+                            VertexBufferDescriptor const &srcDesc,
+                            float *dst,
+                            VertexBufferDescriptor const &dstDesc,
+                            int numPatchCoords,
+                            PatchCoord const *patchCoords,
+                            Far::PatchTables const *patchTable);
+
+    /// \brief Static limit eval function. It takes an array of PatchCoord
+    ///        and evaluate limit values on given PatchTable.
+    ///
+    /// @param src              Input primvar pointer. An offset of srcDesc
+    ///                         will be applied internally (i.e. the pointer
+    ///                         should not include the offset)
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst              Output primvar pointer. An offset of dstDesc
+    ///                         will be applied internally.
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param dstDs            Output s-derivatives pointer. An offset of
+    ///                         dstDsDesc will be applied internally.
+    ///
+    /// @param dstDsDesc        vertex buffer descriptor for the dstDs buffer
+    ///
+    /// @param dstDt            Output t-derivatives pointer. An offset of
+    ///                         dstDtDesc will be applied internally.
+    ///
+    /// @param dstDtDesc        vertex buffer descriptor for the dstDt buffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       Far::PatchTable on which primvars are evaluated
+    ///                         for the patchCoords
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    static bool EvalPatches(const float *src,
+                            VertexBufferDescriptor const &srcDesc,
+                            float *dst,
+                            VertexBufferDescriptor const &dstDesc,
+                            float *dstDs,
+                            VertexBufferDescriptor const &dstDsDesc,
+                            float *dstDt,
+                            VertexBufferDescriptor const &dstDtDesc,
+                            int numPatchCoords,
+                            PatchCoord const *patchCoords,
+                            Far::PatchTables const *patchTable);
 
     /// \brief synchronize all asynchronous computation invoked on this device.
     static void Synchronize(void * /*deviceContext = NULL*/) {


### PR DESCRIPTION
- it takes number and pointer for the input PatchCoords.
- add derivative evaluations.
- enhance glEvalLimit example to see the derivative evaluation works.