### PR TITLE
Lower-case Internal namespace to match convention.

### DIFF
--- a/opensubdiv/far/stencilBuilder.cpp
+++ b/opensubdiv/far/stencilBuilder.cpp
@@ -29,7 +29,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Far {
-namespace Internal {
+namespace internal {
 
 struct PointDerivWeight {
     float p;
@@ -446,7 +446,7 @@ StencilBuilder::Index::AddFaceVaryingWithWeight(Index const &, float)
     // Not supported.
 }
 
-} // end namespace Internal
+} // end namespace internal
 } // end namespace Far
 } // end namespace OPENSUBDIV_VERSION
 } // end namespace OpenSubdiv

--- a/opensubdiv/far/stencilBuilder.h
+++ b/opensubdiv/far/stencilBuilder.h
@@ -34,7 +34,7 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Far {
-namespace Internal {
+namespace internal {
 
 class WeightTable;
 
@@ -102,7 +102,7 @@ private:
     bool _isVarying;
 };
 
-} // end namespace Internal
+} // end namespace internal
 } // end namespace Far
 } // end namespace OPENSUBDIV_VERSION
 } // end namespace OpenSubdiv

--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -70,7 +70,7 @@ StencilTableFactory::Create(TopologyRefiner const & refiner,
     }
 
     bool interpolateVarying = options.interpolationMode==INTERPOLATE_VARYING;
-    Internal::StencilBuilder builder(refiner.GetLevel(0).GetNumVertices(),
+    internal::StencilBuilder builder(refiner.GetLevel(0).GetNumVertices(),
                                 interpolateVarying,
                                 /*genControlVerts*/ true,
                                 /*compactWeights*/  true);
@@ -81,8 +81,8 @@ StencilTableFactory::Create(TopologyRefiner const & refiner,
     //
     PrimvarRefiner primvarRefiner(refiner);
 
-    Internal::StencilBuilder::Index srcIndex(&builder, 0);
-    Internal::StencilBuilder::Index dstIndex(&builder,
+    internal::StencilBuilder::Index srcIndex(&builder, 0);
+    internal::StencilBuilder::Index dstIndex(&builder,
                                         refiner.GetLevel(0).GetNumVertices());
     for (int level=1; level<=maxlevel; ++level) {
         if (not interpolateVarying) {
@@ -258,13 +258,13 @@ StencilTableFactory::AppendEndCapStencilTable(
     int nEndCapStencils = endCapStencilTable->GetNumStencils();
     int nEndCapStencilsElements = 0;
 
-    Internal::StencilBuilder builder(refiner.GetLevel(0).GetNumVertices(),
+    internal::StencilBuilder builder(refiner.GetLevel(0).GetNumVertices(),
                                 /*isVarying*/       false,
                                 /*genControlVerts*/ false,
                                 /*compactWeights*/  factorize);
-    Internal::StencilBuilder::Index origin(&builder, 0);
-    Internal::StencilBuilder::Index dst = origin;
-    Internal::StencilBuilder::Index srcIdx = origin;
+    internal::StencilBuilder::Index origin(&builder, 0);
+    internal::StencilBuilder::Index dst = origin;
+    internal::StencilBuilder::Index srcIdx = origin;
 
     for (int i = 0 ; i < nEndCapStencils; ++i) {
         Stencil src = endCapStencilTable->GetStencil(i);
@@ -416,12 +416,12 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
     // Generate limit stencils for locations
     //
 
-    Internal::StencilBuilder builder(refiner.GetLevel(0).GetNumVertices(),
+    internal::StencilBuilder builder(refiner.GetLevel(0).GetNumVertices(),
                                 /*isVarying*/       false,
                                 /*genControlVerts*/ false,
                                 /*compactWeights*/  true);
-    Internal::StencilBuilder::Index origin(&builder, 0);
-    Internal::StencilBuilder::Index dst = origin;
+    internal::StencilBuilder::Index origin(&builder, 0);
+    internal::StencilBuilder::Index dst = origin;
 
     float wP[20], wDs[20], wDt[20];
 


### PR DESCRIPTION
Renamed "Internal" namespace to "internal" to match the convention in the rest
of the library.