### PR TITLE
Replacing obsolete TopologyRefiner methods with TopologyLevel

### DIFF
--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -236,12 +236,14 @@ calcNormals(OpenSubdiv::Far::TopologyRefiner * refiner,
     typedef OpenSubdiv::Far::ConstIndexArray IndexArray;
 
     // calc normal vectors
-    int nverts = refiner->GetNumVertices(0),
-        nfaces = refiner->GetNumFaces(0);
+    OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner->GetLevel(0);
+
+    int nverts = refBaseLevel.GetNumVertices(),
+        nfaces = refBaseLevel.GetNumFaces();
 
     for (int face = 0; face < nfaces; ++face) {
 
-        IndexArray fverts = refiner->GetFaceVertices(0, face);
+        IndexArray fverts = refBaseLevel.GetFaceVertices(face);
 
         float const * p0 = &pos[fverts[0]*3],
                     * p1 = &pos[fverts[1]*3],
@@ -704,12 +706,13 @@ createOsdMesh(int level, int kernel) {
             OpenSubdiv::Far::TopologyRefinerFactory<Shape>::Options(sdctype, sdcoptions));
 
     // save coarse topology (used for coarse mesh drawing)
+    OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner->GetLevel(0);
 
     // create cage edge index
-    int nedges = refiner->GetNumEdges(0);
+    int nedges = refBaseLevel.GetNumEdges();
     std::vector<int> edgeIndices(nedges*2);
     for(int i=0; i<nedges; ++i) {
-        IndexArray verts = refiner->GetEdgeVertices(0, i);
+        IndexArray verts = refBaseLevel.GetEdgeVertices(i);
         edgeIndices[i*2  ]=verts[0];
         edgeIndices[i*2+1]=verts[1];
     }

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -277,22 +277,24 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level, int kernel, Scheme scheme=
             Far::TopologyRefinerFactory<Shape>::Options(sdctype, sdcoptions));
 
     // save coarse topology (used for coarse mesh drawing)
-    int nedges = refiner->GetNumEdges(0),
-        nverts = refiner->GetNumVertices(0);
+    Far::TopologyLevel const & refBaseLevel = refiner->GetLevel(0);
+
+    int nedges = refBaseLevel.GetNumEdges(),
+        nverts = refBaseLevel.GetNumVertices();
 
     g_coarseEdges.resize(nedges*2);
     g_coarseEdgeSharpness.resize(nedges);
     g_coarseVertexSharpness.resize(nverts);
 
     for(int i=0; i<nedges; ++i) {
-        IndexArray verts = refiner->GetEdgeVertices(0, i);
+        IndexArray verts = refBaseLevel.GetEdgeVertices(i);
         g_coarseEdges[i*2  ]=verts[0];
         g_coarseEdges[i*2+1]=verts[1];
-        g_coarseEdgeSharpness[i]=refiner->GetEdgeSharpness(0, i);
+        g_coarseEdgeSharpness[i]=refBaseLevel.GetEdgeSharpness(i);
     }
 
     for(int i=0; i<nverts; ++i) {
-        g_coarseVertexSharpness[i]=refiner->GetVertexSharpness(0, i);
+        g_coarseVertexSharpness[i]=refBaseLevel.GetVertexSharpness(i);
     }
 
     g_orgPositions=shape->verts;

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -645,7 +645,7 @@ createFarGLMesh(Shape * shape, int maxlevel) {
             fvarBuffer.resize(refiner->GetNumFVarValuesTotal(channel), 0);
             Vertex * values = &fvarBuffer[0];
 
-            int nCoarseValues = refiner->GetNumFVarValues(0);
+            int nCoarseValues = refiner->GetLevel(0).GetNumFVarValues(channel);
 
             for (int i=0; i<nCoarseValues; ++i) {
                 float const * ptr = &shape->uvs[i*2];

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -212,7 +212,7 @@ createVertNumbers(OpenSubdiv::Far::TopologyRefiner const & refiner,
 
     if (refiner.IsUniform()) {
         for (int i=0; i<maxlevel; ++i) {
-            firstvert += refiner.GetNumVertices(i);
+            firstvert += refiner.GetLevel(i).GetNumVertices();
         }
     }
 
@@ -225,7 +225,7 @@ createVertNumbers(OpenSubdiv::Far::TopologyRefiner const & refiner,
     } else {
 
         for (int level=0, vert=0; level<=refiner.GetMaxLevel(); ++level) {
-            for (int i=0; i<refiner.GetNumVertices(level); ++i, ++vert) {
+            for (int i=0; i<refiner.GetLevel(level).GetNumVertices(); ++i, ++vert) {
                 snprintf(buf, 16, "%d", i);
                 g_font->Print3D(vertexBuffer[vert].GetPos(), buf, 1);
             }
@@ -245,16 +245,17 @@ createEdgeNumbers(OpenSubdiv::Far::TopologyRefiner const & refiner,
             firstvert = 0;
 
         for (int i=0; i<maxlevel; ++i) {
-            firstvert += refiner.GetNumVertices(i);
+            firstvert += refiner.GetLevel(i).GetNumVertices();
         }
 
+        OpenSubdiv::Far::TopologyLevel const & refLastLevel = refiner.GetLevel(maxlevel);
+
         static char buf[16];
-        for (int i=0; i<refiner.GetNumEdges(maxlevel); ++i) {
+        for (int i=0; i<refLastLevel.GetNumEdges(); ++i) {
 
             Vertex center(0.0f, 0.0f, 0.0f);
 
-            OpenSubdiv::Far::ConstIndexArray const verts =
-                refiner.GetEdgeVertices(maxlevel, i);
+            OpenSubdiv::Far::ConstIndexArray const verts = refLastLevel.GetEdgeVertices(i);
             assert(verts.size()==2);
 
             center.AddWithWeight(vertexBuffer[firstvert+verts[0]], 0.5f);
@@ -266,7 +267,7 @@ createEdgeNumbers(OpenSubdiv::Far::TopologyRefiner const & refiner,
             }
 
             if (sharpness) {
-                float sharpness = refiner.GetEdgeSharpness(maxlevel, i);
+                float sharpness = refLastLevel.GetEdgeSharpness(i);
                 if (sharpness>0.0f) {
                     snprintf(buf, 16, "%g", sharpness);
                     g_font->Print3D(center.GetPos(), buf, std::min(8,(int)sharpness+4));
@@ -289,15 +290,16 @@ createFaceNumbers(OpenSubdiv::Far::TopologyRefiner const & refiner,
             firstvert = 0;
 
         for (int i=0; i<maxlevel; ++i) {
-            firstvert += refiner.GetNumVertices(i);
+            firstvert += refiner.GetLevel(i).GetNumVertices();
         }
 
-        for (int face=0; face<refiner.GetNumFaces(maxlevel); ++face) {
+        OpenSubdiv::Far::TopologyLevel const & refLastLevel = refiner.GetLevel(maxlevel);
+
+        for (int face=0; face<refLastLevel.GetNumFaces(); ++face) {
 
             Vertex center(0.0f, 0.0f, 0.0f);
 
-            OpenSubdiv::Far::ConstIndexArray const verts =
-                refiner.GetFaceVertices(maxlevel, face);
+            OpenSubdiv::Far::ConstIndexArray const verts = refLastLevel.GetFaceVertices(face);
 
             float weight = 1.0f / (float)verts.size();
 
@@ -310,19 +312,20 @@ createFaceNumbers(OpenSubdiv::Far::TopologyRefiner const & refiner,
         }
     } else {
         int maxlevel = refiner.GetMaxLevel(),
-//            patch = refiner.GetNumFaces(0),
-            firstvert = refiner.GetNumVertices(0);
+//            patch = refiner.GetLevel(0).GetNumFaces(),
+            firstvert = refiner.GetLevel(0).GetNumVertices();
 
         for (int level=1; level<=maxlevel; ++level) {
 
-            int nfaces = refiner.GetNumFaces(level);
+            OpenSubdiv::Far::TopologyLevel const & refLevel = refiner.GetLevel(level);
+
+            int nfaces = refLevel.GetNumFaces();
 
             for (int face=0; face<nfaces; ++face /*, ++patch */) {
 
                 Vertex center(0.0f, 0.0f, 0.0f);
 
-                OpenSubdiv::Far::ConstIndexArray const verts =
-                    refiner.GetFaceVertices(level, face);
+                OpenSubdiv::Far::ConstIndexArray const verts = refLevel.GetFaceVertices(face);
 
                 float weight = 1.0f / (float)verts.size();
 
@@ -332,7 +335,7 @@ createFaceNumbers(OpenSubdiv::Far::TopologyRefiner const & refiner,
                 snprintf(buf, 16, "%d", face);
                 g_font->Print3D(center.GetPos(), buf, 2);
             }
-            firstvert+=refiner.GetNumVertices(level);
+            firstvert+=refLevel.GetNumVertices();
         }
     }
 }

--- a/examples/farViewer/gl_mesh.cpp
+++ b/examples/farViewer/gl_mesh.cpp
@@ -269,9 +269,9 @@ GLMesh::initializeBuffers(Options options,
 
     OpenSubdiv::Far::TopologyLevel const & refLastLevel = refiner.GetLevel(maxlevel);
 
-    int nverts = refLastLevel.GetNumVertices(maxlevel),
-        nedges = refLastLevel.GetNumEdges(maxlevel),
-        nfaces = refLastLevel.GetNumFaces(maxlevel),
+    int nverts = refLastLevel.GetNumVertices(),
+        nedges = refLastLevel.GetNumEdges(),
+        nfaces = refLastLevel.GetNumFaces(),
         firstvert = 0;
 
 

--- a/examples/farViewer/gl_mesh.cpp
+++ b/examples/farViewer/gl_mesh.cpp
@@ -265,15 +265,18 @@ GLMesh::initializeBuffers(Options options,
 
     typedef OpenSubdiv::Far::ConstIndexArray IndexArray;
 
-    int maxlevel = refiner.GetMaxLevel(),
-        nverts = refiner.GetNumVertices(maxlevel),
-        nedges = refiner.GetNumEdges(maxlevel),
-        nfaces = refiner.GetNumFaces(maxlevel),
+    int maxlevel = refiner.GetMaxLevel();
+
+    OpenSubdiv::Far::TopologyLevel const & refLastLevel = refiner.GetLevel(maxlevel);
+
+    int nverts = refLastLevel.GetNumVertices(maxlevel),
+        nedges = refLastLevel.GetNumEdges(maxlevel),
+        nfaces = refLastLevel.GetNumFaces(maxlevel),
         firstvert = 0;
 
 
     for (int i=0; i<maxlevel; ++i) {
-        firstvert += refiner.GetNumVertices(i);
+        firstvert += refiner.GetLevel(i).GetNumVertices();
     }
 
     float const * vertData =  &vertexData[firstvert*3];
@@ -287,31 +290,33 @@ GLMesh::initializeBuffers(Options options,
         // set colors
         if (options.vertColorMode==VERTCOLOR_BY_LEVEL) {
 
-            for (int level=0, ofs=3; level<=refiner.GetMaxLevel(); ++level) {
-                for (int vert=0; vert<refiner.GetNumVertices(level); ++vert, ofs+=6) {
+            for (int level=0, ofs=3; level<=maxlevel; ++level) {
+                for (int vert=0; vert<refiner.GetLevel(level).GetNumVertices(); ++vert, ofs+=6) {
                     setColorByLevel(level, &vbo[ofs]);
                 }
             }
         } else if (options.vertColorMode==VERTCOLOR_BY_SHARPNESS) {
 
-            for (int vert=0, ofs=3; vert<refiner.GetNumVertices(maxlevel); ++vert, ofs+=6) {
-               setColorBySharpness(refiner.GetVertexSharpness(maxlevel, vert), &vbo[ofs]);
+            for (int vert=0, ofs=3; vert<refLastLevel.GetNumVertices(); ++vert, ofs+=6) {
+               setColorBySharpness(refLastLevel.GetVertexSharpness(vert), &vbo[ofs]);
             }
         } else if (options.vertColorMode==VERTCOLOR_BY_PARENT_TYPE) {
 
             int ofs=3;
             if (maxlevel>0) {
-                for (int vert=0; vert<refiner.GetNumFaces(maxlevel-1); ++vert, ofs+=6) {
+                OpenSubdiv::Far::TopologyLevel const & refPrevLevel = refiner.GetLevel(maxlevel-1);
+
+                for (int vert=0; vert<refPrevLevel.GetNumFaces(); ++vert, ofs+=6) {
                     memcpy(&vbo[ofs], g_parentTypeColors[1], sizeof(float)*3);
                 }
-                for (int vert=0; vert<refiner.GetNumEdges(maxlevel-1); ++vert, ofs+=6) {
+                for (int vert=0; vert<refPrevLevel.GetNumEdges(); ++vert, ofs+=6) {
                     memcpy(&vbo[ofs], g_parentTypeColors[2], sizeof(float)*3);
                 }
-                for (int vert=0; vert<refiner.GetNumVertices(maxlevel-1); ++vert, ofs+=6) {
+                for (int vert=0; vert<refPrevLevel.GetNumVertices(); ++vert, ofs+=6) {
                     memcpy(&vbo[ofs], g_parentTypeColors[3], sizeof(float)*3);
                 }
             } else {
-                for (int vert=0; vert<refiner.GetNumVertices(maxlevel); ++vert, ofs+=6) {
+                for (int vert=0; vert<refLastLevel.GetNumVertices(); ++vert, ofs+=6) {
                     memcpy(&vbo[ofs], g_parentTypeColors[0], sizeof(float)*3);
                 }
             }
@@ -337,7 +342,7 @@ GLMesh::initializeBuffers(Options options,
             eao[edge*2  ] = edge*2;
             eao[edge*2+1] = edge*2+1;
 
-            IndexArray const verts = refiner.GetEdgeVertices(maxlevel, edge);
+            IndexArray const verts = refLastLevel.GetEdgeVertices(edge);
 
             float * v0 = &vbo[edge*2*6],
                   * v1 = v0+6;
@@ -353,7 +358,7 @@ GLMesh::initializeBuffers(Options options,
                 setColorByLevel(maxlevel, v1+3);
              } else  if (options.edgeColorMode==EDGECOLOR_BY_SHARPNESS) {
 
-                float sharpness = refiner.GetEdgeSharpness(maxlevel, edge);
+                float sharpness = refLastLevel.GetEdgeSharpness(edge);
                 setColorBySharpness(sharpness, v0+3);
                 setColorBySharpness(sharpness, v1+3);
             } else {
@@ -372,7 +377,7 @@ GLMesh::initializeBuffers(Options options,
 
         memcpy(&vbo[0], vertData, nverts*sizeof(float)*3);
 
-        int nfaceverts = refiner.GetNumFaceVertices(maxlevel);
+        int nfaceverts = refLastLevel.GetNumFaceVertices();
 
         std::vector<int> & eao = _eao[COMP_FACE];
         eao.resize(nfaceverts);
@@ -381,7 +386,7 @@ GLMesh::initializeBuffers(Options options,
 
         for (int face=0, ofs=0; face<nfaces; ++face) {
 
-            IndexArray fverts = refiner.GetFaceVertices(maxlevel, face);
+            IndexArray fverts = refLastLevel.GetFaceVertices(face);
             for (int vert=0; vert<fverts.size(); ++vert) {
                 eao[ofs++] = fverts[vert];
             }
@@ -421,7 +426,7 @@ GLMesh::InitializeFVar(Options options, TopologyRefiner const & refiner,
         if (options.vertColorMode==VERTCOLOR_BY_LEVEL) {
 
             for (int level=0, ofs=3; level<=refiner.GetMaxLevel(); ++level) {
-                for (int vert=0; vert<refiner.GetNumFVarValues(level); ++vert, ofs+=6) {
+                for (int vert=0; vert<refiner.GetLevel(level).GetNumFVarValues(channel); ++vert, ofs+=6) {
                     assert(ofs<(int)vbo.size());
                     setColorByLevel(level, &vbo[ofs]);
                 }
@@ -604,7 +609,7 @@ GLMesh::initializeBuffers(Options options, TopologyRefiner const & refiner,
         if (options.vertColorMode==VERTCOLOR_BY_LEVEL) {
 
             for (int level=0, ofs=3; level<=refiner.GetMaxLevel(); ++level) {
-                for (int vert=0; vert<refiner.GetNumVertices(level); ++vert, ofs+=6) {
+                for (int vert=0; vert<refiner.GetLevel(level).GetNumVertices(); ++vert, ofs+=6) {
                     assert(ofs<(int)vbo.size());
                     setColorByLevel(level, &vbo[ofs]);
                 }

--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -178,22 +178,24 @@ createCoarseMesh(OpenSubdiv::Far::TopologyRefiner const & refiner) {
     typedef OpenSubdiv::Far::ConstIndexArray IndexArray;
 
     // save coarse topology (used for coarse mesh drawing)
-    int nedges = refiner.GetNumEdges(0),
-        nverts = refiner.GetNumVertices(0);
+    OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner.GetLevel(0);
+
+    int nedges = refBaseLevel.GetNumEdges(),
+        nverts = refBaseLevel.GetNumVertices();
 
     g_coarseEdges.resize(nedges*2);
     g_coarseEdgeSharpness.resize(nedges);
     g_coarseVertexSharpness.resize(nverts);
 
     for(int i=0; i<nedges; ++i) {
-        IndexArray verts = refiner.GetEdgeVertices(0, i);
+        IndexArray verts = refBaseLevel.GetEdgeVertices(i);
         g_coarseEdges[i*2  ]=verts[0];
         g_coarseEdges[i*2+1]=verts[1];
-        g_coarseEdgeSharpness[i]=refiner.GetEdgeSharpness(0, i);
+        g_coarseEdgeSharpness[i]=refBaseLevel.GetEdgeSharpness(i);
     }
 
     for(int i=0; i<nverts; ++i) {
-        g_coarseVertexSharpness[i]=refiner.GetVertexSharpness(0, i);
+        g_coarseVertexSharpness[i]=refBaseLevel.GetVertexSharpness(i);
     }
 
     // assign a randomly generated color for each vertex ofthe mesh
@@ -258,7 +260,7 @@ updateGeom() {
     if (! g_topologyRefiner) return;
 
     // note that for patch eval we need coarse+refined combined buffer.
-    int nCoarseVertices = g_topologyRefiner->GetNumVertices(0);
+    int nCoarseVertices = g_topologyRefiner->GetLevel(0).GetNumVertices();
     Osd::CpuEvaluator::EvalStencils(g_vertexData,
                                     Osd::VertexBufferDescriptor(0, 3, 3),
                                     g_vertexData,

--- a/examples/glEvalLimit/particles.cpp
+++ b/examples/glEvalLimit/particles.cpp
@@ -70,14 +70,15 @@ STParticles::STParticles(Refiner const & refiner, int nparticles, bool centered)
     {   // initialize topology adjacency
         _adjacency.resize(nptexfaces);
 
-        int nfaces = refiner.GetNumFaces(0),
+        OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner.GetLevel(0);
+
+        int nfaces = refBaseLevel.GetNumFaces(),
            adjfaces[4],
            adjedges[4];
 
         for (int face=0, ptexface=0; face<nfaces; ++face) {
 
-            OpenSubdiv::Far::ConstIndexArray fverts =
-                refiner.GetFaceVertices(0, face);
+            OpenSubdiv::Far::ConstIndexArray fverts = refBaseLevel.GetFaceVertices(face);
 
             if (fverts.size()==4) {
                 ptexIndices.GetAdjacency(refiner, face, 0, adjfaces, adjedges);

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -368,7 +368,7 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level, Scheme scheme = kCatmark) 
             OpenSubdiv::Far::TopologyRefinerFactory<Shape>::Options(sdctype, sdcoptions));
 
     // save coarse topology (used for coarse mesh drawing)
-    OpenSubdiv::Far::TopologyLeve const & refBaseLevel = refiner->GetLevel(0);
+    OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner->GetLevel(0);
     int nedges = refBaseLevel.GetNumEdges(),
         nverts = refBaseLevel.GetNumVertices();
 

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -280,13 +280,15 @@ calcNormals(OpenSubdiv::Far::TopologyRefiner const & refiner,
 
     typedef OpenSubdiv::Far::ConstIndexArray IndexArray;
 
+    OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner.GetLevel(0);
+
     // calc normal vectors
     int nverts = (int)pos.size()/3;
 
-    int nfaces = refiner.GetNumFaces(0);
+    int nfaces = refBaseLevel.GetNumFaces();
     for (int face = 0; face < nfaces; ++face) {
 
-        IndexArray fverts = refiner.GetFaceVertices(0, face);
+        IndexArray fverts = refBaseLevel.GetFaceVertices(face);
 
         assert(fverts.size()>=2);
 
@@ -366,22 +368,23 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level, Scheme scheme = kCatmark) 
             OpenSubdiv::Far::TopologyRefinerFactory<Shape>::Options(sdctype, sdcoptions));
 
     // save coarse topology (used for coarse mesh drawing)
-    int nedges = refiner->GetNumEdges(0),
-        nverts = refiner->GetNumVertices(0);
+    OpenSubdiv::Far::TopologyLeve const & refBaseLevel = refiner->GetLevel(0);
+    int nedges = refBaseLevel.GetNumEdges(),
+        nverts = refBaseLevel.GetNumVertices();
 
     g_coarseEdges.resize(nedges*2);
     g_coarseEdgeSharpness.resize(nedges);
     g_coarseVertexSharpness.resize(nverts);
 
     for(int i=0; i<nedges; ++i) {
-        IndexArray verts = refiner->GetEdgeVertices(0, i);
+        IndexArray verts = refBaseLevel.GetEdgeVertices(i);
         g_coarseEdges[i*2  ]=verts[0];
         g_coarseEdges[i*2+1]=verts[1];
-        g_coarseEdgeSharpness[i]=refiner->GetEdgeSharpness(0, i);
+        g_coarseEdgeSharpness[i]=refBaseLevel.GetEdgeSharpness(i);
     }
 
     for(int i=0; i<nverts; ++i) {
-        g_coarseVertexSharpness[i]=refiner->GetVertexSharpness(0, i);
+        g_coarseVertexSharpness[i]=refBaseLevel.GetVertexSharpness(i);
     }
 
     g_orgPositions=shape->verts;

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -322,13 +322,15 @@ calcNormals(OpenSubdiv::Far::TopologyRefiner * refiner,
 
     typedef OpenSubdiv::Far::ConstIndexArray IndexArray;
 
+    OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner->GetLevel(0);
+
     // calc normal vectors
-    int nverts = refiner->GetNumVertices(0),
-        nfaces = refiner->GetNumFaces(0);
+    int nverts = refBaseLevel.GetNumVertices(),
+        nfaces = refBaseLevel.GetNumFaces();
 
     for (int face = 0; face < nfaces; ++face) {
 
-        IndexArray fverts = refiner->GetFaceVertices(0, face);
+        IndexArray fverts = refBaseLevel.GetFaceVertices(face);
 
         float const * p0 = &pos[fverts[0]*3],
                     * p1 = &pos[fverts[1]*3],
@@ -907,10 +909,12 @@ createOsdMesh(int level, int kernel) {
     // save coarse topology (used for coarse mesh drawing)
 
     // create cage edge index
-    int nedges = refiner->GetNumEdges(0);
+    OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner->GetLevel(0);
+
+    int nedges = refBaseLevel.GetNumEdges();
     std::vector<int> edgeIndices(nedges*2);
     for(int i=0; i<nedges; ++i) {
-        IndexArray verts = refiner->GetEdgeVertices(0, i);
+        IndexArray verts = refBaseLevel.GetEdgeVertices(i);
         edgeIndices[i*2  ]=verts[0];
         edgeIndices[i*2+1]=verts[1];
     }

--- a/examples/glShareTopology/sceneBase.cpp
+++ b/examples/glShareTopology/sceneBase.cpp
@@ -165,7 +165,7 @@ SceneBase::createStencilTable(Shape const *shape, int level, bool varying,
             }
         }
     }
-    int numControlVertices = refiner->GetNumVertices(0);
+    int numControlVertices = refiner->GetLevel(0).GetNumVertices();
 
     _stencilTableSize = createMeshRefiner(vertexStencils, varyingStencils,
                                           numControlVertices);

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -284,22 +284,24 @@ createMesh(ShapeDesc const & shapeDesc, int level) {
             OpenSubdiv::Far::TopologyRefinerFactory<Shape>::Options(sdctype, sdcoptions));
 
     // save coarse topology (used for coarse mesh drawing)
-    int nedges = refiner->GetNumEdges(0),
-        nverts = refiner->GetNumVertices(0);
+    OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner->GetLevel(0);
+
+    int nedges = refBaseLevel.GetNumEdges(),
+        nverts = refBaseLevel.GetNumVertices();
 
     g_coarseEdges.resize(nedges*2);
     g_coarseEdgeSharpness.resize(nedges);
     g_coarseVertexSharpness.resize(nverts);
 
     for(int i=0; i<nedges; ++i) {
-        IndexArray verts = refiner->GetEdgeVertices(0, i);
+        IndexArray verts = refBaseLevel.GetEdgeVertices(i);
         g_coarseEdges[i*2  ]=verts[0];
         g_coarseEdges[i*2+1]=verts[1];
-        g_coarseEdgeSharpness[i]=refiner->GetEdgeSharpness(0, i);
+        g_coarseEdgeSharpness[i]=refBaseLevel.GetEdgeSharpness(i);
     }
 
     for(int i=0; i<nverts; ++i) {
-        g_coarseVertexSharpness[i]=refiner->GetVertexSharpness(0, i);
+        g_coarseVertexSharpness[i]=refBaseLevel.GetVertexSharpness(i);
     }
 
     g_orgPositions=shape->verts;

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -533,22 +533,24 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level, int kernel, Scheme scheme=
             Far::TopologyRefinerFactory<Shape>::Options(sdctype, sdcoptions));
 
     // save coarse topology (used for coarse mesh drawing)
-    int nedges = refiner->GetNumEdges(0),
-        nverts = refiner->GetNumVertices(0);
+    OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner->GetLevel(0);
+
+    int nedges = refBaseLevel.GetNumEdges(),
+        nverts = refBaseLevel.GetNumVertices();
 
     g_coarseEdges.resize(nedges*2);
     g_coarseEdgeSharpness.resize(nedges);
     g_coarseVertexSharpness.resize(nverts);
 
     for(int i=0; i<nedges; ++i) {
-        IndexArray verts = refiner->GetEdgeVertices(0, i);
+        IndexArray verts = refBaseLevel.GetEdgeVertices(i);
         g_coarseEdges[i*2  ]=verts[0];
         g_coarseEdges[i*2+1]=verts[1];
-        g_coarseEdgeSharpness[i]=refiner->GetEdgeSharpness(0, i);
+        g_coarseEdgeSharpness[i]=refBaseLevel.GetEdgeSharpness(i);
     }
 
     for(int i=0; i<nverts; ++i) {
-        g_coarseVertexSharpness[i]=refiner->GetVertexSharpness(0, i);
+        g_coarseVertexSharpness[i]=refBaseLevel.GetVertexSharpness(i);
     }
 
     g_orgPositions=shape->verts;

--- a/opensubdiv/far/stencilTablesFactory.cpp
+++ b/opensubdiv/far/stencilTablesFactory.cpp
@@ -63,7 +63,7 @@ StencilTablesFactory::Create(TopologyRefiner const & refiner,
     StencilTables * result = new StencilTables;
 
     // always initialize numControlVertices (useful for torus case)
-    result->_numControlVertices = refiner.GetNumVertices(0);
+    result->_numControlVertices = refiner.GetLevel(0).GetNumVertices();
 
     int maxlevel = std::min(int(options.maxLevel), refiner.GetMaxLevel());
     if (maxlevel==0 and (not options.generateControlVerts)) {
@@ -112,7 +112,7 @@ StencilTablesFactory::Create(TopologyRefiner const & refiner,
     //
     for (int level=1;level<=maxlevel; ++level) {
 
-        dstAlloc->Resize(refiner.GetNumVertices(level));
+        dstAlloc->Resize(refiner.GetLevel(level).GetNumVertices());
 
         if (options.interpolationMode==INTERPOLATE_VERTEX) {
             refiner.Interpolate(level, *srcAlloc, *dstAlloc);
@@ -152,7 +152,7 @@ StencilTablesFactory::Create(TopologyRefiner const & refiner,
         }
 
         // Allocate
-        result->_numControlVertices = refiner.GetNumVertices(0);
+        result->_numControlVertices = refiner.GetLevel(0).GetNumVertices();
 
         if (options.generateControlVerts) {
             nstencils += result->_numControlVertices;
@@ -300,10 +300,10 @@ StencilTablesFactory::AppendEndCapStencilTables(
             //                          stencilsIndexOffset
             //
             //
-            stencilsIndexOffset = nverts - refiner.GetNumVertices(maxlevel);
+            stencilsIndexOffset = nverts - refiner.GetLevel(maxlevel).GetNumVertices();
             controlVertsIndexOffset = stencilsIndexOffset;
 
-        } else if (nBaseStencils == (nverts -refiner.GetNumVertices(0))) {
+        } else if (nBaseStencils == (nverts -refiner.GetLevel(0).GetNumVertices())) {
 
             // the table does not contain stencils for the control vertices
             //
@@ -321,8 +321,8 @@ StencilTablesFactory::AppendEndCapStencilTables(
             //  <-------------------------------->
             //                          controlVertsIndexOffset
             //
-            stencilsIndexOffset = nBaseStencils - refiner.GetNumVertices(maxlevel);
-            controlVertsIndexOffset = nverts - refiner.GetNumVertices(maxlevel);
+            stencilsIndexOffset = nBaseStencils - refiner.GetLevel(maxlevel).GetNumVertices();
+            controlVertsIndexOffset = nverts - refiner.GetLevel(maxlevel).GetNumVertices();
 
         } else {
             // these are not the stencils you are looking for.
@@ -362,7 +362,7 @@ StencilTablesFactory::AppendEndCapStencilTables(
 
     // create new stencil tables
     StencilTables * result = new StencilTables;
-    result->_numControlVertices = refiner.GetNumVertices(0);
+    result->_numControlVertices = refiner.GetLevel(0).GetNumVertices();
     result->resize(nBaseStencils + nEndCapStencils,
                    nBaseStencilsElements + nEndCapStencilsElements);
 
@@ -437,7 +437,7 @@ LimitStencilTablesFactory::Create(TopologyRefiner const & refiner,
     } else {
         // Sanity checks
         if (cvstencils->GetNumStencils() != (uniform ?
-            refiner.GetNumVertices(maxlevel) :
+            refiner.GetLevel(maxlevel).GetNumVertices() :
                 refiner.GetNumVerticesTotal())) {
                 return 0;
         }
@@ -562,7 +562,7 @@ LimitStencilTablesFactory::Create(TopologyRefiner const & refiner,
         // XXXX manuelk should offset creation be optional ?
         result->generateOffsets();
     }
-    result->_numControlVertices = refiner.GetNumVertices(0);
+    result->_numControlVertices = refiner.GetLevel(0).GetNumVertices();
 
     return result;
 }

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -192,18 +192,6 @@ TopologyRefiner::GetNumFVarValuesTotal(int channel) const {
     return sum;
 }
 
-int
-TopologyRefiner::GetNumHoles(int level) const {
-    int sum = 0;
-    Vtr::Level const & lvl = getLevel(level);
-    for (Index face = 0; face < lvl.getNumFaces(); ++face) {
-        if (lvl.isFaceHole(face)) {
-            ++sum;
-        }
-    }
-    return sum;
-}
-
 
 //
 //  Main refinement method -- allocating and initializing levels and refinements:

--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -217,8 +217,8 @@ public:
     /// \brief Apply vertex and varying interpolation weights to a primvar
     ///        buffer
     ///
-    /// The destination buffer must allocate an array of data for all the
-    /// refined vertices (at least GetNumVerticesTotal()-GetNumVertices(0))
+    /// The destination buffer must allocate an array of data for all the refined
+    /// vertices (at least GetNumVerticesTotal()-GetLevel(0).GetNumVertices())
     ///
     /// @param src  Source primvar buffer (\ref templating control vertex data)
     ///
@@ -231,7 +231,7 @@ public:
     /// level of refinement.
     ///
     /// The destination buffer must allocate an array of data for all the
-    /// refined vertices (at least GetNumVertices(level))
+    /// refined vertices (at least GetLevel(level).GetNumVertices())
     ///
     /// @param level  The refinement level
     ///
@@ -247,8 +247,8 @@ public:
     /// This method can be a useful alternative if the varying primvar data
     /// does not need to be re-computed over time.
     ///
-    /// The destination buffer must allocate an array of data for all the
-    /// refined vertices (at least GetNumVerticesTotal()-GetNumVertices(0))
+    /// The destination buffer must allocate an array of data for all the refined
+    /// vertices (at least GetNumVerticesTotal()-GetLevel(0).GetNumVertices())
     ///
     /// @param src  Source primvar buffer (\ref templating control vertex data)
     ///
@@ -263,7 +263,7 @@ public:
     /// does not need to be re-computed over time.
     ///
     /// The destination buffer must allocate an array of data for all the
-    /// refined vertices (at least GetNumVertices(level))
+    /// refined vertices (at least GetLevel(level).GetNumVertices())
     ///
     /// @param level  The refinement level
     ///
@@ -288,7 +288,7 @@ public:
     /// The source buffer must refer to an array of previously interpolated
     /// vertex data for the last refinement level.  The destination buffer
     /// must allocate an array for all vertices at the last refinement level
-    /// (at least GetNumVertices(GetMaxLevel()))
+    /// (at least GetLevel(GetMaxLevel()).GetNumVertices())
     ///
     /// @param src  Source primvar buffer (refined vertex data) for last level
     ///
@@ -316,73 +316,6 @@ public:
     int GetNumFVarValuesTotal(int channel = 0) const;
 
     //@}
-
-
-    //
-    //  Access to data per-level -- being made obsolete via this->GetLevel(level).Method():
-    //
-    //  Component inventory:
-    int GetNumVertices(int level) const     { return GetLevel(level).GetNumVertices(); }
-    int GetNumEdges(int level) const        { return GetLevel(level).GetNumEdges(); }
-    int GetNumFaces(int level) const        { return GetLevel(level).GetNumFaces(); }
-    int GetNumFaceVertices(int level) const { return GetLevel(level).GetNumFaceVertices(); }
-
-    //  Component tags:
-    float GetEdgeSharpness(int level, Index e) const   { return GetLevel(level).GetEdgeSharpness(e); }
-    float GetVertexSharpness(int level, Index v) const { return GetLevel(level).GetVertexSharpness(v); }
-    bool IsFaceHole(int level, Index f) const          { return GetLevel(level).IsFaceHole(f); }
-
-    Sdc::Crease::Rule GetVertexRule(int level, Index v) const { return GetLevel(level).GetVertexRule(v); }
-
-    //  Face-varying values:
-    int             GetNumFVarValues(int level,           int channel = 0) const { return GetLevel(level).GetNumFVarValues(channel); }
-    ConstIndexArray GetFVarFaceValues(int level, Index f, int channel = 0) const { return GetLevel(level).GetFVarFaceValues(f, channel); }
-
-    //  Component neighbors:
-    ConstIndexArray GetFaceVertices(int level, Index f) const { return GetLevel(level).GetFaceVertices(f); }
-    ConstIndexArray GetFaceEdges(int level, Index f) const    { return GetLevel(level).GetFaceEdges(f); }
-    ConstIndexArray GetEdgeVertices(int level, Index e) const { return GetLevel(level).GetEdgeVertices(e); }
-    ConstIndexArray GetEdgeFaces(int level, Index e) const    { return GetLevel(level).GetEdgeFaces(e); }
-    ConstIndexArray GetVertexFaces(int level, Index v) const  { return GetLevel(level).GetVertexFaces(v); }
-    ConstIndexArray GetVertexEdges(int level, Index v) const  { return GetLevel(level).GetVertexEdges(v); }
-
-    ConstLocalIndexArray GetEdgeFaceLocalIndices(int level, Index e) const   { return GetLevel(level).GetEdgeFaceLocalIndices(e); }
-    ConstLocalIndexArray GetVertexFaceLocalIndices(int level, Index v) const { return GetLevel(level).GetVertexFaceLocalIndices(v); }
-    ConstLocalIndexArray GetVertexEdgeLocalIndices(int level, Index v) const { return GetLevel(level).GetVertexEdgeLocalIndices(v); }
-
-    Index FindEdge(int level, Index v0, Index v1) const { return GetLevel(level).FindEdge(v0, v1); }
-
-    //  Child components:
-    ConstIndexArray GetFaceChildFaces(int level, Index f) const { return GetLevel(level).GetFaceChildFaces(f); }
-    ConstIndexArray GetFaceChildEdges(int level, Index f) const { return GetLevel(level).GetFaceChildEdges(f); }
-    ConstIndexArray GetEdgeChildEdges(int level, Index e) const { return GetLevel(level).GetEdgeChildEdges(e); }
-
-    Index GetFaceChildVertex(  int level, Index f) const { return GetLevel(level).GetFaceChildVertex(f); }
-    Index GetEdgeChildVertex(  int level, Index e) const { return GetLevel(level).GetEdgeChildVertex(e); }
-    Index GetVertexChildVertex(int level, Index v) const { return GetLevel(level).GetVertexChildVertex(v); }
-
-    //  Parent components:
-    Index GetFaceParentFace(int level, Index f) const { return GetLevel(level).GetFaceParentFace(f); }
-    Index GetFaceBaseFace(int level, Index f) const   { return GetLevel(level).GetFaceBaseFace(f); }
-
-    //  Debugging aides:
-    bool ValidateTopology(int level) const                    { return GetLevel(level).ValidateTopology(); }
-    void PrintTopology(int level, bool children = true) const { GetLevel(level).PrintTopology(children); }
-
-
-    //  UNDER RE-CONSIDERATION...
-    //
-    //  Potentially too special-purpose to warrant public method (needs to iterate through all faces):
-    int GetNumHoles(int level) const;
-
-    //  Appears to be completely unused:
-    bool FaceIsRegular(int level, Index face) const {
-        ConstIndexArray fVerts = _levels[level]->getFaceVertices(face);
-        Vtr::Level::VTag compFaceVertTag =
-            _levels[level]->getFaceCompositeVTag(fVerts);
-        return not compFaceVertTag._xordinary;
-    }
-
 
 protected:
 
@@ -549,7 +482,7 @@ TopologyRefiner::Interpolate(T const * src, U * dst) const {
         Interpolate(level, src, dst);
 
         src = dst;
-        dst += GetNumVertices(level);
+        dst += GetLevel(level).GetNumVertices();
     }
 }
 
@@ -777,7 +710,7 @@ TopologyRefiner::InterpolateVarying(T const * src, U * dst) const {
         InterpolateVarying(level, src, dst);
 
         src = dst;
-        dst += GetNumVertices(level);
+        dst += GetLevel(level).GetNumVertices();
     }
 }
 

--- a/opensubdiv/far/topologyRefinerFactory.cpp
+++ b/opensubdiv/far/topologyRefinerFactory.cpp
@@ -317,13 +317,14 @@ bool
 TopologyRefinerFactory<TopologyRefinerFactoryBase::TopologyDescriptor>::assignComponentTags(
     TopologyRefiner & refiner, TopologyDescriptor const & desc) {
 
+    TopologyLevel const & refBaseLevel = refiner.GetLevel(0);
 
     if ((desc.numCreases>0) and desc.creaseVertexIndexPairs and desc.creaseWeights) {
 
         int const * vertIndexPairs = desc.creaseVertexIndexPairs;
         for (int edge=0; edge<desc.numCreases; ++edge, vertIndexPairs+=2) {
 
-            Index idx = refiner.FindEdge(0, vertIndexPairs[0], vertIndexPairs[1]);
+            Index idx = refBaseLevel.FindEdge(vertIndexPairs[0], vertIndexPairs[1]);
 
             if (idx!=Vtr::INDEX_INVALID) {
                 refiner.setBaseEdgeSharpness(idx, desc.creaseWeights[edge]);
@@ -342,7 +343,7 @@ TopologyRefinerFactory<TopologyRefinerFactoryBase::TopologyDescriptor>::assignCo
 
             int idx = desc.cornerVertexIndices[vert];
 
-            if (idx >= 0 and idx < refiner.GetNumVertices(0)) {
+            if (idx >= 0 and idx < refBaseLevel.GetNumVertices()) {
                 refiner.setBaseVertexSharpness(idx, desc.cornerWeights[vert]);
             } else {
                 char msg[1024];

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -343,7 +343,7 @@ TopologyRefinerFactory<MESH>::assignComponentTopology(TopologyRefiner& /* refine
     //
     //      void TopologyRefiner::setBaseVertexNonManifold(Index vertex, bool b);
     //
-    //  Also consider using TopologyRefiner::ValidateTopology() when debugging to ensure
+    //  Also consider using TopologyLevel::ValidateTopology() when debugging to ensure
     //  that topolology has been completely and correctly specified.
     //
     return false;

--- a/opensubdiv/osd/cpuSmoothNormalContext.cpp
+++ b/opensubdiv/osd/cpuSmoothNormalContext.cpp
@@ -36,14 +36,14 @@ CpuSmoothNormalContext::CpuSmoothNormalContext(
     Far::TopologyRefiner const & refiner, int level, bool resetMemory) :
         _numVertices(0), _resetMemory(resetMemory) {
 
-    int nfaces = refiner.GetNumFaces(level),
+    int nfaces = refiner.GetLevel(level).GetNumFaces(),
         nverts = nfaces * 4;
 
     _faceVerts.resize(nverts);
     Far::Index * dest = &_faceVerts[0];
 
     for (int face=0; face<nfaces; ++face, dest+=4) {
-        Far::ConstIndexArray fverts = refiner.GetFaceVertices(level, face);
+        Far::ConstIndexArray fverts = refiner.GetLevel(level).GetFaceVertices(face);
         memcpy(dest, fverts.begin(), 4 * sizeof(Far::Index));
     }
 }

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -325,7 +325,7 @@ public:
 
     virtual void Refine() {
 
-        int numControlVertices = _refiner->GetNumVertices(0);
+        int numControlVertices = _refiner->GetLevel(0).GetNumVertices();
 
         VertexBufferDescriptor srcDesc = _vertexDesc;
         VertexBufferDescriptor dstDesc(srcDesc);

--- a/regression/common/vtr_utils.cpp
+++ b/regression/common/vtr_utils.cpp
@@ -46,7 +46,7 @@ InterpolateFVarData(OpenSubdiv::Far::TopologyRefiner & refiner,
         fvarWidth = 2;
 
     int numValuesTotal = refiner.GetNumFVarValuesTotal(channel),
-            numValues0 = refiner.GetNumFVarValues(0, channel);
+            numValues0 = refiner.GetLevel(0).GetNumFVarValues(channel);
 
     if (shape.uvs.empty() or numValuesTotal<=0) {
         return;
@@ -57,7 +57,7 @@ InterpolateFVarData(OpenSubdiv::Far::TopologyRefiner & refiner,
         std::vector<FVarVertex> buffer(numValuesTotal);
 
         int maxlevel = refiner.GetMaxLevel(),
-            numValuesM = refiner.GetNumFVarValues(maxlevel, channel);
+            numValuesM = refiner.GetLevel(maxlevel).GetNumFVarValues(channel);
 
         memcpy(&buffer[0], &shape.uvs[0], shape.uvs.size()*sizeof(float));
 

--- a/regression/common/vtr_utils.h
+++ b/regression/common/vtr_utils.h
@@ -155,14 +155,14 @@ InterpolateVtrVertexData(const char *shapeStr, Scheme scheme, int maxlevel,
 
     // populate coarse mesh positions
     data.resize(refiner->GetNumVerticesTotal());
-    for (int i=0; i<refiner->GetNumVertices(0); i++) {
+    for (int i=0; i<refiner->GetLevel(0).GetNumVertices(); i++) {
         data[i].SetPosition(shape->verts[i*3+0],
                             shape->verts[i*3+1],
                             shape->verts[i*3+2]);
     }
 
     T * verts = &data[0];
-    refiner->Interpolate(verts, verts+refiner->GetNumVertices(0));
+    refiner->Interpolate(verts, verts+refiner->GetLevel(0).GetNumVertices());
 
     delete shape;
     return refiner;
@@ -204,7 +204,7 @@ TopologyRefinerFactory<Shape>::assignComponentTopology(
     Far::TopologyRefiner & refiner, Shape const & shape) {
 
     { // Face relations:
-        int nfaces = refiner.GetNumFaces(0);
+        int nfaces = refiner.GetLevel(0).GetNumFaces();
 
         for (int i=0, ofs=0; i < nfaces; ++i) {
 
@@ -235,7 +235,7 @@ TopologyRefinerFactory<Shape>::assignFaceVaryingTopology(
     // UV layyout (we only parse 1 channel)
     if (not shape.faceuvs.empty()) {
 
-        int nfaces = refiner.GetNumFaces(0),
+        int nfaces = refiner.GetLevel(0).GetNumFaces(),
            channel = refiner.createBaseFVarChannel( (int)shape.uvs.size()/2 );
 
         for (int i=0, ofs=0; i < nfaces; ++i) {
@@ -273,7 +273,7 @@ TopologyRefinerFactory<Shape>::assignComponentTags(
 
             for (int j=0; j<(int)t->intargs.size()-1; j += 2) {
 
-                OpenSubdiv::Vtr::Index edge = refiner.FindEdge(/*level*/0, t->intargs[j], t->intargs[j+1]);
+                OpenSubdiv::Vtr::Index edge = refiner.GetLevel(0).FindEdge(t->intargs[j], t->intargs[j+1]);
                 if (edge==OpenSubdiv::Vtr::INDEX_INVALID) {
                     printf("cannot find edge for crease tag (%d,%d)\n", t->intargs[j], t->intargs[j+1] );
                     return false;
@@ -287,7 +287,7 @@ TopologyRefinerFactory<Shape>::assignComponentTags(
 
             for (int j=0; j<(int)t->intargs.size(); ++j) {
                 int vertex = t->intargs[j];
-                if (vertex<0 or vertex>=refiner.GetNumVertices(/*level*/0)) {
+                if (vertex<0 or vertex>=refiner.GetLevel(0).GetNumVertices()) {
                     printf("cannot find vertex for corner tag (%d)\n", vertex );
                     return false;
                 } else {

--- a/regression/osd_regression/main.cpp
+++ b/regression/osd_regression/main.cpp
@@ -284,7 +284,7 @@ checkMeshCPU( FarTopologyRefiner *refiner,
         vb,
         Osd::VertexBufferDescriptor(0, 3, 3),
         vb,
-        Osd::VertexBufferDescriptor(refiner->GetNumVertices(0)*3, 3, 3),
+        Osd::VertexBufferDescriptor(refiner->GetLevel(0).GetNumVertices()*3, 3, 3),
         vertexStencils);
 
     int result = checkVertexBuffer(*refiner, refmesh, vb->BindCpuBuffer(), 
@@ -316,7 +316,7 @@ checkMeshCPUGL(FarTopologyRefiner *refiner,
         vb,
         Osd::VertexBufferDescriptor(0, 3, 3),
         vb,
-        Osd::VertexBufferDescriptor(refiner->GetNumVertices(0)*3, 3, 3),
+        Osd::VertexBufferDescriptor(refiner->GetLevel(0).GetNumVertices()*3, 3, 3),
         vertexStencils);
 
     int result = checkVertexBuffer(*refiner, refmesh, 

--- a/tutorials/far/tutorial_0/far_tutorial_0.cpp
+++ b/tutorials/far/tutorial_0/far_tutorial_0.cpp
@@ -149,23 +149,25 @@ int main(int, char **) {
 
     { // Output OBJ of the highest level refined -----------
 
+        Far::TopologyLevel const & refLastLevel = refiner->GetLevel(maxlevel);
+
         // Print vertex positions
         for (int level=0, firstVert=0; level<=maxlevel; ++level) {
 
             if (level==maxlevel) {
-                for (int vert=0; vert<refiner->GetNumVertices(maxlevel); ++vert) {
+                for (int vert=0; vert<refLastLevel.GetNumVertices(); ++vert) {
                     float const * pos = verts[firstVert+vert].GetPosition();
                     printf("v %f %f %f\n", pos[0], pos[1], pos[2]);
                 }
             } else {
-                firstVert += refiner->GetNumVertices(level);
+                firstVert += refiner->GetLevel(level).GetNumVertices();
             }
         }
 
         // Print faces
-        for (int face=0; face<refiner->GetNumFaces(maxlevel); ++face) {
+        for (int face=0; face<refLastLevel.GetNumFaces(); ++face) {
 
-            Far::ConstIndexArray fverts = refiner->GetFaceVertices(maxlevel, face);
+            Far::ConstIndexArray fverts = refLastLevel.GetFaceVertices(face);
 
             // all refined Catmark faces should be quads
             assert(fverts.size()==4);

--- a/tutorials/far/tutorial_1/far_tutorial_1.cpp
+++ b/tutorials/far/tutorial_1/far_tutorial_1.cpp
@@ -454,23 +454,25 @@ int main(int, char **) {
 
     { // Output OBJ of the highest level refined -----------
 
+        Far::TopologyLevel const & refLastLevel = refiner->GetLevel(maxlevel);
+
         // Print vertex positions
         for (int level=0, firstVert=0; level<=maxlevel; ++level) {
 
             if (level==maxlevel) {
-                for (int vert=0; vert<refiner->GetNumVertices(maxlevel); ++vert) {
+                for (int vert=0; vert<refLastLevel.GetNumVertices(); ++vert) {
                     float const * pos = verts[firstVert+vert].GetPosition();
                     printf("v %f %f %f\n", pos[0], pos[1], pos[2]);
                 }
             } else {
-                firstVert += refiner->GetNumVertices(level);
+                firstVert += refiner->GetLevel(level).GetNumVertices();
             }
         }
 
         // Print faces
-        for (int face=0; face<refiner->GetNumFaces(maxlevel); ++face) {
+        for (int face=0; face<refLastLevel.GetNumFaces(); ++face) {
 
-            Far::ConstIndexArray fverts = refiner->GetFaceVertices(maxlevel, face);
+            Far::ConstIndexArray fverts = refLastLevel.GetFaceVertices(face);
 
             // all refined Catmark faces should be quads
             assert(fverts.size()==4);

--- a/tutorials/far/tutorial_1/hbr_to_vtr.h
+++ b/tutorials/far/tutorial_1/hbr_to_vtr.h
@@ -339,7 +339,7 @@ FarTopologyRefinerFactory<OsdHbrConverter>::assignComponentTopology(
     OsdHbrConverter::EdgeMap & edges = const_cast<OsdHbrConverter &>(conv).GetEdges();
 
     { // Face relations:
-        int nfaces = refiner.GetNumFaces(/*level*/0);
+        int nfaces = refiner.GetLevel(0).GetNumFaces();
         for (int i=0; i < nfaces; ++i) {
 
             IndexArray dstFaceVerts = refiner.setBaseFaceVertices(i);
@@ -377,7 +377,7 @@ FarTopologyRefinerFactory<OsdHbrConverter>::assignComponentTopology(
     }
 
     { // Vert relations
-        for (int i=0; i<refiner.GetNumVertices(/*level*/0); ++i) {
+        for (int i=0; i<refiner.GetLevel(0).GetNumVertices(); ++i) {
 
             OsdHbrVertex const * v = hmesh.GetVertex(i);
 
@@ -451,7 +451,7 @@ FarTopologyRefinerFactory<OsdHbrConverter>::assignComponentTags(
     }
 
     // Initialize vertex sharpness
-    for (int i=0; i<refiner.GetNumVertices(/*level*/0); ++i) {
+    for (int i=0; i<refiner.GetLevel(0).GetNumVertices(); ++i) {
         refiner.setBaseVertexSharpness(i, hmesh.GetVertex(i)->GetSharpness());
     }
 

--- a/tutorials/far/tutorial_2/far_tutorial_2.cpp
+++ b/tutorials/far/tutorial_2/far_tutorial_2.cpp
@@ -166,11 +166,11 @@ int main(int, char **) {
       // particles at the location of the refined vertices (don't forget to
       // turn shading on in the viewport to see the colors)
 
-        int nverts = refiner->GetNumVertices(maxlevel);
+        int nverts = refiner->GetLevel(maxlevel).GetNumVertices();
 
         // Position the 'verts' pointer to the first vertex of our 'maxlevel' level
         for (int level=0; level<maxlevel; ++level) {
-            verts += refiner->GetNumVertices(level);
+            verts += refiner->GetLevel(level).GetNumVertices();
         }
 
         // Output particle positions

--- a/tutorials/far/tutorial_3/far_tutorial_3.cpp
+++ b/tutorials/far/tutorial_3/far_tutorial_3.cpp
@@ -214,7 +214,7 @@ int main(int, char **) {
 
     // Allocate & interpolate the 'face-varying' primvar data
     int channel = 0,
-        nCoarseFVVerts = refiner->GetNumFVarValues(0, channel);
+        nCoarseFVVerts = refiner->GetLevel(0).GetNumFVarValues(channel);
 
     std::vector<FVarVertex> fvBuffer(refiner->GetNumFVarValuesTotal(channel));
     FVarVertex * fvVerts = &fvBuffer[0];
@@ -229,16 +229,18 @@ int main(int, char **) {
 
     { // Output OBJ of the highest level refined -----------
 
+        Far::TopologyLevel const & refLastLevel = refiner->GetLevel(maxlevel).
+
         // Print vertex positions
         for (int level=0, firstVert=0; level<=maxlevel; ++level) {
 
             if (level==maxlevel) {
-                for (int vert=0; vert<refiner->GetNumVertices(level); ++vert) {
+                for (int vert=0; vert<refLastLevel.GetNumVertices(); ++vert) {
                     float const * pos = verts[firstVert+vert].GetPosition();
                     printf("v %f %f %f\n", pos[0], pos[1], pos[2]);
                 }
             } else {
-                firstVert += refiner->GetNumVertices(level);
+                firstVert += refiner->GetLevel(level).GetNumVertices();
             }
         }
 
@@ -246,21 +248,21 @@ int main(int, char **) {
         for (int level=0, firstVert=0; level<=maxlevel; ++level) {
 
             if (level==maxlevel) {
-                for (int vert=0; vert<refiner->GetNumFVarValues(level, channel); ++vert) {
+                for (int vert=0; vert<refLastLevel.GetNumFVarValues(channel); ++vert) {
                     FVarVertex const & uv = fvVerts[firstVert+vert];
                     printf("vt %f %f\n", uv.u, uv.v);
                 }
             } else {
-                firstVert += refiner->GetNumFVarValues(level, channel);
+                firstVert += refiner->GetLevel(level).GetNumFVarValues(channel);
             }
         }
 
 
         // Print faces
-        for (int face=0; face<refiner->GetNumFaces(maxlevel); ++face) {
+        for (int face=0; face<refLastLevel.GetNumFaces(); ++face) {
 
-            Far::ConstIndexArray fverts = refiner->GetFaceVertices(maxlevel, face),
-                                 fvverts = refiner->GetFVarFaceValues(maxlevel, face, channel);
+            Far::ConstIndexArray fverts = refLastLevel.GetFaceVertices(face),
+                                 fvverts = refLastLevel.GetFVarFaceValues(face, channel);
 
             // all refined Catmark faces should be quads
             assert(fverts.size()==4 and fvverts.size()==4);

--- a/tutorials/far/tutorial_3/far_tutorial_3.cpp
+++ b/tutorials/far/tutorial_3/far_tutorial_3.cpp
@@ -229,7 +229,7 @@ int main(int, char **) {
 
     { // Output OBJ of the highest level refined -----------
 
-        Far::TopologyLevel const & refLastLevel = refiner->GetLevel(maxlevel).
+        Far::TopologyLevel const & refLastLevel = refiner->GetLevel(maxlevel);
 
         // Print vertex positions
         for (int level=0, firstVert=0; level<=maxlevel; ++level) {

--- a/tutorials/far/tutorial_5/far_tutorial_5.cpp
+++ b/tutorials/far/tutorial_5/far_tutorial_5.cpp
@@ -121,7 +121,7 @@ int main(int, char **) {
     int maxlevel = 4;
     refiner->RefineUniform(Far::TopologyRefiner::UniformOptions(maxlevel));
 
-    int nverts = refiner->GetNumVertices(maxlevel);
+    int nverts = refiner->GetLevel(maxlevel).GetNumVertices();
 
     // Use the Far::StencilTables factory to create discrete stencil tables
     Far::StencilTablesFactory::Options options;

--- a/tutorials/far/tutorial_7/far_tutorial_7.cpp
+++ b/tutorials/far/tutorial_7/far_tutorial_7.cpp
@@ -150,7 +150,7 @@ int main(int, char **) {
     int start = 0, end = 0; // stencils batches for each level of subdivision
     for (int level=0; level<maxlevel; ++level) {
 
-        int nverts = refiner->GetNumVertices(level+1);
+        int nverts = refiner->GetLevel(level+1).GetNumVertices();
 
         Vertex const * srcVerts = reinterpret_cast<Vertex *>(g_verts);
         if (level>0) {
@@ -180,9 +180,11 @@ int main(int, char **) {
         // Print vertex positions
         for (int level=1, firstvert=0; level<=maxlevel; ++level) {
 
+            Far::TopologyLevel conat & refLevel = refiner->GetLevel(level);
+
             printf("g level_%d\n", level);
 
-            int nverts = refiner->GetNumVertices(level);
+            int nverts = refLevel.GetNumVertices();
             for (int vert=0; vert<nverts; ++vert) {
                 float const * pos = verts[vert].GetPosition();
                 printf("v %f %f %f\n", pos[0], pos[1], pos[2]);
@@ -190,9 +192,9 @@ int main(int, char **) {
             verts += nverts;
  
             // Print faces
-            for (int face=0; face<refiner->GetNumFaces(level); ++face) {
+            for (int face=0; face<refLevel.GetNumFaces(); ++face) {
 
-                Far::ConstIndexArray fverts = refiner->GetFaceVertices(level, face);
+                Far::ConstIndexArray fverts = refLevel.GetFaceVertices(face);
 
                 // all refined Catmark faces should be quads
                 assert(fverts.size()==4);

--- a/tutorials/far/tutorial_7/far_tutorial_7.cpp
+++ b/tutorials/far/tutorial_7/far_tutorial_7.cpp
@@ -180,7 +180,7 @@ int main(int, char **) {
         // Print vertex positions
         for (int level=1, firstvert=0; level<=maxlevel; ++level) {
 
-            Far::TopologyLevel conat & refLevel = refiner->GetLevel(level);
+            Far::TopologyLevel const & refLevel = refiner->GetLevel(level);
 
             printf("g level_%d\n", level);
 

--- a/tutorials/osd/tutorial_0/osd_tutorial_0.cpp
+++ b/tutorials/osd/tutorial_0/osd_tutorial_0.cpp
@@ -87,7 +87,7 @@ int main(int, char **) {
 
         stencilTables = Far::StencilTablesFactory::Create(*refiner, options);
 
-        nCoarseVerts = refiner->GetNumVertices(0);
+        nCoarseVerts = refiner->GetLevel(0).GetNumVertices();
         nRefinedVerts = stencilTables->GetNumStencils();
 
         // We are done with Far: cleanup tables


### PR DESCRIPTION
This is a first pass to getting rid of the TopologyRefiners many level-specific queries outside the Far layer itself.  Once all usage everywhere has been replaced, I'll remove the unused methods from TopologyRefiner.