### PR TITLE
Moved protected TopologyRefiner modifiers to its Factory class

### DIFF
--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -189,56 +189,6 @@ public:
 protected:
 
     //
-    //  For use by the TopologyRefinerFactory<MESH> subclasses to construct the base level:
-    //
-    template <class MESH>
-    friend class TopologyRefinerFactory;
-
-    //  Topology sizing methods required before allocation:
-    void setNumBaseFaces(   int count) { _levels[0]->resizeFaces(count); }
-    void setNumBaseEdges(   int count) { _levels[0]->resizeEdges(count); }
-    void setNumBaseVertices(int count) { _levels[0]->resizeVertices(count); }
-
-    void setNumBaseFaceVertices(Index f, int count) { _levels[0]->resizeFaceVertices(f, count); }
-    void setNumBaseEdgeFaces(   Index e, int count) { _levels[0]->resizeEdgeFaces(e, count); }
-    void setNumBaseVertexFaces( Index v, int count) { _levels[0]->resizeVertexFaces(v, count); }
-    void setNumBaseVertexEdges( Index v, int count) { _levels[0]->resizeVertexEdges(v, count); }
-
-    //  Topology assignment methods to populate base level after allocation:
-    IndexArray setBaseFaceVertices(Index f) { return _levels[0]->getFaceVertices(f); }
-    IndexArray setBaseFaceEdges(   Index f) { return _levels[0]->getFaceEdges(f); }
-    IndexArray setBaseEdgeVertices(Index e) { return _levels[0]->getEdgeVertices(e); }
-    IndexArray setBaseEdgeFaces(   Index e) { return _levels[0]->getEdgeFaces(e); }
-    IndexArray setBaseVertexFaces( Index v) { return _levels[0]->getVertexFaces(v); }
-    IndexArray setBaseVertexEdges( Index v) { return _levels[0]->getVertexEdges(v); }
-
-    LocalIndexArray setBaseEdgeFaceLocalIndices(Index e)   { return _levels[0]->getEdgeFaceLocalIndices(e); }
-    LocalIndexArray setBaseVertexFaceLocalIndices(Index v) { return _levels[0]->getVertexFaceLocalIndices(v); }
-    LocalIndexArray setBaseVertexEdgeLocalIndices(Index v) { return _levels[0]->getVertexEdgeLocalIndices(v); }
-
-    void populateBaseLocalIndices() { _levels[0]->populateLocalIndices(); }
-
-    void setBaseEdgeNonManifold(Index e, bool b) { _levels[0]->setEdgeNonManifold(e, b); }
-    void setBaseVertexNonManifold(Index v, bool b) { _levels[0]->setVertexNonManifold(v, b); }
-
-    //  Optional feature tagging methods for setting sharpness, holes, etc.:
-    void setBaseEdgeSharpness(Index e, float s)   { _levels[0]->getEdgeSharpness(e) = s; }
-    void setBaseVertexSharpness(Index v, float s) { _levels[0]->getVertexSharpness(v) = s; }
-
-    void setBaseFaceHole(Index f, bool b) { _levels[0]->setFaceHole(f, b); _hasHoles |= b; }
-
-    //  Optional methods for creating and assigning face-varying data channels:
-    int createBaseFVarChannel(int numValues);
-    int createBaseFVarChannel(int numValues, Sdc::Options const& options);
-
-    IndexArray setBaseFVarFaceValues(Index face, int channel = 0);
-
-    void setBaseMaxValence(int valence) { _levels[0]->setMaxValence(valence); }
-    void initializeBaseInventory() { initializeInventory(); }
-
-protected:
-
-    //
     //  Lower level protected methods intended strictly for internal use:
     //
     friend class TopologyRefinerFactoryBase;
