### PR TITLE
Mac build and shader compiler error fix.

### DIFF
--- a/examples/common/glUtils.cpp
+++ b/examples/common/glUtils.cpp
@@ -171,6 +171,18 @@ bool GL_ARBSeparateShaderObjectsOrGL_VERSION_4_1(){
 #endif
 }
 
+bool GL_ARBComputeShaderOrGL_VERSION_4_3() {
+#if defined(OSD_USES_GLEW)
+    return (glewIsSupported("GL_ARB_compute_shader") == GL_TRUE) ||
+           (GLEW_VERSION_4_3);
+#else
+#if defined(GL_ARB_compute_shader) || defined(GL_VERSION_4_3)
+    return true;
+#else
+    return false;
+#endif
+#endif
+}
 
-                      
+
 }   // namesapce GLUtils

--- a/examples/common/glUtils.h
+++ b/examples/common/glUtils.h
@@ -47,6 +47,7 @@ const std::string &GetShaderVersion();
 const std::string &GetShaderVersionInclude();
 
 bool GL_ARBSeparateShaderObjectsOrGL_VERSION_4_1();
+bool GL_ARBComputeShaderOrGL_VERSION_4_3();
 
 };
 

--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -1289,7 +1289,9 @@ initHUD() {
     g_hud.AddPullDownButton(compute_pulldown, "GL XFB", kGLXFB);
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    g_hud.AddPullDownButton(compute_pulldown, "GL Compute", kGLCompute);
+    if (GLUtils::GL_ARBComputeShaderOrGL_VERSION_4_3()) {
+        g_hud.AddPullDownButton(compute_pulldown, "GL Compute", kGLCompute);
+    }
 #endif
 
     int endcap_pulldown = g_hud.AddPullDown("End cap (E)", 10, 140, 200,

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -2013,8 +2013,7 @@ int main(int argc, char ** argv) {
     g_hud.AddPullDownButton(compute_pulldown, "GLSL TransformFeedback", kGLSL);
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    // Must also check at run time for OpenGL 4.3
-    if (GLEW_VERSION_4_3) {
+    if (GLUtils::GL_ARBComputeShaderOrGL_VERSION_4_3()) {
         g_hud.AddPullDownButton(compute_pulldown, "GLSL Compute", kGLSLCompute);
     }
 #endif

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -1133,7 +1133,9 @@ initHUD() {
     g_hud.AddPullDownButton(compute_pulldown, "GL XFB", kGLXFB);
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    g_hud.AddPullDownButton(compute_pulldown, "GL Compute", kGLCompute);
+    if (GLUtils::GL_ARBComputeShaderOrGL_VERSION_4_3()) {
+        g_hud.AddPullDownButton(compute_pulldown, "GL Compute", kGLCompute);
+    }
 #endif
 
     for (int i = 1; i < 11; ++i) {

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -1718,8 +1718,7 @@ initHUD() {
     g_hud.AddPullDownButton(compute_pulldown, "GLSL TransformFeedback", kGLSL);
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    // Must also check at run time for OpenGL 4.3
-    if (GLEW_VERSION_4_3) {
+    if (GLUtils::GL_ARBComputeShaderOrGL_VERSION_4_3()) {
         g_hud.AddPullDownButton(compute_pulldown, "GLSL Compute", kGLSLCompute);
     }
 #endif

--- a/opensubdiv/osd/clVertexBuffer.cpp
+++ b/opensubdiv/osd/clVertexBuffer.cpp
@@ -86,10 +86,7 @@ CLVertexBuffer::allocate(cl_context clContext) {
     int size = _numVertices * _numElements * sizeof(float);
     cl_int err;
 
-    // XXX: do we really need a dummy buffer?
-    float *ptr = new float[_numVertices * _numElements];
-    _clMemory = clCreateBuffer(clContext, CL_MEM_READ_WRITE, size, ptr, &err);
-    delete[] ptr;
+    _clMemory = clCreateBuffer(clContext, CL_MEM_READ_WRITE, size, NULL, &err);
 
     if (err != CL_SUCCESS) return false;
     return true;

--- a/opensubdiv/osd/cpuPatchTable.h
+++ b/opensubdiv/osd/cpuPatchTable.h
@@ -30,7 +30,6 @@
 #include <vector>
 #include "../far/patchDescriptor.h"
 #include "../osd/nonCopyable.h"
-#include "../osd/opengl.h"
 #include "../osd/types.h"
 
 namespace OpenSubdiv {

--- a/opensubdiv/osd/glslXFBKernel.glsl
+++ b/opensubdiv/osd/glslXFBKernel.glsl
@@ -173,11 +173,11 @@ void getBSplineWeights(float t, inout vec4 point, inout vec4 deriv) {
 }
 
 uint getDepth(uint patchBits) {
-    return (patchBits & 0x7);
+    return (patchBits & 0x7U);
 }
 
 float getParamFraction(uint patchBits) {
-    uint nonQuadRoot = (patchBits >> 3) & 0x1;
+    uint nonQuadRoot = (patchBits >> 3) & 0x1U;
     uint depth = getDepth(patchBits);
     if (nonQuadRoot == 1) {
         return 1.0f / float( 1 << (depth-1) );
@@ -189,8 +189,8 @@ float getParamFraction(uint patchBits) {
 vec2 normalizePatchCoord(uint patchBits, vec2 uv) {
     float frac = getParamFraction(patchBits);
 
-    uint iu = (patchBits >> 22) & 0x3ff;
-    uint iv = (patchBits >> 12) & 0x3ff;
+    uint iu = (patchBits >> 22) & 0x3ffU;
+    uint iv = (patchBits >> 12) & 0x3ffU;
 
     // top left corner
     float pu = float(iu*frac);
@@ -201,24 +201,24 @@ vec2 normalizePatchCoord(uint patchBits, vec2 uv) {
 }
 
 void adjustBoundaryWeights(uint bits, inout vec4 sWeights, inout vec4 tWeights) {
-    uint boundary = ((bits >> 4) & 0xf);
+    uint boundary = ((bits >> 4) & 0xfU);
 
-    if ((boundary & 1) != 0) {
+    if ((boundary & 1U) != 0) {
         tWeights[2] -= tWeights[0];
         tWeights[1] += 2*tWeights[0];
         tWeights[0] = 0;
     }
-    if ((boundary & 2) != 0) {
+    if ((boundary & 2U) != 0) {
         sWeights[1] -= sWeights[3];
         sWeights[2] += 2*sWeights[3];
         sWeights[3] = 0;
     }
-    if ((boundary & 4) != 0) {
+    if ((boundary & 4U) != 0) {
         tWeights[1] -= tWeights[3];
         tWeights[2] += 2*tWeights[3];
         tWeights[3] = 0;
     }
-    if ((boundary & 8) != 0) {
+    if ((boundary & 8U) != 0) {
         sWeights[2] -= sWeights[0];
         sWeights[1] += 2*sWeights[0];
         sWeights[0] = 0;


### PR DESCRIPTION
- Use unsigned constant in XFB shader
- add GLUtils::GL_ARBComputeShaderOrGL_VERSION_4_3() to see the runtime capability
  of GLSL compute kernel for the examples UI
- delete unnecessary include