### PR TITLE
Remove mention of vtr from tests and examples.

### DIFF
--- a/examples/dxPtexViewer/CMakeLists.txt
+++ b/examples/dxPtexViewer/CMakeLists.txt
@@ -56,7 +56,7 @@ _add_possibly_cuda_executable(dxPtexViewer WIN32
     "${SOURCE_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:regression_vtr_utils_obj>
+    $<TARGET_OBJECTS:regression_far_utils_obj>
     $<TARGET_OBJECTS:examples_common_obj>
 )
 

--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -61,7 +61,7 @@ OpenSubdiv::Osd::D3D11MeshInterface *g_mesh;
 #include "Ptexture.h"
 #include "PtexUtils.h"
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/d3d11Hud.h"
@@ -697,7 +697,7 @@ createOsdMesh(int level, int kernel) {
 
     typedef OpenSubdiv::Far::ConstIndexArray IndexArray;
 
-    // create Vtr mesh (topology)
+    // create Far mesh (topology)
     OpenSubdiv::Sdc::SchemeType sdctype = GetSdcType(*shape);
     OpenSubdiv::Sdc::Options sdcoptions = GetSdcOptions(*shape);
 

--- a/examples/dxViewer/CMakeLists.txt
+++ b/examples/dxViewer/CMakeLists.txt
@@ -63,7 +63,7 @@ _add_possibly_cuda_executable(dxViewer WIN32
     "${SOURCE_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:regression_vtr_utils_obj>
+    $<TARGET_OBJECTS:regression_far_utils_obj>
     $<TARGET_OBJECTS:examples_common_obj>
 )
 

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -60,7 +60,7 @@
 OpenSubdiv::Osd::D3D11MeshInterface *g_mesh = NULL;
 OpenSubdiv::Osd::D3D11LegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/d3d11Hud.h"
@@ -268,7 +268,7 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level, int kernel, Scheme scheme=
 
     Shape * shape = Shape::parseObj(shapeDesc.data.c_str(), shapeDesc.scheme);
 
-    // create Vtr mesh (topology)
+    // create Far mesh (topology)
     Sdc::SchemeType sdctype = GetSdcType(*shape);
     Sdc::Options sdcoptions = GetSdcOptions(*shape);
 

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -53,7 +53,7 @@ GLFWmonitor* g_primary=0;
 #include <far/stencilTableFactory.h>
 #include <far/primvarRefiner.h>
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glUtils.h"

--- a/examples/farViewer/gl_mesh.h
+++ b/examples/farViewer/gl_mesh.h
@@ -25,7 +25,7 @@
 #ifndef GL_MESH_H
 #define GL_MESH_H
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../../regression/common/hbr_utils.h"
 #include <far/patchTable.h>
 

--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -79,7 +79,7 @@ GLFWmonitor* g_primary=0;
 
 #include <far/error.h>
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"
@@ -500,7 +500,7 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level) {
 
     Shape * shape = Shape::parseObj(shapeDesc.data.c_str(), shapeDesc.scheme);
 
-    // create Vtr mesh (topology)
+    // create Far mesh (topology)
     OpenSubdiv::Sdc::SchemeType sdctype = GetSdcType(*shape);
     OpenSubdiv::Sdc::Options sdcoptions = GetSdcOptions(*shape);
 

--- a/examples/glFVarViewer/CMakeLists.txt
+++ b/examples/glFVarViewer/CMakeLists.txt
@@ -59,7 +59,7 @@ _add_glfw_executable(glFVarViewer
     "${SHADER_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:regression_vtr_utils_obj>
+    $<TARGET_OBJECTS:regression_far_utils_obj>
     $<TARGET_OBJECTS:examples_common_obj>
 )
 

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -34,7 +34,7 @@ GLFWmonitor* g_primary = 0;
 #include <osd/glMesh.h>
 OpenSubdiv::Osd::GLMeshInterface *g_mesh = NULL;
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"
@@ -341,7 +341,7 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level, Scheme scheme = kCatmark) 
 
     Shape * shape = Shape::parseObj(shapeDesc.data.c_str(), shapeDesc.scheme);
 
