### PR TITLE
Workaround GLSL shader compiler on AMD

### DIFF
--- a/opensubdiv/osd/glslPatchBSpline.glsl
+++ b/opensubdiv/osd/glslPatchBSpline.glsl
@@ -59,7 +59,7 @@ in block {
 out block {
     OsdPerPatchVertexBezier v;
     OSD_USER_VARYING_DECLARE
-} outpt[];
+} outpt[16];
 
 layout(vertices = 16) out;
 

--- a/opensubdiv/osd/glslPatchGregory.glsl
+++ b/opensubdiv/osd/glslPatchGregory.glsl
@@ -57,7 +57,7 @@ in block {
 out block {
     OsdPerPatchVertexGregory v;
     OSD_USER_VARYING_DECLARE
-} outpt[];
+} outpt[4];
 
 layout(vertices = 4) out;
 

--- a/opensubdiv/osd/glslPatchGregoryBasis.glsl
+++ b/opensubdiv/osd/glslPatchGregoryBasis.glsl
@@ -57,7 +57,7 @@ in block {
 out block {
     OsdPerPatchVertexGregoryBasis v;
     OSD_USER_VARYING_DECLARE
-} outpt[];
+} outpt[20];
 
 layout(vertices = 20) out;
 


### PR DESCRIPTION
Added a size specifier to the shader output array declaration
in the BSpline control shader. This seems to be required by the
GLSL compiler on AMD and is harmless elsewhere.