### PR TITLE
Eliminated direct member access to Vtr classes from Far

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1005,7 +1005,7 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
 
         if (levelIndex < refiner.GetMaxLevel()) {
             refinement      = &refiner.getRefinement(levelIndex);
-            refinedFaceTags = &refinement->_parentFaceTag[0];
+            refinedFaceTags = &refinement->getParentFaceSparseTag(0);
         }
 
         for (int faceIndex = 0; faceIndex < level->getNumFaces(); ++faceIndex) {
@@ -1108,31 +1108,31 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
             if (hasBoundaryVertex or hasNonManifoldVertex) {
                 Vtr::ConstIndexArray fEdges = level->getFaceEdges(faceIndex);
 
-                int boundaryEdgeMask = ((level->_edgeTags[fEdges[0]]._boundary) << 0) |
-                                       ((level->_edgeTags[fEdges[1]]._boundary) << 1) |
-                                       ((level->_edgeTags[fEdges[2]]._boundary) << 2) |
-                                       ((level->_edgeTags[fEdges[3]]._boundary) << 3);
+                int boundaryEdgeMask = ((level->getEdgeTag(fEdges[0])._boundary) << 0) |
+                                       ((level->getEdgeTag(fEdges[1])._boundary) << 1) |
+                                       ((level->getEdgeTag(fEdges[2])._boundary) << 2) |
+                                       ((level->getEdgeTag(fEdges[3])._boundary) << 3);
                 if (hasNonManifoldVertex) {
-                    int nonManEdgeMask = ((level->_edgeTags[fEdges[0]]._nonManifold) << 0) |
-                                         ((level->_edgeTags[fEdges[1]]._nonManifold) << 1) |
-                                         ((level->_edgeTags[fEdges[2]]._nonManifold) << 2) |
-                                         ((level->_edgeTags[fEdges[3]]._nonManifold) << 3);
+                    int nonManEdgeMask = ((level->getEdgeTag(fEdges[0])._nonManifold) << 0) |
+                                         ((level->getEdgeTag(fEdges[1])._nonManifold) << 1) |
+                                         ((level->getEdgeTag(fEdges[2])._nonManifold) << 2) |
+                                         ((level->getEdgeTag(fEdges[3])._nonManifold) << 3);
                     boundaryEdgeMask |= nonManEdgeMask;
                 }
 
                 if (boundaryEdgeMask) {
                     patchTag.assignBoundaryPropertiesFromEdgeMask(boundaryEdgeMask);
                 } else {
-                    int boundaryVertMask = ((level->_vertTags[fVerts[0]]._boundary) << 0) |
-                                           ((level->_vertTags[fVerts[1]]._boundary) << 1) |
-                                           ((level->_vertTags[fVerts[2]]._boundary) << 2) |
-                                           ((level->_vertTags[fVerts[3]]._boundary) << 3);
+                    int boundaryVertMask = ((level->getVertexTag(fVerts[0])._boundary) << 0) |
+                                           ((level->getVertexTag(fVerts[1])._boundary) << 1) |
+                                           ((level->getVertexTag(fVerts[2])._boundary) << 2) |
+                                           ((level->getVertexTag(fVerts[3])._boundary) << 3);
 
                     if (hasNonManifoldVertex) {
-                        int nonManVertMask = ((level->_vertTags[fVerts[0]]._nonManifold) << 0) |
-                                             ((level->_vertTags[fVerts[1]]._nonManifold) << 1) |
-                                             ((level->_vertTags[fVerts[2]]._nonManifold) << 2) |
-                                             ((level->_vertTags[fVerts[3]]._nonManifold) << 3);
+                        int nonManVertMask = ((level->getVertexTag(fVerts[0])._nonManifold) << 0) |
+                                             ((level->getVertexTag(fVerts[1])._nonManifold) << 1) |
+                                             ((level->getVertexTag(fVerts[2])._nonManifold) << 2) |
+                                             ((level->getVertexTag(fVerts[3])._nonManifold) << 3);
                         boundaryVertMask |= nonManVertMask;
                     }
                     patchTag.assignBoundaryPropertiesFromVertexMask(boundaryVertMask);
@@ -1162,14 +1162,14 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
                     } else {
                         int xordVertex = 0;
                         int xordCount = 0;
-                        if (level->_vertTags[fVerts[0]]._xordinary) { xordCount++; xordVertex = 0; }
-                        if (level->_vertTags[fVerts[1]]._xordinary) { xordCount++; xordVertex = 1; }
-                        if (level->_vertTags[fVerts[2]]._xordinary) { xordCount++; xordVertex = 2; }
-                        if (level->_vertTags[fVerts[3]]._xordinary) { xordCount++; xordVertex = 3; }
+                        if (level->getVertexTag(fVerts[0])._xordinary) { xordCount++; xordVertex = 0; }
+                        if (level->getVertexTag(fVerts[1])._xordinary) { xordCount++; xordVertex = 1; }
+                        if (level->getVertexTag(fVerts[2])._xordinary) { xordCount++; xordVertex = 2; }
+                        if (level->getVertexTag(fVerts[3])._xordinary) { xordCount++; xordVertex = 3; }
 
                         if (xordCount == 1) {
                             //  We require the vertex opposite the xordinary vertex be interior:
-                            if (not level->_vertTags[fVerts[(xordVertex + 2) % 4]]._boundary) {
+                            if (not level->getVertexTag(fVerts[(xordVertex + 2) % 4])._boundary) {
                                 patchTag._isRegular = true;
                             }
                         }

--- a/opensubdiv/far/primvarRefiner.h
+++ b/opensubdiv/far/primvarRefiner.h
@@ -646,8 +646,8 @@ PrimvarRefiner::interpFVarFromFaces(int level, T const & src, U & dst, int chann
     Vtr::internal::Level const & parentLevel = refinement.parent();
     Vtr::internal::Level const & childLevel  = refinement.child();
 
-    Vtr::internal::FVarLevel const & parentFVar = *parentLevel._fvarChannels[channel];
-    Vtr::internal::FVarLevel const & childFVar  = *childLevel._fvarChannels[channel];
+    Vtr::internal::FVarLevel const & parentFVar = parentLevel.getFVarLevel(channel);
+    Vtr::internal::FVarLevel const & childFVar  = childLevel.getFVarLevel(channel);
 
     Vtr::internal::StackBuffer<float,16> fValueWeights(parentLevel.getMaxValence());
 
@@ -692,9 +692,9 @@ PrimvarRefiner::interpFVarFromEdges(int level, T const & src, U & dst, int chann
     Vtr::internal::Level const & parentLevel = refinement.parent();
     Vtr::internal::Level const & childLevel  = refinement.child();
 
-    Vtr::internal::FVarRefinement const & refineFVar = *refinement._fvarChannels[channel];
-    Vtr::internal::FVarLevel const &      parentFVar = *parentLevel._fvarChannels[channel];
-    Vtr::internal::FVarLevel const &      childFVar  = *childLevel._fvarChannels[channel];
+    Vtr::internal::FVarRefinement const & refineFVar = refinement.getFVarRefinement(channel);
+    Vtr::internal::FVarLevel const &      parentFVar = parentLevel.getFVarLevel(channel);
+    Vtr::internal::FVarLevel const &      childFVar  = childLevel.getFVarLevel(channel);
 
     //
     //  Allocate and intialize (if linearly interpolated) interpolation weights for
@@ -705,7 +705,7 @@ PrimvarRefiner::interpFVarFromEdges(int level, T const & src, U & dst, int chann
 
     Mask eMask(eVertWeights, 0, eFaceWeights);
 
-    bool isLinearFVar = parentFVar._isLinear;
+    bool isLinearFVar = parentFVar.isLinear();
     if (isLinearFVar) {
         eMask.SetNumVertexWeights(2);
         eMask.SetNumEdgeWeights(0);
@@ -836,11 +836,11 @@ PrimvarRefiner::interpFVarFromVerts(int level, T const & src, U & dst, int chann
     Vtr::internal::Level const & parentLevel = refinement.parent();
     Vtr::internal::Level const & childLevel  = refinement.child();
 
-    Vtr::internal::FVarRefinement const & refineFVar = *refinement._fvarChannels[channel];
-    Vtr::internal::FVarLevel const &      parentFVar = *parentLevel._fvarChannels[channel];
-    Vtr::internal::FVarLevel const &      childFVar  = *childLevel._fvarChannels[channel];
+    Vtr::internal::FVarRefinement const & refineFVar = refinement.getFVarRefinement(channel);
+    Vtr::internal::FVarLevel const &      parentFVar = parentLevel.getFVarLevel(channel);
+    Vtr::internal::FVarLevel const &      childFVar  = childLevel.getFVarLevel(channel);
 
-    bool isLinearFVar = parentFVar._isLinear;
+    bool isLinearFVar = parentFVar.isLinear();
 
     Vtr::internal::StackBuffer<float,32> weightBuffer(2*parentLevel.getMaxValence());
 
@@ -1031,7 +1031,7 @@ PrimvarRefiner::limit(T const & src, U & dstPos, U1 * dstTan1Ptr, U2 * dstTan2Pt
         //  Incomplete vertices (present in sparse refinement) do not have their full
         //  topological neighborhood to determine a proper limit -- just leave the
         //  vertex at the refined location and continue to the next:
-        if (level._vertTags[vert]._incomplete || (vEdges.size() == 0)) {
+        if (level.getVertexTag(vert)._incomplete || (vEdges.size() == 0)) {
             dstPos[vert].Clear();
             dstPos[vert].AddWithWeight(src[vert], 1.0);
             if (hasTangents) {
@@ -1133,7 +1133,7 @@ PrimvarRefiner::limitFVar(T const & src, U * dst, int channel) const {
     Sdc::Scheme<SCHEME> scheme(_refiner._subdivOptions);
 
     Vtr::internal::Level const &      level       = _refiner.getLevel(_refiner.GetMaxLevel());
-    Vtr::internal::FVarLevel const &  fvarChannel = *level._fvarChannels[channel];
+    Vtr::internal::FVarLevel const &  fvarChannel = level.getFVarLevel(channel);
 
     int maxWeightsPerMask = 1 + 2 * level.getMaxValence();
 
@@ -1154,8 +1154,8 @@ PrimvarRefiner::limitFVar(T const & src, U * dst, int channel) const {
         //
         //  The same can be done if the face-varying channel is purely linear.
         //
-        bool isIncomplete = (level._vertTags[vert]._incomplete || (vEdges.size() == 0));
-        if (isIncomplete || fvarChannel._isLinear) {
+        bool isIncomplete = (level.getVertexTag(vert)._incomplete || (vEdges.size() == 0));
+        if (isIncomplete || fvarChannel.isLinear()) {
             for (int i = 0; i < vValues.size(); ++i) {
                 Vtr::Index vValue = vValues[i];
 

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -332,7 +332,7 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
 
     Vtr::internal::Level const& level = selector.getRefinement().parent();
 
-    int  regularFaceSize           =  selector.getRefinement()._regFaceSize;
+    int  regularFaceSize           =  selector.getRefinement().getRegularFaceSize();
     bool considerSingleCreasePatch = _adaptiveOptions.useSingleCreasePatch && (regularFaceSize == 4);
 
     //
@@ -354,7 +354,7 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
         considerFVarChannels = false;
 
         for (int channel = 0; channel < numFVarChannels; ++channel) {
-            if (not level._fvarChannels[channel]->isLinear()) {
+            if (not level.getFVarLevel(channel).isLinear()) {
                 considerFVarChannels = true;
                 break;
             }
@@ -467,9 +467,9 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
             } else {
                 //  Make sure the adjacent boundary vertices were not sharpened, or equivalently,
                 //  that only one corner is sharp:
-                unsigned int infSharpCount = level._vertTags[faceVerts[0]]._infSharp;
+                unsigned int infSharpCount = level.getVertexTag(faceVerts[0])._infSharp;
                 for (int i = 1; i < faceVerts.size(); ++i) {
-                    infSharpCount += level._vertTags[faceVerts[i]]._infSharp;
+                    infSharpCount += level.getVertexTag(faceVerts[i])._infSharp;
                 }
                 selectFace = (infSharpCount != 1);
             }
@@ -481,7 +481,7 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
         //
         if (not selectFace and considerFVarChannels) {
             for (int channel = 0; not selectFace && (channel < numFVarChannels); ++channel) {
-                Vtr::internal::FVarLevel const & fvarLevel = *level._fvarChannels[channel];
+                Vtr::internal::FVarLevel const & fvarLevel = level.getFVarLevel(channel);
 
                 //
                 //  Retrieve the counterpart to the face-vertices composite tag for the face-values

--- a/opensubdiv/far/topologyRefinerFactory.cpp
+++ b/opensubdiv/far/topologyRefinerFactory.cpp
@@ -152,10 +152,6 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
     //
     Vtr::internal::Level&  baseLevel = refiner.getLevel(0);
 
-    assert((int)baseLevel._edgeTags.size() == baseLevel.getNumEdges());
-    assert((int)baseLevel._vertTags.size() == baseLevel.getNumVertices());
-    assert((int)baseLevel._faceTags.size() == baseLevel.getNumFaces());
-
     Sdc::Options options = refiner.GetSchemeOptions();
     Sdc::Crease  creasing(options);
 
@@ -168,10 +164,10 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
     //  properties of their incident edges.
     //
     for (Vtr::Index eIndex = 0; eIndex < baseLevel.getNumEdges(); ++eIndex) {
-        Vtr::internal::Level::ETag& eTag       = baseLevel._edgeTags[eIndex];
-        float&          eSharpness = baseLevel._edgeSharpness[eIndex];
+        Vtr::internal::Level::ETag& eTag       = baseLevel.getEdgeTag(eIndex);
+        float&                      eSharpness = baseLevel.getEdgeSharpness(eIndex);
 
-        eTag._boundary = (baseLevel._edgeFaceCountsAndOffsets[eIndex*2 + 0] < 2);
+        eTag._boundary = (baseLevel.getNumEdgeFaces(eIndex) < 2);
         if (eTag._boundary || (eTag._nonManifold && sharpenNonManFeatures)) {
             eSharpness = Sdc::Crease::SHARPNESS_INFINITE;
         }
@@ -187,8 +183,8 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
     int schemeRegularBoundaryValence = schemeRegularInteriorValence / 2;
 
     for (Vtr::Index vIndex = 0; vIndex < baseLevel.getNumVertices(); ++vIndex) {
-        Vtr::internal::Level::VTag& vTag       = baseLevel._vertTags[vIndex];
-        float&          vSharpness = baseLevel._vertSharpness[vIndex];
+        Vtr::internal::Level::VTag& vTag       = baseLevel.getVertexTag(vIndex);
+        float&                      vSharpness = baseLevel.getVertexSharpness(vIndex);
 
         Vtr::ConstIndexArray vEdges = baseLevel.getVertexEdges(vIndex);
         Vtr::ConstIndexArray vFaces = baseLevel.getVertexFaces(vIndex);
@@ -201,7 +197,7 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
         int semiSharpEdgeCount   = 0;
         int nonManifoldEdgeCount = 0;
         for (int i = 0; i < vEdges.size(); ++i) {
-            Vtr::internal::Level::ETag const& eTag = baseLevel._edgeTags[vEdges[i]];
+            Vtr::internal::Level::ETag const& eTag = baseLevel.getEdgeTag(vEdges[i]);
 
             boundaryEdgeCount    += eTag._boundary;
             infSharpEdgeCount    += eTag._infSharp;
@@ -257,7 +253,7 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
         //
         if (makeBoundaryFacesHoles && vTag._boundary) {
             for (int i = 0; i < vFaces.size(); ++i) {
-                baseLevel._faceTags[vFaces[i]]._hole = true;
+                baseLevel.getFaceTag(vFaces[i])._hole = true;
 
                 //  Don't forget this -- but it will eventually move to the Level
                 refiner._hasHoles = true;

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -217,6 +217,15 @@ public:
     void setVertexNonManifold(Index vertIndex, bool b);
     bool isVertexNonManifold(Index vertIndex) const;
 
+    //  General access to all component tags:
+    VTag const & getVertexTag(Index vertIndex) const { return _vertTags[vertIndex]; }
+    ETag const & getEdgeTag(Index edgeIndex) const { return _edgeTags[edgeIndex]; }
+    FTag const & getFaceTag(Index faceIndex) const { return _faceTags[faceIndex]; }
+
+    VTag & getVertexTag(Index vertIndex) { return _vertTags[vertIndex]; }
+    ETag & getEdgeTag(Index edgeIndex) { return _edgeTags[edgeIndex]; }
+    FTag & getFaceTag(Index faceIndex) { return _faceTags[faceIndex]; }
+
 public:
 
     //  Debugging aides:

--- a/opensubdiv/vtr/refinement.h
+++ b/opensubdiv/vtr/refinement.h
@@ -76,6 +76,14 @@ public:
     Level const& child() const  { return *_child; }
     Level&       child()        { return *_child; }
 
+    Sdc::Split getSplitType() const { return _splitType; }
+    int getRegularFaceSize() const { return _regFaceSize; }
+
+    //  Face-varying:
+    int getNumFVarChannels() const { return (int) _fvarChannels.size(); }
+
+    FVarRefinement const & getFVarRefinement(int c) const { return *_fvarChannels[c]; }
+
     //
     //  Options associated with the actual refinement operation, which may end up
     //  quite involved if we want to allow for the refinement of data that is not
@@ -188,6 +196,15 @@ public:
         unsigned char _parentType    : 2;  // type of parent component:  vertex, edge or face
         unsigned char _indexInParent : 2;  // index of child wrt parent:  0-3, or iterative if N > 4
     };
+
+    //  Methods to access and modify tags:
+    SparseTag const & getParentFaceSparseTag(  Index f) const { return _parentFaceTag[f]; }
+    SparseTag const & getParentEdgeSparseTag(  Index e) const { return _parentEdgeTag[e]; }
+    SparseTag const & getParentVertexSparseTag(Index v) const { return _parentVertexTag[v]; }
+
+    SparseTag & getParentFaceSparseTag(  Index f) { return _parentFaceTag[f]; }
+    SparseTag & getParentEdgeSparseTag(  Index e) { return _parentEdgeTag[e]; }
+    SparseTag & getParentVertexSparseTag(Index v) { return _parentVertexTag[v]; }
 
 //  Remaining methods should really be protected -- for use by subclasses...
 public:


### PR DESCRIPTION
This is a side-effect of unfriending the Far classes from Vtr -- a few Far classes were directly accessing member variables as friends.  The intent is to appropriately protect members of Vtr classes in the near future, so a few missing accessors were added and the Far classes updated to use them.