### PR TITLE
Removed primvar interpolation dependency on varying interface

### DIFF
--- a/opensubdiv/far/primvarRefiner.h
+++ b/opensubdiv/far/primvarRefiner.h
@@ -80,9 +80,6 @@ public:
     ///           void Clear();
     ///           void AddWithWeight(MySource const & value, float weight);
     ///           void AddWithWeight(MyDestination const & value, float weight);
-    ///
-    ///           // optional
-    ///           void AddVaryingWithWeight(MySource const & value, float weight);
     ///       };
     ///
     ///       \endcode
@@ -101,8 +98,7 @@ public:
     ///       Far tutorials</a> for code examples.
     ///
 
-    /// \brief Apply vertex and varying interpolation weights to a primvar
-    ///        buffer
+    /// \brief Apply vertex interpolation weights to a primvar buffer
     ///
     /// The destination buffer must allocate an array of data for all the refined
     /// vertices (at least GetNumVerticesTotal()-GetLevel(0).GetNumVertices())
@@ -113,9 +109,8 @@ public:
     ///
     template <class T, class U> void Interpolate(T const * src, U * dst) const;
 
-    /// \brief Apply vertex and varying interpolation weights to a primvar
-    ///        buffer for a single level
-    /// level of refinement.
+    /// \brief Apply vertex interpolation weights to a primvar buffer for a single
+    ///        level level of refinement.
     ///
     /// The destination buffer must allocate an array of data for all the
     /// refined vertices (at least GetLevel(level).GetNumVertices())
@@ -129,10 +124,10 @@ public:
     template <class T, class U> void Interpolate(int level, T const & src, U & dst) const;
 
 
-    /// \brief Apply only varying interpolation weights to a primvar buffer
+    /// \brief Apply varying interpolation weights to a primvar buffer
     ///
-    /// This method can be a useful alternative if the varying primvar data
-    /// does not need to be re-computed over time.
+    /// This method is useful if the varying primvar data does not need to be
+    /// re-computed over time.
     ///
     /// The destination buffer must allocate an array of data for all the refined
     /// vertices (at least GetNumVerticesTotal()-GetLevel(0).GetNumVertices())
@@ -146,8 +141,8 @@ public:
     /// \brief Apply only varying interpolation weights to a primvar buffer
     ///        for a single level level of refinement.
     ///
-    /// This method can be a useful alternative if the varying primvar data
-    /// does not need to be re-computed over time.
+    /// This method can useful if the varying primvar data does not need to be
+    /// re-computed over time.
     ///
     /// The destination buffer must allocate an array of data for all the
     /// refined vertices (at least GetLevel(level).GetNumVertices())
@@ -160,10 +155,12 @@ public:
     ///
     template <class T, class U> void InterpolateVarying(int level, T const & src, U & dst) const;
 
-    /// \brief Apply uniform (per-face) primvar data between levels.  Data is simply copied
-    /// from a parent face to its child faces and does not involve any weighting.  Setting
-    /// the source primvar data for the base level to be the index of each face allows the
-    /// propagation of the base face to primvar data for child faces in all levels.
+    /// \brief Apply uniform (per-face) primvar data between levels.
+    ///
+    /// Data is simply copied from a parent face to its child faces and does not involve
+    /// any weighting.  Setting the source primvar data for the base level to be the index
+    /// of each face allows the propagation of the base face to primvar data for child
+    /// faces in all levels.
     ///
     template <class T, class U> void InterpolateFaceUniform(T const * src, U * dst) const;
 
@@ -332,8 +329,6 @@ PrimvarRefiner::interpolateChildVertsFromFaces(
         //  Declare and compute mask weights for this vertex relative to its parent face:
         ConstIndexArray fVerts = parent.getFaceVertices(face);
 
-        float fVaryingWeight = 1.0f / (float) fVerts.size();
-
         Mask fMask(fVertWeights, 0, 0);
         Vtr::internal::FaceInterface fHood(fVerts.size());
 
@@ -345,8 +340,6 @@ PrimvarRefiner::interpolateChildVertsFromFaces(
         for (int i = 0; i < fVerts.size(); ++i) {
 
             dst[cVert].AddWithWeight(src[fVerts[i]], fVertWeights[i]);
-
-            dst[cVert].AddVaryingWithWeight(src[fVerts[i]], fVaryingWeight);
         }
     }
 }
