### PR TITLE
Renaming of face-varying methods to access values per face

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -859,7 +859,7 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
 
                 if (generateFVarPatches) {
                     for (fvc=fvc.begin(); fvc!=fvc.end(); ++fvc) {
-                        ConstIndexArray fvalues = refLevel.GetFVarFaceValues(face, *fvc);
+                        ConstIndexArray fvalues = refLevel.GetFaceFVarValues(face, *fvc);
                         for (int vert=0; vert<fvalues.size(); ++vert) {
                             assert((levelVertOffset + fvalues[vert]) < (int)table->getFVarPatchesValues(fvc.pos()).size());
                             fptr[fvc.pos()][vert] = levelFVarVertOffsets[fvc.pos()] + fvalues[vert];

--- a/opensubdiv/far/topologyLevel.h
+++ b/opensubdiv/far/topologyLevel.h
@@ -59,8 +59,10 @@ public:
 
     Sdc::Crease::Rule GetVertexRule(Index v) const { return _level->getVertexRule(v); }
 
-    int             GetNumFVarValues(          int channel = 0) const { return _level->getNumFVarValues(channel); }
-    ConstIndexArray GetFVarFaceValues(Index f, int channel = 0) const { return _level->getFVarFaceValues(f, channel); }
+    int GetNumFVarChannels() const              { return _level->getNumFVarChannels(); }
+    int GetNumFVarValues(int channel = 0) const { return _level->getNumFVarValues(channel); }
+
+    ConstIndexArray GetFaceFVarValues(Index f, int channel = 0) const { return _level->getFVarFaceValues(f, channel); }
 
     ConstIndexArray GetFaceVertices(Index f) const { return _level->getFaceVertices(f); }
     ConstIndexArray GetFaceEdges(Index f) const    { return _level->getFaceEdges(f); }

--- a/opensubdiv/far/topologyRefinerFactory.cpp
+++ b/opensubdiv/far/topologyRefinerFactory.cpp
@@ -382,29 +382,25 @@ TopologyRefinerFactory<TopologyRefinerFactoryBase::TopologyDescriptor>::assignFa
 
         for (int channel=0; channel<desc.numFVarChannels; ++channel) {
 
-            int        channelSize    = desc.fvarChannels[channel].numValues;
-            int const* channelIndices = desc.fvarChannels[channel].valueIndices;
+            int        numFVarValues = desc.fvarChannels[channel].numValues;
+            int const* srcFVarValues = desc.fvarChannels[channel].valueIndices;
 
-#if defined(DEBUG) or defined(_DEBUG)
-            int channelIndex = createBaseFVarChannel(refiner, channelSize);
-            assert(channelIndex == channel);
-#else
-            createBaseFVarChannel(refiner, channelSize);
-#endif
-            for (int face=0, idx=0; face<desc.numFaces; ++face) {
+            createBaseFVarChannel(refiner, numFVarValues);
 
-                IndexArray dstFaceValues = getBaseFVarFaceValues(refiner, face, channel);
+            for (int face = 0, srcNext = 0; face < desc.numFaces; ++face) {
+
+                IndexArray dstFaceFVarValues = getBaseFaceFVarValues(refiner, face, channel);
 
                 if (desc.isLeftHanded) {
-                    dstFaceValues[0] = channelIndices[idx++];
-                    for (int vert=dstFaceValues.size()-1; vert > 0; --vert) {
+                    dstFaceFVarValues[0] = srcFVarValues[srcNext++];
+                    for (int vert = dstFaceFVarValues.size() - 1; vert > 0; --vert) {
                         
-                        dstFaceValues[vert] = channelIndices[idx++];
+                        dstFaceFVarValues[vert] = srcFVarValues[srcNext++];
                     }
                 } else {
-                    for (int vert=0; vert<dstFaceValues.size(); ++vert) {
+                    for (int vert = 0; vert < dstFaceFVarValues.size(); ++vert) {
                         
-                        dstFaceValues[vert] = channelIndices[idx++];
+                        dstFaceFVarValues[vert] = srcFVarValues[srcNext++];
                     }
                 }
             }

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -78,8 +78,8 @@ public:
         //
         struct FVarChannel {
 
-            int         numValues;
-            int const * valueIndices;
+            int           numValues;
+            Index const * valueIndices;
 
             FVarChannel() : numValues(0), valueIndices(0) { }
         };
@@ -136,7 +136,7 @@ protected:
     //  Optional methods for creating and assigning face-varying data channels:
     static int createBaseFVarChannel(TopologyRefiner & newRefiner, int numValues);
     static int createBaseFVarChannel(TopologyRefiner & newRefiner, int numValues, Sdc::Options const& fvarOptions);
-    static IndexArray getBaseFVarFaceValues(TopologyRefiner & newRefiner, Index face, int channel = 0);
+    static IndexArray getBaseFaceFVarValues(TopologyRefiner & newRefiner, Index face, int channel = 0);
 
     static void setBaseMaxValence(TopologyRefiner & newRefiner, int valence);
     static void initializeBaseInventory(TopologyRefiner & newRefiner);
@@ -285,7 +285,7 @@ TopologyRefinerFactoryBase::createBaseFVarChannel(TopologyRefiner & newRefiner, 
     return newRefiner._levels[0]->createFVarChannel(numValues, newOptions);
 }
 inline IndexArray
-TopologyRefinerFactoryBase::getBaseFVarFaceValues(TopologyRefiner & newRefiner, Index face, int channel) {
+TopologyRefinerFactoryBase::getBaseFaceFVarValues(TopologyRefiner & newRefiner, Index face, int channel) {
     return newRefiner._levels[0]->getFVarFaceValues(face, channel);
 }
 
@@ -550,7 +550,7 @@ TopologyRefinerFactory<MESH>::assignFaceVaryingTopology(TopologyRefiner& /* refi
     //      int TopologyRefiner::createBaseFVarChannel(int numValues)
     //
     //  For each channel, populate the face-vertex values:
-    //      IndexArray TopologyRefiner::setBaseFVarFaceValues(Index face, int channel = 0)
+    //      IndexArray TopologyRefiner::setBaseFaceFVarValues(Index face, int channel = 0)
     //
     return true;
 }

--- a/regression/common/far_utils.h
+++ b/regression/common/far_utils.h
@@ -249,7 +249,7 @@ TopologyRefinerFactory<Shape>::assignFaceVaryingTopology(
 
         for (int i=0, ofs=0; i < nfaces; ++i) {
 
-            Far::IndexArray dstFaceUVs = getBaseFVarFaceValues(refiner, i, channel);
+            Far::IndexArray dstFaceUVs = getBaseFaceFVarValues(refiner, i, channel);
 
             if (shape.isLeftHanded) {
                 dstFaceUVs[0] = shape.faceuvs[ofs++];

--- a/tutorials/far/tutorial_3/far_tutorial_3.cpp
+++ b/tutorials/far/tutorial_3/far_tutorial_3.cpp
@@ -63,8 +63,6 @@ struct Vertex {
         _position[2]+=weight*src._position[2];
     }
 
-    void AddVaryingWithWeight(Vertex const &, float) { }
-
     // Public interface ------------------------------------
     void SetPosition(float x, float y, float z) {
         _position[0]=x;
@@ -268,7 +266,7 @@ int main(int, char **) {
         for (int face = 0; face < nfaces; ++face) {
 
             Far::ConstIndexArray fverts = refLastLevel.GetFaceVertices(face);
-            Far::ConstIndexArray fuvs   = refLastLevel.GetFVarFaceValues(face, channel);
+            Far::ConstIndexArray fuvs   = refLastLevel.GetFaceFVarValues(face, channel);
 
             // all refined Catmark faces should be quads
             assert(fverts.size()==4 and fuvs.size()==4);


### PR DESCRIPTION
As discussed, I replaced the string FVarFaceValues with FaceFVarValues in a couple of methods in Far -- accessing FVarValues through the TopologyLevel and assigning the base mesh in the RefinerFactory.  I also update the default factory's assignment of face-varying data to be more consistent with the desired terminology.

There is some internal usage in Vtr that still retains the old FVarFaceValue term that I'll deal with soon with some other minor changes to Vtr.