### PR TITLE
Moved base-face propagation to Far::PrimvarRefiner

### DIFF
--- a/opensubdiv/far/topologyLevel.h
+++ b/opensubdiv/far/topologyLevel.h
@@ -84,7 +84,6 @@ public:
     Index GetVertexChildVertex(Index v) const { return _refToChild->getVertexChildVertex(v); }
 
     Index GetFaceParentFace(Index f) const { return _refToParent->getChildFaceParentFace(f); }
-    Index GetFaceBaseFace(  Index f) const { return _refToParent->getChildFaceBaseFace(f); }
 
     bool ValidateTopology() const { return _level->validateTopology(); }
     void PrintTopology(bool children = true) const { _level->print((children && _refToChild) ? _refToChild : 0); }

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -141,16 +141,6 @@ TopologyRefiner::appendLevel(Vtr::internal::Level & newLevel) {
 void
 TopologyRefiner::appendRefinement(Vtr::internal::Refinement & newRefinement) {
 
-    //
-    //  There may be properties to transfer between refinements that cannot be passed on
-    //  when refining between the parent and child since they exist "above" the parent:
-    //
-    bool applyBaseFace = (_isUniform && _uniformOptions.applyBaseFacePerFace) ||
-                        (!_isUniform && _adaptiveOptions.applyBaseFacePerFace);
-    if (applyBaseFace) {
-        newRefinement.propagateBaseFace(_refinements.size() ? _refinements.back() : 0);
-    }
-
     _refinements.push_back(&newRefinement);
 }
 

--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -118,13 +118,10 @@ public:
 
         UniformOptions(int level) :
             refinementLevel(level),
-            applyBaseFacePerFace(false),
             orderVerticesFromFacesFirst(false),
             fullTopologyInLastLevel(false) { }
 
         unsigned int refinementLevel:4,             ///< Number of refinement iterations
-                     applyBaseFacePerFace:1,        ///< For each refined face, record the index
-                                                    ///< of the base face from which it originates
                      orderVerticesFromFacesFirst:1, ///< Order child vertices from faces first
                                                     ///< instead of child vertices of vertices
                      fullTopologyInLastLevel:1;     ///< Skip topological relationships in the last
@@ -151,15 +148,12 @@ public:
         AdaptiveOptions(int level) :
             isolationLevel(level),
             useSingleCreasePatch(false),
-            applyBaseFacePerFace(false),
             orderVerticesFromFacesFirst(false) { }
 
         unsigned int isolationLevel:4,              ///< Number of iterations applied to isolate
                                                     ///< extraordinary vertices and creases
                      useSingleCreasePatch:1,        ///< Use 'single-crease' patch and stop
                                                     ///< isolation where applicable
-                     applyBaseFacePerFace:1,        ///< For each refined face, record the index
-                                                    ///< of the base face from which it originates
                      orderVerticesFromFacesFirst:1; ///< Order child vertices from faces first
                                                     ///< instead of child vertices of vertices
     };

--- a/opensubdiv/vtr/refinement.cpp
+++ b/opensubdiv/vtr/refinement.cpp
@@ -1081,26 +1081,6 @@ Refinement::subdivideFVarChannels() {
 }
 
 //
-//  Methods to inherit properties between refinements in a hierarchy:
-//
-void
-Refinement::propagateBaseFace(Refinement const * grandParent) {
-
-    _childFaceBaseFaceIndex.resize(_child->_faceCount);
-
-    if (grandParent == 0) {
-        _childFaceBaseFaceIndex = _childFaceParentIndex;
-    } else {
-        IndexVector &       childBaseFace  = _childFaceBaseFaceIndex;
-        IndexVector const & parentBaseFace = grandParent->_childFaceBaseFaceIndex;
-
-        for (Index cFace = 0; cFace < _child->_faceCount; ++cFace) {
-            childBaseFace[cFace] = parentBaseFace[_childFaceParentIndex[cFace]];
-        }
-    }
-}
-
-//
 //  Marking of sparse child components -- including those selected and those neighboring...
 //
 //      For schemes requiring neighboring support, this is the equivalent of the "guarantee

--- a/opensubdiv/vtr/refinement.h
+++ b/opensubdiv/vtr/refinement.h
@@ -147,9 +147,6 @@ public:
 
     Index getChildVertexParentIndex(Index v) const  { return _childVertexParentIndex[v]; }
 
-    //  Child-to-"ancestor" relationships:
-    Index getChildFaceBaseFace(Index f) const { return _childFaceBaseFaceIndex[f]; }
-
 //
 //  Modifiers intended for internal/protected use:
 //
@@ -247,8 +244,6 @@ public:
     void populateVertexTagsFromParentFaces();
     void populateVertexTagsFromParentEdges();
     void populateVertexTagsFromParentVertices();
-
-    void propagateBaseFace(Refinement const * previousRefinement);
 
     //
     //  Methods (and types) involved in subdividing the topology -- though not
@@ -379,11 +374,6 @@ public:
     //  Refinement data for face-varying channels present in the Levels being refined:
     //
     std::vector<FVarRefinement*> _fvarChannels;
-
-    //
-    //  Child-to-base/ancestor mappings:
-    //
-    IndexVector _childFaceBaseFaceIndex;
 };
 
 inline ConstIndexArray


### PR DESCRIPTION
This change set removes the support we added within refinement to propagate the base face of each child face through the refinement hierarchy.  The same -- and more -- can be now be done with the Far::PrimvarRefiner's methods to apply primvar data that is per-face or uniform between levels.  So primvar data can either be directly computed for level, or a set of integers (one per face) can be used to assign the base face to each child face in a level.

Comments and conventions are currently pending for the PrimvarRefiners methods, and the addition follows the existing convention of multi-level methods using ptrs and single-level methods using references -- to be revisited later.