### PR TITLE
Fix CMakeLists: make project-relative include path overridable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,6 +687,17 @@ endmacro()
 #-------------------------------------------------------------------------------
 # Build targets
 
+
+# if you want to build examples against installed OpenSubdiv header files,
+# use OPENSUBDIV_INCLUDE_DIR.
+
+# example: if you have already installed opensubdiv libs in this cmake setup,
+# set (OPENSUBDIV_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INCDIR_BASE})
+
+if (NOT OPENSUBDIV_INCLUDE_DIR)
+    set(OPENSUBDIV_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/opensubdiv")
+endif()
+
 if (NOT NO_TESTS)
     enable_testing()
 endif()

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -148,7 +148,7 @@ endif()
 #-------------------------------------------------------------------------------
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
@@ -165,4 +165,3 @@ add_library(examples_common_obj
         ${EXAMPLES_COMMON_HEADER_FILES}
         ${INC_FILES}
 )
-

--- a/examples/common/objAnim.cpp
+++ b/examples/common/objAnim.cpp
@@ -23,8 +23,7 @@
 //
 
 #include "objAnim.h"
-
-#include <../regression/common/shape_utils.h>
+#include "../../regression/common/shape_utils.h"
 
 #include <cassert>
 #include <cstdio>

--- a/examples/dxPtexViewer/CMakeLists.txt
+++ b/examples/dxPtexViewer/CMakeLists.txt
@@ -35,8 +35,7 @@ set(PLATFORM_LIBRARIES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${DXSDK_INCLUDE_DIR}"
     "${PTEX_INCLUDE_DIR}"
 )

--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -61,7 +61,7 @@ OpenSubdiv::Osd::D3D11MeshInterface *g_mesh;
 #include "Ptexture.h"
 #include "PtexUtils.h"
 
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/d3d11Hud.h"

--- a/examples/dxViewer/CMakeLists.txt
+++ b/examples/dxViewer/CMakeLists.txt
@@ -34,8 +34,7 @@ set(PLATFORM_LIBRARIES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${DXSDK_INCLUDE_DIR}"
 )
 

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -60,7 +60,7 @@
 OpenSubdiv::Osd::D3D11MeshInterface *g_mesh = NULL;
 OpenSubdiv::Osd::D3D11LegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/d3d11Hud.h"

--- a/examples/dxViewer/init_shapes.h
+++ b/examples/dxViewer/init_shapes.h
@@ -22,7 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include <common/shape_utils.h>
+#include "../../regression/common/shape_utils.h"
+#include "../../regression/shapes/all.h"
 
 struct ShapeDesc {
 
@@ -35,62 +36,6 @@ struct ShapeDesc {
 };
 
 static std::vector<ShapeDesc> g_defaultShapes;
-
-#include <shapes/catmark_bishop.h>
-#include <shapes/catmark_car.h>
-#include <shapes/catmark_chaikin0.h>
-#include <shapes/catmark_chaikin1.h>
-#include <shapes/catmark_chaikin2.h>
-#include <shapes/catmark_cube_corner0.h>
-#include <shapes/catmark_cube_corner1.h>
-#include <shapes/catmark_cube_corner2.h>
-#include <shapes/catmark_cube_corner3.h>
-#include <shapes/catmark_cube_corner4.h>
-#include <shapes/catmark_cube_creases0.h>
-#include <shapes/catmark_cube_creases1.h>
-#include <shapes/catmark_cube.h>
-#include <shapes/catmark_dart_edgecorner.h>
-#include <shapes/catmark_dart_edgeonly.h>
-#include <shapes/catmark_edgecorner.h>
-#include <shapes/catmark_edgeonly.h>
-#include <shapes/catmark_fan.h>
-#include <shapes/catmark_flap.h>
-#include <shapes/catmark_flap2.h>
-#include <shapes/catmark_gregory_test1.h>
-#include <shapes/catmark_gregory_test2.h>
-#include <shapes/catmark_gregory_test3.h>
-#include <shapes/catmark_gregory_test4.h>
-#include <shapes/catmark_gregory_test5.h>
-#include <shapes/catmark_gregory_test6.h>
-#include <shapes/catmark_gregory_test7.h>
-#include <shapes/catmark_helmet.h>
-#include <shapes/catmark_hole_test1.h>
-#include <shapes/catmark_hole_test2.h>
-#include <shapes/catmark_pawn.h>
-#include <shapes/catmark_pyramid_creases0.h>
-#include <shapes/catmark_pyramid_creases1.h>
-#include <shapes/catmark_pyramid.h>
-#include <shapes/catmark_rook.h>
-#include <shapes/catmark_square_hedit0.h>
-#include <shapes/catmark_square_hedit1.h>
-#include <shapes/catmark_square_hedit2.h>
-#include <shapes/catmark_square_hedit3.h>
-#include <shapes/catmark_tent_creases0.h>
-#include <shapes/catmark_tent_creases1.h>
-#include <shapes/catmark_tent.h>
-#include <shapes/catmark_torus.h>
-#include <shapes/catmark_torus_creases0.h>
-
-#include <shapes/loop_cube_creases0.h>
-#include <shapes/loop_cube_creases1.h>
-#include <shapes/loop_cube.h>
-#include <shapes/loop_icosahedron.h>
-#include <shapes/loop_saddle_edgecorner.h>
-#include <shapes/loop_saddle_edgeonly.h>
-#include <shapes/loop_triangle_edgecorner.h>
-#include <shapes/loop_triangle_edgeonly.h>
-#include <shapes/loop_chaikin0.h>
-#include <shapes/loop_chaikin1.h>
 
 //------------------------------------------------------------------------------
 static void initShapes() {

--- a/examples/farViewer/CMakeLists.txt
+++ b/examples/farViewer/CMakeLists.txt
@@ -31,8 +31,7 @@ set(SHADER_FILES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -55,8 +55,7 @@ GLFWmonitor* g_primary=0;
 #include <far/stencilTableFactory.h>
 #include <far/primvarRefiner.h>
 
-#include <common/vtr_utils.h>
-
+#include "../../regression/common/vtr_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glUtils.h"

--- a/examples/farViewer/gl_mesh.h
+++ b/examples/farViewer/gl_mesh.h
@@ -25,8 +25,8 @@
 #ifndef GL_MESH_H
 #define GL_MESH_H
 
-#include <common/vtr_utils.h>
-#include <common/hbr_utils.h>
+#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/hbr_utils.h"
 #include <far/patchTable.h>
 
 #include "../common/glUtils.h"

--- a/examples/farViewer/init_shapes.h
+++ b/examples/farViewer/init_shapes.h
@@ -22,7 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include <common/shape_utils.h>
+#include "../../regression/common/shape_utils.h"
+#include "../../regression/shapes/all.h"
 
 struct ShapeDesc {
 
@@ -35,61 +36,6 @@ struct ShapeDesc {
 };
 
 static std::vector<ShapeDesc> g_shapes;
-
-#include <shapes/catmark_bishop.h>
-#include <shapes/catmark_car.h>
-#include <shapes/catmark_chaikin0.h>
-#include <shapes/catmark_chaikin1.h>
-#include <shapes/catmark_chaikin2.h>
-#include <shapes/catmark_cube_corner0.h>
-#include <shapes/catmark_cube_corner1.h>
-#include <shapes/catmark_cube_corner2.h>
-#include <shapes/catmark_cube_corner3.h>
-#include <shapes/catmark_cube_corner4.h>
-#include <shapes/catmark_cube_creases0.h>
-#include <shapes/catmark_cube_creases1.h>
-#include <shapes/catmark_cube.h>
-#include <shapes/catmark_dart_edgecorner.h>
-#include <shapes/catmark_dart_edgeonly.h>
-#include <shapes/catmark_edgecorner.h>
-#include <shapes/catmark_edgeonly.h>
-#include <shapes/catmark_fan.h>
-#include <shapes/catmark_flap.h>
-#include <shapes/catmark_flap2.h>
-#include <shapes/catmark_fvar_bound0.h>
-#include <shapes/catmark_fvar_bound1.h>
-#include <shapes/catmark_fvar_bound2.h>
-#include <shapes/catmark_gregory_test0.h>
-#include <shapes/catmark_gregory_test1.h>
-#include <shapes/catmark_gregory_test2.h>
-#include <shapes/catmark_gregory_test3.h>
-#include <shapes/catmark_gregory_test4.h>
-#include <shapes/catmark_helmet.h>
-#include <shapes/catmark_pyramid_creases0.h>
-#include <shapes/catmark_pyramid_creases1.h>
-#include <shapes/catmark_pyramid.h>
-#include <shapes/catmark_square_hedit0.h>
-#include <shapes/catmark_square_hedit1.h>
-#include <shapes/catmark_square_hedit2.h>
-#include <shapes/catmark_square_hedit3.h>
-#include <shapes/catmark_tent_creases0.h>
-#include <shapes/catmark_tent_creases1.h>
-#include <shapes/catmark_tent.h>
-#include <shapes/catmark_torus.h>
-#include <shapes/catmark_torus_creases0.h>
-#include <shapes/catmark_smoothtris0.h>
-#include <shapes/catmark_smoothtris1.h>
-
-#include <shapes/loop_cube_creases0.h>
-#include <shapes/loop_cube_creases1.h>
-#include <shapes/loop_cube.h>
-#include <shapes/loop_icosahedron.h>
-#include <shapes/loop_saddle_edgecorner.h>
-#include <shapes/loop_saddle_edgeonly.h>
-#include <shapes/loop_triangle_edgecorner.h>
-#include <shapes/loop_triangle_edgeonly.h>
-#include <shapes/loop_chaikin0.h>
-#include <shapes/loop_chaikin1.h>
 
 //------------------------------------------------------------------------------
 static void initShapes() {

--- a/examples/glEvalLimit/CMakeLists.txt
+++ b/examples/glEvalLimit/CMakeLists.txt
@@ -30,8 +30,7 @@ list(APPEND PLATFORM_LIBRARIES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -95,7 +95,7 @@ GLFWmonitor* g_primary=0;
 
 #include <far/error.h>
 
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"

--- a/examples/glEvalLimit/init_shapes.h
+++ b/examples/glEvalLimit/init_shapes.h
@@ -22,7 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include <common/shape_utils.h>
+#include "../../regression/common/shape_utils.h"
+#include "../../regression/shapes/all.h"
 
 struct ShapeDesc {
 
@@ -36,51 +37,6 @@ struct ShapeDesc {
 
 static std::vector<ShapeDesc> g_defaultShapes;
 
-#include <shapes/catmark_bishop.h>
-#include <shapes/catmark_car.h>
-#include <shapes/catmark_chaikin0.h>
-#include <shapes/catmark_chaikin1.h>
-#include <shapes/catmark_chaikin2.h>
-#include <shapes/catmark_cube_corner0.h>
-#include <shapes/catmark_cube_corner1.h>
-#include <shapes/catmark_cube_corner2.h>
-#include <shapes/catmark_cube_corner3.h>
-#include <shapes/catmark_cube_corner4.h>
-#include <shapes/catmark_cube_creases0.h>
-#include <shapes/catmark_cube_creases1.h>
-#include <shapes/catmark_cube.h>
-#include <shapes/catmark_dart_edgecorner.h>
-#include <shapes/catmark_dart_edgeonly.h>
-#include <shapes/catmark_edgecorner.h>
-#include <shapes/catmark_edgeonly.h>
-#include <shapes/catmark_fan.h>
-#include <shapes/catmark_flap.h>
-#include <shapes/catmark_flap2.h>
-#include <shapes/catmark_gregory_test0.h>
-#include <shapes/catmark_gregory_test1.h>
-#include <shapes/catmark_gregory_test2.h>
-#include <shapes/catmark_gregory_test3.h>
-#include <shapes/catmark_gregory_test4.h>
-#include <shapes/catmark_gregory_test5.h>
-#include <shapes/catmark_gregory_test6.h>
-#include <shapes/catmark_gregory_test7.h>
-#include <shapes/catmark_helmet.h>
-#include <shapes/catmark_hole_test1.h>
-#include <shapes/catmark_hole_test2.h>
-#include <shapes/catmark_pawn.h>
-#include <shapes/catmark_pyramid_creases0.h>
-#include <shapes/catmark_pyramid_creases1.h>
-#include <shapes/catmark_pyramid.h>
-#include <shapes/catmark_rook.h>
-#include <shapes/catmark_square_hedit0.h>
-#include <shapes/catmark_square_hedit1.h>
-#include <shapes/catmark_square_hedit2.h>
-#include <shapes/catmark_square_hedit3.h>
-#include <shapes/catmark_tent_creases0.h>
-#include <shapes/catmark_tent_creases1.h>
-#include <shapes/catmark_tent.h>
-#include <shapes/catmark_torus.h>
-#include <shapes/catmark_torus_creases0.h>
 
 //------------------------------------------------------------------------------
 static void initShapes() {

--- a/examples/glFVarViewer/CMakeLists.txt
+++ b/examples/glFVarViewer/CMakeLists.txt
@@ -35,8 +35,7 @@ list(APPEND PLATFORM_LIBRARIES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -43,14 +43,12 @@ GLFWwindow* g_window = 0;
 GLFWmonitor* g_primary = 0;
 
 #include <far/error.h>
-
 #include <osd/cpuEvaluator.h>
 #include <osd/cpuGLVertexBuffer.h>
-
 #include <osd/glMesh.h>
 OpenSubdiv::Osd::GLMeshInterface *g_mesh = NULL;
 
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"

--- a/examples/glFVarViewer/init_shapes.h
+++ b/examples/glFVarViewer/init_shapes.h
@@ -22,7 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include <common/shape_utils.h>
+#include "../../regression/common/shape_utils.h"
+#include "../../regression/shapes/all.h"
 
 struct ShapeDesc {
 
@@ -35,63 +36,6 @@ struct ShapeDesc {
 };
 
 static std::vector<ShapeDesc> g_defaultShapes;
-
-#include <shapes/catmark_bishop.h>
-#include <shapes/catmark_car.h>
-#include <shapes/catmark_chaikin0.h>
-#include <shapes/catmark_chaikin1.h>
-#include <shapes/catmark_cube_corner0.h>
-#include <shapes/catmark_cube_corner1.h>
-#include <shapes/catmark_cube_corner2.h>
-#include <shapes/catmark_cube_corner3.h>
-#include <shapes/catmark_cube_corner4.h>
-#include <shapes/catmark_cube_creases0.h>
-#include <shapes/catmark_cube_creases1.h>
-#include <shapes/catmark_cube.h>
-#include <shapes/catmark_dart_edgecorner.h>
-#include <shapes/catmark_dart_edgeonly.h>
-#include <shapes/catmark_edgecorner.h>
-#include <shapes/catmark_edgeonly.h>
-#include <shapes/catmark_fan.h>
-#include <shapes/catmark_flap.h>
-#include <shapes/catmark_flap2.h>
-#include <shapes/catmark_fvar_bound0.h>
-#include <shapes/catmark_fvar_bound1.h>
-#include <shapes/catmark_fvar_bound2.h>
-#include <shapes/catmark_gregory_test1.h>
-#include <shapes/catmark_gregory_test2.h>
-#include <shapes/catmark_gregory_test3.h>
-#include <shapes/catmark_gregory_test4.h>
-#include <shapes/catmark_helmet.h>
-#include <shapes/catmark_hole_test1.h>
-#include <shapes/catmark_hole_test2.h>
-#include <shapes/catmark_pawn.h>
-#include <shapes/catmark_pyramid_creases0.h>
-#include <shapes/catmark_pyramid_creases1.h>
-#include <shapes/catmark_pyramid.h>
-#include <shapes/catmark_rook.h>
-#include <shapes/catmark_square_hedit0.h>
-#include <shapes/catmark_square_hedit1.h>
-#include <shapes/catmark_square_hedit2.h>
-#include <shapes/catmark_square_hedit3.h>
-#include <shapes/catmark_tent_creases0.h>
-#include <shapes/catmark_tent_creases1.h>
-#include <shapes/catmark_tent.h>
-#include <shapes/catmark_torus.h>
-#include <shapes/catmark_torus_creases0.h>
-
-#include <shapes/bilinear_cube.h>
-
-#include <shapes/loop_cube_creases0.h>
-#include <shapes/loop_cube_creases1.h>
-#include <shapes/loop_cube.h>
-#include <shapes/loop_icosahedron.h>
-#include <shapes/loop_saddle_edgecorner.h>
-#include <shapes/loop_saddle_edgeonly.h>
-#include <shapes/loop_triangle_edgecorner.h>
-#include <shapes/loop_triangle_edgeonly.h>
-#include <shapes/loop_chaikin0.h>
-#include <shapes/loop_chaikin1.h>
 
 //------------------------------------------------------------------------------
 static void initShapes() {

--- a/examples/glImaging/CMakeLists.txt
+++ b/examples/glImaging/CMakeLists.txt
@@ -23,8 +23,7 @@
 #
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -84,7 +84,7 @@
 
 #include <osd/glMesh.h>
 
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include "../common/patchColors.h"
 #include "../common/stb_image_write.h"    // common.obj has an implementation.
 #include "../common/glShaderCache.h"

--- a/examples/glImaging/init_shapes.h
+++ b/examples/glImaging/init_shapes.h
@@ -22,7 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include <common/shape_utils.h>
+#include "../../regression/common/shape_utils.h"
+#include "../../regression/shapes/all.h"
 
 struct ShapeDesc {
 
@@ -35,73 +36,6 @@ struct ShapeDesc {
 };
 
 static std::vector<ShapeDesc> g_shapes;
-
-#include <shapes/catmark_bishop.h>
-#include <shapes/catmark_car.h>
-#include <shapes/catmark_chaikin0.h>
-#include <shapes/catmark_chaikin1.h>
-#include <shapes/catmark_chaikin2.h>
-#include <shapes/catmark_cube_corner0.h>
-#include <shapes/catmark_cube_corner1.h>
-#include <shapes/catmark_cube_corner2.h>
-#include <shapes/catmark_cube_corner3.h>
-#include <shapes/catmark_cube_corner4.h>
-#include <shapes/catmark_cube_creases0.h>
-#include <shapes/catmark_cube_creases1.h>
-#include <shapes/catmark_cube_creases2.h>
-#include <shapes/catmark_cube.h>
-#include <shapes/catmark_dart_edgecorner.h>
-#include <shapes/catmark_dart_edgeonly.h>
-#include <shapes/catmark_edgecorner.h>
-#include <shapes/catmark_edgeonly.h>
-#include <shapes/catmark_fan.h>
-#include <shapes/catmark_flap.h>
-#include <shapes/catmark_flap2.h>
-#include <shapes/catmark_fvar_bound0.h>
-#include <shapes/catmark_fvar_bound1.h>
-#include <shapes/catmark_fvar_bound2.h>
-#include <shapes/catmark_gregory_test0.h>
-#include <shapes/catmark_gregory_test1.h>
-#include <shapes/catmark_gregory_test2.h>
-#include <shapes/catmark_gregory_test3.h>
-#include <shapes/catmark_gregory_test4.h>
-#include <shapes/catmark_gregory_test5.h>
-#include <shapes/catmark_gregory_test6.h>
-#include <shapes/catmark_gregory_test7.h>
-#include <shapes/catmark_helmet.h>
-#include <shapes/catmark_hole_test1.h>
-#include <shapes/catmark_hole_test2.h>
-#include <shapes/catmark_hole_test3.h>
-#include <shapes/catmark_hole_test4.h>
-#include <shapes/catmark_pawn.h>
-#include <shapes/catmark_pyramid_creases0.h>
-#include <shapes/catmark_pyramid_creases1.h>
-#include <shapes/catmark_pyramid.h>
-#include <shapes/catmark_rook.h>
-#include <shapes/catmark_smoothtris0.h>
-#include <shapes/catmark_smoothtris1.h>
-#include <shapes/catmark_square_hedit0.h>
-#include <shapes/catmark_square_hedit1.h>
-#include <shapes/catmark_square_hedit2.h>
-#include <shapes/catmark_square_hedit3.h>
-#include <shapes/catmark_tent_creases0.h>
-#include <shapes/catmark_tent_creases1.h>
-#include <shapes/catmark_tent.h>
-#include <shapes/catmark_torus.h>
-#include <shapes/catmark_torus_creases0.h>
-
-#include <shapes/bilinear_cube.h>
-
-#include <shapes/loop_cube_creases0.h>
-#include <shapes/loop_cube_creases1.h>
-#include <shapes/loop_cube.h>
-#include <shapes/loop_icosahedron.h>
-#include <shapes/loop_saddle_edgecorner.h>
-#include <shapes/loop_saddle_edgeonly.h>
-#include <shapes/loop_triangle_edgecorner.h>
-#include <shapes/loop_triangle_edgeonly.h>
-#include <shapes/loop_chaikin0.h>
-#include <shapes/loop_chaikin1.h>
 
 //------------------------------------------------------------------------------
 static void initShapes() {

--- a/examples/glPaintTest/CMakeLists.txt
+++ b/examples/glPaintTest/CMakeLists.txt
@@ -37,8 +37,7 @@ list(APPEND PLATFORM_LIBRARIES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLEW_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
 )

--- a/examples/glPaintTest/glPaintTest.cpp
+++ b/examples/glPaintTest/glPaintTest.cpp
@@ -44,14 +44,12 @@ GLFWmonitor* g_primary=0;
 
 #include <far/error.h>
 #include <far/ptexIndices.h>
-
 #include <osd/cpuEvaluator.h>
 #include <osd/cpuGLVertexBuffer.h>
-
 #include <osd/glMesh.h>
 OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"

--- a/examples/glPaintTest/init_shapes.h
+++ b/examples/glPaintTest/init_shapes.h
@@ -22,7 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include <common/shape_utils.h>
+#include "../../regression/common/shape_utils.h"
+#include "../../regression/shapes/all.h"
 
 struct ShapeDesc {
 
@@ -35,48 +36,6 @@ struct ShapeDesc {
 };
 
 static std::vector<ShapeDesc> g_defaultShapes;
-
-#include <shapes/catmark_bishop.h>
-#include <shapes/catmark_car.h>
-#include <shapes/catmark_chaikin0.h>
-#include <shapes/catmark_chaikin1.h>
-#include <shapes/catmark_chaikin2.h>
-#include <shapes/catmark_cube_corner0.h>
-#include <shapes/catmark_cube_corner1.h>
-#include <shapes/catmark_cube_corner2.h>
-#include <shapes/catmark_cube_corner3.h>
-#include <shapes/catmark_cube_corner4.h>
-#include <shapes/catmark_cube_creases0.h>
-#include <shapes/catmark_cube_creases1.h>
-#include <shapes/catmark_cube.h>
-#include <shapes/catmark_dart_edgecorner.h>
-#include <shapes/catmark_dart_edgeonly.h>
-#include <shapes/catmark_edgecorner.h>
-#include <shapes/catmark_edgeonly.h>
-#include <shapes/catmark_fan.h>
-#include <shapes/catmark_flap.h>
-#include <shapes/catmark_flap2.h>
-#include <shapes/catmark_gregory_test1.h>
-#include <shapes/catmark_gregory_test2.h>
-#include <shapes/catmark_gregory_test3.h>
-#include <shapes/catmark_gregory_test4.h>
-#include <shapes/catmark_helmet.h>
-#include <shapes/catmark_hole_test1.h>
-#include <shapes/catmark_hole_test2.h>
-#include <shapes/catmark_pawn.h>
-#include <shapes/catmark_pyramid_creases0.h>
-#include <shapes/catmark_pyramid_creases1.h>
-#include <shapes/catmark_pyramid.h>
-#include <shapes/catmark_rook.h>
-#include <shapes/catmark_square_hedit0.h>
-#include <shapes/catmark_square_hedit1.h>
-#include <shapes/catmark_square_hedit2.h>
-#include <shapes/catmark_square_hedit3.h>
-#include <shapes/catmark_tent_creases0.h>
-#include <shapes/catmark_tent_creases1.h>
-#include <shapes/catmark_tent.h>
-#include <shapes/catmark_torus.h>
-#include <shapes/catmark_torus_creases0.h>
 
 //------------------------------------------------------------------------------
 static void initShapes() {

--- a/examples/glPtexViewer/CMakeLists.txt
+++ b/examples/glPtexViewer/CMakeLists.txt
@@ -38,8 +38,7 @@ list(APPEND PLATFORM_LIBRARIES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
     "${PTEX_INCLUDE_DIR}"
 )

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -92,7 +92,7 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 #include "Ptexture.h"
 #include "PtexUtils.h"
 
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"

--- a/examples/glShareTopology/CMakeLists.txt
+++ b/examples/glShareTopology/CMakeLists.txt
@@ -35,8 +35,7 @@ list(APPEND PLATFORM_LIBRARIES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -82,7 +82,7 @@ GLFWmonitor* g_primary=0;
 #endif
 
 
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include "init_shapes.h"
 
 #include "../common/stopwatch.h"

--- a/examples/glShareTopology/init_shapes.h
+++ b/examples/glShareTopology/init_shapes.h
@@ -22,7 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include <common/shape_utils.h>
+#include "../../regression/common/shape_utils.h"
+#include "../../regression/shapes/all.h"
 
 struct ShapeDesc {
 
@@ -37,75 +38,6 @@ struct ShapeDesc {
 };
 
 static std::vector<ShapeDesc> g_defaultShapes;
-
-#include <shapes/catmark_bishop.h>
-#include <shapes/catmark_car.h>
-#include <shapes/catmark_chaikin0.h>
-#include <shapes/catmark_chaikin1.h>
-#include <shapes/catmark_chaikin2.h>
-#include <shapes/catmark_cube_corner0.h>
-#include <shapes/catmark_cube_corner1.h>
-#include <shapes/catmark_cube_corner2.h>
-#include <shapes/catmark_cube_corner3.h>
-#include <shapes/catmark_cube_corner4.h>
-#include <shapes/catmark_cube_creases0.h>
-#include <shapes/catmark_cube_creases1.h>
-#include <shapes/catmark_cube_creases2.h>
-#include <shapes/catmark_cube.h>
-#include <shapes/catmark_dart_edgecorner.h>
-#include <shapes/catmark_dart_edgeonly.h>
-#include <shapes/catmark_edgecorner.h>
-#include <shapes/catmark_edgeonly.h>
-#include <shapes/catmark_fan.h>
-#include <shapes/catmark_flap.h>
-#include <shapes/catmark_flap2.h>
-#include <shapes/catmark_fvar_bound0.h>
-#include <shapes/catmark_fvar_bound1.h>
-#include <shapes/catmark_fvar_bound2.h>
-#include <shapes/catmark_gregory_test0.h>
-#include <shapes/catmark_gregory_test1.h>
-#include <shapes/catmark_gregory_test2.h>
-#include <shapes/catmark_gregory_test3.h>
-#include <shapes/catmark_gregory_test4.h>
-#include <shapes/catmark_gregory_test5.h>
-#include <shapes/catmark_gregory_test6.h>
-#include <shapes/catmark_gregory_test7.h>
-#include <shapes/catmark_helmet.h>
-#include <shapes/catmark_hole_test1.h>
-#include <shapes/catmark_hole_test2.h>
-#include <shapes/catmark_hole_test3.h>
-#include <shapes/catmark_hole_test4.h>
-#include <shapes/catmark_lefthanded.h>
-#include <shapes/catmark_righthanded.h>
-#include <shapes/catmark_pawn.h>
-#include <shapes/catmark_pyramid_creases0.h>
-#include <shapes/catmark_pyramid_creases1.h>
-#include <shapes/catmark_pyramid.h>
-#include <shapes/catmark_rook.h>
-#include <shapes/catmark_smoothtris0.h>
-#include <shapes/catmark_smoothtris1.h>
-#include <shapes/catmark_square_hedit0.h>
-#include <shapes/catmark_square_hedit1.h>
-#include <shapes/catmark_square_hedit2.h>
-#include <shapes/catmark_square_hedit3.h>
-#include <shapes/catmark_tent_creases0.h>
-#include <shapes/catmark_tent_creases1.h>
-#include <shapes/catmark_tent.h>
-#include <shapes/catmark_torus.h>
-#include <shapes/catmark_torus_creases0.h>
-
-#include <shapes/bilinear_cube.h>
-
-#include <shapes/loop_cube_creases0.h>
-#include <shapes/loop_cube_creases1.h>
-#include <shapes/loop_cube.h>
-#include <shapes/loop_icosahedron.h>
-#include <shapes/loop_saddle_edgecorner.h>
-#include <shapes/loop_saddle_edgeonly.h>
-#include <shapes/loop_triangle_edgecorner.h>
-#include <shapes/loop_triangle_edgeonly.h>
-#include <shapes/loop_chaikin0.h>
-#include <shapes/loop_chaikin1.h>
 
 //------------------------------------------------------------------------------
 static void initShapes() {

--- a/examples/glShareTopology/sceneBase.cpp
+++ b/examples/glShareTopology/sceneBase.cpp
@@ -22,11 +22,11 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
+#include "sceneBase.h"
 #include <limits>
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include <far/patchTableFactory.h>
 #include <far/stencilTableFactory.h>
-#include "sceneBase.h"
 
 using namespace OpenSubdiv;
 

--- a/examples/glStencilViewer/CMakeLists.txt
+++ b/examples/glStencilViewer/CMakeLists.txt
@@ -30,8 +30,7 @@ list(APPEND PLATFORM_LIBRARIES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -42,7 +42,7 @@
 GLFWwindow* g_window=0;
 GLFWmonitor* g_primary=0;
 
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glUtils.h"

--- a/examples/glStencilViewer/init_shapes.h
+++ b/examples/glStencilViewer/init_shapes.h
@@ -22,7 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include <common/shape_utils.h>
+#include "../../regression/common/shape_utils.h"
+#include "../../regression/shapes/all.h"
 
 struct ShapeDesc {
 
@@ -35,62 +36,6 @@ struct ShapeDesc {
 };
 
 static std::vector<ShapeDesc> g_defaultShapes;
-
-#include <shapes/catmark_bishop.h>
-#include <shapes/catmark_car.h>
-#include <shapes/catmark_chaikin0.h>
-#include <shapes/catmark_chaikin1.h>
-#include <shapes/catmark_chaikin2.h>
-#include <shapes/catmark_cube_corner0.h>
-#include <shapes/catmark_cube_corner1.h>
-#include <shapes/catmark_cube_corner2.h>
-#include <shapes/catmark_cube_corner3.h>
-#include <shapes/catmark_cube_corner4.h>
-#include <shapes/catmark_cube_creases0.h>
-#include <shapes/catmark_cube_creases1.h>
-#include <shapes/catmark_cube.h>
-#include <shapes/catmark_dart_edgecorner.h>
-#include <shapes/catmark_dart_edgeonly.h>
-#include <shapes/catmark_edgecorner.h>
-#include <shapes/catmark_edgeonly.h>
-#include <shapes/catmark_fan.h>
-#include <shapes/catmark_flap.h>
-#include <shapes/catmark_flap2.h>
-#include <shapes/catmark_gregory_test1.h>
-#include <shapes/catmark_gregory_test2.h>
-#include <shapes/catmark_gregory_test3.h>
-#include <shapes/catmark_gregory_test4.h>
-#include <shapes/catmark_gregory_test5.h>
-#include <shapes/catmark_gregory_test6.h>
-#include <shapes/catmark_gregory_test7.h>
-#include <shapes/catmark_helmet.h>
-#include <shapes/catmark_hole_test1.h>
-#include <shapes/catmark_hole_test2.h>
-#include <shapes/catmark_pawn.h>
-#include <shapes/catmark_pyramid_creases0.h>
-#include <shapes/catmark_pyramid_creases1.h>
-#include <shapes/catmark_pyramid.h>
-#include <shapes/catmark_rook.h>
-#include <shapes/catmark_square_hedit0.h>
-#include <shapes/catmark_square_hedit1.h>
-#include <shapes/catmark_square_hedit2.h>
-#include <shapes/catmark_square_hedit3.h>
-#include <shapes/catmark_tent_creases0.h>
-#include <shapes/catmark_tent_creases1.h>
-#include <shapes/catmark_tent.h>
-#include <shapes/catmark_torus.h>
-#include <shapes/catmark_torus_creases0.h>
-
-#include <shapes/loop_cube_creases0.h>
-#include <shapes/loop_cube_creases1.h>
-#include <shapes/loop_cube.h>
-#include <shapes/loop_icosahedron.h>
-#include <shapes/loop_saddle_edgecorner.h>
-#include <shapes/loop_saddle_edgeonly.h>
-#include <shapes/loop_triangle_edgecorner.h>
-#include <shapes/loop_triangle_edgeonly.h>
-#include <shapes/loop_chaikin0.h>
-#include <shapes/loop_chaikin1.h>
 
 //------------------------------------------------------------------------------
 static void initShapes() {

--- a/examples/glViewer/CMakeLists.txt
+++ b/examples/glViewer/CMakeLists.txt
@@ -30,8 +30,7 @@ set(SHADER_FILES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${PROJECT_SOURCE_DIR}/regression"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -86,7 +86,7 @@ GLFWmonitor* g_primary=0;
 OpenSubdiv::Osd::GLMeshInterface *g_mesh = NULL;
 OpenSubdiv::Osd::GLLegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 
-#include <common/vtr_utils.h>
+#include "../../regression/common/vtr_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"

--- a/examples/glViewer/init_shapes.h
+++ b/examples/glViewer/init_shapes.h
@@ -22,7 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include <common/shape_utils.h>
+#include "../../regression/common/shape_utils.h"
+#include "../../regression/shapes/all.h"
 
 struct ShapeDesc {
 
@@ -37,84 +38,6 @@ struct ShapeDesc {
 };
 
 static std::vector<ShapeDesc> g_defaultShapes;
-
-#include <shapes/catmark_bishop.h>
-#include <shapes/catmark_car.h>
-#include <shapes/catmark_chaikin0.h>
-#include <shapes/catmark_chaikin1.h>
-#include <shapes/catmark_chaikin2.h>
-#include <shapes/catmark_cube_corner0.h>
-#include <shapes/catmark_cube_corner1.h>
-#include <shapes/catmark_cube_corner2.h>
-#include <shapes/catmark_cube_corner3.h>
-#include <shapes/catmark_cube_corner4.h>
-#include <shapes/catmark_cube_creases0.h>
-#include <shapes/catmark_cube_creases1.h>
-#include <shapes/catmark_cube_creases2.h>
-#include <shapes/catmark_cube.h>
-#include <shapes/catmark_dart_edgecorner.h>
-#include <shapes/catmark_dart_edgeonly.h>
-#include <shapes/catmark_edgecorner.h>
-#include <shapes/catmark_edgeonly.h>
-#include <shapes/catmark_fan.h>
-#include <shapes/catmark_flap.h>
-#include <shapes/catmark_flap2.h>
-#include <shapes/catmark_fvar_bound0.h>
-#include <shapes/catmark_fvar_bound1.h>
-#include <shapes/catmark_fvar_bound2.h>
-#include <shapes/catmark_gregory_test0.h>
-#include <shapes/catmark_gregory_test1.h>
-#include <shapes/catmark_gregory_test2.h>
-#include <shapes/catmark_gregory_test3.h>
-#include <shapes/catmark_gregory_test4.h>
-#include <shapes/catmark_gregory_test5.h>
-#include <shapes/catmark_gregory_test6.h>
-#include <shapes/catmark_gregory_test7.h>
-#include <shapes/catmark_helmet.h>
-#include <shapes/catmark_hole_test1.h>
-#include <shapes/catmark_hole_test2.h>
-#include <shapes/catmark_hole_test3.h>
-#include <shapes/catmark_hole_test4.h>
-#include <shapes/catmark_lefthanded.h>
-#include <shapes/catmark_righthanded.h>
-#include <shapes/catmark_pole8.h>
-#include <shapes/catmark_pole64.h>
-#include <shapes/catmark_pole360.h>
-#include <shapes/catmark_nonman_quadpole8.h>
-#include <shapes/catmark_nonman_quadpole64.h>
-#include <shapes/catmark_nonman_quadpole360.h>
-#include <shapes/catmark_pawn.h>
-#include <shapes/catmark_pyramid_creases0.h>
-#include <shapes/catmark_pyramid_creases1.h>
-#include <shapes/catmark_pyramid.h>
-#include <shapes/catmark_rook.h>
-#include <shapes/catmark_smoothtris0.h>
-#include <shapes/catmark_smoothtris1.h>
-#include <shapes/catmark_square_hedit0.h>
-#include <shapes/catmark_square_hedit1.h>
-#include <shapes/catmark_square_hedit2.h>
-#include <shapes/catmark_square_hedit3.h>
-#include <shapes/catmark_tent_creases0.h>
-#include <shapes/catmark_tent_creases1.h>
-#include <shapes/catmark_tent.h>
-#include <shapes/catmark_torus.h>
-#include <shapes/catmark_torus_creases0.h>
-
-#include <shapes/bilinear_cube.h>
-
-#include <shapes/loop_cube_creases0.h>
-#include <shapes/loop_cube_creases1.h>
-#include <shapes/loop_cube.h>
-#include <shapes/loop_icosahedron.h>
-#include <shapes/loop_saddle_edgecorner.h>
-#include <shapes/loop_saddle_edgeonly.h>
-#include <shapes/loop_triangle_edgecorner.h>
-#include <shapes/loop_triangle_edgeonly.h>
-#include <shapes/loop_chaikin0.h>
-#include <shapes/loop_chaikin1.h>
-#include <shapes/loop_pole8.h>
-#include <shapes/loop_pole64.h>
-#include <shapes/loop_pole360.h>
 
 //------------------------------------------------------------------------------
 static void initShapes() {

--- a/examples/mayaPolySmooth/CMakeLists.txt
+++ b/examples/mayaPolySmooth/CMakeLists.txt
@@ -41,7 +41,7 @@ set(PLATFORM_LIBRARIES
 )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${MAYA_INCLUDE_DIRS}"
 )
 

--- a/regression/common/CMakeLists.txt
+++ b/regression/common/CMakeLists.txt
@@ -33,10 +33,7 @@ set(REGRESSION_COMMON_HEADER_FILES
     vtr_utils.h
 )
 
-include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
-    "${CMAKE_CURRENT_BINARY_DIR}"
-)
+include_directories("${OPENSUBDIV_INCLUDE_DIR}")
 
 add_library(regression_common_obj
     OBJECT

--- a/regression/common/cmp_utils.h
+++ b/regression/common/cmp_utils.h
@@ -27,7 +27,7 @@
 
 #include <far/topologyRefinerFactory.h>
 
-#include "../../regression/common/hbr_utils.h"
+#include "hbr_utils.h"
 
 //------------------------------------------------------------------------------
 

--- a/regression/common/hbr_utils.h
+++ b/regression/common/hbr_utils.h
@@ -37,7 +37,7 @@
 #include <hbr/cornerEdit.h>
 #include <hbr/holeEdit.h>
 
-#include "../../regression/common/shape_utils.h"
+#include "shape_utils.h"
 
 #include <sstream>
 

--- a/regression/common/vtr_utils.cpp
+++ b/regression/common/vtr_utils.cpp
@@ -22,7 +22,7 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include "../../regression/common/vtr_utils.h"
+#include "vtr_utils.h"
 
 struct FVarVertex {
 

--- a/regression/common/vtr_utils.h
+++ b/regression/common/vtr_utils.h
@@ -29,7 +29,7 @@
 #include <far/primvarRefiner.h>
 #include <far/types.h>
 
-#include "../../regression/common/shape_utils.h"
+#include "shape_utils.h"
 
 //------------------------------------------------------------------------------
 

--- a/regression/far_regression/CMakeLists.txt
+++ b/regression/far_regression/CMakeLists.txt
@@ -22,7 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-include_directories("${PROJECT_SOURCE_DIR}/opensubdiv")
+include_directories("${OPENSUBDIV_INCLUDE_DIR}")
 
 set(SOURCE_FILES
     far_regression.cpp

--- a/regression/hbr_regression/CMakeLists.txt
+++ b/regression/hbr_regression/CMakeLists.txt
@@ -22,7 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-include_directories("${PROJECT_SOURCE_DIR}/opensubdiv")
+include_directories("${OPENSUBDIV_INCLUDE_DIR}")
 
 _add_possibly_cuda_executable(hbr_regression
    main.cpp

--- a/regression/osd_regression/CMakeLists.txt
+++ b/regression/osd_regression/CMakeLists.txt
@@ -23,7 +23,7 @@
 #
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/opensubdiv"
+    "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/regression/osd_regression/main.cpp
+++ b/regression/osd_regression/main.cpp
@@ -48,15 +48,12 @@ GLFWwindow* g_window=0;
 
 #include <osd/cpuEvaluator.h>
 #include <osd/cpuVertexBuffer.h>
-
-
 #include <osd/cpuGLVertexBuffer.h>
-
 #include <far/stencilTableFactory.h>
 
-#include "../../regression/common/cmp_utils.h"
-#include "../../regression/common/hbr_utils.h"
-#include "../../regression/common/vtr_utils.h"
+#include "../common/cmp_utils.h"
+#include "../common/hbr_utils.h"
+#include "../common/vtr_utils.h"
 
 //
 // Regression testing matching Osd to Hbr

--- a/regression/shapes/all.h
+++ b/regression/shapes/all.h
@@ -1,0 +1,105 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+#ifndef OPENSUBDIV_REGRESSION_SHAPES_ALL_H
+#define OPENSUBDIV_REGRESSION_SHAPES_ALL_H
+
+#include "catmark_bishop.h"
+#include "catmark_car.h"
+#include "catmark_chaikin0.h"
+#include "catmark_chaikin1.h"
+#include "catmark_chaikin2.h"
+#include "catmark_cube_corner0.h"
+#include "catmark_cube_corner1.h"
+#include "catmark_cube_corner2.h"
+#include "catmark_cube_corner3.h"
+#include "catmark_cube_corner4.h"
+#include "catmark_cube_creases0.h"
+#include "catmark_cube_creases1.h"
+#include "catmark_cube_creases2.h"
+#include "catmark_cube.h"
+#include "catmark_dart_edgecorner.h"
+#include "catmark_dart_edgeonly.h"
+#include "catmark_edgecorner.h"
+#include "catmark_edgeonly.h"
+#include "catmark_fan.h"
+#include "catmark_flap.h"
+#include "catmark_flap2.h"
+#include "catmark_fvar_bound0.h"
+#include "catmark_fvar_bound1.h"
+#include "catmark_fvar_bound2.h"
+#include "catmark_gregory_test0.h"
+#include "catmark_gregory_test1.h"
+#include "catmark_gregory_test2.h"
+#include "catmark_gregory_test3.h"
+#include "catmark_gregory_test4.h"
+#include "catmark_gregory_test5.h"
+#include "catmark_gregory_test6.h"
+#include "catmark_gregory_test7.h"
+#include "catmark_helmet.h"
+#include "catmark_hole_test1.h"
+#include "catmark_hole_test2.h"
+#include "catmark_hole_test3.h"
+#include "catmark_hole_test4.h"
+#include "catmark_lefthanded.h"
+#include "catmark_righthanded.h"
+#include "catmark_pole8.h"
+#include "catmark_pole64.h"
+#include "catmark_pole360.h"
+#include "catmark_nonman_quadpole8.h"
+#include "catmark_nonman_quadpole64.h"
+#include "catmark_nonman_quadpole360.h"
+#include "catmark_pawn.h"
+#include "catmark_pyramid_creases0.h"
+#include "catmark_pyramid_creases1.h"
+#include "catmark_pyramid.h"
+#include "catmark_rook.h"
+#include "catmark_smoothtris0.h"
+#include "catmark_smoothtris1.h"
+#include "catmark_square_hedit0.h"
+#include "catmark_square_hedit1.h"
+#include "catmark_square_hedit2.h"
+#include "catmark_square_hedit3.h"
+#include "catmark_tent_creases0.h"
+#include "catmark_tent_creases1.h"
+#include "catmark_tent.h"
+#include "catmark_torus.h"
+#include "catmark_torus_creases0.h"
+
+#include "bilinear_cube.h"
+
+#include "loop_cube_creases0.h"
+#include "loop_cube_creases1.h"
+#include "loop_cube.h"
+#include "loop_icosahedron.h"
+#include "loop_saddle_edgecorner.h"
+#include "loop_saddle_edgeonly.h"
+#include "loop_triangle_edgecorner.h"
+#include "loop_triangle_edgeonly.h"
+#include "loop_chaikin0.h"
+#include "loop_chaikin1.h"
+#include "loop_pole8.h"
+#include "loop_pole64.h"
+#include "loop_pole360.h"
+
+#endif   // OPENSUBDIV_REGRESSION_SHAPES_ALL_H


### PR DESCRIPTION
All examples, regression tests and tutorials directly looked into
opensubdiv source directory to grab the header files. This is somewhat
convenient during development but they can mistakenly access private
header files.

With this change, when OPENSUBDIV_INCLUDE_DIR is given to cmake,
it will be used as an include search path to build examples etc.
Otherwise it follows the same behavior as before.

Also replaces include references to the files in regression dir
to be relative, and cleanups some copy-paste patterns.