### PR TITLE
Fix build breakage due to recent examples/common refactor.

### DIFF
--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -73,6 +73,10 @@ if( OPENGL_FOUND AND (GLEW_FOUND AND GLFW_FOUND) OR (APPLE AND GLFW_FOUND))
         include_directories("${GLEW_INCLUDE_DIR}")
     endif()
 
+    if (GLFW_FOUND)
+        include_directories("${GLFW_INCLUDE_DIR}")
+    endif()
+
 endif()
 
 

--- a/examples/dxViewer/CMakeLists.txt
+++ b/examples/dxViewer/CMakeLists.txt
@@ -42,6 +42,15 @@ if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
 endif()
 
+# XXX: This is unfortunate, we should probably refactor examples_common_obj
+# to separate out the GL from the DX dependencies so that we don't end up
+# in the situation where we have to link in GLFW for dxViewer.
+if (GLFW_FOUND)
+    list(APPEND PLATFORM_LIBRARIES
+        "${GLFW_LIBRARIES}"
+    )
+endif()
+
 set(SOURCE_FILES
     dxViewer.cpp
 )


### PR DESCRIPTION
- Make sure to declare usage of the include files if GLFW is found
- When GLFW is found and is compiled into examples/common, we need to
  unfortunately link it into dxViewer.  Hopefully we can refactor common
  so that this won't be necessary in the future.