### PR TITLE
Re-protected members of all major Vtr classes

### DIFF
--- a/opensubdiv/vtr/CMakeLists.txt
+++ b/opensubdiv/vtr/CMakeLists.txt
@@ -36,21 +36,22 @@ set(SOURCE_FILES
      triRefinement.cpp
 )
 
+set(PRIVATE_HEADER_FILES
+     quadRefinement.h
+     triRefinement.h
+)
+
 set(PUBLIC_HEADER_FILES
      array.h
      componentInterfaces.h
      fvarLevel.h
      fvarRefinement.h
      level.h
-     quadRefinement.h
      refinement.h
      sparseSelector.h
      stackBuffer.h
-     triRefinement.h
      types.h
 )
-
-set(PRIVATE_HEADER_FILES )
 
 set(DOXY_HEADER_FILES ${PUBLIC_HEADER_FILES})
 

--- a/opensubdiv/vtr/fvarLevel.h
+++ b/opensubdiv/vtr/fvarLevel.h
@@ -234,8 +234,10 @@ public:
     void print() const;
     void buildFaceVertexSiblingsFromVertexFaceSiblings(std::vector<Sibling>& fvSiblings) const;
 
-//  Members temporarily public pending re-assessment of friends:
-public:
+private:
+    //  Just as Refinements build Levels, FVarRefinements build FVarLevels...
+    friend class FVarRefinement;
+
     Level const & _level;
 
     //  Linear interpolation options vary between channels:
@@ -280,30 +282,30 @@ public:
 inline ConstIndexArray
 FVarLevel::getFaceValues(Index fIndex) const {
 
-    int vCount  = _level._faceVertCountsAndOffsets[fIndex*2];
-    int vOffset = _level._faceVertCountsAndOffsets[fIndex*2+1];
+    int vCount  = _level.getNumFaceVertices(fIndex);
+    int vOffset = _level.getOffsetOfFaceVertices(fIndex);
     return ConstIndexArray(&_faceVertValues[vOffset], vCount);
 }
 inline IndexArray
 FVarLevel::getFaceValues(Index fIndex) {
 
-    int vCount  = _level._faceVertCountsAndOffsets[fIndex*2];
-    int vOffset = _level._faceVertCountsAndOffsets[fIndex*2+1];
+    int vCount  = _level.getNumFaceVertices(fIndex);
+    int vOffset = _level.getOffsetOfFaceVertices(fIndex);
     return IndexArray(&_faceVertValues[vOffset], vCount);
 }
 
 inline FVarLevel::ConstSiblingArray
 FVarLevel::getVertexFaceSiblings(Index vIndex) const {
 
-    int vCount  = _level._vertFaceCountsAndOffsets[vIndex*2];
-    int vOffset = _level._vertFaceCountsAndOffsets[vIndex*2+1];
+    int vCount  = _level.getNumVertexFaces(vIndex);
+    int vOffset = _level.getOffsetOfVertexFaces(vIndex);
     return ConstSiblingArray(&_vertFaceSiblings[vOffset], vCount);
 }
 inline FVarLevel::SiblingArray
 FVarLevel::getVertexFaceSiblings(Index vIndex) {
 
-    int vCount  = _level._vertFaceCountsAndOffsets[vIndex*2];
-    int vOffset = _level._vertFaceCountsAndOffsets[vIndex*2+1];
+    int vCount  = _level.getNumVertexFaces(vIndex);
+    int vOffset = _level.getOffsetOfVertexFaces(vIndex);
     return SiblingArray(&_vertFaceSiblings[vOffset], vCount);
 }
 

--- a/opensubdiv/vtr/fvarRefinement.h
+++ b/opensubdiv/vtr/fvarRefinement.h
@@ -86,8 +86,7 @@ public:
     void propagateValueCreases();
     void reclassifySemisharpValues();
 
