### PR TITLE
add c++11 option for ICC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,10 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANGCC OR CMAKE_COMPILER_IS_IC
             endif()
 
         endforeach()
+        
+        # ICC need the option "-std=c++11" to support c++11
+        list(APPEND OSD_COMPILER_FLAGS -std=c++11)        
+        
     endif()
 
 elseif(MSVC)


### PR DESCRIPTION
ICC need the option "-std=c++11" to support c++11 features. The build has been tested with ICC15.0.3.