### PR TITLE
Added more public constants to <far/types.h>

### DIFF
--- a/opensubdiv/far/types.h
+++ b/opensubdiv/far/types.h
@@ -35,7 +35,8 @@ namespace OPENSUBDIV_VERSION {
 namespace Far {
 
 //
-//  Typedef's for indices we want at the Far level -- need to go elsewhere eventually...
+//  Typedef's for indices that are inherited from the Vtr level -- eventually
+//  these primitive Vtr types may be declared at a lower, more public level.
 //
 typedef Vtr::Index       Index;
 typedef Vtr::LocalIndex  LocalIndex;
@@ -45,6 +46,11 @@ typedef Vtr::LocalIndexArray  LocalIndexArray;
 
 typedef Vtr::ConstIndexArray       ConstIndexArray;
 typedef Vtr::ConstLocalIndexArray  ConstLocalIndexArray;
+
+inline bool IndexIsValid(Index index) { return Vtr::IndexIsValid(index); }
+
+static const Index INDEX_INVALID = Vtr::INDEX_INVALID;
+static const int   VALENCE_LIMIT = Vtr::VALENCE_LIMIT;
 
 } // end namespace Far
 


### PR DESCRIPTION
far/types.h contains typedef's for equivalence to Vtr::Index but was missing equivalent constants, requiring public use of Vtr::INDEX_INVALID rather than Far::INDEX_INVALID.  Added the missing constants and inline bool Far::IndexIsValid().  Ideally we would have a lower level where these would be defined in future, rather than in Vtr.