### PR TITLE
Moved Vtr classes within internal namespace:

### DIFF
--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
@@ -44,7 +44,7 @@ EndCapBSplineBasisPatchFactory::EndCapBSplineBasisPatchFactory(
 
 ConstIndexArray
 EndCapBSplineBasisPatchFactory::GetPatchPoints(
-    Vtr::Level const * level, Index faceIndex) {
+    Vtr::internal::Level const * level, Index faceIndex) {
 
     // XXX: For now, always create new 16 indices for each patch.
     // we'll optimize later to share all regular control points with

--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.h
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.h
@@ -67,7 +67,7 @@ public:
     /// @param faceIndex        vtr faceIndex at the level
     ///
     ConstIndexArray GetPatchPoints(
-        Vtr::Level const * level, Index faceIndex);
+        Vtr::internal::Level const * level, Index faceIndex);
 
     /// \brief Create a StencilTable for end patch points, relative to the max
     ///        subdivision level.

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
@@ -57,7 +57,7 @@ EndCapGregoryBasisPatchFactory::Create(TopologyRefiner const & refiner,
     Index faceIndex, int fvarChannel) {
 
     // Gregory patches are end-caps: they only exist on max-level
-    Vtr::Level const & level = refiner.getLevel(refiner.GetMaxLevel());
+    Vtr::internal::Level const & level = refiner.getLevel(refiner.GetMaxLevel());
 
     GregoryBasis::ProtoBasis basis(level, faceIndex, fvarChannel);
     GregoryBasis * result = new GregoryBasis;
@@ -72,7 +72,7 @@ EndCapGregoryBasisPatchFactory::addPatchBasis(Index faceIndex,
                                    bool verticesMask[4][5]) {
 
     // Gregory patches only exist on the hight
-    Vtr::Level const & level = _refiner->getLevel(_refiner->GetMaxLevel());
+    Vtr::internal::Level const & level = _refiner->getLevel(_refiner->GetMaxLevel());
 
     // Gather the CVs that influence the Gregory patch and their relative
     // weights in a basis
@@ -111,7 +111,7 @@ EndCapGregoryBasisPatchFactory::addPatchBasis(Index faceIndex,
 //         gregory patch edges
 ConstIndexArray
 EndCapGregoryBasisPatchFactory::GetPatchPoints(
-    Vtr::Level const * level, Index faceIndex,
+    Vtr::internal::Level const * level, Index faceIndex,
     PatchTableFactory::PatchFaceTag const * levelPatchTags)
 {
     // allocate indices (awkward)

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.h
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.h
@@ -93,7 +93,7 @@ public:
     /// @param levelPatchTags   Array of patchTags for all faces in the level
     ///
     ConstIndexArray GetPatchPoints(
-        Vtr::Level const * level, Index faceIndex,
+        Vtr::internal::Level const * level, Index faceIndex,
         PatchTableFactory::PatchFaceTag const * levelPatchTags);
 
     /// \brief Create a StencilTable for end patch points, relative to the max

--- a/opensubdiv/far/endCapLegacyGregoryPatchFactory.cpp
+++ b/opensubdiv/far/endCapLegacyGregoryPatchFactory.cpp
@@ -40,7 +40,7 @@ EndCapLegacyGregoryPatchFactory::EndCapLegacyGregoryPatchFactory(
 
 ConstIndexArray
 EndCapLegacyGregoryPatchFactory::GetPatchPoints(
-    Vtr::Level const * level, Index faceIndex,
+    Vtr::internal::Level const * level, Index faceIndex,
     PatchTableFactory::PatchFaceTag const * levelPatchTags,
     int levelVertOffset) {
 
@@ -70,7 +70,7 @@ EndCapLegacyGregoryPatchFactory::GetPatchPoints(
 //  Populate the quad-offsets table used by Gregory patches
 //
 static void getQuadOffsets(
-    Vtr::Level const& level, Index faceIndex, unsigned int offsets[]) {
+    Vtr::internal::Level const& level, Index faceIndex, unsigned int offsets[]) {
 
     Vtr::ConstIndexArray fVerts = level.getFaceVertices(faceIndex);
 
@@ -112,7 +112,7 @@ EndCapLegacyGregoryPatchFactory::Finalize(
     size_t numTotalGregoryPatches = 
         numGregoryPatches + numGregoryBoundaryPatches;
 
-    Vtr::Level const &level = _refiner.getLevel(_refiner.GetMaxLevel());
+    Vtr::internal::Level const &level = _refiner.getLevel(_refiner.GetMaxLevel());
 
     quadOffsetsTable->resize(numTotalGregoryPatches*4);
 
@@ -151,7 +151,7 @@ EndCapLegacyGregoryPatchFactory::Finalize(
     int levelLast = _refiner.GetMaxLevel();
     for (int i = 0; i <= levelLast; ++i) {
 
-        Vtr::Level const * level = &_refiner.getLevel(i);
+        Vtr::internal::Level const * level = &_refiner.getLevel(i);
 
         if (i == levelLast) {
 

--- a/opensubdiv/far/endCapLegacyGregoryPatchFactory.h
+++ b/opensubdiv/far/endCapLegacyGregoryPatchFactory.h
@@ -26,14 +26,16 @@
 #define OPENSUBDIV3_FAR_END_CAP_LEGACY_GREGORY_PATCH_FACTORY_H
 
 #include "../far/patchTableFactory.h"
+#include "../vtr/level.h"
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
-class PatchTable;
-class TopologyRefiner;
 
 namespace Far {
+
+class PatchTable;
+class TopologyRefiner;
 
 /// \brief    This factory generates legacy (OpenSubdiv 2.x) gregory patches.
 ///
@@ -57,7 +59,7 @@ public:
     ///
     /// @param levelVertOffset  relative offset of patch vertex indices
     ///
-    ConstIndexArray GetPatchPoints(Vtr::Level const * level, Index faceIndex,
+    ConstIndexArray GetPatchPoints(Vtr::internal::Level const * level, Index faceIndex,
                                    PatchTableFactory::PatchFaceTag const * levelPatchTags,
                                    int levelVertOffset);
 

--- a/opensubdiv/far/gregoryBasis.cpp
+++ b/opensubdiv/far/gregoryBasis.cpp
@@ -57,7 +57,7 @@ namespace Far {
 // vertices.
 //
 static void
-getQuadOffsets(Vtr::Level const & level, Vtr::Index fIndex,
+getQuadOffsets(Vtr::internal::Level const & level, Vtr::Index fIndex,
     Vtr::Index offsets[], int fvarChannel=-1) {
 
     Far::ConstIndexArray fPoints = (fvarChannel<0) ?
@@ -150,7 +150,7 @@ inline float computeCoefficient(int valence) {
 }
 
 GregoryBasis::ProtoBasis::ProtoBasis(
-    Vtr::Level const & level, Index faceIndex, int fvarChannel) {
+    Vtr::internal::Level const & level, Index faceIndex, int fvarChannel) {
 
     Vtr::ConstIndexArray facePoints = (fvarChannel<0) ?
         level.getFaceVertices(faceIndex) :

--- a/opensubdiv/far/gregoryBasis.h
+++ b/opensubdiv/far/gregoryBasis.h
@@ -202,7 +202,7 @@ public:
     //
     struct ProtoBasis {
 
-        ProtoBasis(Vtr::Level const & level, Vtr::Index faceIndex, int fvarChannel=-1);
+        ProtoBasis(Vtr::internal::Level const & level, Vtr::Index faceIndex, int fvarChannel=-1);
 
         int GetNumElements() const;
 

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -462,8 +462,8 @@ PatchTableFactory::gatherFVarData(AdaptiveContext & context, int level,
     FVarChannelCursor & fvc = context.fvarChannelCursor;
     for (fvc=fvc.begin(); fvc!=fvc.end(); ++fvc) {
 
-        Vtr::Level const & vtxLevel = refiner.getLevel(level);
-        Vtr::FVarLevel const & fvarLevel = vtxLevel.getFVarLevel(*fvc);
+        Vtr::internal::Level const & vtxLevel = refiner.getLevel(level);
+        Vtr::internal::FVarLevel const & fvarLevel = vtxLevel.getFVarLevel(*fvc);
 
         if (refiner.GetFVarLinearInterpolation(*fvc)!=Sdc::Options::FVAR_LINEAR_ALL) {
 
@@ -480,7 +480,7 @@ PatchTableFactory::gatherFVarData(AdaptiveContext & context, int level,
             ConstIndexArray faceVerts = vtxLevel.getFaceVertices(faceIndex),
                             fvarValues = fvarLevel.getFaceValues(faceIndex);
 
-            Vtr::FVarLevel::ValueTag compFVarTagsForFace =
+            Vtr::internal::FVarLevel::ValueTag compFVarTagsForFace =
                 fvarLevel.getFaceCompositeValueTag(fvarValues, faceVerts);
 
             if (compFVarTagsForFace.isMismatch()) {
@@ -517,9 +517,9 @@ PatchTableFactory::gatherFVarData(AdaptiveContext & context, int level,
                 //  of each vertex merged with the FVar tag of its value) while computing the
                 //  composite VTag:
                 //
-                Vtr::Level::VTag fvarVertTags[4];
+                Vtr::internal::Level::VTag fvarVertTags[4];
 
-                Vtr::Level::VTag compFVarVTag =
+                Vtr::internal::Level::VTag compFVarVTag =
                             fvarLevel.getFaceCompositeValueAndVTag(fvarValues, faceVerts, fvarVertTags);
 
                 //
@@ -531,11 +531,11 @@ PatchTableFactory::gatherFVarData(AdaptiveContext & context, int level,
                 fvarPatchTag._isRegular = not compFVarVTag._xordinary;
 
                 if (compFVarVTag._boundary) {
-                    Vtr::Level::ETag fvarEdgeTags[4];
+                    Vtr::internal::Level::ETag fvarEdgeTags[4];
 
                     ConstIndexArray faceEdges = vtxLevel.getFaceEdges(faceIndex);
 
-                    Vtr::Level::ETag compFVarETag =
+                    Vtr::internal::Level::ETag compFVarETag =
                                 fvarLevel.getFaceCompositeCombinedEdgeTag(faceEdges, fvarEdgeTags);
 
                     if (compFVarETag._boundary) {
@@ -668,8 +668,8 @@ PatchTableFactory::computePatchParam(
     bool nonquad = (refiner.GetLevel(depth).GetFaceVertices(faceIndex).size() != 4);
 
     for (int i = depth; i > 0; --i) {
-        Vtr::Refinement const& refinement  = refiner.getRefinement(i-1);
-        Vtr::Level const&      parentLevel = refiner.getLevel(i-1);
+        Vtr::internal::Refinement const& refinement  = refiner.getRefinement(i-1);
+        Vtr::internal::Level const&      parentLevel = refiner.getLevel(i-1);
 
         Vtr::Index parentFaceIndex    = refinement.getChildFaceParentFace(faceIndex);
                  childIndexInParent = refinement.getChildFaceInParentFace(faceIndex);
@@ -988,7 +988,7 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
     PatchFaceTag * levelPatchTags = &context.patchTags[0];
 
     for (int levelIndex = 0; levelIndex < refiner.GetNumLevels(); ++levelIndex) {
-        Vtr::Level const * level = &refiner.getLevel(levelIndex);
+        Vtr::internal::Level const * level = &refiner.getLevel(levelIndex);
 
         //
         //  Given components at Level[i], we need to be looking at Refinement[i] -- and not
@@ -1000,8 +1000,8 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
         //    - what Faces are "transitional" (already done in Refinement for parent)
         //    - what Faces are "complete" (applied to this Level in previous refinement)
         //
-        Vtr::Refinement const            * refinement = 0;
-        Vtr::Refinement::SparseTag const * refinedFaceTags = 0;
+        Vtr::internal::Refinement const            * refinement = 0;
+        Vtr::internal::Refinement::SparseTag const * refinedFaceTags = 0;
 
         if (levelIndex < refiner.GetMaxLevel()) {
             refinement      = &refiner.getRefinement(levelIndex);
@@ -1032,8 +1032,8 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
             //  "incomplete" (and all are tagged) the face must be "incomplete", so get the
             //  "composite" tag which combines bits for all vertices:
             //
-            Vtr::Refinement::SparseTag refinedFaceTag = refinedFaceTags ?
-                refinedFaceTags[faceIndex] : Vtr::Refinement::SparseTag();
+            Vtr::internal::Refinement::SparseTag refinedFaceTag = refinedFaceTags ?
+                refinedFaceTags[faceIndex] : Vtr::internal::Refinement::SparseTag();
 
             if (refinedFaceTag._selected) {
                 continue;
@@ -1042,7 +1042,7 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
             Vtr::ConstIndexArray fVerts = level->getFaceVertices(faceIndex);
             assert(fVerts.size() == 4);
 
-            Vtr::Level::VTag compFaceVertTag = level->getFaceCompositeVTag(fVerts);
+            Vtr::internal::Level::VTag compFaceVertTag = level->getFaceCompositeVTag(fVerts);
             if (compFaceVertTag._incomplete) {
                 continue;
             }
@@ -1085,7 +1085,7 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
                 not hasXOrdinaryVertex and not hasBoundaryVertex and not hasNonManifoldVertex) {
 
                 Vtr::ConstIndexArray fEdges = level->getFaceEdges(faceIndex);
-                Vtr::Level::ETag compFaceETag = level->getFaceCompositeETag(fEdges);
+                Vtr::internal::Level::ETag compFaceETag = level->getFaceCompositeETag(fEdges);
 
                 if (compFaceETag._semiSharp or compFaceETag._infSharp) {
                     float sharpness = 0;
@@ -1321,7 +1321,7 @@ PatchTableFactory::populateAdaptivePatches(
     }
 
     for (int i = 0; i < refiner.GetNumLevels(); ++i) {
-        Vtr::Level const * level = &refiner.getLevel(i);
+        Vtr::internal::Level const * level = &refiner.getLevel(i);
 
         const PatchFaceTag * levelPatchTags = &context.patchTags[levelFaceOffset];
 

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -32,11 +32,9 @@
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
-//  Forward declarations (for internal implementation purposes):
-namespace Vtr { class Level; }
-
 namespace Far {
 
+//  Forward declarations (for internal implementation purposes):
 class PtexIndices;
 class TopologyRefiner;
 

--- a/opensubdiv/far/primvarRefiner.h
+++ b/opensubdiv/far/primvarRefiner.h
@@ -47,8 +47,6 @@
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
-namespace Vtr { class SparseSelector; }
-
 namespace Far {
 
 
@@ -196,17 +194,17 @@ private:
     PrimvarRefiner(PrimvarRefiner const & src) : _refiner(src._refiner) { }
     PrimvarRefiner & operator=(PrimvarRefiner const &) { return *this; }
 
-    template <Sdc::SchemeType SCHEME, class T, class U> void interpolateChildVertsFromFaces(Vtr::Refinement const &, T const & src, U & dst) const;
-    template <Sdc::SchemeType SCHEME, class T, class U> void interpolateChildVertsFromEdges(Vtr::Refinement const &, T const & src, U & dst) const;
-    template <Sdc::SchemeType SCHEME, class T, class U> void interpolateChildVertsFromVerts(Vtr::Refinement const &, T const & src, U & dst) const;
+    template <Sdc::SchemeType SCHEME, class T, class U> void interpolateChildVertsFromFaces(Vtr::internal::Refinement const &, T const & src, U & dst) const;
+    template <Sdc::SchemeType SCHEME, class T, class U> void interpolateChildVertsFromEdges(Vtr::internal::Refinement const &, T const & src, U & dst) const;
+    template <Sdc::SchemeType SCHEME, class T, class U> void interpolateChildVertsFromVerts(Vtr::internal::Refinement const &, T const & src, U & dst) const;
 
-    template <class T, class U> void varyingInterpolateChildVertsFromFaces(Vtr::Refinement const &, T const & src, U & dst) const;
-    template <class T, class U> void varyingInterpolateChildVertsFromEdges(Vtr::Refinement const &, T const & src, U & dst) const;
-    template <class T, class U> void varyingInterpolateChildVertsFromVerts(Vtr::Refinement const &, T const & src, U & dst) const;
+    template <class T, class U> void varyingInterpolateChildVertsFromFaces(Vtr::internal::Refinement const &, T const & src, U & dst) const;
+    template <class T, class U> void varyingInterpolateChildVertsFromEdges(Vtr::internal::Refinement const &, T const & src, U & dst) const;
+    template <class T, class U> void varyingInterpolateChildVertsFromVerts(Vtr::internal::Refinement const &, T const & src, U & dst) const;
 
-    template <Sdc::SchemeType SCHEME, class T, class U> void faceVaryingInterpolateChildVertsFromFaces(Vtr::Refinement const &, T const & src, U & dst, int channel) const;
-    template <Sdc::SchemeType SCHEME, class T, class U> void faceVaryingInterpolateChildVertsFromEdges(Vtr::Refinement const &, T const & src, U & dst, int channel) const;
-    template <Sdc::SchemeType SCHEME, class T, class U> void faceVaryingInterpolateChildVertsFromVerts(Vtr::Refinement const &, T const & src, U & dst, int channel) const;
+    template <Sdc::SchemeType SCHEME, class T, class U> void faceVaryingInterpolateChildVertsFromFaces(Vtr::internal::Refinement const &, T const & src, U & dst, int channel) const;
+    template <Sdc::SchemeType SCHEME, class T, class U> void faceVaryingInterpolateChildVertsFromEdges(Vtr::internal::Refinement const &, T const & src, U & dst, int channel) const;
+    template <Sdc::SchemeType SCHEME, class T, class U> void faceVaryingInterpolateChildVertsFromVerts(Vtr::internal::Refinement const &, T const & src, U & dst, int channel) const;
 
     template <Sdc::SchemeType SCHEME, class T, class U, class U1, class U2> void limit(T const & src, U & pos, U1 * tan1, U2 * tan2) const;
 
@@ -238,7 +236,7 @@ PrimvarRefiner::Interpolate(int level, T const & src, U & dst) const {
 
     assert(level>0 and level<=(int)_refiner._refinements.size());
 
-    Vtr::Refinement const & refinement = _refiner.getRefinement(level-1);
+    Vtr::internal::Refinement const & refinement = _refiner.getRefinement(level-1);
 
     switch (_refiner._subdivType) {
     case Sdc::SCHEME_CATMARK:
@@ -262,13 +260,13 @@ PrimvarRefiner::Interpolate(int level, T const & src, U & dst) const {
 template <Sdc::SchemeType SCHEME, class T, class U>
 inline void
 PrimvarRefiner::interpolateChildVertsFromFaces(
-    Vtr::Refinement const & refinement, T const & src, U & dst) const {
+    Vtr::internal::Refinement const & refinement, T const & src, U & dst) const {
 
     if (refinement.getNumChildVerticesFromFaces() == 0) return;
 
     Sdc::Scheme<SCHEME> scheme(_refiner._subdivOptions);
 
-    const Vtr::Level& parent = refinement.parent();
+    const Vtr::internal::Level& parent = refinement.parent();
 
     Vtr::internal::StackBuffer<float,16> fVertWeights(parent.getMaxValence());
 
@@ -283,8 +281,8 @@ PrimvarRefiner::interpolateChildVertsFromFaces(
 
         float fVaryingWeight = 1.0f / (float) fVerts.size();
 
-        Vtr::MaskInterface fMask(fVertWeights, 0, 0);
-        Vtr::FaceInterface fHood(fVerts.size());
+        Vtr::internal::MaskInterface fMask(fVertWeights, 0, 0);
+        Vtr::internal::FaceInterface fHood(fVerts.size());
 
         scheme.ComputeFaceVertexMask(fHood, fMask);
 
@@ -303,14 +301,14 @@ PrimvarRefiner::interpolateChildVertsFromFaces(
 template <Sdc::SchemeType SCHEME, class T, class U>
 inline void
 PrimvarRefiner::interpolateChildVertsFromEdges(
-    Vtr::Refinement const & refinement, T const & src, U & dst) const {
+    Vtr::internal::Refinement const & refinement, T const & src, U & dst) const {
 
     Sdc::Scheme<SCHEME> scheme(_refiner._subdivOptions);
 
-    const Vtr::Level& parent = refinement.parent();
-    const Vtr::Level& child  = refinement.child();
+    const Vtr::internal::Level& parent = refinement.parent();
+    const Vtr::internal::Level& child  = refinement.child();
 
-    Vtr::EdgeInterface eHood(parent);
+    Vtr::internal::EdgeInterface eHood(parent);
 
     float                               eVertWeights[2];
     Vtr::internal::StackBuffer<float,8> eFaceWeights(parent.getMaxEdgeFaces());
@@ -325,7 +323,7 @@ PrimvarRefiner::interpolateChildVertsFromEdges(
         ConstIndexArray eVerts = parent.getEdgeVertices(edge),
                         eFaces = parent.getEdgeFaces(edge);
 
-        Vtr::MaskInterface eMask(eVertWeights, 0, eFaceWeights);
+        Vtr::internal::MaskInterface eMask(eVertWeights, 0, eFaceWeights);
 
         eHood.SetIndex(edge);
 
@@ -375,14 +373,14 @@ PrimvarRefiner::interpolateChildVertsFromEdges(
 template <Sdc::SchemeType SCHEME, class T, class U>
 inline void
 PrimvarRefiner::interpolateChildVertsFromVerts(
-    Vtr::Refinement const & refinement, T const & src, U & dst) const {
+    Vtr::internal::Refinement const & refinement, T const & src, U & dst) const {
 
     Sdc::Scheme<SCHEME> scheme(_refiner._subdivOptions);
 
-    const Vtr::Level& parent = refinement.parent();
-    const Vtr::Level& child  = refinement.child();
+    const Vtr::internal::Level& parent = refinement.parent();
+    const Vtr::internal::Level& child  = refinement.child();
 
-    Vtr::VertexInterface vHood(parent, child);
+    Vtr::internal::VertexInterface vHood(parent, child);
 
     Vtr::internal::StackBuffer<float,32> weightBuffer(2*parent.getMaxValence());
 
@@ -400,7 +398,7 @@ PrimvarRefiner::interpolateChildVertsFromVerts(
               * vEdgeWeights = weightBuffer,
               * vFaceWeights = vEdgeWeights + vEdges.size();
 
-        Vtr::MaskInterface vMask(&vVertWeight, vEdgeWeights, vFaceWeights);
+        Vtr::internal::MaskInterface vMask(&vVertWeight, vEdgeWeights, vFaceWeights);
 
         vHood.SetIndex(vert, cVert);
 
@@ -466,7 +464,7 @@ PrimvarRefiner::InterpolateVarying(int level, T const & src, U & dst) const {
 
     assert(level>0 and level<=(int)_refiner._refinements.size());
 
-    Vtr::Refinement const & refinement = _refiner.getRefinement(level-1);
+    Vtr::internal::Refinement const & refinement = _refiner.getRefinement(level-1);
 
     varyingInterpolateChildVertsFromFaces(refinement, src, dst);
     varyingInterpolateChildVertsFromEdges(refinement, src, dst);
@@ -476,11 +474,11 @@ PrimvarRefiner::InterpolateVarying(int level, T const & src, U & dst) const {
 template <class T, class U>
 inline void
 PrimvarRefiner::varyingInterpolateChildVertsFromFaces(
-    Vtr::Refinement const & refinement, T const & src, U & dst) const {
+    Vtr::internal::Refinement const & refinement, T const & src, U & dst) const {
 
     if (refinement.getNumChildVerticesFromFaces() == 0) return;
 
-    const Vtr::Level& parent = refinement.parent();
+    const Vtr::internal::Level& parent = refinement.parent();
 
     for (int face = 0; face < parent.getNumFaces(); ++face) {
 
@@ -504,9 +502,9 @@ PrimvarRefiner::varyingInterpolateChildVertsFromFaces(
 template <class T, class U>
 inline void
 PrimvarRefiner::varyingInterpolateChildVertsFromEdges(
-    Vtr::Refinement const & refinement, T const & src, U & dst) const {
+    Vtr::internal::Refinement const & refinement, T const & src, U & dst) const {
 
-    const Vtr::Level& parent = refinement.parent();
+    const Vtr::internal::Level& parent = refinement.parent();
 
     for (int edge = 0; edge < parent.getNumEdges(); ++edge) {
 
@@ -528,9 +526,9 @@ PrimvarRefiner::varyingInterpolateChildVertsFromEdges(
 template <class T, class U>
 inline void
 PrimvarRefiner::varyingInterpolateChildVertsFromVerts(
-    Vtr::Refinement const & refinement, T const & src, U & dst) const {
+    Vtr::internal::Refinement const & refinement, T const & src, U & dst) const {
 
-    const Vtr::Level& parent = refinement.parent();
+    const Vtr::internal::Level& parent = refinement.parent();
 
     for (int vert = 0; vert < parent.getNumVertices(); ++vert) {
 
@@ -568,7 +566,7 @@ PrimvarRefiner::InterpolateFaceVarying(int level, T const & src, U & dst, int ch
 
     assert(level>0 and level<=(int)_refiner._refinements.size());
 
-    Vtr::Refinement const & refinement = _refiner.getRefinement(level-1);
+    Vtr::internal::Refinement const & refinement = _refiner.getRefinement(level-1);
 
     switch (_refiner._subdivType) {
     case Sdc::SCHEME_CATMARK:
@@ -592,17 +590,17 @@ PrimvarRefiner::InterpolateFaceVarying(int level, T const & src, U & dst, int ch
 template <Sdc::SchemeType SCHEME, class T, class U>
 inline void
 PrimvarRefiner::faceVaryingInterpolateChildVertsFromFaces(
-    Vtr::Refinement const & refinement, T const & src, U & dst, int channel) const {
+    Vtr::internal::Refinement const & refinement, T const & src, U & dst, int channel) const {
 
     if (refinement.getNumChildVerticesFromFaces() == 0) return;
 
     Sdc::Scheme<SCHEME> scheme(_refiner._subdivOptions);
 
-    const Vtr::Level& parentLevel = refinement.parent();
-    const Vtr::Level& childLevel  = refinement.child();
+    const Vtr::internal::Level& parentLevel = refinement.parent();
+    const Vtr::internal::Level& childLevel  = refinement.child();
 
-    const Vtr::FVarLevel& parentFVar = *parentLevel._fvarChannels[channel];
-    const Vtr::FVarLevel& childFVar  = *childLevel._fvarChannels[channel];
+    const Vtr::internal::FVarLevel& parentFVar = *parentLevel._fvarChannels[channel];
+    const Vtr::internal::FVarLevel& childFVar  = *childLevel._fvarChannels[channel];
 
     Vtr::internal::StackBuffer<float,16> fValueWeights(parentLevel.getMaxValence());
 
@@ -622,8 +620,8 @@ PrimvarRefiner::faceVaryingInterpolateChildVertsFromFaces(
         //  Declare and compute mask weights for this vertex relative to its parent face:
         ConstIndexArray fValues = parentFVar.getFaceValues(face);
 
-        Vtr::MaskInterface fMask(fValueWeights, 0, 0);
-        Vtr::FaceInterface fHood(fValues.size());
+        Vtr::internal::MaskInterface fMask(fValueWeights, 0, 0);
+        Vtr::internal::FaceInterface fHood(fValues.size());
 
         scheme.ComputeFaceVertexMask(fHood, fMask);
 
@@ -639,16 +637,16 @@ PrimvarRefiner::faceVaryingInterpolateChildVertsFromFaces(
 template <Sdc::SchemeType SCHEME, class T, class U>
 inline void
 PrimvarRefiner::faceVaryingInterpolateChildVertsFromEdges(
-    Vtr::Refinement const & refinement, T const & src, U & dst, int channel) const {
+    Vtr::internal::Refinement const & refinement, T const & src, U & dst, int channel) const {
 
     Sdc::Scheme<SCHEME> scheme(_refiner._subdivOptions);
 
-    const Vtr::Level& parentLevel = refinement.parent();
-    const Vtr::Level& childLevel  = refinement.child();
+    const Vtr::internal::Level& parentLevel = refinement.parent();
+    const Vtr::internal::Level& childLevel  = refinement.child();
 
-    const Vtr::FVarRefinement& refineFVar = *refinement._fvarChannels[channel];
-    const Vtr::FVarLevel&      parentFVar = *parentLevel._fvarChannels[channel];
-    const Vtr::FVarLevel&      childFVar  = *childLevel._fvarChannels[channel];
+    const Vtr::internal::FVarRefinement& refineFVar = *refinement._fvarChannels[channel];
+    const Vtr::internal::FVarLevel&      parentFVar = *parentLevel._fvarChannels[channel];
+    const Vtr::internal::FVarLevel&      childFVar  = *childLevel._fvarChannels[channel];
 
     //
     //  Allocate and intialize (if linearly interpolated) interpolation weights for
@@ -657,7 +655,7 @@ PrimvarRefiner::faceVaryingInterpolateChildVertsFromEdges(
     float                               eVertWeights[2];
     Vtr::internal::StackBuffer<float,8> eFaceWeights(parentLevel.getMaxEdgeFaces());
 
-    Vtr::MaskInterface eMask(eVertWeights, 0, eFaceWeights);
+    Vtr::internal::MaskInterface eMask(eVertWeights, 0, eFaceWeights);
 
     bool isLinearFVar = parentFVar._isLinear;
     if (isLinearFVar) {
@@ -669,7 +667,7 @@ PrimvarRefiner::faceVaryingInterpolateChildVertsFromEdges(
         eVertWeights[1] = 0.5f;
     }
 
-    Vtr::EdgeInterface eHood(parentLevel);
+    Vtr::internal::EdgeInterface eHood(parentLevel);
 
     for (int edge = 0; edge < parentLevel.getNumEdges(); ++edge) {
 
@@ -782,16 +780,16 @@ PrimvarRefiner::faceVaryingInterpolateChildVertsFromEdges(
 template <Sdc::SchemeType SCHEME, class T, class U>
 inline void
 PrimvarRefiner::faceVaryingInterpolateChildVertsFromVerts(
-    Vtr::Refinement const & refinement, T const & src, U & dst, int channel) const {
+    Vtr::internal::Refinement const & refinement, T const & src, U & dst, int channel) const {
 
     Sdc::Scheme<SCHEME> scheme(_refiner._subdivOptions);
 
-    const Vtr::Level& parentLevel = refinement.parent();
-    const Vtr::Level& childLevel  = refinement.child();
+    const Vtr::internal::Level& parentLevel = refinement.parent();
+    const Vtr::internal::Level& childLevel  = refinement.child();
 
-    const Vtr::FVarRefinement& refineFVar = *refinement._fvarChannels[channel];
-    const Vtr::FVarLevel&      parentFVar = *parentLevel._fvarChannels[channel];
-    const Vtr::FVarLevel&      childFVar  = *childLevel._fvarChannels[channel];
+    const Vtr::internal::FVarRefinement& refineFVar = *refinement._fvarChannels[channel];
+    const Vtr::internal::FVarLevel&      parentFVar = *parentLevel._fvarChannels[channel];
+    const Vtr::internal::FVarLevel&      childFVar  = *childLevel._fvarChannels[channel];
 
     bool isLinearFVar = parentFVar._isLinear;
 
@@ -799,7 +797,7 @@ PrimvarRefiner::faceVaryingInterpolateChildVertsFromVerts(
 
     Vtr::internal::StackBuffer<Vtr::Index,16> vEdgeValues(parentLevel.getMaxValence());
 
-    Vtr::VertexInterface vHood(parentLevel, childLevel);
+    Vtr::internal::VertexInterface vHood(parentLevel, childLevel);
 
     for (int vert = 0; vert < parentLevel.getNumVertices(); ++vert) {
 
@@ -830,7 +828,7 @@ PrimvarRefiner::faceVaryingInterpolateChildVertsFromVerts(
             float * vEdgeWeights = weightBuffer;
             float * vFaceWeights = vEdgeWeights + vEdges.size();
 
-            Vtr::MaskInterface vMask(&vVertWeight, vEdgeWeights, vFaceWeights);
+            Vtr::internal::MaskInterface vMask(&vVertWeight, vEdgeWeights, vFaceWeights);
 
             vHood.SetIndex(vert, cVert);
 
@@ -898,8 +896,8 @@ PrimvarRefiner::faceVaryingInterpolateChildVertsFromVerts(
             //      - otherwise if the PARENT is a crease, both will be creases (no transition)
             //      - otherwise the parent must be a corner and the child a crease (transition)
             //
-            Vtr::FVarLevel::ConstValueTagArray pValueTags = parentFVar.getVertexValueTags(vert);
-            Vtr::FVarLevel::ConstValueTagArray cValueTags = childFVar.getVertexValueTags(cVert);
+            Vtr::internal::FVarLevel::ConstValueTagArray pValueTags = parentFVar.getVertexValueTags(vert);
+            Vtr::internal::FVarLevel::ConstValueTagArray cValueTags = childFVar.getVertexValueTags(cVert);
 
             for (int cSibling = 0; cSibling < cVertValues.size(); ++cSibling) {
                 int pSibling = refineFVar.getChildValueParentSource(cVert, cSibling);
@@ -997,7 +995,7 @@ PrimvarRefiner::limit(T const & src, U & dstPos, U1 * dstTan1Ptr, U2 * dstTan2Pt
 
     Sdc::Scheme<SCHEME> scheme(_refiner._subdivOptions);
 
-    Vtr::Level const & level = _refiner.getLevel(_refiner.GetMaxLevel());
+    Vtr::internal::Level const & level = _refiner.getLevel(_refiner.GetMaxLevel());
 
     int  maxWeightsPerMask = 1 + 2 * level.getMaxValence();
     bool hasTangents = (dstTan1Ptr && dstTan2Ptr);
@@ -1016,13 +1014,13 @@ PrimvarRefiner::limit(T const & src, U & dstPos, U1 * dstTan1Ptr, U2 * dstTan2Pt
           * eTan2Weights = eTan1Weights + maxWeightsPerMask,
           * fTan2Weights = fTan1Weights + maxWeightsPerMask;
 
-    Vtr::MaskInterface posMask( vPosWeights,  ePosWeights,  fPosWeights);
-    Vtr::MaskInterface tan1Mask(vTan1Weights, eTan1Weights, fTan1Weights);
-    Vtr::MaskInterface tan2Mask(vTan2Weights, eTan2Weights, fTan2Weights);
+    Vtr::internal::MaskInterface posMask( vPosWeights,  ePosWeights,  fPosWeights);
+    Vtr::internal::MaskInterface tan1Mask(vTan1Weights, eTan1Weights, fTan1Weights);
+    Vtr::internal::MaskInterface tan2Mask(vTan2Weights, eTan2Weights, fTan2Weights);
 
     //  This is a bit obscure -- assigning both parent and child as last level -- but
     //  this mask type was intended for another purpose.  Consider one for the limit:
-    Vtr::VertexInterface vHood(level, level);
+    Vtr::internal::VertexInterface vHood(level, level);
 
     for (int vert = 0; vert < level.getNumVertices(); ++vert) {
         ConstIndexArray vEdges = level.getVertexEdges(vert);
@@ -1154,8 +1152,8 @@ PrimvarRefiner::faceVaryingLimit(T const & src, U * dst, int channel) const {
 
     Sdc::Scheme<SCHEME> scheme(_refiner._subdivOptions);
 
-    Vtr::Level const &      level       = _refiner.getLevel(_refiner.GetMaxLevel());
-    Vtr::FVarLevel const &  fvarChannel = *level._fvarChannels[channel];
+    Vtr::internal::Level const &      level       = _refiner.getLevel(_refiner.GetMaxLevel());
+    Vtr::internal::FVarLevel const &  fvarChannel = *level._fvarChannels[channel];
 
     int maxWeightsPerMask = 1 + 2 * level.getMaxValence();
 
@@ -1163,7 +1161,7 @@ PrimvarRefiner::faceVaryingLimit(T const & src, U * dst, int channel) const {
     Vtr::internal::StackBuffer<Index,16> vEdgeBuffer(level.getMaxValence());
 
     //  This is a bit obscure -- assign both parent and child as last level
-    Vtr::VertexInterface vHood(level, level);
+    Vtr::internal::VertexInterface vHood(level, level);
 
     for (int vert = 0; vert < level.getNumVertices(); ++vert) {
 
@@ -1196,7 +1194,7 @@ PrimvarRefiner::faceVaryingLimit(T const & src, U * dst, int channel) const {
                   * eWeights = vWeights + 1,
                   * fWeights = eWeights + vEdges.size();
 
-            Vtr::MaskInterface vMask(vWeights, eWeights, fWeights);
+            Vtr::internal::MaskInterface vMask(vWeights, eWeights, fWeights);
 
             vHood.SetIndex(vert, vert);
 

--- a/opensubdiv/far/ptexIndices.cpp
+++ b/opensubdiv/far/ptexIndices.cpp
@@ -49,7 +49,7 @@ PtexIndices::initializePtexIndices(TopologyRefiner const &refiner) {
     int regFaceSize = Sdc::SchemeTypeTraits::GetRegularFaceSize(
             refiner.GetSchemeType());
 
-    Vtr::Level const & coarseLevel = refiner.getLevel(0);
+    Vtr::internal::Level const & coarseLevel = refiner.getLevel(0);
 
     int nfaces = coarseLevel.getNumFaces();
     _ptexIndices.resize(nfaces+1);
@@ -77,7 +77,7 @@ PtexIndices::GetFaceId(Index f) const {
 namespace {
     // Returns the face adjacent to 'face' along edge 'edge'
     inline Index
-    getAdjacentFace(Vtr::Level const & level, Index edge, Index face) {
+    getAdjacentFace(Vtr::internal::Level const & level, Index edge, Index face) {
         Far::ConstIndexArray adjFaces = level.getEdgeFaces(edge);
         if (adjFaces.size()!=2) {
             return -1;
@@ -100,7 +100,7 @@ PtexIndices::GetAdjacency(
         return;
     }
 
-    Vtr::Level const & level = refiner.getLevel(0);
+    Vtr::internal::Level const & level = refiner.getLevel(0);
 
     ConstIndexArray fedges = level.getFaceEdges(face);
 

--- a/opensubdiv/far/topologyLevel.h
+++ b/opensubdiv/far/topologyLevel.h
@@ -93,9 +93,9 @@ public:
 private:
     friend class TopologyRefiner;
 
-    Vtr::Level const *      _level;
-    Vtr::Refinement const * _refToParent;
-    Vtr::Refinement const * _refToChild;
+    Vtr::internal::Level const *      _level;
+    Vtr::internal::Refinement const * _refToParent;
+    Vtr::internal::Refinement const * _refToChild;
 
 public:
     //  Not intended for public use, but required by std::vector, etc...

--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -50,7 +50,7 @@
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
-namespace Vtr { class SparseSelector; }
+namespace Vtr { namespace internal { class SparseSelector; } }
 
 namespace Far {
 
@@ -254,11 +254,11 @@ protected:
     friend class PtexIndices;
     friend class PrimvarRefiner;
 
-    Vtr::Level & getLevel(int l) { return *_levels[l]; }
-    Vtr::Level const & getLevel(int l) const { return *_levels[l]; }
+    Vtr::internal::Level & getLevel(int l) { return *_levels[l]; }
+    Vtr::internal::Level const & getLevel(int l) const { return *_levels[l]; }
 
-    Vtr::Refinement & getRefinement(int l) { return *_refinements[l]; }
-    Vtr::Refinement const & getRefinement(int l) const { return *_refinements[l]; }
+    Vtr::internal::Refinement & getRefinement(int l) { return *_refinements[l]; }
+    Vtr::internal::Refinement const & getRefinement(int l) const { return *_refinements[l]; }
 
 private:
     //  Not default constructible or copyable:
@@ -266,13 +266,13 @@ private:
     TopologyRefiner(TopologyRefiner const &) : _uniformOptions(0), _adaptiveOptions(0) { }
     TopologyRefiner & operator=(TopologyRefiner const &) { return *this; }
 
-    void selectFeatureAdaptiveComponents(Vtr::SparseSelector& selector);
+    void selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& selector);
 
     void initializeInventory();
-    void updateInventory(Vtr::Level const & newLevel);
+    void updateInventory(Vtr::internal::Level const & newLevel);
 
-    void appendLevel(Vtr::Level & newLevel);
-    void appendRefinement(Vtr::Refinement & newRefinement);
+    void appendLevel(Vtr::internal::Level & newLevel);
+    void appendRefinement(Vtr::internal::Refinement & newRefinement);
     void assembleFarLevels();
 
 private:
@@ -296,8 +296,8 @@ private:
     int _maxValence;
 
     //  There is some redundancy here -- to be reduced later
-    std::vector<Vtr::Level *>      _levels;
-    std::vector<Vtr::Refinement *> _refinements;
+    std::vector<Vtr::internal::Level *>      _levels;
+    std::vector<Vtr::internal::Refinement *> _refinements;
 
     std::vector<TopologyLevel> _farLevels;;
 };

--- a/opensubdiv/far/topologyRefinerFactory.cpp
+++ b/opensubdiv/far/topologyRefinerFactory.cpp
@@ -39,7 +39,7 @@ namespace Far {
 bool
 TopologyRefinerFactoryBase::prepareComponentTopologySizing(TopologyRefiner& refiner) {
 
-    Vtr::Level& baseLevel = refiner.getLevel(0);
+    Vtr::internal::Level& baseLevel = refiner.getLevel(0);
 
     //
     //  At minimum we require face-vertices (the total count of which can be determined
@@ -103,7 +103,7 @@ bool
 TopologyRefinerFactoryBase::prepareComponentTopologyAssignment(TopologyRefiner& refiner, bool fullValidation,
                                                                TopologyCallback callback, void const * callbackData) {
 
-    Vtr::Level& baseLevel = refiner.getLevel(0);
+    Vtr::internal::Level& baseLevel = refiner.getLevel(0);
 
     bool completeMissingTopology = (baseLevel.getNumEdges() == 0);
     if (completeMissingTopology) {
@@ -150,7 +150,7 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
     //  Since both involve traversing the edge and vertex lists and noting the presence of
     //  boundaries -- best to do both at once...
     //
-    Vtr::Level&  baseLevel = refiner.getLevel(0);
+    Vtr::internal::Level&  baseLevel = refiner.getLevel(0);
 
     assert((int)baseLevel._edgeTags.size() == baseLevel.getNumEdges());
     assert((int)baseLevel._vertTags.size() == baseLevel.getNumVertices());
@@ -167,7 +167,7 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
     //  properties of their incident edges.
     //
     for (Vtr::Index eIndex = 0; eIndex < baseLevel.getNumEdges(); ++eIndex) {
-        Vtr::Level::ETag& eTag       = baseLevel._edgeTags[eIndex];
+        Vtr::internal::Level::ETag& eTag       = baseLevel._edgeTags[eIndex];
         float&          eSharpness = baseLevel._edgeSharpness[eIndex];
 
         eTag._boundary = (baseLevel._edgeFaceCountsAndOffsets[eIndex*2 + 0] < 2);
@@ -186,7 +186,7 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
     int schemeRegularBoundaryValence = schemeRegularInteriorValence / 2;
 
     for (Vtr::Index vIndex = 0; vIndex < baseLevel.getNumVertices(); ++vIndex) {
-        Vtr::Level::VTag& vTag       = baseLevel._vertTags[vIndex];
+        Vtr::internal::Level::VTag& vTag       = baseLevel._vertTags[vIndex];
         float&          vSharpness = baseLevel._vertSharpness[vIndex];
 
         Vtr::ConstIndexArray vEdges = baseLevel.getVertexEdges(vIndex);
@@ -200,7 +200,7 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
         int semiSharpEdgeCount   = 0;
         int nonManifoldEdgeCount = 0;
         for (int i = 0; i < vEdges.size(); ++i) {
-            Vtr::Level::ETag const& eTag = baseLevel._edgeTags[vEdges[i]];
+            Vtr::internal::Level::ETag const& eTag = baseLevel._edgeTags[vEdges[i]];
 
             boundaryEdgeCount    += eTag._boundary;
             infSharpEdgeCount    += eTag._infSharp;
@@ -233,7 +233,7 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
         vTag._semiSharp      = Sdc::Crease::IsSemiSharp(vSharpness);
         vTag._semiSharpEdges = (semiSharpEdgeCount > 0);
 
-        vTag._rule = (Vtr::Level::VTag::VTagSize)creasing.DetermineVertexVertexRule(vSharpness, sharpEdgeCount);
+        vTag._rule = (Vtr::internal::Level::VTag::VTagSize)creasing.DetermineVertexVertexRule(vSharpness, sharpEdgeCount);
 
         //
         //  Assign topological tags -- note that the "xordinary" tag is not strictly
@@ -257,7 +257,7 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
 bool
 TopologyRefinerFactoryBase::prepareFaceVaryingChannels(TopologyRefiner& refiner) {
 
-    Vtr::Level& baseLevel = refiner.getLevel(0);
+    Vtr::internal::Level& baseLevel = refiner.getLevel(0);
 
     int regVertexValence   = Sdc::SchemeTypeTraits::GetRegularVertexValence(refiner.GetSchemeType());
     int regBoundaryValence = regVertexValence / 2;
@@ -332,7 +332,7 @@ TopologyRefinerFactory<TopologyRefinerFactoryBase::TopologyDescriptor>::assignCo
                 char msg[1024];
                 snprintf(msg, 1024, "Edge %d specified to be sharp does not exist (%d, %d)",
                     edge, vertIndexPairs[0], vertIndexPairs[1]);
-                reportInvalidTopology(Vtr::Level::TOPOLOGY_INVALID_CREASE_EDGE, msg, desc);
+                reportInvalidTopology(Vtr::internal::Level::TOPOLOGY_INVALID_CREASE_EDGE, msg, desc);
             }
         }
     }
@@ -348,7 +348,7 @@ TopologyRefinerFactory<TopologyRefinerFactoryBase::TopologyDescriptor>::assignCo
             } else {
                 char msg[1024];
                 snprintf(msg, 1024, "Vertex %d specified to be sharp does not exist", idx);
-                reportInvalidTopology(Vtr::Level::TOPOLOGY_INVALID_CREASE_VERT, msg, desc);
+                reportInvalidTopology(Vtr::internal::Level::TOPOLOGY_INVALID_CREASE_VERT, msg, desc);
             }
         }
     }

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -99,7 +99,7 @@ protected:
     //  Protected methods invoked by the subclass template to verify and process each
     //  stage of construction implemented by the subclass:
     //
-    typedef Vtr::Level::ValidationCallback TopologyCallback;
+    typedef Vtr::internal::Level::ValidationCallback TopologyCallback;
 
     static bool prepareComponentTopologySizing(TopologyRefiner& refiner);
     static bool prepareComponentTopologyAssignment(TopologyRefiner& refiner, bool fullValidation,
@@ -181,7 +181,7 @@ protected:
     static bool assignFaceVaryingTopology(TopologyRefiner& refiner, MESH const& mesh);
 
     //  Optional miscellaneous specializations -- error reporting, etc.:
-    typedef Vtr::Level::TopologyError TopologyError;
+    typedef Vtr::internal::Level::TopologyError TopologyError;
 
     static void reportInvalidTopology(TopologyError errCode, char const * msg, MESH const& mesh);
 };

--- a/opensubdiv/vtr/fvarLevel.cpp
+++ b/opensubdiv/vtr/fvarLevel.cpp
@@ -45,6 +45,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  Simple (for now) constructor and destructor:
@@ -1079,6 +1080,7 @@ FVarLevel::getFaceCompositeCombinedEdgeTag(ConstIndexArray & faceEdges,
     return compETag;
 }
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/fvarLevel.h
+++ b/opensubdiv/vtr/fvarLevel.h
@@ -41,6 +41,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  FVarLevel:
@@ -363,6 +364,7 @@ FVarLevel::findVertexValueIndex(Index vertexIndex, Index valueIndex) const {
     return vvIndex;
 }
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/fvarRefinement.cpp
+++ b/opensubdiv/vtr/fvarRefinement.cpp
@@ -45,6 +45,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  Simple (for now) constructor and destructor:
@@ -693,6 +694,7 @@ FVarRefinement::getFractionalWeight(Index pVert, LocalIndex pSibling,
             interiorEdgeCount, pEdgeSharpness, cEdgeSharpness);
 }
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/fvarRefinement.h
+++ b/opensubdiv/vtr/fvarRefinement.h
@@ -41,6 +41,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  FVarRefinement:
@@ -107,6 +108,7 @@ public:
     std::vector<LocalIndex> _childValueParentSource;
 };
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -53,6 +53,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  Simple (for now) constructor and destructor:
@@ -1964,6 +1965,7 @@ Level::completeFVarChannelTopology(int channel, int regBoundaryValence) {
     return _fvarChannels[channel]->completeTopologyFromFaceValues(regBoundaryValence);
 }
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -41,6 +41,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 class Refinement;
 class FVarLevel;
@@ -761,6 +762,7 @@ Level::shareFaceVertCountsAndOffsets() const {
         (int)_faceVertCountsAndOffsets.size());
 }
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/maskInterfaces.h
+++ b/opensubdiv/vtr/maskInterfaces.h
@@ -38,6 +38,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  Simple classes supporting the interfaces required of generic types in the Scheme mask
@@ -190,6 +191,7 @@ private:
     int _fCount;
 };
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/quadRefinement.cpp
+++ b/opensubdiv/vtr/quadRefinement.cpp
@@ -35,6 +35,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  Simple constructor, destructor and basic initializers:
@@ -1011,6 +1012,7 @@ QuadRefinement::markSparseFaceChildren() {
     }
 }
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/quadRefinement.h
+++ b/opensubdiv/vtr/quadRefinement.h
@@ -33,6 +33,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  QuadRefinement:
@@ -92,6 +93,7 @@ private:
     //
 };
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/refinement.cpp
+++ b/opensubdiv/vtr/refinement.cpp
@@ -41,6 +41,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  Simple constructor, destructor and basic initializers:
@@ -1256,6 +1257,7 @@ Refinement::markSparseEdgeChildren() {
     }
 }
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/refinement.h
+++ b/opensubdiv/vtr/refinement.h
@@ -40,6 +40,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 class FVarRefinement;
 
@@ -424,6 +425,7 @@ Refinement::getEdgeChildEdges(Index parentEdge) {
     return IndexArray(&_edgeChildEdgeIndices[parentEdge*2], 2);
 }
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/sparseSelector.cpp
+++ b/opensubdiv/vtr/sparseSelector.cpp
@@ -32,6 +32,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  Component selection methods:
@@ -93,6 +94,7 @@ SparseSelector::selectFace(Index parentFace) {
     }
 }
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/sparseSelector.h
+++ b/opensubdiv/vtr/sparseSelector.h
@@ -38,6 +38,8 @@ namespace Vtr {
 
 class Refinement;
 
+namespace internal {
+
 //
 //  SparseSelector:
 //      Class supporting "selection" of components in a Level for sparse Refinement.
@@ -92,6 +94,7 @@ private:
     bool        _selected;
 };
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/triRefinement.cpp
+++ b/opensubdiv/vtr/triRefinement.cpp
@@ -35,6 +35,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  Simple constructor, destructor and basic initializers:
@@ -921,6 +922,8 @@ TriRefinement::markSparseFaceChildren() {
         }
     }
 }
+
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/vtr/triRefinement.h
+++ b/opensubdiv/vtr/triRefinement.h
@@ -33,6 +33,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
+namespace internal {
 
 //
 //  TriRefinement:
@@ -96,6 +97,7 @@ private:
     IndexVector _localFaceChildFaceCountsAndOffsets;
 };
 
+} // end namespace internal
 } // end namespace Vtr
 
 } // end namespace OPENSUBDIV_VERSION


### PR DESCRIPTION
This changes set moves all major Vtr classes into the namespace internal -- discouraging them from public use (given we must export for internal usage).  All references to Vtr classes within Far was appropriately updated.  There didn't appear to be any external usage of Vtr.