@@ -306,23 +256,6 @@ inline Sdc::Options::FVarLinearInterpolation
 TopologyRefiner::GetFVarLinearInterpolation(int channel) const {
 
     return _levels[0]->getFVarOptions(channel).GetFVarLinearInterpolation();
-}
-inline int
-TopologyRefiner::createBaseFVarChannel(int numValues) {
-
-    return _levels[0]->createFVarChannel(numValues, _subdivOptions);
-}
-inline int
-TopologyRefiner::createBaseFVarChannel(int numValues, Sdc::Options const& fvarOptions) {
-
-    Sdc::Options options = _subdivOptions;
-    options.SetFVarLinearInterpolation(fvarOptions.GetFVarLinearInterpolation());
-    return _levels[0]->createFVarChannel(numValues, options);
-}
-inline IndexArray
-TopologyRefiner::setBaseFVarFaceValues(Index face, int channel) {
-
-    return _levels[0]->getFVarFaceValues(face, channel);
 }
 
 } // end namespace Far

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -44,9 +44,10 @@ namespace Far {
 //  TopologyRefinerFactoryBase:
 //      This is an abstract base class for subclasses that are intended to construct
 //  TopologyRefiner from external mesh representations.  These subclasses are
-//  parameterized by the mesh type <class MESH>.  The base class provides all
-//  implementation details related to assembly and validation that are independent
-//  of the subclass' mesh type.
+//  parameterized by the mesh type <class MESH>.
+//      This base class provides all implementation details related to assembly and
+//  validation that are independent of the subclass' mesh type.  It also includes a
+//  suite of methods for modifying/assembling a newly created TopologyRefiner.
 //
 class TopologyRefinerFactoryBase {
 
@@ -96,6 +97,57 @@ public:
 protected:
 
     //
+    //  For use by subclasses to construct the base level:
+    //
+    //  Topology sizing methods required before allocation:
+    static void setNumBaseFaces(TopologyRefiner & newRefiner, int count);
+    static void setNumBaseEdges(TopologyRefiner & newRefiner, int count);
+    static void setNumBaseVertices(TopologyRefiner & newRefiner, int count);
+
+    static int getNumBaseFaces(TopologyRefiner const & newRefiner);
+    static int getNumBaseEdges(TopologyRefiner const & newRefiner);
+    static int getNumBaseVertices(TopologyRefiner const & newRefiner);
+
+    static void setNumBaseFaceVertices(TopologyRefiner & newRefiner, Index f, int count);
+    static void setNumBaseEdgeFaces(TopologyRefiner & newRefiner, Index e, int count);
+    static void setNumBaseVertexFaces(TopologyRefiner & newRefiner, Index v, int count);
+    static void setNumBaseVertexEdges(TopologyRefiner & newRefiner, Index v, int count);
+
+    //  Topology assignment methods to populate base level after allocation:
+    static IndexArray getBaseFaceVertices(TopologyRefiner & newRefiner, Index f);
+    static IndexArray getBaseFaceEdges(TopologyRefiner & newRefiner,    Index f);
+    static IndexArray getBaseEdgeVertices(TopologyRefiner & newRefiner, Index e);
+    static IndexArray getBaseEdgeFaces(TopologyRefiner & newRefiner,    Index e);
+    static IndexArray getBaseVertexFaces(TopologyRefiner & newRefiner,  Index v);
+    static IndexArray getBaseVertexEdges(TopologyRefiner & newRefiner,  Index v);
+
+    static LocalIndexArray getBaseEdgeFaceLocalIndices(TopologyRefiner & newRefiner, Index e);
+    static LocalIndexArray getBaseVertexFaceLocalIndices(TopologyRefiner & newRefiner, Index v);
+    static LocalIndexArray getBaseVertexEdgeLocalIndices(TopologyRefiner & newRefiner, Index v);
+
+    static Index findBaseEdge(TopologyRefiner const & newRefiner, Index v0, Index v1);
+
+    static void populateBaseLocalIndices(TopologyRefiner & newRefiner);
+
+    static void setBaseEdgeNonManifold(TopologyRefiner & newRefiner, Index e, bool b);
+    static void setBaseVertexNonManifold(TopologyRefiner & newRefiner, Index v, bool b);
+
+    //  Optional feature tagging methods for setting sharpness, holes, etc.:
+    static void setBaseEdgeSharpness(TopologyRefiner & newRefiner, Index e, float s);
+    static void setBaseVertexSharpness(TopologyRefiner & newRefiner, Index v, float s);
+    static void setBaseFaceHole(TopologyRefiner & newRefiner, Index f, bool b);
+
+    //  Optional methods for creating and assigning face-varying data channels:
+    static int createBaseFVarChannel(TopologyRefiner & newRefiner, int numValues);
+    static int createBaseFVarChannel(TopologyRefiner & newRefiner, int numValues, Sdc::Options const& fvarOptions);
+    static IndexArray getBaseFVarFaceValues(TopologyRefiner & newRefiner, Index face, int channel = 0);
+
+    static void setBaseMaxValence(TopologyRefiner & newRefiner, int valence);
+    static void initializeBaseInventory(TopologyRefiner & newRefiner);
+
+protected:
+
+    //
     //  Protected methods invoked by the subclass template to verify and process each
     //  stage of construction implemented by the subclass:
     //
@@ -107,6 +159,148 @@ protected:
     static bool prepareComponentTagsAndSharpness(TopologyRefiner& refiner);
     static bool prepareFaceVaryingChannels(TopologyRefiner& refiner);
 };
+
+
+//
+//  Inline methods:
+//
+inline void
+TopologyRefinerFactoryBase::setNumBaseFaces(TopologyRefiner & newRefiner, int count) {
+    newRefiner._levels[0]->resizeFaces(count);
+}
+inline void
+TopologyRefinerFactoryBase::setNumBaseEdges(TopologyRefiner & newRefiner, int count) {
+    newRefiner._levels[0]->resizeEdges(count);
+}
+inline void
+TopologyRefinerFactoryBase::setNumBaseVertices(TopologyRefiner & newRefiner, int count) {
+    newRefiner._levels[0]->resizeVertices(count);
+}
+
+inline int
+TopologyRefinerFactoryBase::getNumBaseFaces(TopologyRefiner const & newRefiner) {
+    return newRefiner._levels[0]->getNumFaces();
+}
+inline int
+TopologyRefinerFactoryBase::getNumBaseEdges(TopologyRefiner const & newRefiner) {
+    return newRefiner._levels[0]->getNumEdges();
+}
+inline int
+TopologyRefinerFactoryBase::getNumBaseVertices(TopologyRefiner const & newRefiner) {
+    return newRefiner._levels[0]->getNumVertices();
+}
+
+inline void
+TopologyRefinerFactoryBase::setNumBaseFaceVertices(TopologyRefiner & newRefiner, Index f, int count) {
+    newRefiner._levels[0]->resizeFaceVertices(f, count);
+}
+inline void
+TopologyRefinerFactoryBase::setNumBaseEdgeFaces(TopologyRefiner & newRefiner, Index e, int count) {
+    newRefiner._levels[0]->resizeEdgeFaces(e, count);
+}
+inline void
+TopologyRefinerFactoryBase::setNumBaseVertexFaces(TopologyRefiner & newRefiner, Index v, int count) {
+    newRefiner._levels[0]->resizeVertexFaces(v, count);
+}
+inline void
+TopologyRefinerFactoryBase::setNumBaseVertexEdges(TopologyRefiner & newRefiner, Index v, int count) {
+    newRefiner._levels[0]->resizeVertexEdges(v, count);
+}
+
+inline IndexArray
+TopologyRefinerFactoryBase::getBaseFaceVertices(TopologyRefiner & newRefiner, Index f) {
+    return newRefiner._levels[0]->getFaceVertices(f);
+}
+inline IndexArray
+TopologyRefinerFactoryBase::getBaseFaceEdges(TopologyRefiner & newRefiner,    Index f) {
+    return newRefiner._levels[0]->getFaceEdges(f);
+}
+inline IndexArray
+TopologyRefinerFactoryBase::getBaseEdgeVertices(TopologyRefiner & newRefiner, Index e) {
+    return newRefiner._levels[0]->getEdgeVertices(e);
+}
+inline IndexArray
+TopologyRefinerFactoryBase::getBaseEdgeFaces(TopologyRefiner & newRefiner,    Index e) {
+    return newRefiner._levels[0]->getEdgeFaces(e);
+}
+inline IndexArray
+TopologyRefinerFactoryBase::getBaseVertexFaces(TopologyRefiner & newRefiner,  Index v) {
+    return newRefiner._levels[0]->getVertexFaces(v);
+}
+inline IndexArray
+TopologyRefinerFactoryBase::getBaseVertexEdges(TopologyRefiner & newRefiner,  Index v) {
+    return newRefiner._levels[0]->getVertexEdges(v);
+}
+
+inline LocalIndexArray
+TopologyRefinerFactoryBase::getBaseEdgeFaceLocalIndices(TopologyRefiner & newRefiner, Index e)   {
+    return newRefiner._levels[0]->getEdgeFaceLocalIndices(e);
+}
+inline LocalIndexArray
+TopologyRefinerFactoryBase::getBaseVertexFaceLocalIndices(TopologyRefiner & newRefiner, Index v) {
+    return newRefiner._levels[0]->getVertexFaceLocalIndices(v);
+}
+inline LocalIndexArray
+TopologyRefinerFactoryBase::getBaseVertexEdgeLocalIndices(TopologyRefiner & newRefiner, Index v) {
+    return newRefiner._levels[0]->getVertexEdgeLocalIndices(v);
+}
+
+inline Index
+TopologyRefinerFactoryBase::findBaseEdge(TopologyRefiner const & newRefiner, Index v0, Index v1) {
+    return newRefiner._levels[0]->findEdge(v0, v1);
+}
+
+inline void
+TopologyRefinerFactoryBase::populateBaseLocalIndices(TopologyRefiner & newRefiner) {
+    newRefiner._levels[0]->populateLocalIndices();
+}
+
+inline void
+TopologyRefinerFactoryBase::setBaseEdgeNonManifold(TopologyRefiner & newRefiner, Index e, bool b) {
+    newRefiner._levels[0]->setEdgeNonManifold(e, b);
+}
+inline void
+TopologyRefinerFactoryBase::setBaseVertexNonManifold(TopologyRefiner & newRefiner, Index v, bool b) {
+    newRefiner._levels[0]->setVertexNonManifold(v, b);
+}
+
+inline void
+TopologyRefinerFactoryBase::setBaseEdgeSharpness(TopologyRefiner & newRefiner, Index e, float s)   {
+    newRefiner._levels[0]->getEdgeSharpness(e) = s;
+}
+inline void
+TopologyRefinerFactoryBase::setBaseVertexSharpness(TopologyRefiner & newRefiner, Index v, float s) {
+    newRefiner._levels[0]->getVertexSharpness(v) = s;
+}
+inline void
+TopologyRefinerFactoryBase::setBaseFaceHole(TopologyRefiner & newRefiner, Index f, bool b) {
+    newRefiner._levels[0]->setFaceHole(f, b);
+    newRefiner._hasHoles |= b;
+}
+
+inline int
+TopologyRefinerFactoryBase::createBaseFVarChannel(TopologyRefiner & newRefiner, int numValues) {
+    return newRefiner._levels[0]->createFVarChannel(numValues, newRefiner._subdivOptions);
+}
+inline int
+TopologyRefinerFactoryBase::createBaseFVarChannel(TopologyRefiner & newRefiner, int numValues, Sdc::Options const& fvarOptions) {
+    Sdc::Options newOptions = newRefiner._subdivOptions;
+    newOptions.SetFVarLinearInterpolation(fvarOptions.GetFVarLinearInterpolation());
+    return newRefiner._levels[0]->createFVarChannel(numValues, newOptions);
+}
+inline IndexArray
+TopologyRefinerFactoryBase::getBaseFVarFaceValues(TopologyRefiner & newRefiner, Index face, int channel) {
+    return newRefiner._levels[0]->getFVarFaceValues(face, channel);
+}
+
+inline void
+TopologyRefinerFactoryBase::setBaseMaxValence(TopologyRefiner & newRefiner, int valence) {
+    newRefiner._levels[0]->setMaxValence(valence);
+}
+inline void
+TopologyRefinerFactoryBase::initializeBaseInventory(TopologyRefiner & newRefiner) {
+    newRefiner.initializeInventory();
+}
 
 
 //

--- a/tutorials/far/tutorial_1/far_tutorial_1.cpp
+++ b/tutorials/far/tutorial_1/far_tutorial_1.cpp
@@ -234,31 +234,31 @@ TopologyRefinerFactory<Converter>::resizeComponentTopology(
 
     // Faces and face-verts
     int nfaces = conv.GetNumFaces();
-    refiner.setNumBaseFaces(nfaces);
+    setNumBaseFaces(refiner, nfaces);
     for (int face=0; face<nfaces; ++face) {
 
         int nv = conv.GetNumFaceVerts(face);
-        refiner.setNumBaseFaceVertices(face, nv);
+        setNumBaseFaceVertices(refiner, face, nv);
     }
 
    // Edges and edge-faces
     int nedges = conv.GetNumEdges();
-    refiner.setNumBaseEdges(nedges);
+    setNumBaseEdges(refiner, nedges);
     for (int edge=0; edge<nedges; ++edge) {
 
         int nf = conv.GetNumEdgeFaces(edge);
-        refiner.setNumBaseEdgeFaces(edge, nf);
+        setNumBaseEdgeFaces(refiner, edge, nf);
     }
 
     // Vertices and vert-faces and vert-edges
     int nverts = conv.GetNumVertices();
-    refiner.setNumBaseVertices(nverts);
+    setNumBaseVertices(refiner, nverts);
     for (int vert=0; vert<nverts; ++vert) {
 
         int ne = conv.GetNumVertexEdges(vert),
             nf = conv.GetNumVertexFaces(vert);
-        refiner.setNumBaseVertexEdges(vert, ne);
-        refiner.setNumBaseVertexFaces(vert, nf);
+        setNumBaseVertexEdges(refiner, vert, ne);
+        setNumBaseVertexFaces(refiner, vert, nf);
     }
     return true;
 }
@@ -274,8 +274,8 @@ TopologyRefinerFactory<Converter>::assignComponentTopology(
         int nfaces = conv.GetNumFaces();
         for (int face=0; face<nfaces; ++face) {
 
-            IndexArray dstFaceVerts = refiner.setBaseFaceVertices(face);
-            IndexArray dstFaceEdges = refiner.setBaseFaceEdges(face);
+            IndexArray dstFaceVerts = getBaseFaceVertices(refiner, face);
+            IndexArray dstFaceEdges = getBaseFaceEdges(refiner, face);
 
             int const * faceverts = conv.GetFaceVerts(face);
             int const * faceedges = conv.GetFaceEdges(face);
@@ -297,12 +297,12 @@ TopologyRefinerFactory<Converter>::assignComponentTopology(
         for (int edge=0; edge<nedges; ++edge) {
 
             //  Edge-vertices:
-            IndexArray dstEdgeVerts = refiner.setBaseEdgeVertices(edge);
+            IndexArray dstEdgeVerts = getBaseEdgeVertices(refiner, edge);
             dstEdgeVerts[0] = conv.GetEdgeVertices(edge)[0];
             dstEdgeVerts[1] = conv.GetEdgeVertices(edge)[1];
 
             //  Edge-faces
-            IndexArray dstEdgeFaces = refiner.setBaseEdgeFaces(edge);
+            IndexArray dstEdgeFaces = getBaseEdgeFaces(refiner, edge);
             for (int face=0; face<conv.GetNumEdgeFaces(face); ++face) {
                 dstEdgeFaces[face] = conv.GetEdgeFaces(edge)[face];
             }
@@ -314,22 +314,22 @@ TopologyRefinerFactory<Converter>::assignComponentTopology(
         for (int vert=0; vert<nverts; ++vert) {
 
             //  Vert-Faces:
-            IndexArray vertFaces = refiner.setBaseVertexFaces(vert);
-            //LocalIndexArray vertInFaceIndices = refiner.setBaseVertexFaceLocalIndices(vert);
+            IndexArray vertFaces = getBaseVertexFaces(refiner, vert);
+            //LocalIndexArray vertInFaceIndices = getBaseVertexFaceLocalIndices(refiner, vert);
             for (int face=0; face<conv.GetNumVertexFaces(vert); ++face) {
                 vertFaces[face] = conv.GetVertexFaces(vert)[face];
             }
 
             //  Vert-Edges:
-            IndexArray vertEdges = refiner.setBaseVertexEdges(vert);
-            //LocalIndexArray vertInEdgeIndices = refiner.setBaseVertexEdgeLocalIndices(vert);
+            IndexArray vertEdges = getBaseVertexEdges(refiner, vert);
+            //LocalIndexArray vertInEdgeIndices = getBaseVertexEdgeLocalIndices(refiner, vert);
             for (int edge=0; edge<conv.GetNumVertexEdges(vert); ++edge) {
                 vertEdges[edge] = conv.GetVertexEdges(vert)[edge];
             }
         }
     }
 
-    refiner.populateBaseLocalIndices();
+    populateBaseLocalIndices(refiner);
 
     return true;
 };
@@ -341,7 +341,7 @@ TopologyRefinerFactory<Converter>::assignComponentTags(
 
     // arbitrarily sharpen the 4 bottom edges of the pyramid to 2.5f
     for (int edge=0; edge<conv.GetNumEdges(); ++edge) {
-        refiner.setBaseEdgeSharpness(edge, g_edgeCreases[edge]);
+        setBaseEdgeSharpness(refiner, edge, g_edgeCreases[edge]);
     }
     return true;
 }


### PR DESCRIPTION
The suite of base-level modifiers in Far::TopologyRefiner was only used by its Factory, so in the interest of stripping unnecessary baggage from TopologyRefiner they were all moved to its Factory class.  They were added to TopologyRefinerFactoryBase rather than TopologyRefinerFactory<MESH> as they are all independent of the template parameter <MESH>.

Existing Factory<MESH> classes for Shape, Descriptor, etc. were all updated.