-    // create Vtr mesh (topology)
+    // create Far mesh (topology)
     OpenSubdiv::Sdc::SchemeType sdctype = GetSdcType(*shape);
     OpenSubdiv::Sdc::Options sdcoptions = GetSdcOptions(*shape);
 

--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -68,7 +68,7 @@
 
 #include <osd/glMesh.h>
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../common/patchColors.h"
 #include "../common/stb_image_write.h"    // common.obj has an implementation.
 #include "../common/glShaderCache.h"
@@ -285,7 +285,7 @@ void runTest(ShapeDesc const &shapeDesc, std::string const &kernel,
     Shape const * shape = Shape::parseObj(shapeDesc.data.c_str(),
                                           shapeDesc.scheme);
 
-    // create Vtr mesh (topology)
+    // create Far mesh (topology)
     Sdc::SchemeType sdctype = GetSdcType(*shape);
     Sdc::Options sdcoptions = GetSdcOptions(*shape);
 

--- a/examples/glPaintTest/glPaintTest.cpp
+++ b/examples/glPaintTest/glPaintTest.cpp
@@ -36,7 +36,7 @@ GLFWmonitor* g_primary=0;
 #include <osd/glMesh.h>
 OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"
@@ -203,7 +203,7 @@ createOsdMesh() {
 
     g_orgPositions=shape->verts;
 
-    // create Vtr mesh (topology)
+    // create Far mesh (topology)
     OpenSubdiv::Sdc::SchemeType sdctype = GetSdcType(*shape);
     OpenSubdiv::Sdc::Options sdcoptions = GetSdcOptions(*shape);
 

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -92,7 +92,7 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 #include "Ptexture.h"
 #include "PtexUtils.h"
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"
@@ -888,7 +888,7 @@ createOsdMesh(int level, int kernel) {
 
     typedef OpenSubdiv::Far::ConstIndexArray IndexArray;
 
-    // create Vtr mesh (topology)
+    // create Far mesh (topology)
     OpenSubdiv::Sdc::SchemeType sdctype = GetSdcType(*shape);
     OpenSubdiv::Sdc::Options sdcoptions = GetSdcOptions(*shape);
 

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -68,7 +68,7 @@ GLFWmonitor* g_primary=0;
 #endif
 
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "init_shapes.h"
 
 #include "../common/stopwatch.h"

--- a/examples/glShareTopology/sceneBase.cpp
+++ b/examples/glShareTopology/sceneBase.cpp
@@ -24,7 +24,7 @@
 
 #include "sceneBase.h"
 #include <limits>
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include <far/patchTableFactory.h>
 #include <far/stencilTableFactory.h>
 

--- a/examples/glStencilViewer/CMakeLists.txt
+++ b/examples/glStencilViewer/CMakeLists.txt
@@ -47,7 +47,7 @@ _add_glfw_executable(glStencilViewer
     glStencilViewer.cpp
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:regression_vtr_utils_obj>
+    $<TARGET_OBJECTS:regression_far_utils_obj>
     $<TARGET_OBJECTS:examples_common_obj>
 )
 

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -28,7 +28,7 @@
 GLFWwindow* g_window=0;
 GLFWmonitor* g_primary=0;
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"
@@ -293,7 +293,7 @@ createMesh(ShapeDesc const & shapeDesc, int level) {
 
     Shape const * shape = Shape::parseObj(shapeDesc.data.c_str(), shapeDesc.scheme);
 
-    // create Vtr mesh (topology)
+    // create Far mesh (topology)
     OpenSubdiv::Sdc::SchemeType sdctype = GetSdcType(*shape);
     OpenSubdiv::Sdc::Options sdcoptions = GetSdcOptions(*shape);
 

--- a/examples/glViewer/CMakeLists.txt
+++ b/examples/glViewer/CMakeLists.txt
@@ -58,7 +58,7 @@ _add_glfw_executable(glViewer
     "${SHADER_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:regression_vtr_utils_obj>
+    $<TARGET_OBJECTS:regression_far_utils_obj>
     $<TARGET_OBJECTS:examples_common_obj>
 )
 

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -72,7 +72,7 @@ GLFWmonitor* g_primary=0;
 OpenSubdiv::Osd::GLMeshInterface *g_mesh = NULL;
 OpenSubdiv::Osd::GLLegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"
@@ -517,7 +517,7 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level, int kernel, Scheme scheme=
         shape = Shape::parseObj(shapeDesc.data.c_str(), shapeDesc.scheme, shapeDesc.isLeftHanded);
     }
 
-    // create Vtr mesh (topology)
+    // create Far mesh (topology)
     Sdc::SchemeType sdctype = GetSdcType(*shape);
     Sdc::Options sdcoptions = GetSdcOptions(*shape);
 

--- a/regression/common/CMakeLists.txt
+++ b/regression/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(REGRESSION_COMMON_HEADER_FILES
     cmp_utils.h
     hbr_utils.h
     shape_utils.h
-    vtr_utils.h
+    far_utils.h
 )
 
 include_directories("${OPENSUBDIV_INCLUDE_DIR}")
@@ -41,9 +41,9 @@ add_library(regression_common_obj
         ${REGRESSION_COMMON_HEADER_FILES}
 )
 
-add_library(regression_vtr_utils_obj
+add_library(regression_far_utils_obj
     OBJECT
-        vtr_utils.cpp
-        vtr_utils.h
+        far_utils.cpp
+        far_utils.h
 )
 

--- a/regression/common/cmp_utils.h
+++ b/regression/common/cmp_utils.h
@@ -71,7 +71,7 @@ GetReorderedHbrVertexData(
             typedef OpenSubdiv::Far::ConstIndexArray ConstIndexArray;
 
             {   // Populate base level
-                // note : topological ordering is identical between Hbr and Vtr
+                // note : topological ordering is identical between Hbr and Far
                 // for the base level
                 OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner.GetLevel(0);
 
@@ -89,10 +89,10 @@ GetReorderedHbrVertexData(
 
                 for (int edge = 0; edge <nedges; ++edge) {
 
-                    ConstIndexArray vtrVerts = refBaseLevel.GetEdgeVertices(edge);
+                    ConstIndexArray farVerts = refBaseLevel.GetEdgeVertices(edge);
 
-                    Hvertex const * v0 = hmesh.GetVertex(vtrVerts[0]),
-                                  * v1 = hmesh.GetVertex(vtrVerts[1]);
+                    Hvertex const * v0 = hmesh.GetVertex(farVerts[0]),
+                                  * v1 = hmesh.GetVertex(farVerts[1]);
 
                     Hhalfedge * e = v0->GetEdge(v1);
                     if (not e) {
@@ -160,10 +160,10 @@ GetReorderedHbrVertexData(
                 // populate child edges
                 for (int edge=0; edge < refLevel.GetNumEdges(); ++edge) {
 
-                    ConstIndexArray vtrVerts = refLevel.GetEdgeVertices(edge);
+                    ConstIndexArray farVerts = refLevel.GetEdgeVertices(edge);
 
-                    Hvertex const * v0 = current.verts[vtrVerts[0]],
-                                  * v1 = current.verts[vtrVerts[1]];
+                    Hvertex const * v0 = current.verts[farVerts[0]],
+                                  * v1 = current.verts[farVerts[1]];
                     assert(v0 and v1);
 
                     Hhalfedge * e= v0->GetEdge(v1);

--- a/regression/common/far_utils.cpp
+++ b/regression/common/far_utils.cpp
@@ -22,7 +22,7 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include "vtr_utils.h"
+#include "far_utils.h"
 
 struct FVarVertex {
 

--- a/regression/common/far_utils.h
+++ b/regression/common/far_utils.h
@@ -22,8 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#ifndef VTR_UTILS_H
-#define VTR_UTILS_H
+#ifndef FAR_UTILS_H
+#define FAR_UTILS_H
 
 #include <far/topologyRefinerFactory.h>
 #include <far/primvarRefiner.h>
@@ -135,13 +135,13 @@ InterpolateFVarData(OpenSubdiv::Far::TopologyRefiner & refiner,
 
 template <class T>
 OpenSubdiv::Far::TopologyRefiner *
-InterpolateVtrVertexData(const char *shapeStr, Scheme scheme, int maxlevel,
+InterpolateFarVertexData(const char *shapeStr, Scheme scheme, int maxlevel,
     std::vector<T> &data) {
 
     typedef OpenSubdiv::Far::TopologyRefiner FarTopologyRefiner;
     typedef OpenSubdiv::Far::TopologyRefinerFactory<Shape> FarTopologyRefinerFactory;
 
-    // Vtr interpolation
+    // Far interpolation
     Shape * shape = Shape::parseObj(shapeStr, scheme);
 
     FarTopologyRefiner * refiner =
@@ -279,8 +279,8 @@ TopologyRefinerFactory<Shape>::assignComponentTags(
 
             for (int j=0; j<(int)t->intargs.size()-1; j += 2) {
 
-                OpenSubdiv::Vtr::Index edge = findBaseEdge(refiner, t->intargs[j], t->intargs[j+1]);
-                if (edge==OpenSubdiv::Vtr::INDEX_INVALID) {
+                OpenSubdiv::Far::Index edge = findBaseEdge(refiner, t->intargs[j], t->intargs[j+1]);
+                if (edge==OpenSubdiv::Far::INDEX_INVALID) {
                     printf("cannot find edge for crease tag (%d,%d)\n", t->intargs[j], t->intargs[j+1] );
                     return false;
                 } else {
@@ -331,4 +331,4 @@ TopologyRefinerFactory<Shape>::reportInvalidTopology(
 
 //------------------------------------------------------------------------------
 
-#endif /* VTR_UTILS_H */
+#endif /* FAR_UTILS_H */

--- a/regression/far_regression/far_regression.cpp
+++ b/regression/far_regression/far_regression.cpp
@@ -27,7 +27,7 @@
 
 
 #include "../../regression/common/hbr_utils.h"
-#include "../../regression/common/vtr_utils.h"
+#include "../../regression/common/far_utils.h"
 #include "../../regression/common/cmp_utils.h"
 
 #include "init_shapes.h"
@@ -121,17 +121,17 @@ typedef OpenSubdiv::Far::TopologyRefinerFactory<Shape> FarTopologyRefinerFactory
 //------------------------------------------------------------------------------
 #ifdef foo
 static void
-printVertexData(std::vector<xyzVV> const & hbrBuffer, std::vector<xyzVV> const & vtrBuffer) {
+printVertexData(std::vector<xyzVV> const & hbrBuffer, std::vector<xyzVV> const & farBuffer) {
 
-    assert(hbrBuffer.size()==vtrBuffer.size());
+    assert(hbrBuffer.size()==farBuffer.size());
     for (int i=0; i<(int)hbrBuffer.size(); ++i) {
 
         float const * hbr = hbrBuffer[i].GetPos(),
-                    * vtr = vtrBuffer[i].GetPos();
+                    * far = farBuffer[i].GetPos();
 
-        printf("%3d %d (%f %f %f) (%f %f %f)\n", i, hbrBuffer[i]==vtrBuffer[i],
+        printf("%3d %d (%f %f %f) (%f %f %f)\n", i, hbrBuffer[i]==farBuffer[i],
                                                     hbr[0], hbr[1], hbr[2],
-                                                    vtr[0], vtr[1], vtr[2]);
+                                                    far[0], far[1], far[2]);
     }
 }
 #endif
@@ -148,40 +148,40 @@ checkMesh(ShapeDesc const & desc, int maxlevel) {
           deltaCnt[3] = {0.0f, 0.0f, 0.0f};
 
     std::vector<xyzVV> hbrVertexData,
-                       vtrVertexData;
+                       farVertexData;
 
     Hmesh *  hmesh = interpolateHbrVertexData<xyzVV>(
         desc.data.c_str(), desc.scheme, maxlevel);
 
     FarTopologyRefiner * refiner =
-        InterpolateVtrVertexData<xyzVV>(
-            desc.data.c_str(), desc.scheme, maxlevel, vtrVertexData);
+        InterpolateFarVertexData<xyzVV>(
+            desc.data.c_str(), desc.scheme, maxlevel, farVertexData);
 
     // copy Hbr vertex data into a re-ordered buffer (for easier comparison)
     GetReorderedHbrVertexData(*refiner, *hmesh, &hbrVertexData);
 
-    int nverts = (int)vtrVertexData.size();
+    int nverts = (int)farVertexData.size();
 
     for (int i=0; i<nverts; ++i) {
 
         xyzVV & hbrVert = hbrVertexData[i],
-              & vtrVert = vtrVertexData[i];
+              & farVert = farVertexData[i];
 
 #ifdef __INTEL_COMPILER // remark #1572: floating-point equality and inequality comparisons are unreliable
 #pragma warning disable 1572
 #endif
-        if ( hbrVert.GetPos()[0] != vtrVert.GetPos()[0] )
+        if ( hbrVert.GetPos()[0] != farVert.GetPos()[0] )
             deltaCnt[0]++;
-        if ( hbrVert.GetPos()[1] != vtrVert.GetPos()[1] )
+        if ( hbrVert.GetPos()[1] != farVert.GetPos()[1] )
             deltaCnt[1]++;
-        if ( hbrVert.GetPos()[2] != vtrVert.GetPos()[2] )
+        if ( hbrVert.GetPos()[2] != farVert.GetPos()[2] )
             deltaCnt[2]++;
 #ifdef __INTEL_COMPILER
 #pragma warning enable 1572
 #endif
-        float delta[3] = { hbrVert.GetPos()[0] - vtrVert.GetPos()[0],
-                           hbrVert.GetPos()[1] - vtrVert.GetPos()[1],
-                           hbrVert.GetPos()[2] - vtrVert.GetPos()[2] };
+        float delta[3] = { hbrVert.GetPos()[0] - farVert.GetPos()[0],
+                           hbrVert.GetPos()[1] - farVert.GetPos()[1],
+                           hbrVert.GetPos()[2] - farVert.GetPos()[2] };
 
         deltaAvg[0]+=delta[0];
         deltaAvg[1]+=delta[1];
@@ -194,9 +194,9 @@ checkMesh(ShapeDesc const & desc, int maxlevel) {
                        " (%.10f %.10f %.10f)\n", i, dist, hbrVert.GetPos()[0],
                                                           hbrVert.GetPos()[1],
                                                           hbrVert.GetPos()[2],
-                                                          vtrVert.GetPos()[0],
-                                                          vtrVert.GetPos()[1],
-                                                          vtrVert.GetPos()[2] );
+                                                          farVert.GetPos()[0],
+                                                          farVert.GetPos()[1],
+                                                          farVert.GetPos()[2] );
            count++;
         }
     }

--- a/regression/osd_regression/main.cpp
+++ b/regression/osd_regression/main.cpp
@@ -53,7 +53,7 @@ GLFWwindow* g_window=0;
 
 #include "../common/cmp_utils.h"
 #include "../common/hbr_utils.h"
-#include "../common/vtr_utils.h"
+#include "../common/far_utils.h"
 
 //
 // Regression testing matching Osd to Hbr
@@ -333,18 +333,18 @@ checkMesh( char const * msg, std::string const & shape, int levels, Scheme schem
     xyzmesh * refmesh = 
         interpolateHbrVertexData<xyzVV>(shape.c_str(), scheme, levels);
 
-    std::vector<xyzVV> vtrVertexData;
+    std::vector<xyzVV> farVertexData;
 
     FarTopologyRefiner *refiner =
-        InterpolateVtrVertexData(shape.c_str(), scheme, levels, 
-            vtrVertexData);
+        InterpolateFarVertexData(shape.c_str(), scheme, levels, 
+            farVertexData);
 
     switch (backend) {
         case kBackendCPU:
-            result = checkMeshCPU(refiner, vtrVertexData, refmesh); 
+            result = checkMeshCPU(refiner, farVertexData, refmesh); 
             break;
         case kBackendCPUGL: 
-            result = checkMeshCPUGL(refiner, vtrVertexData, refmesh); 
+            result = checkMeshCPUGL(refiner, farVertexData, refmesh); 
             break;
     }
 


### PR DESCRIPTION
- Renamed common/vtr_utils to common/far_utils.
- Renamed all mentions of Vtr in the sources of tests and examples.