### PR TITLE
Renamed internal face-varying methods for consistency with public

### DIFF
--- a/opensubdiv/far/gregoryBasis.cpp
+++ b/opensubdiv/far/gregoryBasis.cpp
@@ -62,7 +62,7 @@ getQuadOffsets(Vtr::internal::Level const & level, Vtr::Index fIndex,
 
     Far::ConstIndexArray fPoints = (fvarChannel<0) ?
         level.getFaceVertices(fIndex) :
-            level.getFVarFaceValues(fIndex, fvarChannel);
+            level.getFaceFVarValues(fIndex, fvarChannel);
     assert(fPoints.size()==4);
 
     for (int i = 0; i < 4; ++i) {
@@ -155,7 +155,7 @@ GregoryBasis::ProtoBasis::ProtoBasis(
 
     Vtr::ConstIndexArray facePoints = (fvarChannel<0) ?
         level.getFaceVertices(faceIndex) :
-            level.getFVarFaceValues(faceIndex, fvarChannel);
+            level.getFaceFVarValues(faceIndex, fvarChannel);
     assert(facePoints.size()==4);
 
     int maxvalence = level.getMaxValence(),

--- a/opensubdiv/far/topologyLevel.h
+++ b/opensubdiv/far/topologyLevel.h
@@ -62,7 +62,7 @@ public:
     int GetNumFVarChannels() const              { return _level->getNumFVarChannels(); }
     int GetNumFVarValues(int channel = 0) const { return _level->getNumFVarValues(channel); }
 
-    ConstIndexArray GetFaceFVarValues(Index f, int channel = 0) const { return _level->getFVarFaceValues(f, channel); }
+    ConstIndexArray GetFaceFVarValues(Index f, int channel = 0) const { return _level->getFaceFVarValues(f, channel); }
 
     ConstIndexArray GetFaceVertices(Index f) const { return _level->getFaceVertices(f); }
     ConstIndexArray GetFaceEdges(Index f) const    { return _level->getFaceEdges(f); }

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -286,7 +286,7 @@ TopologyRefinerFactoryBase::createBaseFVarChannel(TopologyRefiner & newRefiner, 
 }
 inline IndexArray
 TopologyRefinerFactoryBase::getBaseFaceFVarValues(TopologyRefiner & newRefiner, Index face, int channel) {
-    return newRefiner._levels[0]->getFVarFaceValues(face, channel);
+    return newRefiner._levels[0]->getFaceFVarValues(face, channel);
 }
 
 inline void

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -627,7 +627,7 @@ Level::gatherQuadRegularRingAroundVertex(
         //
         ConstIndexArray fPoints = (fvarChannel < 0)
                                 ? level.getFaceVertices(vFaces[i])
-                                : level.getFVarFaceValues(vFaces[i], fvarChannel);
+                                : level.getFaceFVarValues(vFaces[i], fvarChannel);
 
         int vInThisFace = vInFaces[i];
 
@@ -663,7 +663,7 @@ Level::gatherQuadLinearPatchPoints(
 
     ConstIndexArray facePoints = (fvarChannel < 0) ?
                                  level.getFaceVertices(thisFace) :
-                                 level.getFVarFaceValues(thisFace, fvarChannel);
+                                 level.getFaceFVarValues(thisFace, fvarChannel);
 
     patchPoints[0] = facePoints[rotatedVerts[0]];
     patchPoints[1] = facePoints[rotatedVerts[1]];
@@ -713,7 +713,7 @@ Level::gatherQuadRegularInteriorPatchPoints(
     ConstIndexArray thisFaceVerts = level.getFaceVertices(thisFace);
 
     ConstIndexArray facePoints = (fvarChannel < 0) ? thisFaceVerts :
-                                 level.getFVarFaceValues(thisFace, fvarChannel);
+                                 level.getFaceFVarValues(thisFace, fvarChannel);
 
     patchPoints[0] = facePoints[rotatedVerts[0]];
     patchPoints[1] = facePoints[rotatedVerts[1]];
@@ -739,7 +739,7 @@ Level::gatherQuadRegularInteriorPatchPoints(
         int   vInIntFace = vInFaces[intFaceInVFaces];
 
         facePoints = (fvarChannel < 0) ? level.getFaceVertices(intFace) :
-                     level.getFVarFaceValues(intFace, fvarChannel);
+                     level.getFaceFVarValues(intFace, fvarChannel);
 
         patchPoints[pointIndex++] = facePoints[fastMod4(vInIntFace + 1)];
         patchPoints[pointIndex++] = facePoints[fastMod4(vInIntFace + 2)];
@@ -844,11 +844,11 @@ Level::gatherQuadRegularBoundaryPatchPoints(
         intV1FacePoints = level.getFaceVertices(intV1Face);
         nextFacePoints  = level.getFaceVertices(nextFace);
     } else {
-        thisFacePoints  = level.getFVarFaceValues(face, fvarChannel);
-        prevFacePoints  = level.getFVarFaceValues(prevFace, fvarChannel);
-        intV0FacePoints = level.getFVarFaceValues(intV0Face, fvarChannel);
-        intV1FacePoints = level.getFVarFaceValues(intV1Face, fvarChannel);
-        nextFacePoints  = level.getFVarFaceValues(nextFace, fvarChannel);
+        thisFacePoints  = level.getFaceFVarValues(face, fvarChannel);
+        prevFacePoints  = level.getFaceFVarValues(prevFace, fvarChannel);
+        intV0FacePoints = level.getFaceFVarValues(intV0Face, fvarChannel);
+        intV1FacePoints = level.getFaceFVarValues(intV1Face, fvarChannel);
+        nextFacePoints  = level.getFaceFVarValues(nextFace, fvarChannel);
     }
 
     patchPoints[0] = thisFacePoints[fastMod4(boundaryEdgeInFace + 1)];
@@ -948,10 +948,10 @@ Level::gatherQuadRegularCornerPatchPoints(
         intFacePoints  = level.getFaceVertices(intFace);
         nextFacePoints = level.getFaceVertices(nextFace);
     } else {
-        thisFacePoints = level.getFVarFaceValues(face);
-        prevFacePoints = level.getFVarFaceValues(prevFace);
-        intFacePoints  = level.getFVarFaceValues(intFace);
-        nextFacePoints = level.getFVarFaceValues(nextFace);
+        thisFacePoints = level.getFaceFVarValues(face);
+        prevFacePoints = level.getFaceFVarValues(prevFace);
+        intFacePoints  = level.getFaceFVarValues(intFace);
+        nextFacePoints = level.getFaceFVarValues(nextFace);
     }
 
     patchPoints[0] = thisFacePoints[         cornerVertInFace];
@@ -1951,12 +1951,12 @@ Level::getFVarOptions(int channel) const {
 }
 
 ConstIndexArray
-Level::getFVarFaceValues(Index faceIndex, int channel) const {
+Level::getFaceFVarValues(Index faceIndex, int channel) const {
     return _fvarChannels[channel]->getFaceValues(faceIndex);
 }
 
 IndexArray
-Level::getFVarFaceValues(Index faceIndex, int channel) {
+Level::getFaceFVarValues(Index faceIndex, int channel) {
     return _fvarChannels[channel]->getFaceValues(faceIndex);
 }
 

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -208,7 +208,7 @@ public:
     Sdc::Options getFVarOptions(int channel = 0) const; 
     int getNumFVarChannels() const { return (int) _fvarChannels.size(); }
     int getNumFVarValues(int channel = 0) const;
-    ConstIndexArray getFVarFaceValues(Index faceIndex, int channel = 0) const;
+    ConstIndexArray getFaceFVarValues(Index faceIndex, int channel = 0) const;
 
     FVarLevel & getFVarLevel(int channel = 0) { return *_fvarChannels[channel]; }
     FVarLevel const & getFVarLevel(int channel = 0) const { return *_fvarChannels[channel]; }
@@ -329,7 +329,7 @@ public:
     int  createFVarChannel(int fvarValueCount, Sdc::Options const& options);
     void destroyFVarChannel(int channel = 0);
 
-    IndexArray getFVarFaceValues(Index faceIndex, int channel = 0);
+    IndexArray getFaceFVarValues(Index faceIndex, int channel = 0);
 
     void completeFVarChannelTopology(int channel, int regBoundaryValence);
 


### PR DESCRIPTION
In keeping with the public change from GetFVarFaceValues() to GetFaceFVarValues(), these changes apply a similar renaming to internal classes that used the same convention.