### PR TITLE
Examples cleanup: factor out control mesh drawing.

### DIFF
--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -52,6 +52,7 @@ set(EXAMPLES_COMMON_HEADER_FILES
 if( OPENGL_FOUND AND (GLEW_FOUND AND GLFW_FOUND) OR (APPLE AND GLFW_FOUND))
 
     list(APPEND EXAMPLES_COMMON_SOURCE_FILES
+        glControlMeshDisplay.cpp
         glFramebuffer.cpp
         glHud.cpp
         glUtils.cpp
@@ -59,6 +60,7 @@ if( OPENGL_FOUND AND (GLEW_FOUND AND GLFW_FOUND) OR (APPLE AND GLFW_FOUND))
     )
 
     list(APPEND EXAMPLES_COMMON_HEADER_FILES
+        glControlMeshDisplay.h
         glFramebuffer.h
         glHud.h
         glUtils.h
@@ -83,12 +85,14 @@ endif()
 if(DXSDK_FOUND)
 
     list(APPEND EXAMPLES_COMMON_SOURCE_FILES
+        d3d11ControlMeshDisplay.cpp
         d3d11Hud.cpp
         d3d11Utils.cpp
         d3d11ShaderCache.cpp
     )
 
     list(APPEND EXAMPLES_COMMON_HEADER_FILES
+        d3d11ControlMeshDisplay.h
         d3d11Hud.h
         d3d11Utils.h
         d3d11ShaderCache.h

--- a/examples/common/d3d11ControlMeshDisplay.cpp
+++ b/examples/common/d3d11ControlMeshDisplay.cpp
@@ -1,0 +1,268 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#include "d3d11ControlMeshDisplay.h"
+#include "../common/d3d11Utils.h"
+
+#include <vector>
+
+#define SAFE_RELEASE(p) { if(p) { (p)->Release(); (p)=NULL; } }
+
+static const char *s_VS =
+"cbuffer cbPerFrame : register( b0 ) { matrix g_mViewProjection; };        \n"
+"struct vertexIn { float3 pos : POSITION0; float sharpness : COLOR0; };    \n"
+"struct vertexOut { float4 pos : SV_POSITION; float sharpness : COLOR0; }; \n"
+"vertexOut vs_main(vertexIn IN) {                                          \n"
+"  vertexOut vout;                                                         \n"
+"  vout.pos = mul(g_mViewProjection, float4(IN.pos, 1));                   \n"
+"  vout.sharpness = IN.sharpness;                                          \n"
+"  return vout;                                                            \n"
+"}                                                                         \n";
+
+static const char *s_PS =
+"struct pixelIn { float4 pos : SV_POSITION; float sharpness : COLOR0; };   \n"
+"Buffer<float> edgeSharpness : register(t0);                               \n"
+"float4 sharpnessToColor(float s) {                                        \n"
+"  //  0.0       2.0       4.0                                             \n"
+"  // green --- yellow --- red                                             \n"
+"  return float4(min(1, s * 0.5),                                          \n"
+"                min(1, 2 - s * 0.5),                                      \n"
+"                0, 1);                                                    \n"
+"}                                                                         \n"
+"float4 ps_main(pixelIn IN, uint primitiveID : SV_PrimitiveID)             \n"
+"  : SV_Target {                                                           \n"
+"  float sharpness = edgeSharpness[primitiveID];                           \n"
+"  return sharpnessToColor(sharpness);                                     \n"
+"}                                                                         \n";
+
+namespace {
+    struct CB_CONTROL_MESH_DISPLAY
+    {
+        float mViewProjection[16];
+    };
+};
+
+D3D11ControlMeshDisplay::D3D11ControlMeshDisplay(
+    ID3D11DeviceContext *deviceContext) :
+    _displayEdges(true), _displayVertices(false),
+    _deviceContext(deviceContext), _inputLayout(0), _vertexShader(0),
+    _pixelShader(0), _rasterizerState(0), _constantBuffer(0),
+    _edgeSharpnessSRV(0), _edgeSharpness(0), _edgeIndices(0),
+    _numEdges(0), _numPoints(0) {
+}
+
+D3D11ControlMeshDisplay::~D3D11ControlMeshDisplay() {
+    SAFE_RELEASE(_inputLayout);
+    SAFE_RELEASE(_vertexShader);
+    SAFE_RELEASE(_pixelShader);
+    SAFE_RELEASE(_rasterizerState);
+    SAFE_RELEASE(_constantBuffer);
+    SAFE_RELEASE(_edgeSharpness);
+    SAFE_RELEASE(_edgeSharpnessSRV);
+    SAFE_RELEASE(_edgeIndices);
+}
+
+bool
+D3D11ControlMeshDisplay::createProgram() {
+    ID3D11Device *device = NULL;
+    _deviceContext->GetDevice(&device);
+
+    ID3DBlob* pVSBlob;
+    ID3DBlob* pPSBlob;
+    pVSBlob = D3D11Utils::CompileShader(s_VS, "vs_main", "vs_4_0");
+    pPSBlob = D3D11Utils::CompileShader(s_PS, "ps_main", "ps_4_0");
+    assert(pVSBlob);
+    assert(pPSBlob);
+
+    D3D11_INPUT_ELEMENT_DESC inputElementDesc[] = {
+        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,               0,
+          D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "COLOR",    0, DXGI_FORMAT_R32_FLOAT,       0, sizeof(float)*3,
+          D3D11_INPUT_PER_VERTEX_DATA, 0 },
+    };
+    device->CreateInputLayout(inputElementDesc, ARRAYSIZE(inputElementDesc),
+        pVSBlob->GetBufferPointer(),
+        pVSBlob->GetBufferSize(),
+        &_inputLayout);
+    assert(_inputLayout);
+
+    device->CreateVertexShader(pVSBlob->GetBufferPointer(),
+        pVSBlob->GetBufferSize(),
+        NULL, &_vertexShader);
+    assert(_vertexShader);
+
+    device->CreatePixelShader(pPSBlob->GetBufferPointer(),
+        pPSBlob->GetBufferSize(),
+        NULL, &_pixelShader);
+    assert(_pixelShader);
+
+    D3D11_RASTERIZER_DESC rasDesc;
+    rasDesc.FillMode = D3D11_FILL_SOLID;
+    rasDesc.CullMode = D3D11_CULL_NONE;
+    rasDesc.FrontCounterClockwise = FALSE;
+    rasDesc.DepthBias = 0;
+    rasDesc.DepthBiasClamp = 0;
+    rasDesc.SlopeScaledDepthBias = 0.0f;
+    rasDesc.DepthClipEnable = FALSE;
+    rasDesc.ScissorEnable = FALSE;
+    rasDesc.MultisampleEnable = FALSE;
+    rasDesc.AntialiasedLineEnable = FALSE;
+    device->CreateRasterizerState(&rasDesc, &_rasterizerState);
+    assert(_rasterizerState);
+
+    // constant buffer
+    D3D11_BUFFER_DESC cbDesc;
+    cbDesc.Usage = D3D11_USAGE_DYNAMIC;
+    cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+    cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+    cbDesc.MiscFlags = 0;
+    cbDesc.ByteWidth = sizeof(CB_CONTROL_MESH_DISPLAY);
+
+    device->CreateBuffer(&cbDesc, NULL, &_constantBuffer);
+    assert(_constantBuffer);
+    return true;
+}
+
+
+void
+D3D11ControlMeshDisplay::Draw(ID3D11Buffer *buffer, int stride,
+                              const float *modelViewProjectionMatrix) {
+
+    if (_displayEdges == false && _displayVertices == false) return;
+
+    if (_vertexShader == NULL) createProgram();
+    if (_vertexShader == NULL) return;
+
+    UINT hStrides = stride*sizeof(float);
+    UINT hOffsets = 0;
+    _deviceContext->IASetVertexBuffers(0, 1, &buffer, &hStrides, &hOffsets);
+
+    D3D11_MAPPED_SUBRESOURCE MappedResource;
+    _deviceContext->Map(_constantBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &MappedResource);
+    CB_CONTROL_MESH_DISPLAY * pData = (CB_CONTROL_MESH_DISPLAY *)MappedResource.pData;
+    memcpy(pData->mViewProjection, modelViewProjectionMatrix, sizeof(float) * 16);
+    _deviceContext->Unmap(_constantBuffer, 0);
+
+    _deviceContext->IASetInputLayout(_inputLayout);
+    _deviceContext->VSSetShader(_vertexShader, NULL, 0);
+    _deviceContext->HSSetShader(NULL, NULL, 0);
+    _deviceContext->DSSetShader(NULL, NULL, 0);
+    _deviceContext->GSSetShader(NULL, NULL, 0);
+    _deviceContext->PSSetShaderResources(0, 1, &_edgeSharpnessSRV);
+    _deviceContext->PSSetShader(_pixelShader, NULL, 0);
+    _deviceContext->RSSetState(_rasterizerState);
+    _deviceContext->VSSetConstantBuffers(0, 1, &_constantBuffer);
+
+    if (_displayEdges) {
+        _deviceContext->IASetIndexBuffer(_edgeIndices, DXGI_FORMAT_R32_UINT, 0);
+        _deviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_LINELIST);
+        _deviceContext->DrawIndexed(_numEdges * 2, 0, 0);
+    }
+    if (_displayVertices) {
+        // TODO: need geometry shader to draw bigger points
+        _deviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_POINTLIST);
+        _deviceContext->Draw(_numPoints, 0);
+    }
+
+}
+
+void
+D3D11ControlMeshDisplay::SetTopology(
+    OpenSubdiv::Far::TopologyLevel const &level) {
+    int nEdges = level.GetNumEdges();
+    int nVerts = level.GetNumVertices();
+
+    std::vector<int> edgeIndices;
+    std::vector<float> edgeSharpnesses;
+    std::vector<float> vertSharpnesses;
+
+    edgeIndices.reserve(nEdges * 2);
+    edgeSharpnesses.reserve(nEdges);
+    vertSharpnesses.reserve(nVerts);
+
+    for (int i = 0; i < nEdges; ++i) {
+        OpenSubdiv::Far::ConstIndexArray verts = level.GetEdgeVertices(i);
+        edgeIndices.push_back(verts[0]);
+        edgeIndices.push_back(verts[1]);
+        edgeSharpnesses.push_back(level.GetEdgeSharpness(i));
+    }
+
+    for (int i = 0; i < nVerts; ++i) {
+        vertSharpnesses.push_back(level.GetVertexSharpness(i));
+    }
+
+    _numEdges = nEdges;
+    _numPoints = nVerts;
+
+    ID3D11Device *device = NULL;
+    _deviceContext->GetDevice(&device);
+
+    SAFE_RELEASE(_edgeIndices);
+    // create edge index buffer
+    D3D11_BUFFER_DESC bufferDesc;
+    ZeroMemory(&bufferDesc, sizeof(bufferDesc));
+    bufferDesc.ByteWidth = (int)edgeIndices.size() * sizeof(int);
+    bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+    bufferDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
+    bufferDesc.CPUAccessFlags = 0;
+    bufferDesc.MiscFlags = 0;
+    bufferDesc.StructureByteStride = sizeof(int);
+
+    D3D11_SUBRESOURCE_DATA subData;
+    ZeroMemory(&subData, sizeof(subData));
+    subData.pSysMem = &edgeIndices[0];
+    subData.SysMemPitch = 0;
+    subData.SysMemSlicePitch = 0;
+
+    HRESULT hr = device->CreateBuffer(&bufferDesc, &subData, &_edgeIndices);
+    assert(_edgeIndices);
+
+    // edge sharpness
+    SAFE_RELEASE(_edgeSharpness);
+    SAFE_RELEASE(_edgeSharpnessSRV);
+    ZeroMemory(&bufferDesc, sizeof(bufferDesc));
+    bufferDesc.ByteWidth = (int)edgeSharpnesses.size() * sizeof(float);
+    bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+    bufferDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+    bufferDesc.CPUAccessFlags = 0;
+    bufferDesc.MiscFlags = 0;
+    bufferDesc.StructureByteStride = sizeof(float);
+
+    ZeroMemory(&subData, sizeof(subData));
+    subData.pSysMem = &edgeSharpnesses[0];
+    subData.SysMemPitch = 0;
+    subData.SysMemSlicePitch = 0;
+
+    hr = device->CreateBuffer(&bufferDesc, &subData, &_edgeSharpness);
+    assert(_edgeSharpness);
+
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
+    ZeroMemory(&srvDesc, sizeof(srvDesc));
+    srvDesc.Format = DXGI_FORMAT_R32_FLOAT;
+    srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+    srvDesc.Buffer.NumElements = _numEdges;
+    hr = device->CreateShaderResourceView(_edgeSharpness, &srvDesc, &_edgeSharpnessSRV);
+    assert(_edgeSharpnessSRV);
+}
+