@@ -390,9 +383,6 @@ PrimvarRefiner::interpolateChildVertsFromEdges(
         dst[cVert].Clear();
         dst[cVert].AddWithWeight(src[eVerts[0]], eVertWeights[0]);
         dst[cVert].AddWithWeight(src[eVerts[1]], eVertWeights[1]);
-
-        dst[cVert].AddVaryingWithWeight(src[eVerts[0]], 0.5f);
-        dst[cVert].AddVaryingWithWeight(src[eVerts[1]], 0.5f);
 
         if (eMask.GetNumFaceWeights() > 0) {
 
@@ -489,8 +479,6 @@ PrimvarRefiner::interpolateChildVertsFromVerts(
             }
         }
         dst[cVert].AddWithWeight(src[vert], vVertWeight);
-
-        dst[cVert].AddVaryingWithWeight(src[vert], 1.0f);
     }
 }
 
@@ -580,7 +568,7 @@ PrimvarRefiner::varyingInterpolateChildVertsFromFaces(
         dst[cVert].Clear();
 
         for (int i = 0; i < fVerts.size(); ++i) {
-            dst[cVert].AddVaryingWithWeight(src[fVerts[i]], fVaryingWeight);
+            dst[cVert].AddWithWeight(src[fVerts[i]], fVaryingWeight);
         }
     }
 }
@@ -604,8 +592,8 @@ PrimvarRefiner::varyingInterpolateChildVertsFromEdges(
         //  Apply the weights to the parent edges's vertices
         dst[cVert].Clear();
 
-        dst[cVert].AddVaryingWithWeight(src[eVerts[0]], 0.5f);
-        dst[cVert].AddVaryingWithWeight(src[eVerts[1]], 0.5f);
+        dst[cVert].AddWithWeight(src[eVerts[0]], 0.5f);
+        dst[cVert].AddWithWeight(src[eVerts[1]], 0.5f);
     }
 }
 
@@ -624,7 +612,7 @@ PrimvarRefiner::varyingInterpolateChildVertsFromVerts(
 
         //  Apply the weights to the parent vertex
         dst[cVert].Clear();
-        dst[cVert].AddVaryingWithWeight(src[vert], 1.0f);
+        dst[cVert].AddWithWeight(src[vert], 1.0f);
     }
 }
 

--- a/opensubdiv/far/stencilBuilder.cpp
+++ b/opensubdiv/far/stencilBuilder.cpp
@@ -304,13 +304,11 @@ private:
 };
 
 StencilBuilder::StencilBuilder(int coarseVertCount, 
-                               bool isVarying, 
                                bool genCtrlVertStencils, 
                                bool compactWeights)
         : _weightTable(new WeightTable(coarseVertCount, 
                                    genCtrlVertStencils, 
                                    compactWeights))
-        , _isVarying(isVarying)
 {
 }
 
@@ -368,8 +366,6 @@ StencilBuilder::GetStencilDvWeights() const {
 void
 StencilBuilder::Index::AddWithWeight(Index const & src, float weight)
 {
-    if (_owner->_isVarying)
-        return;
     // Ignore no-op weights.
     if (weight == 0)
         return;
@@ -426,24 +422,6 @@ StencilBuilder::Index::AddWithWeight(Stencil const& src,
         _owner->_weightTable->AddWithWeight(srcIndex, _index, wgt,
                            _owner->_weightTable->GetPointDerivAccumulator());
     }
-}
-
-void 
-StencilBuilder::Index::AddVaryingWithWeight(Index const &src, float weight)
-{
-    if (not _owner->_isVarying)
-        return;
-    // Ignore no-op weights.
-    if (weight == 0)
-        return;
-    _owner->_weightTable->AddWithWeight(src._index, _index, weight,
-                                _owner->_weightTable->GetScalarAccumulator());
-}
-
-void 
-StencilBuilder::Index::AddFaceVaryingWithWeight(Index const &, float)
-{
-    // Not supported.
 }
 
 } // end namespace internal

--- a/opensubdiv/far/stencilBuilder.h
+++ b/opensubdiv/far/stencilBuilder.h
@@ -41,7 +41,6 @@ class WeightTable;
 class StencilBuilder {
 public:
     StencilBuilder(int coarseVertCount, 
-                   bool isVarying=false,
                    bool genCtrlVertStencils=true,
                    bool compactWeights=true);
     ~StencilBuilder();
@@ -82,9 +81,6 @@ public:
         void AddWithWeight(Stencil const& src,
                                      float weight, float du, float dv);
 
-        void AddVaryingWithWeight(Index const &, float);
-        void AddFaceVaryingWithWeight(Index const &, float);
-        
         Index operator[](int index) const {
             return Index(_owner, index+_index);
         }
@@ -99,7 +95,6 @@ public:
 
 private:
     WeightTable* _weightTable;
-    bool _isVarying;
 };
 
 } // end namespace internal

