### PR TITLE
Fix out of bounds memory access in CPU stencil eval.

### DIFF
--- a/opensubdiv/osd/cpuEvaluator.h
+++ b/opensubdiv/osd/cpuEvaluator.h
@@ -80,6 +80,9 @@ public:
         (void)instance;       // unused
         (void)deviceContext;  // unused
 
+        if (stencilTable->GetNumStencils() == 0)
+            return false;
+
         return EvalStencils(srcBuffer->BindCpuBuffer(), srcDesc,
                             dstBuffer->BindCpuBuffer(), dstDesc,
                             &stencilTable->GetSizes()[0],


### PR DESCRIPTION
When the stencil table contains no stencils, bail out
on the EvalStencil before indexing into the stencil table.