-//  Members temporarily public pending re-assessment of friends:
-public:
+private:
     //
     //  Identify the Refinement, its Levels and assigned FVarLevels for more
     //  immediate access -- child FVarLevel is non-const as it is to be assigned:

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -1947,7 +1947,7 @@ Level::getNumFVarValues(int channel) const {
 
 Sdc::Options
 Level::getFVarOptions(int channel) const {
-    return _fvarChannels[channel]->_options;
+    return _fvarChannels[channel]->getOptions();
 }
 
 ConstIndexArray

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -44,6 +44,9 @@ namespace Vtr {
 namespace internal {
 
 class Refinement;
+class TriRefinement;
+class QuadRefinement;
+class FVarRefinement;
 class FVarLevel;
 
 //
@@ -350,6 +353,7 @@ public:
     int getNumVertexEdges(     Index vertIndex) const { return _vertEdgeCountsAndOffsets[2*vertIndex]; }
     int getOffsetOfVertexEdges(Index vertIndex) const { return _vertEdgeCountsAndOffsets[2*vertIndex + 1]; }
 
+    ConstIndexArray getFaceVertices() const;
 
     //
     //  Note that for some relations, the size of the relations for a child component
@@ -391,8 +395,12 @@ public:
 
     IndexArray shareFaceVertCountsAndOffsets() const;
 
-//  Members temporarily public pending re-assessment of friends:
-public:
+private:
+    //  Refinement classes (including all subclasses) build a Level:
+    friend class Refinement;
+    friend class TriRefinement;
+    friend class QuadRefinement;
+
     //
     //  A Level is independent of subdivision scheme or options.  While it may have been
     //  affected by them in its construction, they are not associated with it -- a Level
@@ -487,6 +495,11 @@ Level::resizeFaceVertices(Index faceIndex, int count) {
     countOffsetPair[1] = (faceIndex == 0) ? 0 : (countOffsetPair[-2] + countOffsetPair[-1]);
 
     _maxValence = std::max(_maxValence, count);
+}
+
+inline ConstIndexArray
+Level::getFaceVertices() const {
+    return ConstIndexArray(&_faceVertIndices[0], (int)_faceVertIndices.size());
 }
 
 //

--- a/opensubdiv/vtr/refinement.h
+++ b/opensubdiv/vtr/refinement.h
@@ -78,6 +78,7 @@ public:
 
     Sdc::Split getSplitType() const { return _splitType; }
     int getRegularFaceSize() const { return _regFaceSize; }
+    Sdc::Options getOptions() const { return _options; }
 
     //  Face-varying:
     int getNumFVarChannels() const { return (int) _fvarChannels.size(); }
@@ -119,6 +120,8 @@ public:
 
     void refine(Options options = Options());
 
+    bool hasFaceVerticesFirst() const { return _faceVertsFirst; }
+
 public:
     //
     //  Access to members -- some testing classes (involving vertex interpolation)
@@ -146,8 +149,9 @@ public:
     ConstIndexArray  getFaceChildEdges(Index parentFace) const;
     ConstIndexArray  getEdgeChildEdges(Index parentEdge) const;
 
-    //  Child-to-parent relationships (not yet complete -- unclear how we will define the
-    //  "type" of the parent component, e.g. vertex, edge or face):
+    //  Child-to-parent relationships
+    bool isChildVertexComplete(Index v) const       { return not _childVertexTag[v]._incomplete; }
+
     Index getChildFaceParentFace(Index f) const     { return _childFaceParentIndex[f]; }
     int   getChildFaceInParentFace(Index f) const   { return _childFaceTag[f]._indexInParent; }
 
@@ -205,6 +209,14 @@ public:
     SparseTag & getParentFaceSparseTag(  Index f) { return _parentFaceTag[f]; }
     SparseTag & getParentEdgeSparseTag(  Index e) { return _parentEdgeTag[e]; }
     SparseTag & getParentVertexSparseTag(Index v) { return _parentVertexTag[v]; }
+
+    ChildTag const & getChildFaceTag(  Index f) const { return _childFaceTag[f]; }
+    ChildTag const & getChildEdgeTag(  Index e) const { return _childEdgeTag[e]; }
+    ChildTag const & getChildVertexTag(Index v) const { return _childVertexTag[v]; }
+
+    ChildTag & getChildFaceTag(  Index f) { return _childFaceTag[f]; }
+    ChildTag & getChildEdgeTag(  Index e) { return _childEdgeTag[e]; }
+    ChildTag & getChildVertexTag(Index v) { return _childVertexTag[v]; }
 
 //  Remaining methods should really be protected -- for use by subclasses...
 public:
@@ -307,8 +319,10 @@ public:
     //
     void subdivideFVarChannels();
 
-//  Members temporarily public pending re-assessment of friends:
-public:
+protected:
+    // A debug method of Level prints a Refinement (should really change this)
+    friend void Level::print(const Refinement *) const;
+
     //
     //  Data members -- the logical grouping of some of these (and methods that make use
     //  of them) may lead to grouping them into a few utility classes or structs...

--- a/opensubdiv/vtr/sparseSelector.h
+++ b/opensubdiv/vtr/sparseSelector.h
@@ -35,9 +35,6 @@ namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Vtr {
-
-class Refinement;
-
 namespace internal {
 
 //
@@ -79,13 +76,13 @@ public:
 private:
     SparseSelector() : _refine(0), _selected(false) { }
 
-    bool wasVertexSelected(Index pVertex) const { return _refine->_parentVertexTag[pVertex]._selected; }
-    bool wasEdgeSelected(  Index pEdge) const   { return _refine->_parentEdgeTag[pEdge]._selected; }
-    bool wasFaceSelected(  Index pFace) const   { return _refine->_parentFaceTag[pFace]._selected; }
+    bool wasVertexSelected(Index pVertex) const { return _refine->getParentVertexSparseTag(pVertex)._selected; }
+    bool wasEdgeSelected(  Index pEdge) const   { return _refine->getParentEdgeSparseTag(pEdge)._selected; }
+    bool wasFaceSelected(  Index pFace) const   { return _refine->getParentFaceSparseTag(pFace)._selected; }
 
-    void markVertexSelected(Index pVertex) const { _refine->_parentVertexTag[pVertex]._selected = true; }
-    void markEdgeSelected(  Index pEdge) const   { _refine->_parentEdgeTag[pEdge]._selected = true; }
-    void markFaceSelected(  Index pFace) const   { _refine->_parentFaceTag[pFace]._selected = true; }
+    void markVertexSelected(Index pVertex) const { _refine->getParentVertexSparseTag(pVertex)._selected = true; }
+    void markEdgeSelected(  Index pEdge) const   { _refine->getParentEdgeSparseTag(pEdge)._selected = true; }
+    void markFaceSelected(  Index pFace) const   { _refine->getParentFaceSparseTag(pFace)._selected = true; }
 
     void initializeSelection();
 


### PR DESCRIPTION
We previously made everything in the Vtr classes public to get rid of all of the Far friends that had been added.  Vtr class members are now appropriately made protected or private, and their friends minimized.  A number of missing accessors were added to prevent direct member access.

The Refinement subclass headers were also added to the private header list (these were the first).