--- a/examples/common/d3d11ControlMeshDisplay.h
+++ b/examples/common/d3d11ControlMeshDisplay.h
@@ -1,0 +1,65 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OPENSUBDIV_EXAMPLES_D3D11_CONTROL_MESH_DISPLAY_H
+#define OPENSUBDIV_EXAMPLES_D3D11_CONTROL_MESH_DISPLAY_H
+
+#include <d3d11.h>
+#include <far/topologyLevel.h>
+
+class D3D11ControlMeshDisplay {
+public:
+    D3D11ControlMeshDisplay(ID3D11DeviceContext *deviceContext);
+    ~D3D11ControlMeshDisplay();
+
+    void Draw(ID3D11Buffer *buffer, int stride,
+              const float *modelViewProjectionMatrix);
+
+    void SetTopology(OpenSubdiv::Far::TopologyLevel const &level);
+
+    bool GetEdgesDisplay() const { return _displayEdges; }
+    void SetEdgesDisplay(bool display) { _displayEdges = display; }
+    bool GetVerticesDisplay() const { return _displayVertices; }
+    void SetVerticesDisplay(bool display) { _displayVertices = display; }
+
+private:
+    bool createProgram();
+
+    bool _displayEdges;
+    bool _displayVertices;
+
+    ID3D11DeviceContext *_deviceContext;
+    ID3D11InputLayout *_inputLayout;
+    ID3D11VertexShader *_vertexShader;
+    ID3D11PixelShader *_pixelShader;
+    ID3D11RasterizerState *_rasterizerState;
+    ID3D11Buffer *_constantBuffer;
+    ID3D11ShaderResourceView *_edgeSharpnessSRV;
+    ID3D11Buffer *_edgeSharpness;
+    ID3D11Buffer *_edgeIndices;
+
+    int _numEdges, _numPoints;
+};
+
+#endif  // OPENSUBDIV_EXAMPLES_D3D11_CONTROL_MESH_DISPLAY_H

