### PR TITLE
Removed unnecessary files include by public headers in Far

### DIFF
--- a/examples/glEvalLimit/particles.cpp
+++ b/examples/glEvalLimit/particles.cpp
@@ -27,6 +27,8 @@
 #include <far/ptexIndices.h>
 #include <far/patchMap.h>
 
+#include <cmath>
+
 #ifdef OPENSUBDIV_HAS_TBB
 #include <tbb/parallel_for.h>
 #include <tbb/atomic.h>

--- a/opensubdiv/far/patchParam.h
+++ b/opensubdiv/far/patchParam.h
@@ -29,8 +29,6 @@
 
 #include "../far/types.h"
 
-#include <cassert>
-
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -34,10 +34,7 @@
 #include "../sdc/options.h"
 
 #include <cstdlib>
-#include <cassert>
-#include <algorithm>
 #include <vector>
-#include <map>
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -26,6 +26,7 @@
 #include "../far/ptexIndices.h"
 #include "../far/topologyRefiner.h"
 #include "../vtr/level.h"
+#include "../vtr/fvarLevel.h"
 #include "../vtr/refinement.h"
 #include "../far/endCapBSplineBasisPatchFactory.h"
 #include "../far/endCapGregoryBasisPatchFactory.h"

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -23,6 +23,7 @@
 //
 #include "../far/topologyRefiner.h"
 #include "../far/error.h"
+#include "../vtr/fvarLevel.h"
 #include "../vtr/sparseSelector.h"
 #include "../vtr/quadRefinement.h"
 #include "../vtr/triRefinement.h"

--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -28,24 +28,11 @@
 
 #include "../sdc/types.h"
 #include "../sdc/options.h"
-#include "../vtr/level.h"
-#include "../vtr/refinement.h"
 #include "../far/types.h"
-#include "../far/error.h"
 #include "../far/topologyLevel.h"
 
 #include <vector>
-#include <cassert>
-#include <cstdio>
 
-//  No longer necessary -- remove once we verify nothing implicitly relies on them:
-#include "../sdc/bilinearScheme.h"
-#include "../sdc/catmarkScheme.h"
-#include "../sdc/loopScheme.h"
-#include "../vtr/fvarLevel.h"
-#include "../vtr/fvarRefinement.h"
-#include "../vtr/stackBuffer.h"
-#include "../vtr/componentInterfaces.h"
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {

--- a/opensubdiv/far/topologyRefinerFactory.cpp
+++ b/opensubdiv/far/topologyRefinerFactory.cpp
@@ -25,6 +25,12 @@
 #include "../far/topologyRefiner.h"
 #include "../vtr/level.h"
 
+#include <cstdio>
+#ifdef _MSC_VER
+    #define snprintf _snprintf
+#endif
+
+
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -31,10 +31,6 @@
 
 #include <cassert>
 
-#ifdef _MSC_VER
-    #define snprintf _snprintf
-#endif
-
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 

--- a/regression/common/far_utils.h
+++ b/regression/common/far_utils.h
@@ -29,6 +29,8 @@
 #include <far/primvarRefiner.h>
 #include <far/types.h>
 
+#include <cstdio>
+
 #include "shape_utils.h"
 
 //------------------------------------------------------------------------------

--- a/tutorials/far/tutorial_1/far_tutorial_1.cpp
+++ b/tutorials/far/tutorial_1/far_tutorial_1.cpp
@@ -41,9 +41,10 @@
 // rebuilding them redundantly.
 //
 
-
 #include <opensubdiv/far/topologyRefinerFactory.h>
 #include <opensubdiv/far/primvarRefiner.h>
+
+#include <cstdio>
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
This set of changes was initially to remove a block of include files from far/TopologyRefiner.h that are now no longer necessary. I looked around at a few other public headers and found a few more that appeared to be unnecessary and removed them as well.