### PR TITLE
Command line options for GL context.

### DIFF
--- a/examples/common/glUtils.h
+++ b/examples/common/glUtils.h
@@ -51,7 +51,7 @@
 
 namespace GLUtils {
 
-void SetMinimumGLVersion();
+void SetMinimumGLVersion(int argc=0, char **argv=NULL);
 
 void PrintGLVersion();
 

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -1829,7 +1829,7 @@ int main(int argc, char ** argv) {
 
     static const char windowTitle[] = "OpenSubdiv glViewer " OPENSUBDIV_VERSION_STRING;
 
-    GLUtils::SetMinimumGLVersion();
+    GLUtils::SetMinimumGLVersion(argc, argv);
 
     if (fullscreen) {
 


### PR DESCRIPTION
Adding command line options to glViewer to make it easy
to control the requested GL version and profile.  While
it is only enabled for glViewer in this change, it will
be easy to extend to all our example viewers.  The new
command line options are:

    -glCoreProfile on|off
    -glForwardCompat on|off
    -glVersion M.n