--- a/examples/common/glControlMeshDisplay.cpp
+++ b/examples/common/glControlMeshDisplay.cpp
@@ -1,0 +1,224 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#include "glControlMeshDisplay.h"
+#include "../common/glUtils.h"
+
+#include <vector>
+
+GLControlMeshDisplay::GLControlMeshDisplay() :
+    _displayEdges(true), _displayVertices(false),
+    _program(0), _vao(0),
+    _vertSharpness(0), _edgeSharpnessTexture(0), _edgeIndices(0),
+    _numEdges(0), _numPoints(0) {
+}
+
+GLControlMeshDisplay::~GLControlMeshDisplay() {
+    if (_program)       glDeleteProgram(_program);
+    if (_vertSharpness) glDeleteBuffers(1, &_vertSharpness);
+    if (_edgeSharpnessTexture) glDeleteTextures(1, &_edgeSharpnessTexture);
+    if (_edgeIndices)   glDeleteBuffers(1, &_edgeIndices);
+    if (_vao)           glDeleteVertexArrays(1, &_vao);
+}
+
+bool
+GLControlMeshDisplay::createProgram() {
+    if (_program != 0) glDeleteProgram(_program);
+
+    const std::string glsl_version = GLUtils::GetShaderVersionInclude();
+
+    static const std::string vsSrc =
+        glsl_version +
+        "in vec3 position;                                         \n"
+        "in float vertSharpness;                                   \n"
+        "out float sharpness;                                      \n"
+        "uniform mat4 mvpMatrix;                                   \n"
+        "void main() {                                             \n"
+        "  sharpness = vertSharpness;                              \n"
+        "  gl_Position = mvpMatrix * vec4(position, 1);            \n"
+        "}                                                         \n";
+
+    static const std::string fsSrc =
+        glsl_version +
+        "in float sharpness;                                       \n"
+        "out vec4 color;                                           \n"
+        "uniform int drawMode = 0;                                 \n"
+        "uniform samplerBuffer edgeSharpness;                      \n"
+        "vec4 sharpnessToColor(float s) {                          \n"
+        "  //  0.0       2.0       4.0                             \n"
+        "  // green --- yellow --- red                             \n"
+        "  return vec4(min(1, s * 0.5),                            \n"
+        "              min(1, 2 - s * 0.5),                        \n"
+        "              0, 1);                                      \n"
+        "}                                                         \n"
+        "void main() {                                             \n"
+        "  float sharp = sharpness;                                \n"
+        "  if (drawMode == 1) {                                    \n"
+        "    sharp = texelFetch(edgeSharpness, gl_PrimitiveID).x;  \n"
+        "  }                                                       \n"
+        "  color = sharpnessToColor(sharp);                        \n"
+        "}                                                         \n";
+
+    GLuint vertexShader =
+        GLUtils::CompileShader(GL_VERTEX_SHADER, vsSrc.c_str());
+    GLuint fragmentShader =
+        GLUtils::CompileShader(GL_FRAGMENT_SHADER, fsSrc.c_str());
+
+    _program = glCreateProgram();
+    glAttachShader(_program, vertexShader);
+    glAttachShader(_program, fragmentShader);
+    glLinkProgram(_program);
+
+    GLint status;
+    glGetProgramiv(_program, GL_LINK_STATUS, &status);
+    if (status == GL_FALSE) {
+        GLint infoLogLength;
+        glGetProgramiv(_program, GL_INFO_LOG_LENGTH, &infoLogLength);
+        char *infoLog = new char[infoLogLength];
+        glGetProgramInfoLog(_program, infoLogLength, NULL, infoLog);
+        printf("%s\n", infoLog);
+        delete[] infoLog;
+        exit(1);
+        return false;
+    }
+
+    _uniformMvpMatrix =
+        glGetUniformLocation(_program, "mvpMatrix");
+    _uniformDrawMode =
+        glGetUniformLocation(_program, "drawMode");
+    _uniformEdgeSharpness =
+        glGetUniformLocation(_program, "edgeSharpness");
+    return true;
+}
+
+void
+GLControlMeshDisplay::Draw(GLuint vbo, GLint stride,
+                           const float *modelViewProjectionMatrix) {
+    if (_program == 0) {
+        createProgram();
+        if (_program == 0) return;
+    }
+
+    if (_vao == 0) {
+        glGenVertexArrays(1, &_vao);
+    }
+    glBindVertexArray(_vao);
+
+    glUseProgram(_program);
+
+    glUniformMatrix4fv(_uniformMvpMatrix,
+                       1, GL_FALSE, modelViewProjectionMatrix);
+    glUniform1i(_uniformEdgeSharpness, 0);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_BUFFER, _edgeSharpnessTexture);
+
+    // bind vbo to points
+    glEnableVertexAttribArray(0);
+    glEnableVertexAttribArray(1);
+
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, stride, 0);
+    glBindBuffer(GL_ARRAY_BUFFER, _vertSharpness);
+    glVertexAttribPointer(1, 1, GL_FLOAT, GL_FALSE, 0, 0);
+
+    glPointSize(10.0);
+
+    // draw edges
+    if (_displayEdges) {
+        glUniform1i(_uniformDrawMode, 1);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _edgeIndices);
+        glDrawElements(GL_LINES, _numEdges*2, GL_UNSIGNED_INT, 0);
+    }
+
+    // draw vertices
+    if (_displayVertices) {
+        glUniform1i(_uniformDrawMode, 0);
+        glDrawArrays(GL_POINTS, 0, _numPoints);
+    }
+
+    glPointSize(1.0f);
+
+    glDisableVertexAttribArray(0);
+    glDisableVertexAttribArray(1);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
+
+    glUseProgram(0);
+}
+
+void
+GLControlMeshDisplay::SetTopology(OpenSubdiv::Far::TopologyLevel const &level) {
+    int nEdges = level.GetNumEdges();
+    int nVerts = level.GetNumVertices();
+
+    std::vector<int> edgeIndices;
+    std::vector<float> edgeSharpnesses;
+    std::vector<float> vertSharpnesses;
+
+    edgeIndices.reserve(nEdges * 2);
+    edgeSharpnesses.reserve(nEdges);
+    vertSharpnesses.reserve(nVerts);
+
+    for (int i = 0; i < nEdges; ++i) {
+        OpenSubdiv::Far::ConstIndexArray verts = level.GetEdgeVertices(i);
+        edgeIndices.push_back(verts[0]);
+        edgeIndices.push_back(verts[1]);
+        edgeSharpnesses.push_back(level.GetEdgeSharpness(i));
+    }
+
+    for (int i = 0; i < nVerts; ++i) {
+        vertSharpnesses.push_back(level.GetVertexSharpness(i));
+    }
+
+    if (_vertSharpness == 0) glGenBuffers(1, &_vertSharpness);
+    if (_edgeIndices == 0)   glGenBuffers(1, &_edgeIndices);
+    if (_edgeSharpnessTexture == 0) glGenTextures(1, &_edgeSharpnessTexture);
+    GLuint buffer = 0;
+    glGenBuffers(1, &buffer);
+
+    glBindBuffer(GL_ARRAY_BUFFER, _vertSharpness);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(float)*nVerts,
+                 &vertSharpnesses[0], GL_STATIC_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, _edgeIndices);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(int)*nEdges*2,
+                 &edgeIndices[0], GL_STATIC_DRAW);
+
+    glBindBuffer(GL_ARRAY_BUFFER, buffer);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(float)*nEdges,
+                 &edgeSharpnesses[0], GL_STATIC_DRAW);
+
+    glBindTexture(GL_TEXTURE_BUFFER, _edgeSharpnessTexture);
+    glTexBuffer(GL_TEXTURE_BUFFER, GL_R32F, buffer);
+    glBindTexture(GL_TEXTURE_BUFFER, 0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    glDeleteBuffers(1, &buffer);
+
+    _numEdges = nEdges;
+    _numPoints = nVerts;
+}
+

