### PR TITLE
OpenGL init without errors, example cleanup

### DIFF
--- a/examples/common/glUtils.cpp
+++ b/examples/common/glUtils.cpp
@@ -26,6 +26,8 @@
 #include <string>
 #include "glUtils.h"
 
+#include <GLFW/glfw3.h>
+
 namespace GLUtils {
 
 // Note that glewIsSupported is required here for Core profile, glewGetExtension
@@ -34,6 +36,41 @@ namespace GLUtils {
 #define IS_SUPPORTED(x) \
    (glewIsSupported(x) == GL_TRUE)
 #endif
+
+void
+SetMinimumGLVersion() {
+    // Here 3.2 is the minimum GL version supported, GLFW will allocate
+    // a higher version if possible.
+    int major = 3,
+        minor = 2;
+
+    #define glfwOpenWindowHint glfwWindowHint
+    #define GLFW_OPENGL_VERSION_MAJOR GLFW_CONTEXT_VERSION_MAJOR
+    #define GLFW_OPENGL_VERSION_MINOR GLFW_CONTEXT_VERSION_MINOR
+
+    #ifdef CORE_PROFILE
+    glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    #endif
+
+    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, major);
+    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, minor);
+
+    glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+}
+
+void
+PrintGLVersion() {
+    std::cout << glGetString(GL_VENDOR) << "\n";
+    std::cout << glGetString(GL_RENDERER) << "\n";
+    std::cout << glGetString(GL_VERSION) << "\n";
+
+    int i;
+    std::cout << "Init OpenGL ";
+    glGetIntegerv(GL_MAJOR_VERSION, &i);
+    std::cout << i << ".";
+    glGetIntegerv(GL_MINOR_VERSION, &i);
+    std::cout << i << "\n";
+}
 
 void
 CheckGLErrors(std::string const & where) {
@@ -76,8 +113,6 @@ SupportsAdaptiveTessellation() {
 #endif
 }
 
-///Helper function that parses the open gl version string, retrieving the major 
-///and minor version from it.
 void GetMajorMinorVersion(int *major, int *minor){
     const GLubyte *ver = glGetString(GL_SHADING_LANGUAGE_VERSION);
     if (!ver){
@@ -91,9 +126,6 @@ void GetMajorMinorVersion(int *major, int *minor){
         ss >> *minor;
     }
 }
-
-/** Gets the shader version based on the current opengl version and returns 
- * it in a string form */
 
 std::string
 GetShaderVersion(){

--- a/examples/common/glUtils.h
+++ b/examples/common/glUtils.h
@@ -25,13 +25,35 @@
 #ifndef OPENSUBDIV_EXAMPLES_GL_UTILS_H
 #define OPENSUBDIV_EXAMPLES_GL_UTILS_H
 
+#if defined(__APPLE__)
+    #if defined(OSD_USES_GLEW)
+        #include <GL/glew.h>
+    #else
+        #include <OpenGL/gl3.h>
+    #endif
+    #define GLFW_INCLUDE_GL3
+    #define GLFW_NO_GLU
+#else
+    #include <stdlib.h>
+    #include <GL/glew.h>
+    #if defined(WIN32)
+        #include <GL/wglew.h>
+    #endif
+#endif
+
 #include <osd/opengl.h>
 
 #include <cstdio>
 #include <string>
 #include <iostream>
 
+#define CORE_PROFILE
+
 namespace GLUtils {
+
+void SetMinimumGLVersion();
+
+void PrintGLVersion();
 
 void CheckGLErrors(std::string const & where = "");
 
@@ -39,14 +61,18 @@ GLuint CompileShader(GLenum shaderType, const char *source);
 
 bool SupportsAdaptiveTessellation();
 
+// Helper function that parses the open gl version string, retrieving the
+// major and minor version from it.
 void GetMajorMinorVersion(int *major, int *minor);
 
-
+// Gets the shader version based on the current opengl version and returns 
+// it in a string form.
 std::string GetShaderVersion();
 
 std::string GetShaderVersionInclude();
 
 bool GL_ARBSeparateShaderObjectsOrGL_VERSION_4_1();
+
 bool GL_ARBComputeShaderOrGL_VERSION_4_3();
 
 };

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -1294,13 +1294,15 @@ setGLCoreProfile() {
     #define GLFW_OPENGL_VERSION_MINOR GLFW_CONTEXT_VERSION_MINOR
 
     glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
 #if not defined(__APPLE__)
     glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 4);
-#ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 3);
-#else
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
-#endif
+
+    #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 3);
+    #else
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
+    #endif
 
 #else
     glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 3);

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -22,21 +22,7 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#if defined(__APPLE__)
-    #if defined(OSD_USES_GLEW)
-        #include <GL/glew.h>
-    #else
-        #include <OpenGL/gl3.h>
-    #endif
-    #define GLFW_INCLUDE_GL3
-    #define GLFW_NO_GLU
-#else
-    #include <stdlib.h>
-    #include <GL/glew.h>
-    #if defined(WIN32)
-        #include <GL/wglew.h>
-    #endif
-#endif
+#include "../common/glUtils.h"
 
 #include <GLFW/glfw3.h>
 GLFWwindow* g_window = 0;
@@ -52,7 +38,6 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh = NULL;
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"
-#include "../common/glUtils.h"
 #include "../common/glShaderCache.h"
 
 #include <osd/glslPatchShaderSource.h>
@@ -1205,24 +1190,6 @@ static void
 callbackErrorGLFW(int error, const char* description) {
     fprintf(stderr, "GLFW Error (%d) : %s\n", error, description);
 }
-//------------------------------------------------------------------------------
-static void
-setGLCoreProfile() {
-
-    #define glfwOpenWindowHint glfwWindowHint
-    #define GLFW_OPENGL_VERSION_MAJOR GLFW_CONTEXT_VERSION_MAJOR
-    #define GLFW_OPENGL_VERSION_MINOR GLFW_CONTEXT_VERSION_MINOR
-
-    glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-#if not defined(__APPLE__)
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 4);
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
-#else
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 3);
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
-#endif
-    glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-}
 
 //------------------------------------------------------------------------------
 int main(int argc, char ** argv) {
@@ -1260,10 +1227,7 @@ int main(int argc, char ** argv) {
 
     static const char windowTitle[] = "OpenSubdiv glFVarViewer " OPENSUBDIV_VERSION_STRING;
 
-#define CORE_PROFILE
-#ifdef CORE_PROFILE
-    setGLCoreProfile();
-#endif
+    GLUtils::SetMinimumGLVersion();
 
     if (fullscreen) {
         g_primary = glfwGetPrimaryMonitor();
@@ -1287,11 +1251,13 @@ int main(int argc, char ** argv) {
 
     if (not (g_window=glfwCreateWindow(g_width, g_height, windowTitle,
                                        fullscreen and g_primary ? g_primary : NULL, NULL))) {
-        printf("Failed to open window.\n");
+        std::cerr << "Failed to create OpenGL context.\n";
         glfwTerminate();
         return 1;
     }
+
     glfwMakeContextCurrent(g_window);
+    GLUtils::PrintGLVersion();
 
     // accommodate high DPI displays (e.g. mac retina displays)
     glfwGetFramebufferSize(g_window, &g_width, &g_height);

--- a/examples/glFVarViewer/shader.glsl
+++ b/examples/glFVarViewer/shader.glsl
@@ -112,6 +112,21 @@ out block {
 void main()
 {
     outpt.v.position = ModelViewMatrix * position;
+
+    // We don't actually want to write all these, but some
+    // compilers complain during about failing to fully write
+    // outpt.v if they are excluded.
+    outpt.v.normal = vec3(0);
+    outpt.v.tangent = vec3(0);
+    outpt.v.bitangent = vec3(0);
+    outpt.v.patchCoord = vec4(0);
+    outpt.v.tessCoord = vec2(0);
+#if defined OSD_COMPUTE_NORMAL_DERIVATIVES
+    outpt.v.Nu = vec3(0);
+    outpt.v.Nv = vec3(0);
+#endif
+    // --
+
     OSD_USER_VARYING_PER_VERTEX();
 }
 

--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -22,23 +22,7 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#if defined(__APPLE__)
-    #if defined(OSD_USES_GLEW)
-        #include <GL/glew.h>
-    #else
-        #include <OpenGL/gl3.h>
-    #endif
-    #define GLFW_INCLUDE_GL3
-    #define GLFW_NO_GLU
-#else
-    #include <stdlib.h>
-    #include <GL/glew.h>
-    #if defined(_WIN32)
-        // XXX Must include windows.h here or GLFW pollutes the global namespace
-        #define WIN32_LEAN_AND_MEAN
-        #include <windows.h>
-    #endif
-#endif
+#include "../common/glUtils.h"
 
 #include <iostream>
 #include <fstream>
@@ -96,28 +80,6 @@ using namespace OpenSubdiv;
 static const char *shaderSource =
 #include "shader.gen.h"
 ;
-
-static void
-setGLCoreProfile() {
-    #define glfwOpenWindowHint glfwWindowHint
-    #define GLFW_OPENGL_VERSION_MAJOR GLFW_CONTEXT_VERSION_MAJOR
-    #define GLFW_OPENGL_VERSION_MINOR GLFW_CONTEXT_VERSION_MINOR
-
-    glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-#if not defined(__APPLE__)
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 4);
-#ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 3);
-#else
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
-#endif
-
-#else
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 4);
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 1);
-#endif
-    glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-}
 
 class ShaderCache : public GLShaderCache<OpenSubdiv::Far::PatchDescriptor> {
 public:
@@ -565,14 +527,16 @@ int main(int argc, char ** argv) {
     static const char windowTitle[] =
         "OpenSubdiv imaging test " OPENSUBDIV_VERSION_STRING;
 
-    setGLCoreProfile();
+    GLUtils::SetMinimumGLVersion();
 
     GLFWwindow *window = glfwCreateWindow(width, height, windowTitle, NULL, NULL);
     if (not window) {
-        std::cout << "Failed to open window.\n";
+        std::cerr << "Failed to create OpenGL context.\n";
         glfwTerminate();
     }
+
     glfwMakeContextCurrent(window);
+    GLUtils::PrintGLVersion();
 
 #if defined(OSD_USES_GLEW)
     // this is the only way to initialize glew correctly under core profile context.

--- a/examples/glPaintTest/glPaintTest.cpp
+++ b/examples/glPaintTest/glPaintTest.cpp
@@ -22,21 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#if defined(__APPLE__)
-    #if defined(OSD_USES_GLEW)
-        #include <GL/glew.h>
-    #else
-        #include <OpenGL/gl3.h>
-    #endif
-    #define GLFW_INCLUDE_GL3
-    #define GLFW_NO_GLU
-#else
-    #include <stdlib.h>
-    #include <GL/glew.h>
-    #if defined(WIN32)
-        #include <GL/wglew.h>
-    #endif
-#endif
+
+#include "../common/glUtils.h"
 
 #include <GLFW/glfw3.h>
 GLFWwindow* g_window=0;

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -22,21 +22,7 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#if defined(__APPLE__)
-    #if defined(OSD_USES_GLEW)
-        #include <GL/glew.h>
-    #else
-        #include <OpenGL/gl3.h>
-    #endif
-    #define GLFW_INCLUDE_GL3
-    #define GLFW_NO_GLU
-#else
-    #include <stdlib.h>
-    #include <GL/glew.h>
-    #if defined(WIN32)
-        #include <GL/wglew.h>
-    #endif
-#endif
+#include "../common/glUtils.h"
 
 #include <GLFW/glfw3.h>
 GLFWwindow* g_window=0;
@@ -1176,30 +1162,7 @@ callbackErrorGLFW(int error, const char* description) {
     fprintf(stderr, "GLFW Error (%d) : %s\n", error, description);
 }
 //------------------------------------------------------------------------------
-static void
-setGLCoreProfile() {
 
-    #define glfwOpenWindowHint glfwWindowHint
-    #define GLFW_OPENGL_VERSION_MAJOR GLFW_CONTEXT_VERSION_MAJOR
-    #define GLFW_OPENGL_VERSION_MINOR GLFW_CONTEXT_VERSION_MINOR
-
-    glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-#if not defined(__APPLE__)
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 4);
-#ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 3);
-#else
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
-#endif
-
-#else
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 3);
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
-#endif
-    glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-}
-
-//------------------------------------------------------------------------------
 int main(int argc, char ** argv) {
 
     std::string str;
@@ -1218,17 +1181,16 @@ int main(int argc, char ** argv) {
 
     static const char windowTitle[] = "OpenSubdiv batching example " OPENSUBDIV_VERSION_STRING;
 
-#define CORE_PROFILE
-#ifdef CORE_PROFILE
-    setGLCoreProfile();
-#endif
+    GLUtils::SetMinimumGLVersion();
 
     if (not (g_window=glfwCreateWindow(g_width, g_height, windowTitle, NULL, NULL))) {
-        printf("Failed to open window.\n");
+        std::cerr << "Failed to create OpenGL context.\n";
         glfwTerminate();
         return 1;
     }
+
     glfwMakeContextCurrent(g_window);
+    GLUtils::PrintGLVersion();
 
     // accommocate high DPI displays (e.g. mac retina displays)
     glfwGetFramebufferSize(g_window, &g_width, &g_height);

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -22,21 +22,7 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#if defined(__APPLE__)
-    #if defined(OSD_USES_GLEW)
-        #include <GL/glew.h>
-    #else
-        #include <OpenGL/gl3.h>
-    #endif
-    #define GLFW_INCLUDE_GL3
-    #define GLFW_NO_GLU
-#else
-    #include <stdlib.h>
-    #include <GL/glew.h>
-    #if defined(WIN32)
-        #include <GL/wglew.h>
-    #endif
-#endif
+#include "../common/glUtils.h"
 
 #include <GLFW/glfw3.h>
 GLFWwindow* g_window=0;
@@ -45,7 +31,6 @@ GLFWmonitor* g_primary=0;
 #include "../../regression/common/vtr_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
-#include "../common/glUtils.h"
 #include "../common/glHud.h"
 
 #include <far/patchTableFactory.h>
@@ -1186,25 +1171,6 @@ callbackErrorGLFW(int error, const char* description) {
     fprintf(stderr, "GLFW Error (%d) : %s\n", error, description);
 }
 //------------------------------------------------------------------------------
-static void
-setGLCoreProfile() {
-
-    #define glfwOpenWindowHint glfwWindowHint
-    #define GLFW_OPENGL_VERSION_MAJOR GLFW_CONTEXT_VERSION_MAJOR
-    #define GLFW_OPENGL_VERSION_MINOR GLFW_CONTEXT_VERSION_MINOR
-
-    glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-#if not defined(__APPLE__)
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 4);
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
-#else
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 3);
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
-#endif
-    glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-}
-
-//------------------------------------------------------------------------------
 int main(int argc, char **argv) {
 
     bool fullscreen = false;
@@ -1237,10 +1203,7 @@ int main(int argc, char **argv) {
 
     static const char windowTitle[] = "OpenSubdiv glStencilViewer " OPENSUBDIV_VERSION_STRING;
 
-#define CORE_PROFILE
-#ifdef CORE_PROFILE
-    setGLCoreProfile();
-#endif
+    GLUtils::SetMinimumGLVersion();
 
     if (fullscreen) {
 
@@ -1264,12 +1227,13 @@ int main(int argc, char **argv) {
     }
 
     if (not (g_window=glfwCreateWindow(g_width, g_height, windowTitle,
-                                       fullscreen and g_primary ? g_primary : NULL, NULL))) {
-        printf("Failed to open window.\n");
+                           fullscreen and g_primary ? g_primary : NULL, NULL))) {
+        std::cerr << "Failed to create OpenGL context.\n";
         glfwTerminate();
         return 1;
     }
     glfwMakeContextCurrent(g_window);
+    GLUtils::PrintGLVersion();
 
     // accommodate high DPI displays (e.g. mac retina displays)
     glfwGetFramebufferSize(g_window, &g_width, &g_height);

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -22,21 +22,7 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#if defined(__APPLE__)
-    #if defined(OSD_USES_GLEW)
-        #include <GL/glew.h>
-    #else
-        #include <OpenGL/gl3.h>
-    #endif
-    #define GLFW_INCLUDE_GL3
-    #define GLFW_NO_GLU
-#else
-    #include <stdlib.h>
-    #include <GL/glew.h>
-    #if defined(WIN32)
-        #include <GL/wglew.h>
-    #endif
-#endif
+#include "../common/glUtils.h"
 
 #include <GLFW/glfw3.h>
 GLFWwindow* g_window=0;
@@ -90,7 +76,6 @@ OpenSubdiv::Osd::GLLegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"
-#include "../common/glUtils.h"
 #include "../common/objAnim.h"
 #include "../common/patchColors.h"
 #include "../common/glShaderCache.h"
@@ -314,20 +299,6 @@ struct FVarData
     }
     GLuint textureBuffer;
 } g_fvarData;
-
-static void
-checkGLErrors(std::string const & where = "")
-{
-    GLuint err;
-    while ((err = glGetError()) != GL_NO_ERROR) {
-        std::cerr << "GL error: "
-                  << (where.empty() ? "" : where + " ")
-                  << err << "\n";
-    }
-}
-
-
-
 
 static bool
 linkDefaultProgram() {
@@ -1802,20 +1773,6 @@ callbackErrorGLFW(int error, const char* description) {
     fprintf(stderr, "GLFW Error (%d) : %s\n", error, description);
 }
 //------------------------------------------------------------------------------
-static void
-setGLCoreProfile(int major, int minor) {
-    #define glfwOpenWindowHint glfwWindowHint
-    #define GLFW_OPENGL_VERSION_MAJOR GLFW_CONTEXT_VERSION_MAJOR
-    #define GLFW_OPENGL_VERSION_MINOR GLFW_CONTEXT_VERSION_MINOR
-
-    glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, major);
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, minor);
-
-    glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-}
-
 //------------------------------------------------------------------------------
 int main(int argc, char ** argv) {
 
@@ -1872,10 +1829,7 @@ int main(int argc, char ** argv) {
 
     static const char windowTitle[] = "OpenSubdiv glViewer " OPENSUBDIV_VERSION_STRING;
 
-#define CORE_PROFILE
-#ifdef CORE_PROFILE
-    setGLCoreProfile(4, 4);
-#endif
+    GLUtils::SetMinimumGLVersion();
 
     if (fullscreen) {
 
@@ -1901,26 +1855,14 @@ int main(int argc, char ** argv) {
     g_window = glfwCreateWindow(g_width, g_height, windowTitle,
         fullscreen and g_primary ? g_primary : NULL, NULL);
 
-#ifdef CORE_PROFILE
-    if (not g_window){
-        setGLCoreProfile(4, 2);
-        g_window = glfwCreateWindow(g_width, g_height, windowTitle,
-            fullscreen and g_primary ? g_primary : NULL, NULL);
-    }
-    if (not g_window){
-        setGLCoreProfile(3, 3);
-        g_window = glfwCreateWindow(g_width, g_height, windowTitle,
-            fullscreen and g_primary ? g_primary : NULL, NULL);
-    }
-
-#endif
-    if (not g_window){
+    if (not g_window) {
+        std::cerr << "Failed to create OpenGL context.\n";
         glfwTerminate();
         return 1;
     }
 
-    
     glfwMakeContextCurrent(g_window);
+    GLUtils::PrintGLVersion();
 
     // accommocate high DPI displays (e.g. mac retina displays)
     glfwGetFramebufferSize(g_window, &g_width, &g_height);


### PR DESCRIPTION
The GLFW context version hint is a minimum version, not maximum version so
requesting 4.4 and then falling back to lower versions doesn't make sense.

This change sets the minimum version to 3.2 and attempts to standardize this
across all example apps.

Also print the maximum supported GL version along with the context version
at startup.