--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -71,13 +71,12 @@ StencilTableFactory::Create(TopologyRefiner const & refiner,
 
     bool interpolateVarying = options.interpolationMode==INTERPOLATE_VARYING;
     internal::StencilBuilder builder(refiner.GetLevel(0).GetNumVertices(),
-                                interpolateVarying,
                                 /*genControlVerts*/ true,
                                 /*compactWeights*/  true);
 
     //
     // Interpolate stencils for each refinement level using
-    // PrimvarRefiner::InterpolateLevel<>()
+    // PrimvarRefiner::InterpolateLevel<>() for vertex or varying
     //
     PrimvarRefiner primvarRefiner(refiner);
 
@@ -259,7 +258,6 @@ StencilTableFactory::AppendEndCapStencilTable(
     int nEndCapStencilsElements = 0;
 
     internal::StencilBuilder builder(refiner.GetLevel(0).GetNumVertices(),
-                                /*isVarying*/       false,
                                 /*genControlVerts*/ false,
                                 /*compactWeights*/  factorize);
     internal::StencilBuilder::Index origin(&builder, 0);
@@ -417,7 +415,6 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
     //
 
     internal::StencilBuilder builder(refiner.GetLevel(0).GetNumVertices(),
-                                /*isVarying*/       false,
                                 /*genControlVerts*/ false,
                                 /*compactWeights*/  true);
     internal::StencilBuilder::Index origin(&builder, 0);

--- a/tutorials/far/tutorial_2/far_tutorial_2.cpp
+++ b/tutorials/far/tutorial_2/far_tutorial_2.cpp
@@ -27,8 +27,7 @@
 // Tutorial description:
 //
 // Building on tutorial 0, this example shows how to instantiate a simple mesh,
-// refine it uniformly and then interpolate both 'vertex' and 'varying' primvar
-// data.
+// refine it uniformly and then interpolate both additional primvar data.
 //
 
 #include <opensubdiv/far/topologyRefinerFactory.h>
@@ -39,11 +38,7 @@
 //------------------------------------------------------------------------------
 // Vertex container implementation.
 //
-// We are adding a per-vertex color attribute to our Vertex interface. Unlike
-// the position attribute however, the new color attribute is interpolated using
-// the 'varying' mode of evaluation ('vertex' is bi-cubic, 'varying' is
-// bi-linear). We also implemented the 'AddVaryingWithWeight()' method, which
-// be performing the interpolation on the primvar data.
+// We are adding a per-vertex color attribute to our Vertex interface.
 //
 struct Vertex {
 
@@ -59,11 +54,6 @@ struct Vertex {
         _position[0]+=weight*src._position[0];
         _position[1]+=weight*src._position[1];
         _position[2]+=weight*src._position[2];
-    }
-
-    // The varying interpolation specialization must now be implemented.
-    // Just like 'vertex' interpolation, it is a simple multiply-add.
-    void AddVaryingWithWeight(Vertex const & src, float weight) {
         _color[0]+=weight*src._color[0];
         _color[1]+=weight*src._color[1];
         _color[2]+=weight*src._color[2];
@@ -157,9 +147,7 @@ int main(int, char **) {
     }
 
 
-    // Interpolate all primvar data - not that this will perform both 'vertex' and
-    // 'varying' interpolation at once by calling each specialized method in our
-    // Vertex class with the appropriate weights.
+    // Interpolate all primvar data 
     Far::PrimvarRefiner(*refiner).Interpolate(verts, verts + nCoarseVerts);
 
 
@@ -188,7 +176,7 @@ int main(int, char **) {
         // Add per-particle color attribute ('rgbPP')
         printf("addAttr -ln \"rgbPP\" -dt vectorArray particleShape1;\n");
 
-        // Set per-particle color values from our 'varying' primvar data
+        // Set per-particle color values from our primvar data
         printf("setAttr \"particleShape1.rgbPP\" -type \"vectorArray\" %d ", nverts);
         for (int vert=0; vert<nverts; ++vert) {
             float const * color = verts[vert].GetColor();


### PR DESCRIPTION
As decided, we will be relying solely on the AddWithWeight() interface for all forms of primvar data (vertex, varying and face-varying) and eliminating reliance of AddVaryingWithWeight().  Varying data can be interpolated with different methods rather than through a different interface.

I've updated the core code and dependencies and wanted to get that in place as soon as possible.

There are still a number of unused/empty definitions of AddVaryingWithWeight() in some of the examples, tutorials, etc. since it was a requirement.  I will weed out those unused instances in a separate pass.  It looks like the far/tutorial_2 was more devoted to the varying case and warrants more of a rewrite than the simple update here, which I will also follow up on later.