--- a/examples/common/glControlMeshDisplay.h
+++ b/examples/common/glControlMeshDisplay.h
@@ -1,0 +1,65 @@
+//
+//   Copyright 2015 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OPENSUBDIV_EXAMPLES_GL_CONTROL_MESH_DISPLAY_H
+#define OPENSUBDIV_EXAMPLES_GL_CONTROL_MESH_DISPLAY_H
+
+#include <osd/opengl.h>
+#include <far/topologyLevel.h>
+
+class GLControlMeshDisplay {
+public:
+    GLControlMeshDisplay();
+    ~GLControlMeshDisplay();
+
+    void Draw(GLuint pointsVBO, GLint stride,
+              const float *modelViewProjectionMatrix);
+
+    void SetTopology(OpenSubdiv::Far::TopologyLevel const &level);
+
+    bool GetEdgesDisplay() const { return _displayEdges; }
+    void SetEdgesDisplay(bool display) { _displayEdges = display; }
+    bool GetVerticesDisplay() const { return _displayVertices; }
+    void SetVerticesDisplay(bool display) { _displayVertices = display; }
+
+private:
+    bool createProgram();
+
+    bool _displayEdges;
+    bool _displayVertices;
+
+    GLuint _program;
+    GLuint _uniformMvpMatrix;
+    GLuint _uniformDrawMode;
+    GLuint _uniformEdgeSharpness;
+
+    GLuint _vao;
+    GLuint _vertSharpness;
+    GLuint _edgeSharpnessTexture;
+    GLuint _edgeIndices;
+
+    int _numEdges, _numPoints;
+};
+
+#endif  // OPENSUBDIV_EXAMPLES_GL_CONTROL_MESH_DISPLAY_H

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -63,6 +63,7 @@ OpenSubdiv::Osd::D3D11LegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 #include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
+#include "../common/d3d11ControlMeshDisplay.h"
 #include "../common/d3d11Hud.h"
 #include "../common/d3d11Utils.h"
 #include "../common/d3d11ShaderCache.h"
@@ -100,8 +101,8 @@ enum EndCap      { kEndCapNone = 0,
                    kEndCapGregoryBasis,
                    kEndCapLegacyGregory };
 
-enum HudCheckBox { kHUD_CB_DISPLAY_CAGE_EDGES,
-                   kHUD_CB_DISPLAY_CAGE_VERTS,
+enum HudCheckBox { kHUD_CB_DISPLAY_CONTROL_MESH_EDGES,
+                   kHUD_CB_DISPLAY_CONTROL_MESH_VERTS,
                    kHUD_CB_ANIMATE_VERTICES,
                    kHUD_CB_DISPLAY_PATCH_COLOR,
                    kHUD_CB_DISPLAY_PATCH_CVs,
@@ -122,8 +123,6 @@ int   g_freeze = 0,
       g_adaptive = 1,
       g_endCap = kEndCapBSplineBasis,
       g_singleCreasePatch = 1,
-      g_drawCageEdges = 1,
-      g_drawCageVertices = 0,
       g_drawPatchCVs = 0,
       g_drawNormals = 0,
       g_mbutton[3] = {0, 0, 0};
@@ -146,6 +145,8 @@ int   g_width = 1024,
       g_height = 1024;
 
 D3D11hud *g_hud = NULL;
+D3D11ControlMeshDisplay *g_controlMeshDisplay = NULL;
+float g_modelViewProjectionMatrix[16];
 
 // performance
 float g_cpuTime = 0;
@@ -163,10 +164,6 @@ int g_tessLevel = 1;
 int g_tessLevelMin = 1;
 int g_kernel = kCPU;
 float g_moveScale = 0.0f;
-
-std::vector<int> g_coarseEdges;
-std::vector<float> g_coarseEdgeSharpness;
-std::vector<float> g_coarseVertexSharpness;
 
 ID3D11Device * g_pd3dDevice = NULL;
 ID3D11DeviceContext * g_pd3dDeviceContext = NULL;
@@ -278,24 +275,9 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level, int kernel, Scheme scheme=
 
     // save coarse topology (used for coarse mesh drawing)
     Far::TopologyLevel const & refBaseLevel = refiner->GetLevel(0);
+    g_controlMeshDisplay->SetTopology(refBaseLevel);
 
-    int nedges = refBaseLevel.GetNumEdges(),
-        nverts = refBaseLevel.GetNumVertices();
-
-    g_coarseEdges.resize(nedges*2);
-    g_coarseEdgeSharpness.resize(nedges);
-    g_coarseVertexSharpness.resize(nverts);
-
-    for(int i=0; i<nedges; ++i) {
-        IndexArray verts = refBaseLevel.GetEdgeVertices(i);
-        g_coarseEdges[i*2  ]=verts[0];
-        g_coarseEdges[i*2+1]=verts[1];
-        g_coarseEdgeSharpness[i]=refBaseLevel.GetEdgeSharpness(i);
-    }
-
-    for(int i=0; i<nverts; ++i) {
-        g_coarseVertexSharpness[i]=refBaseLevel.GetVertexSharpness(i);
-    }
+    int nverts = refBaseLevel.GetNumVertices();
 
     g_orgPositions=shape->verts;
 
@@ -689,6 +671,8 @@ bindProgram(Effect effect, OpenSubdiv::Osd::PatchArray const & patch) {
         perspective(pData->ProjectionMatrix, 45.0, aspect, 0.01f, 500.0);
         multMatrix(pData->ModelViewProjectionMatrix, pData->ModelViewMatrix, pData->ProjectionMatrix);
 
+        memcpy(g_modelViewProjectionMatrix, pData->ModelViewProjectionMatrix, sizeof(float) * 16);
+
         g_pd3dDeviceContext->Unmap( g_pcbPerFrame, 0 );
     }
 
@@ -884,6 +868,9 @@ display() {
             patch.GetIndexBase(), 0);
     }
 
+    // draw the control mesh
+    g_controlMeshDisplay->Draw(buffer, 6, g_modelViewProjectionMatrix);
+
     g_fpsTimer.Stop();
     float elapsed = (float)g_fpsTimer.GetElapsed();
     g_fpsTimer.Start();
@@ -969,6 +956,9 @@ quit() {
 
     if (g_hud)
         delete g_hud;
+
+    if (g_controlMeshDisplay)
+        delete g_controlMeshDisplay;
 
     SAFE_RELEASE(g_pRasterizerState);
     SAFE_RELEASE(g_pInputLayout);
@@ -1097,11 +1087,11 @@ callbackSingleCreasePatch(bool checked, int /* a */) {
 static void
 callbackCheckBox(bool checked, int button) {
     switch (button) {
-    case kHUD_CB_DISPLAY_CAGE_EDGES:
-        g_drawCageEdges = checked;
+    case kHUD_CB_DISPLAY_CONTROL_MESH_EDGES:
+        g_controlMeshDisplay->SetEdgesDisplay(checked);
         break;
-    case kHUD_CB_DISPLAY_CAGE_VERTS:
-        g_drawCageVertices = checked;
+    case kHUD_CB_DISPLAY_CONTROL_MESH_VERTS:
+        g_controlMeshDisplay->SetVerticesDisplay(checked);
         break;
     case kHUD_CB_ANIMATE_VERTICES:
         g_moveScale = checked;
@@ -1161,23 +1151,28 @@ initHUD() {
     g_hud->AddPullDownButton(shading_pulldown, "Shaded",      1, g_displayStyle==kShaded);
     g_hud->AddPullDownButton(shading_pulldown, "Wire+Shaded", 2, g_displayStyle==kWireShaded);
 
-//    g_hud->AddCheckBox("Cage Edges (H)",         true,  10, 10, callbackDisplayCageEdges, 0, 'H');
-//    g_hud->AddCheckBox("Cage Verts (J)",         false, 10, 30, callbackDisplayCageVertices, 0, 'J');
-//    g_hud->AddCheckBox("Show normal vector (E)", false, 10, 10, callbackDisplayNormal, 0, 'E');
+    g_hud->AddCheckBox("Control edges (H)",
+                       g_controlMeshDisplay->GetEdgesDisplay(),
+                       10, 10, callbackCheckBox,
+                       kHUD_CB_DISPLAY_CONTROL_MESH_EDGES, 'H');
+    g_hud->AddCheckBox("Control vertices (J)",
+                       g_controlMeshDisplay->GetVerticesDisplay(),
+                       10, 30, callbackCheckBox,
+                       kHUD_CB_DISPLAY_CONTROL_MESH_VERTS, 'J');
 
-    g_hud->AddCheckBox("Patch CVs (L)",             false,                    10, 10,  callbackCheckBox, kHUD_CB_DISPLAY_PATCH_CVs, 'L');
-    g_hud->AddCheckBox("Patch Color (P)",           true,                     10, 30,  callbackCheckBox, kHUD_CB_DISPLAY_PATCH_COLOR, 'P');
-    g_hud->AddCheckBox("Animate vertices (M)",      g_moveScale != 0,         10, 50,  callbackCheckBox, kHUD_CB_ANIMATE_VERTICES, 'M');
-    g_hud->AddCheckBox("Freeze (spc)",              false,                    10, 70,  callbackCheckBox, kHUD_CB_FREEZE, ' ');
-    g_hud->AddCheckBox("Screen space LOD (V)",      g_screenSpaceTess != 0,   10, 110,  callbackCheckBox, kHUD_CB_VIEW_LOD, 'V');
-    g_hud->AddCheckBox("Fractional spacing (T)",    g_fractionalSpacing != 0, 10, 130, callbackCheckBox, kHUD_CB_FRACTIONAL_SPACING, 'T');
-    g_hud->AddCheckBox("Frustum Patch Culling (B)", g_patchCull != 0,         10, 150, callbackCheckBox, kHUD_CB_PATCH_CULL, 'B');
+    g_hud->AddCheckBox("Patch CVs (L)",             false,                    10, 50,  callbackCheckBox, kHUD_CB_DISPLAY_PATCH_CVs, 'L');
+    g_hud->AddCheckBox("Patch Color (P)",           true,                     10, 70,  callbackCheckBox, kHUD_CB_DISPLAY_PATCH_COLOR, 'P');
+    g_hud->AddCheckBox("Animate vertices (M)",      g_moveScale != 0,         10, 110,  callbackCheckBox, kHUD_CB_ANIMATE_VERTICES, 'M');
+    g_hud->AddCheckBox("Freeze (spc)",              false,                    10, 130,  callbackCheckBox, kHUD_CB_FREEZE, ' ');
+    g_hud->AddCheckBox("Screen space LOD (V)",      g_screenSpaceTess != 0,   10, 150,  callbackCheckBox, kHUD_CB_VIEW_LOD, 'V');
+    g_hud->AddCheckBox("Fractional spacing (T)",    g_fractionalSpacing != 0, 10, 170, callbackCheckBox, kHUD_CB_FRACTIONAL_SPACING, 'T');
+    g_hud->AddCheckBox("Frustum Patch Culling (B)", g_patchCull != 0,         10, 190, callbackCheckBox, kHUD_CB_PATCH_CULL, 'B');
 
-    g_hud->AddCheckBox("Adaptive (`)", true, 10, 190, callbackAdaptive, 0, '`');
-    g_hud->AddCheckBox("Single Crease Patch (S)", g_singleCreasePatch!=0, 10, 210, callbackSingleCreasePatch, 0, 'S');
+    g_hud->AddCheckBox("Adaptive (`)", true, 10, 230, callbackAdaptive, 0, '`');
+    g_hud->AddCheckBox("Single Crease Patch (S)", g_singleCreasePatch!=0, 10, 250, callbackSingleCreasePatch, 0, 'S');
 
     int endcap_pulldown = g_hud->AddPullDown(
-        "End cap (E)", 10, 230, 200, callbackEndCap, 'E');
+        "End cap (E)", 10, 270, 200, callbackEndCap, 'E');
     g_hud->AddPullDownButton(endcap_pulldown,"None",
                              kEndCapNone,
                              g_endCap == kEndCapNone);
@@ -1194,7 +1189,7 @@ initHUD() {
     for (int i = 1; i < 11; ++i) {
         char level[16];
         sprintf(level, "Lv. %d", i);
-        g_hud->AddRadioButton(3, level, i==2, 10, 230+i*20, callbackLevel, i, '0'+(i%10));
+        g_hud->AddRadioButton(3, level, i==2, 10, 290+i*20, callbackLevel, i, '0'+(i%10));
     }
 
     int shapes_pulldown = g_hud->AddPullDown("Shape (N)", -300, 10, 300, callbackModel, 'n');
@@ -1317,6 +1312,9 @@ initD3D11(HWND hWnd) {
 
     g_pd3dDevice->CreateDepthStencilState(&depthStencilDesc, &g_pDepthStencilState);
     assert(g_pDepthStencilState);
+
+    // initialize control mesh display
+    g_controlMeshDisplay = new D3D11ControlMeshDisplay(g_pd3dDeviceContext);
 
     return true;
 }

--- a/examples/dxViewer/init_shapes.h
+++ b/examples/dxViewer/init_shapes.h
@@ -27,76 +27,97 @@
 
 struct ShapeDesc {
 
-    ShapeDesc(char const * iname, std::string const & idata, Scheme ischeme) :
-        name(iname), data(idata), scheme(ischeme) { }
+    ShapeDesc(char const * iname, std::string const & idata, Scheme ischeme,
+        bool iIsLeftHanded = false) :
+        name(iname), data(idata), scheme(ischeme), isLeftHanded(iIsLeftHanded) { }
 
     std::string name,
-                data;
+        data;
     Scheme      scheme;
+    bool        isLeftHanded;
 };
 
 static std::vector<ShapeDesc> g_defaultShapes;
 
 //------------------------------------------------------------------------------
 static void initShapes() {
-//    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear) );
+    g_defaultShapes.push_back(ShapeDesc("catmark_cube_corner0", catmark_cube_corner0, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_cube_corner1", catmark_cube_corner1, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_cube_corner2", catmark_cube_corner2, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_cube_corner3", catmark_cube_corner3, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_cube_corner4", catmark_cube_corner4, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_cube_creases0", catmark_cube_creases0, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_cube_creases1", catmark_cube_creases1, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_cube_creases2", catmark_cube_creases2, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_cube", catmark_cube, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_dart_edgecorner", catmark_dart_edgecorner, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_dart_edgeonly", catmark_dart_edgeonly, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_edgecorner", catmark_edgecorner, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_edgeonly", catmark_edgeonly, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_chaikin0", catmark_chaikin0, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_chaikin1", catmark_chaikin1, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_chaikin2", catmark_chaikin2, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_fan", catmark_fan, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_flap", catmark_flap, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_flap2", catmark_flap2, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_fvar_bound0", catmark_fvar_bound0, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_fvar_bound1", catmark_fvar_bound1, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_fvar_bound2", catmark_fvar_bound2, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_gregory_test0", catmark_gregory_test0, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_gregory_test1", catmark_gregory_test1, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_gregory_test2", catmark_gregory_test2, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_gregory_test3", catmark_gregory_test3, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_gregory_test4", catmark_gregory_test4, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_gregory_test5", catmark_gregory_test5, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_gregory_test6", catmark_gregory_test6, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_gregory_test7", catmark_gregory_test7, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_hole_test1", catmark_hole_test1, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_hole_test2", catmark_hole_test2, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_hole_test3", catmark_hole_test3, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_hole_test4", catmark_hole_test4, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_lefthanded", catmark_lefthanded, kCatmark, true /*isLeftHanded*/));
+    g_defaultShapes.push_back(ShapeDesc("catmark_righthanded", catmark_righthanded, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_pole8", catmark_pole8, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_pole64", catmark_pole64, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_pole360", catmark_pole360, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_nonman_quadpole8", catmark_nonman_quadpole8, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_nonman_quadpole64", catmark_nonman_quadpole64, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_nonman_quadpole360", catmark_nonman_quadpole360, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_pyramid_creases0", catmark_pyramid_creases0, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_pyramid_creases1", catmark_pyramid_creases1, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_pyramid", catmark_pyramid, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_tent_creases0", catmark_tent_creases0, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_tent_creases1", catmark_tent_creases1, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_tent", catmark_tent, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_torus", catmark_torus, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_torus_creases0", catmark_torus_creases0, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_single_crease", catmark_single_crease, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_smoothtris0", catmark_smoothtris0, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_smoothtris1", catmark_smoothtris1, kCatmark));
+    //    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit0",    catmark_square_hedit0,    kCatmark ) );
+    //    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit1",    catmark_square_hedit1,    kCatmark ) );
+    //    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit2",    catmark_square_hedit2,    kCatmark ) );
+    //    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit3",    catmark_square_hedit3,    kCatmark ) );
+    g_defaultShapes.push_back(ShapeDesc("catmark_bishop", catmark_bishop, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_car", catmark_car, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_helmet", catmark_helmet, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_pawn", catmark_pawn, kCatmark));
+    g_defaultShapes.push_back(ShapeDesc("catmark_rook", catmark_rook, kCatmark));
 
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner0",     catmark_cube_corner0,     kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner1",     catmark_cube_corner1,     kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner2",     catmark_cube_corner2,     kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner3",     catmark_cube_corner3,     kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner4",     catmark_cube_corner4,     kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_edgecorner",       catmark_edgecorner,       kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_edgeonly",         catmark_edgeonly,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin0",         catmark_chaikin0,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin1",         catmark_chaikin1,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin2",         catmark_chaikin2,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_fan",              catmark_fan,              kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap",             catmark_flap,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap2",            catmark_flap2,            kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test1",    catmark_gregory_test1,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test2",    catmark_gregory_test2,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test3",    catmark_gregory_test3,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test4",    catmark_gregory_test4,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test5",    catmark_gregory_test5,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test6",    catmark_gregory_test6,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test7",    catmark_gregory_test7,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_hole_test1",       catmark_hole_test1,       kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_hole_test2",       catmark_hole_test2,       kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_pyramid_creases0", catmark_pyramid_creases0, kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_pyramid_creases1", catmark_pyramid_creases1, kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_pyramid",          catmark_pyramid,          kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_tent_creases0",    catmark_tent_creases0,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_tent_creases1",    catmark_tent_creases1 ,   kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_tent",             catmark_tent,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_torus",            catmark_torus,            kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_torus_creases0",   catmark_torus_creases0,   kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit0",    catmark_square_hedit0,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit1",    catmark_square_hedit1,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit2",    catmark_square_hedit2,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit3",    catmark_square_hedit3,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_bishop",           catmark_bishop,           kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_car",              catmark_car,              kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_helmet",           catmark_helmet,           kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_pawn",             catmark_pawn,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_rook",             catmark_rook,             kCatmark ) );
+    g_defaultShapes.push_back(ShapeDesc("bilinear_cube", bilinear_cube, kBilinear));
 
-//    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
-
-//    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases0",       loop_cube_creases0,       kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases1",       loop_cube_creases1,       kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_cube",                loop_cube,                kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgecorner",   loop_saddle_edgecorner,   kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgeonly",     loop_saddle_edgeonly,     kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_chaikin0",            loop_chaikin0,            kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_chaikin1",            loop_chaikin1,            kLoop ) );
+    g_defaultShapes.push_back(ShapeDesc("loop_cube_creases0", loop_cube_creases0, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_cube_creases1", loop_cube_creases1, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_cube", loop_cube, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_icosahedron", loop_icosahedron, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_saddle_edgecorner", loop_saddle_edgecorner, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_saddle_edgeonly", loop_saddle_edgeonly, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_triangle_edgeonly", loop_triangle_edgeonly, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_chaikin0", loop_chaikin0, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_chaikin1", loop_chaikin1, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_pole8", loop_pole8, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_pole64", loop_pole64, kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_pole360", loop_pole360, kLoop));
+    
 }
-//------------------------------------------------------------------------------

--- a/examples/glEvalLimit/particles.cpp
+++ b/examples/glEvalLimit/particles.cpp
@@ -271,7 +271,7 @@ STParticles::~STParticles() {
 void
 STParticles::Update(float deltaTime) {
 
-    if (fabs(GetSpeed()) < 0.001f) return;
+    if (deltaTime == 0) return;
     float speed = GetSpeed() * std::max(0.001f, std::min(deltaTime, 0.5f));
 
     _patchCoords.clear();

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -32,6 +32,7 @@ GLFWmonitor* g_primary=0;
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"
+#include "../common/glControlMeshDisplay.h"
 
 #include <far/patchTableFactory.h>
 #include <far/ptexIndices.h>
@@ -97,6 +98,12 @@ enum KernelType { kCPU = 0,
                   kGLXFB,
                   kGLCompute };
 
+enum HudCheckBox { kHUD_CB_DISPLAY_CONTROL_MESH_EDGES,
+                   kHUD_CB_DISPLAY_CONTROL_MESH_VERTS,
+                   kHUD_CB_ANIMATE_VERTICES,
+                   kHUD_CB_FREEZE,
+                   kHUD_CB_BILINEAR };
+
 int g_kernel = kCPU,
     g_isolationLevel = 5; // max level of extraordinary feature isolation
 
@@ -104,8 +111,6 @@ int   g_running = 1,
       g_width = 1024,
       g_height = 1024,
       g_fullscreen = 0,
-      g_drawCageEdges = 1,
-      g_drawCageVertices = 1,
       g_prev_x = 0,
       g_prev_y = 0,
       g_mbutton[3] = {0, 0, 0},
@@ -136,21 +141,13 @@ Stopwatch g_fpsTimer;
 std::vector<float> g_orgPositions;
 std::vector<float> g_positions;
 
-std::vector<int>   g_coarseEdges;
-std::vector<float> g_coarseEdgeSharpness;
-std::vector<float> g_coarseVertexSharpness;
-
 int g_nsamples=2000,
     g_nsamplesDrawn=0;
 
-GLuint g_cageEdgeVAO = 0,
-       g_cageEdgeVBO = 0,
-       g_cageVertexVAO = 0,
-       g_cageVertexVBO = 0,
-       g_stencilsVAO = 0;
+GLuint g_stencilsVAO = 0;
 
 GLhud g_hud;
-
+GLControlMeshDisplay g_controlMeshDisplay;
 
 //------------------------------------------------------------------------------
 
@@ -166,6 +163,7 @@ public:
     virtual ~StencilOutputBase() {}
     virtual void UpdateData(const float *src, int startVertex, int numVertices) = 0;
     virtual void EvalStencils() = 0;
+    virtual GLuint BindSrcBuffer() = 0;
     virtual GLuint BindDstBuffer() = 0;
     virtual int GetNumStencils() const = 0;
 };
@@ -222,6 +220,9 @@ public:
                                 _stencils,
                                 evalInstance,
                                 _deviceContext);
+    }
+    virtual GLuint BindSrcBuffer() {
+        return _srcData->BindVBO();
     }
     virtual GLuint BindDstBuffer() {
         return _dstData->BindVBO();
@@ -288,7 +289,6 @@ updateGeom() {
 static void
 createMesh(ShapeDesc const & shapeDesc, int level) {
 
-    typedef Far::ConstIndexArray IndexArray;
     typedef Far::LimitStencilTableFactory::LocationArray LocationArray;
 
     Shape const * shape = Shape::parseObj(shapeDesc.data.c_str(), shapeDesc.scheme);
@@ -304,25 +304,11 @@ createMesh(ShapeDesc const & shapeDesc, int level) {
     // save coarse topology (used for coarse mesh drawing)
     OpenSubdiv::Far::TopologyLevel const & refBaseLevel = refiner->GetLevel(0);
 
-    int nedges = refBaseLevel.GetNumEdges(),
-        nverts = refBaseLevel.GetNumVertices();
+    g_controlMeshDisplay.SetTopology(refBaseLevel);
+    int nverts = refBaseLevel.GetNumVertices();
 
-    g_coarseEdges.resize(nedges*2);
-    g_coarseEdgeSharpness.resize(nedges);
-    g_coarseVertexSharpness.resize(nverts);
-
-    for(int i=0; i<nedges; ++i) {
-        IndexArray verts = refBaseLevel.GetEdgeVertices(i);
-        g_coarseEdges[i*2  ]=verts[0];
-        g_coarseEdges[i*2+1]=verts[1];
-        g_coarseEdgeSharpness[i]=refBaseLevel.GetEdgeSharpness(i);
-    }
-
-    for(int i=0; i<nverts; ++i) {
-        g_coarseVertexSharpness[i]=refBaseLevel.GetVertexSharpness(i);
-    }
-
-    g_orgPositions=shape->verts;
+    // save rest pose
+    g_orgPositions = shape->verts;
 
     if (g_bilinear) {
         Far::TopologyRefiner::UniformOptions options(level);
@@ -370,14 +356,14 @@ createMesh(ShapeDesc const & shapeDesc, int level) {
 
     delete g_stencilOutput;
     if (g_kernel == kCPU) {
-        g_stencilOutput = new StencilOutput<Osd::CpuVertexBuffer,
+        g_stencilOutput = new StencilOutput<Osd::CpuGLVertexBuffer,
                                             Osd::CpuGLVertexBuffer,
                                             Far::LimitStencilTable,
                                             Osd::CpuEvaluator>(
                                                 g_controlStencils, nverts);
 #ifdef OPENSUBDIV_HAS_OPENMP
     } else if (g_kernel == kOPENMP) {
-        g_stencilOutput = new StencilOutput<Osd::CpuVertexBuffer,
+        g_stencilOutput = new StencilOutput<Osd::CpuGLVertexBuffer,
                                             Osd::CpuGLVertexBuffer,
                                             Far::LimitStencilTable,
                                             Osd::OmpEvaluator>(
@@ -385,7 +371,7 @@ createMesh(ShapeDesc const & shapeDesc, int level) {
 #endif
 #ifdef OPENSUBDIV_HAS_TBB
     } else if (g_kernel == kTBB) {
-        g_stencilOutput = new StencilOutput<Osd::CpuVertexBuffer,
+        g_stencilOutput = new StencilOutput<Osd::CpuGLVertexBuffer,
                                             Osd::CpuGLVertexBuffer,
                                             Far::LimitStencilTable,
                                             Osd::TbbEvaluator>(
@@ -393,7 +379,7 @@ createMesh(ShapeDesc const & shapeDesc, int level) {
 #endif
 #ifdef OPENSUBDIV_HAS_CUDA
     } else if (g_kernel == kCUDA) {
-        g_stencilOutput = new StencilOutput<Osd::CudaVertexBuffer,
+        g_stencilOutput = new StencilOutput<Osd::CudaGLVertexBuffer,
                                             Osd::CudaGLVertexBuffer,
                                             Osd::CudaStencilTable,
                                             Osd::CudaEvaluator>(
@@ -402,7 +388,7 @@ createMesh(ShapeDesc const & shapeDesc, int level) {
 #ifdef OPENSUBDIV_HAS_OPENCL
     } else if (g_kernel == kCL) {
         static Osd::EvaluatorCacheT<Osd::CLEvaluator> clEvaluatorCache;
-        g_stencilOutput = new StencilOutput<Osd::CLVertexBuffer,
+        g_stencilOutput = new StencilOutput<Osd::CLGLVertexBuffer,
                                             Osd::CLGLVertexBuffer,
                                             Osd::CLStencilTable,
                                             Osd::CLEvaluator,
@@ -571,8 +557,7 @@ private:
 
 };
 
-GLSLProgram g_cageProgram,
-            g_samplesProgram;
+GLSLProgram g_samplesProgram;
 
 
 //------------------------------------------------------------------------------
@@ -584,35 +569,6 @@ linkDefaultPrograms() {
 #else
     #define GLSL_VERSION_DEFINE "#version 150\n"
 #endif
-
-    {   // setup control cage program
-        static const char *vsSrc =
-            GLSL_VERSION_DEFINE
-            "in vec3 position;\n"
-            "in vec3 color;\n"
-            "out vec4 fragColor;\n"
-            "uniform mat4 ModelViewProjectionMatrix;\n"
-            "void main() {\n"
-            "  fragColor = vec4(color, 1);\n"
-            "  gl_Position = ModelViewProjectionMatrix * "
-            "                  vec4(position, 1);\n"
-            "}\n";
-
-        static const char *fsSrc =
-            GLSL_VERSION_DEFINE
-            "in vec4 fragColor;\n"
-            "out vec4 color;\n"
-            "void main() {\n"
-            "  color = fragColor;\n"
-            "}\n";
-
-        g_cageProgram.SetVertexShaderSource(vsSrc);
-        g_cageProgram.SetFragShaderSource(fsSrc);
-
-        g_cageProgram.AddAttribute( "position",3 );
-        g_cageProgram.AddAttribute( "color",3 );
-    }
-
     {   // setup samples program
         //
         // this shader takes position, uTangent and vTangent for each point
@@ -693,97 +649,6 @@ linkDefaultPrograms() {
 
     return true;
 }
-//------------------------------------------------------------------------------
-static inline void
-setSharpnessColor(float s, float *r, float *g, float *b) {
-
-    //  0.0       2.0       4.0
-    // green --- yellow --- red
-    *r = std::min(1.0f, s * 0.5f);
-    *g = std::min(1.0f, 2.0f - s*0.5f);
-    *b = 0;
-}
-
-//------------------------------------------------------------------------------
-static void
-drawCageEdges() {
-
-    g_cageProgram.Use( );
-
-    glUniformMatrix4fv(g_cageProgram.GetUniformModelViewProjectionMatrix(),
-                       1, GL_FALSE, g_transformData.ModelViewProjectionMatrix);
-
-    std::vector<float> vbo;
-    vbo.reserve(g_coarseEdges.size() * 6);
-
-    float r, g, b;
-    for (int i = 0; i < (int)g_coarseEdges.size(); i+=2) {
-        setSharpnessColor(g_coarseEdgeSharpness[i/2], &r, &g, &b);
-        for (int j = 0; j < 2; ++j) {
-            vbo.push_back(g_positions[g_coarseEdges[i+j]*3]);
-            vbo.push_back(g_positions[g_coarseEdges[i+j]*3+1]);
-            vbo.push_back(g_positions[g_coarseEdges[i+j]*3+2]);
-            vbo.push_back(r);
-            vbo.push_back(g);
-            vbo.push_back(b);
-        }
-    }
-
-    glBindVertexArray(g_cageEdgeVAO);
-
-    glBindBuffer(GL_ARRAY_BUFFER, g_cageEdgeVBO);
-    glBufferData(GL_ARRAY_BUFFER, (int)vbo.size() * sizeof(float), &vbo[0],
-                 GL_STATIC_DRAW);
-
-    g_cageProgram.EnableVertexAttributes();
-
-    glDrawArrays(GL_LINES, 0, (int)g_coarseEdges.size());
-
-    glBindVertexArray(0);
-    glUseProgram(0);
-}
-
-//------------------------------------------------------------------------------
-static void
-drawCageVertices() {
-
-    g_cageProgram.Use( );
-
-    glUniformMatrix4fv(g_cageProgram.GetUniformModelViewProjectionMatrix(),
-                       1, GL_FALSE, g_transformData.ModelViewProjectionMatrix);
-
-    int numPoints = (int)g_positions.size()/3;
-    std::vector<float> vbo;
-    vbo.reserve(numPoints*6);
-
-    float r, g, b;
-    for (int i = 0; i < numPoints; ++i) {
-
-        setSharpnessColor(g_coarseVertexSharpness[i], &r, &g, &b);
-
-        vbo.push_back(g_positions[i*3+0]);
-        vbo.push_back(g_positions[i*3+1]);
-        vbo.push_back(g_positions[i*3+2]);
-        vbo.push_back(r);
-        vbo.push_back(g);
-        vbo.push_back(b);
-    }
-
-    glBindVertexArray(g_cageVertexVAO);
-
-    glBindBuffer(GL_ARRAY_BUFFER, g_cageVertexVBO);
-    glBufferData(GL_ARRAY_BUFFER, (int)vbo.size() * sizeof(float), &vbo[0],
-                 GL_STATIC_DRAW);
-
-    g_cageProgram.EnableVertexAttributes();
-
-    glPointSize(10.0f);
-    glDrawArrays(GL_POINTS, 0, numPoints);
-    glPointSize(1.0f);
-
-    glBindVertexArray(0);
-    glUseProgram(0);
-}
 
 //------------------------------------------------------------------------------
 static void
@@ -801,9 +666,6 @@ drawStencils() {
 
     glBindVertexArray(g_stencilsVAO);
 
-//    int numEdges = g_controlStencils->GetNumStencils() * 3;
-//    g_samplesProgram.EnableVertexAttributes();
-
     glBindBuffer(GL_ARRAY_BUFFER, g_stencilOutput->BindDstBuffer());
 
     glEnableVertexAttribArray(0);
@@ -812,8 +674,6 @@ drawStencils() {
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(GLfloat)*9, 0);
     glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(GLfloat)*9, (void*)(sizeof(GLfloat)*3));
     glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(GLfloat)*9, (void*)(sizeof(GLfloat)*6));
-
-//    g_samplesProgram.EnableVertexAttributes();
 
     glDrawArrays(GL_POINTS, 0, g_stencilOutput->GetNumStencils());
 
@@ -854,13 +714,12 @@ display() {
 
     glEnable(GL_DEPTH_TEST);
 
-    if (g_drawCageEdges)
-        drawCageEdges();
-
-    if (g_drawCageVertices)
-        drawCageVertices();
-
     drawStencils();
+
+    // draw the control mesh
+    g_controlMeshDisplay.Draw(g_stencilOutput->BindSrcBuffer(), 3*sizeof(float),
+                              g_transformData.ModelViewProjectionMatrix);
+
     s.Stop();
     float drawCpuTime = float(s.GetElapsed() * 1000.0f);
     s.Start();
@@ -1028,41 +887,6 @@ callbackLevel(int l) {
     rebuildMesh();
 }
 
-
-//------------------------------------------------------------------------------
-static void
-callbackAnimate(bool checked, int /* m */) {
-
-    g_moveScale = checked;
-}
-
-//------------------------------------------------------------------------------
-static void
-callbackFreeze(bool checked, int /* f */) {
-
-    g_freeze = checked;
-}
-
-//------------------------------------------------------------------------------
-static void
-callbackDisplayCageVertices(bool checked, int /* d */) {
-
-    g_drawCageVertices = checked;
-}
-
-//------------------------------------------------------------------------------
-static void
-callbackDisplayCageEdges(bool checked, int /* d */) {
-    g_drawCageEdges = checked;
-}
-
-static void
-callbackBilinear(bool checked, int /* a */) {
-    g_bilinear = checked;
-    rebuildMesh();
-}
-
-
 //------------------------------------------------------------------------------
 static void
 callbackModel(int m) {
@@ -1080,6 +904,28 @@ callbackModel(int m) {
 
 //------------------------------------------------------------------------------
 static void
+callbackCheckBox(bool checked, int button) {
+    switch (button) {
+    case kHUD_CB_DISPLAY_CONTROL_MESH_EDGES:
+        g_controlMeshDisplay.SetEdgesDisplay(checked);
+        break;
+    case kHUD_CB_DISPLAY_CONTROL_MESH_VERTS:
+        g_controlMeshDisplay.SetVerticesDisplay(checked);
+        break;
+    case kHUD_CB_ANIMATE_VERTICES:
+        g_moveScale = checked;
+        break;
+    case kHUD_CB_FREEZE:
+        g_freeze = checked;
+        break;
+    case kHUD_CB_BILINEAR:
+        g_bilinear = checked;
+        rebuildMesh();
+    }
+}
+
+//------------------------------------------------------------------------------
+static void
 initHUD() {
 
     int windowWidth = g_width, windowHeight = g_height,
@@ -1093,12 +939,20 @@ initHUD() {
 
     g_hud.SetFrameBuffer(new GLFrameBuffer);
 
-    g_hud.AddCheckBox("Cage Edges (H)", true, 10, 10, callbackDisplayCageEdges, 0, 'h');
-    g_hud.AddCheckBox("Cage Verts (J)", true, 10, 30, callbackDisplayCageVertices, 0, 'j');
-    g_hud.AddCheckBox("Animate vertices (M)", g_moveScale != 0, 10, 50, callbackAnimate, 0, 'm');
-    g_hud.AddCheckBox("Freeze (spc)", false, 10, 70, callbackFreeze, 0, ' ');
-
-    g_hud.AddCheckBox("Bilinear Stencils (`)", g_bilinear!=0, 10, 190, callbackBilinear, 0, '`');
+    g_hud.AddCheckBox("Control edges (H)",
+                      g_controlMeshDisplay.GetEdgesDisplay(),
+                      10, 10, callbackCheckBox,
+                      kHUD_CB_DISPLAY_CONTROL_MESH_EDGES, 'h');
+    g_hud.AddCheckBox("Control vertices (J)",
+                      g_controlMeshDisplay.GetVerticesDisplay(),
+                      10, 30, callbackCheckBox,
+                      kHUD_CB_DISPLAY_CONTROL_MESH_VERTS, 'j');
+    g_hud.AddCheckBox("Animate vertices (M)", g_moveScale != 0,
+                      10, 50, callbackCheckBox, kHUD_CB_ANIMATE_VERTICES, 'm');
+    g_hud.AddCheckBox("Freeze (spc)", g_freeze != 0,
+                      10, 70, callbackCheckBox, kHUD_CB_FREEZE, ' ');
+    g_hud.AddCheckBox("Bilinear Stencils (`)", g_bilinear != 0,
+                      10, 190, callbackCheckBox, kHUD_CB_BILINEAR, '`');
 
     int compute_pulldown = g_hud.AddPullDown("Compute (K)", 250, 10, 300, callbackKernel, 'k');
     g_hud.AddPullDownButton(compute_pulldown, "CPU", kCPU);
@@ -1145,23 +999,12 @@ initGL() {
     glCullFace(GL_BACK);
     glEnable(GL_CULL_FACE);
 
-    glGenVertexArrays(1, &g_cageVertexVAO);
-    glGenVertexArrays(1, &g_cageEdgeVAO);
     glGenVertexArrays(1, &g_stencilsVAO);
-
-    glGenBuffers(1, &g_cageVertexVBO);
-    glGenBuffers(1, &g_cageEdgeVBO);
 }
 
 //------------------------------------------------------------------------------
 static void
 uninitGL() {
-
-    glDeleteBuffers(1, &g_cageVertexVBO);
-    glDeleteBuffers(1, &g_cageEdgeVBO);
-
-    glDeleteVertexArrays(1, &g_cageVertexVAO);
-    glDeleteVertexArrays(1, &g_cageEdgeVAO);
     glDeleteVertexArrays(1, &g_stencilsVAO);
 }
 


### PR DESCRIPTION
- add GLControlMeshDisplay and D3D11ControlMeshDisplay into
  examples/common
- delete all drawCageEdges/drawCageVertices from viewers and
  use ControlMeshDisplay class