### PR TITLE
Renamed per-patch face-varying access methods

### DIFF
--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -393,7 +393,7 @@ createFVarPatchNumbers(OpenSubdiv::Far::PatchTable const & patchTable,
         handle.patchIndex = patch;
 
         OpenSubdiv::Far::ConstIndexArray const cvs =
-            patchTable.GetFVarPatchValues(channel, handle);
+            patchTable.GetPatchFVarValues(channel, handle);
 
         for (int i=0; i<cvs.size(); ++i) {
             snprintf(buf, 16, "%d", i);

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -393,14 +393,14 @@ createFVarPatchNumbers(OpenSubdiv::Far::PatchTable const & patchTable,
         handle.patchIndex = patch;
 
         OpenSubdiv::Far::ConstIndexArray const cvs =
-            patchTable.GetPatchFVarValues(channel, handle);
+            patchTable.GetPatchFVarValues(handle, channel);
 
         for (int i=0; i<cvs.size(); ++i) {
             snprintf(buf, 16, "%d", i);
             g_font->Print3D(fvarBuffer[cvs[i]].GetPos(), buf, 2);
         }
 
-        g_currentFVarPatchType = patchTable.GetFVarPatchType(channel, handle);
+        g_currentFVarPatchType = patchTable.GetFVarPatchType(handle, channel);
     }
 }
 
@@ -632,10 +632,6 @@ createFarGLMesh(Shape * shape, int maxlevel) {
         if (createFVarWire) {
 
             // interpolate fvar values
-
-            //Far::FVarPatchTable const * fvarTable =
-            //    patchTable->GetFVarPatchTable();
-            //assert(fvarTable);
 
             int channel = 0;
 

--- a/examples/farViewer/gl_mesh.cpp
+++ b/examples/farViewer/gl_mesh.cpp
@@ -487,7 +487,7 @@ GLMesh::InitializeFVar(Options options, TopologyRefiner const & refiner,
 
                 handle.patchIndex = patch;
                 OpenSubdiv::Far::PatchDescriptor::Type type =
-                    patchTable->GetFVarPatchType(channel, handle);
+                    patchTable->GetFVarPatchType(handle, channel);
 
                 if (OpenSubdiv::Far::PatchDescriptor::IsAdaptive(type)) {
                     color = getAdaptivePatchColor(

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -151,8 +151,7 @@ struct FVarData
     void Create(OpenSubdiv::Far::PatchTable const *patchTable,
                 int fvarWidth, std::vector<float> const & fvarSrcData) {
         Release();
-        OpenSubdiv::Far::ConstIndexArray indices =
-            patchTable->GetFVarValues(0);
+        OpenSubdiv::Far::ConstIndexArray indices = patchTable->GetFVarValues();
 
         // expand fvardata to per-patch array
         std::vector<float> data;

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -152,7 +152,7 @@ struct FVarData
                 int fvarWidth, std::vector<float> const & fvarSrcData) {
         Release();
         OpenSubdiv::Far::ConstIndexArray indices =
-            patchTable->GetFVarPatchesValues(0);
+            patchTable->GetFVarValues(0);
 
         // expand fvardata to per-patch array
         std::vector<float> data;

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -260,7 +260,7 @@ struct FVarData
                 int fvarWidth, std::vector<float> const & fvarSrcData) {
         Release();
         OpenSubdiv::Far::ConstIndexArray indices =
-            patchTable->GetFVarPatchesValues(0);
+            patchTable->GetFVarValues(0);
 
         // expand fvardata to per-patch array
         std::vector<float> data;

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -259,8 +259,7 @@ struct FVarData
     void Create(OpenSubdiv::Far::PatchTable const *patchTable,
                 int fvarWidth, std::vector<float> const & fvarSrcData) {
         Release();
-        OpenSubdiv::Far::ConstIndexArray indices =
-            patchTable->GetFVarValues(0);
+        OpenSubdiv::Far::ConstIndexArray indices = patchTable->GetFVarValues();
 
         // expand fvardata to per-patch array
         std::vector<float> data;

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -174,8 +174,8 @@ PatchTable::allocateFVarPatchChannels(int numChannels) {
     _fvarChannels.resize(numChannels);
 }
 void
-PatchTable::allocateChannelValues(int channel,
-    int numPatches, int numVerticesTotal) {
+PatchTable::allocateFVarPatchChannelValues(
+        int numPatches, int numVerticesTotal, int channel) {
 
     FVarPatchChannel & c = getFVarPatchChannel(channel);
     if (c.interpolation==Sdc::Options::FVAR_LINEAR_ALL) {
@@ -194,19 +194,20 @@ PatchTable::allocateChannelValues(int channel,
     }
 }
 void
-PatchTable::setFVarPatchChannelLinearInterpolation(int channel,
-        Sdc::Options::FVarLinearInterpolation interpolation) {
+PatchTable::setFVarPatchChannelLinearInterpolation(
+        Sdc::Options::FVarLinearInterpolation interpolation, int channel) {
     FVarPatchChannel & c = getFVarPatchChannel(channel);
     c.interpolation = interpolation;
 }
 void
-PatchTable::setFVarPatchChannelPatchesType(int channel, PatchDescriptor::Type type) {
+PatchTable::setFVarPatchChannelPatchesType(
+        PatchDescriptor::Type type, int channel) {
     FVarPatchChannel & c = getFVarPatchChannel(channel);
     c.patchesType = type;
 }
 void
-PatchTable::setBicubicFVarPatchChannelValues(int channel, int patchSize,
-    std::vector<Index> const & values) {
+PatchTable::setBicubicFVarPatchChannelValues(
+        int patchSize, std::vector<Index> const & values, int channel) {
 
     // This method populates the sparse array of values held in the patch
     // table from a non-sparse array of value indices generated during
@@ -460,7 +461,7 @@ PatchTable::getFVarValues(int channel) {
     return IndexArray(&c.patchValues[0], (int)c.patchValues.size());
 }
 PatchDescriptor::Type
-PatchTable::getFVarPatchType(int channel, int patch) const {
+PatchTable::getFVarPatchType(int patch, int channel) const {
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
     PatchDescriptor::Type type;
     if (c.patchesType!=PatchDescriptor::NON_PATCH) {
@@ -473,15 +474,15 @@ PatchTable::getFVarPatchType(int channel, int patch) const {
     return type;
 }
 PatchDescriptor::Type
-PatchTable::GetFVarPatchType(int channel, PatchHandle const & handle) const {
-    return getFVarPatchType(channel, handle.patchIndex);
+PatchTable::GetFVarPatchType(PatchHandle const & handle, int channel) const {
+    return getFVarPatchType(handle.patchIndex, channel);
 }
 PatchDescriptor::Type
-PatchTable::GetFVarPatchType(int channel, int arrayIndex, int patchIndex) const {
-    return getFVarPatchType(channel, getPatchIndex(arrayIndex, patchIndex));
+PatchTable::GetFVarPatchType(int arrayIndex, int patchIndex, int channel) const {
+    return getFVarPatchType(getPatchIndex(arrayIndex, patchIndex), channel);
 }
 ConstIndexArray
-PatchTable::getPatchFVarValues(int channel, int patch) const {
+PatchTable::getPatchFVarValues(int patch, int channel) const {
 
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
 
@@ -496,12 +497,12 @@ PatchTable::getPatchFVarValues(int channel, int patch) const {
    }
 }
 ConstIndexArray
-PatchTable::GetPatchFVarValues(int channel, PatchHandle const & handle) const {
-    return getPatchFVarValues(channel, handle.patchIndex);
+PatchTable::GetPatchFVarValues(PatchHandle const & handle, int channel) const {
+    return getPatchFVarValues(handle.patchIndex, channel);
 }
 ConstIndexArray
-PatchTable::GetPatchFVarValues(int channel, int arrayIndex, int patchIndex) const {
-    return getPatchFVarValues(channel, getPatchIndex(arrayIndex, patchIndex));
+PatchTable::GetPatchFVarValues(int arrayIndex, int patchIndex, int channel) const {
+    return getPatchFVarValues(getPatchIndex(arrayIndex, patchIndex), channel);
 }
 
 void

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -450,12 +450,12 @@ PatchTable::GetFVarPatchTypes(int channel) const {
     }
 }
 ConstIndexArray
-PatchTable::GetFVarPatchesValues(int channel) const {
+PatchTable::GetFVarValues(int channel) const {
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
     return ConstIndexArray(&c.patchValues[0], (int)c.patchValues.size());
 }
 IndexArray
-PatchTable::getFVarPatchesValues(int channel) {
+PatchTable::getFVarValues(int channel) {
     FVarPatchChannel & c = getFVarPatchChannel(channel);
     return IndexArray(&c.patchValues[0], (int)c.patchValues.size());
 }
@@ -481,7 +481,7 @@ PatchTable::GetFVarPatchType(int channel, int arrayIndex, int patchIndex) const 
     return getFVarPatchType(channel, getPatchIndex(arrayIndex, patchIndex));
 }
 ConstIndexArray
-PatchTable::getFVarPatchValues(int channel, int patch) const {
+PatchTable::getPatchFVarValues(int channel, int patch) const {
 
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
 
@@ -496,12 +496,12 @@ PatchTable::getFVarPatchValues(int channel, int patch) const {
    }
 }
 ConstIndexArray
-PatchTable::GetFVarPatchValues(int channel, PatchHandle const & handle) const {
-    return getFVarPatchValues(channel, handle.patchIndex);
+PatchTable::GetPatchFVarValues(int channel, PatchHandle const & handle) const {
+    return getPatchFVarValues(channel, handle.patchIndex);
 }
 ConstIndexArray
-PatchTable::GetFVarPatchValues(int channel, int arrayIndex, int patchIndex) const {
-    return getFVarPatchValues(channel, getPatchIndex(arrayIndex, patchIndex));
+PatchTable::GetPatchFVarValues(int channel, int arrayIndex, int patchIndex) const {
+    return getPatchFVarValues(channel, getPatchIndex(arrayIndex, patchIndex));
 }
 
 void

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -250,14 +250,14 @@ public:
 
 
     /// \brief Returns the value indices for a given patch in a channel
-    ConstIndexArray GetFVarPatchValues(int channel, PatchHandle const & handle) const;
+    ConstIndexArray GetPatchFVarValues(int channel, PatchHandle const & handle) const;
 
     /// \brief Returns the value indices for a given patch in a channel
-    ConstIndexArray GetFVarPatchValues(int channel, int array, int patch) const;
+    ConstIndexArray GetPatchFVarValues(int channel, int array, int patch) const;
 
 
     /// \brief Returns an array of value indices for the patches in a channel
-    ConstIndexArray GetFVarPatchesValues(int channel) const;
+    ConstIndexArray GetFVarValues(int channel) const;
     //@}
 
 
@@ -376,8 +376,8 @@ private:
     PatchDescriptor::Type getFVarPatchType(int channel, int patch) const;
     Vtr::Array<PatchDescriptor::Type> getFVarPatchTypes(int channel);
 
-    IndexArray getFVarPatchesValues(int channel);
-    ConstIndexArray getFVarPatchValues(int channel, int patch) const;
+    IndexArray getFVarValues(int channel);
+    ConstIndexArray getPatchFVarValues(int channel, int patch) const;
 
     void setBicubicFVarPatchChannelValues(int channel, int patchSize, std::vector<Index> const & values);
 

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -236,28 +236,28 @@ public:
 
 
     /// \brief Returns the interpolation mode for a given channel
-    Sdc::Options::FVarLinearInterpolation GetFVarChannelLinearInterpolation(int channel) const;
+    Sdc::Options::FVarLinearInterpolation GetFVarChannelLinearInterpolation(int channel = 0) const;
 
 
     /// \brief Returns a descriptor for a given patch in a channel
-    PatchDescriptor::Type GetFVarPatchType(int channel, PatchHandle const & handle) const;
+    PatchDescriptor::Type GetFVarPatchType(PatchHandle const & handle, int channel = 0) const;
 
     /// \brief Returns a descriptor for a given patch in a channel
-    PatchDescriptor::Type GetFVarPatchType(int channel, int array, int patch) const;
+    PatchDescriptor::Type GetFVarPatchType(int array, int patch, int channel = 0) const;
 
     /// \brief Returns an array of descriptors for the patches in a channel
-    Vtr::ConstArray<PatchDescriptor::Type> GetFVarPatchTypes(int channel) const;
+    Vtr::ConstArray<PatchDescriptor::Type> GetFVarPatchTypes(int channel = 0) const;
 
 
     /// \brief Returns the value indices for a given patch in a channel
-    ConstIndexArray GetPatchFVarValues(int channel, PatchHandle const & handle) const;
+    ConstIndexArray GetPatchFVarValues(PatchHandle const & handle, int channel = 0) const;
 
     /// \brief Returns the value indices for a given patch in a channel
-    ConstIndexArray GetPatchFVarValues(int channel, int array, int patch) const;
+    ConstIndexArray GetPatchFVarValues(int array, int patch, int channel = 0) const;
 
 
     /// \brief Returns an array of value indices for the patches in a channel
-    ConstIndexArray GetFVarValues(int channel) const;
+    ConstIndexArray GetFVarValues(int channel = 0) const;
     //@}
 
 
@@ -362,24 +362,25 @@ private:
     struct FVarPatchChannel;
     typedef std::vector<FVarPatchChannel> FVarPatchChannelVector;
 
-    FVarPatchChannel & getFVarPatchChannel(int channel);
-    FVarPatchChannel const & getFVarPatchChannel(int channel) const;
+    FVarPatchChannel & getFVarPatchChannel(int channel = 0);
+    FVarPatchChannel const & getFVarPatchChannel(int channel = 0) const;
 
     void allocateFVarPatchChannels(int numChannels);
-    void allocateChannelValues(int channel, int numPatches, int numVerticesTotal);
+    void allocateFVarPatchChannelValues(
+        int numPatches, int numVerticesTotal, int channel = 0);
 
-    void setFVarPatchChannelLinearInterpolation(int channel,
-        Sdc::Options::FVarLinearInterpolation interpolation);
+    void setFVarPatchChannelLinearInterpolation(
+        Sdc::Options::FVarLinearInterpolation interpolation, int channel = 0);
 
-    void setFVarPatchChannelPatchesType(int channel, PatchDescriptor::Type type);
+    void setFVarPatchChannelPatchesType(PatchDescriptor::Type type, int channel = 0);
 
-    PatchDescriptor::Type getFVarPatchType(int channel, int patch) const;
-    Vtr::Array<PatchDescriptor::Type> getFVarPatchTypes(int channel);
+    PatchDescriptor::Type getFVarPatchType(int patch, int channel = 0) const;
+    Vtr::Array<PatchDescriptor::Type> getFVarPatchTypes(int channel = 0);
 
-    IndexArray getFVarValues(int channel);
-    ConstIndexArray getPatchFVarValues(int channel, int patch) const;
+    IndexArray getFVarValues(int channel = 0);
+    ConstIndexArray getPatchFVarValues(int patch, int channel = 0) const;
 
-    void setBicubicFVarPatchChannelValues(int channel, int patchSize, std::vector<Index> const & values);
+    void setBicubicFVarPatchChannelValues(int patchSize, std::vector<Index> const & values, int channel = 0);
 
 private:
 

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -421,7 +421,7 @@ PatchTableFactory::allocateFVarChannels(TopologyRefiner const & refiner,
         Sdc::Options::FVarLinearInterpolation interpolation =
             refiner.GetFVarLinearInterpolation(*fvc);
 
-        table->setFVarPatchChannelLinearInterpolation(fvc.pos(), interpolation);
+        table->setFVarPatchChannelLinearInterpolation(interpolation, fvc.pos());
 
         int nverts = 0;
         if (interpolation==Sdc::Options::FVAR_LINEAR_ALL) {
@@ -429,13 +429,13 @@ PatchTableFactory::allocateFVarChannels(TopologyRefiner const & refiner,
             PatchDescriptor::Type type = options.triangulateQuads ?
                 PatchDescriptor::TRIANGLES : PatchDescriptor::QUADS;
 
-            table->setFVarPatchChannelPatchesType(fvc.pos(), type);
+            table->setFVarPatchChannelPatchesType(type, fvc.pos());
 
             nverts =
                 npatches * PatchDescriptor::GetNumFVarControlVertices(type);
 
         }
-        table->allocateChannelValues(fvc.pos(), npatches, nverts);
+        table->allocateFVarPatchChannelValues(npatches, nverts, fvc.pos());
     }
 }
 
@@ -1519,8 +1519,10 @@ PatchTableFactory::populateAdaptivePatches(
         for (fvc=fvc.begin(); fvc!=fvc.end(); ++fvc) {
 
             if (table->GetFVarChannelLinearInterpolation(fvc.pos())!=Sdc::Options::FVAR_LINEAR_ALL) {
-                table->setBicubicFVarPatchChannelValues(fvc.pos(),
-                    context.fvarPatchSize, context.fvarPatchValues[fvc.pos()]);
+                table->setBicubicFVarPatchChannelValues(
+                    context.fvarPatchSize,
+                    context.fvarPatchValues[fvc.pos()],
+                    fvc.pos());
             }
         }
     }

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -834,7 +834,7 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
 
         fptr = (Index **)alloca(fvc.size()*sizeof(Index *));
         for (fvc=fvc.begin(); fvc!=fvc.end(); ++fvc) {
-            fptr[fvc.pos()] = table->getFVarPatchesValues(fvc.pos()).begin();
+            fptr[fvc.pos()] = table->getFVarValues(fvc.pos()).begin();
         }
     }
 
@@ -861,7 +861,7 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
                     for (fvc=fvc.begin(); fvc!=fvc.end(); ++fvc) {
                         ConstIndexArray fvalues = refLevel.GetFaceFVarValues(face, *fvc);
                         for (int vert=0; vert<fvalues.size(); ++vert) {
-                            assert((levelVertOffset + fvalues[vert]) < (int)table->getFVarPatchesValues(fvc.pos()).size());
+                            assert((levelVertOffset + fvalues[vert]) < (int)table->getFVarValues(fvc.pos()).size());
                             fptr[fvc.pos()][vert] = levelFVarVertOffsets[fvc.pos()] + fvalues[vert];
                         }
                         fptr[fvc.pos()]+=fvalues.size();
@@ -1282,7 +1282,7 @@ PatchTableFactory::populateAdaptivePatches(
 
                 Index pidx = table->getPatchIndex(arrayIndex, 0);
                 int ofs = pidx * 4;
-                fptr[fvc.pos()] = &table->getFVarPatchesValues(fvc.pos())[ofs];
+                fptr[fvc.pos()] = &table->getFVarValues(fvc.pos())[ofs];
             }
             fptrs.getValue(desc) = fptr;
         }


### PR DESCRIPTION
This matches more closely the pattern used elsewhere in Far:
    GetFVarPatchValues() --> GetPatchFVarValues()
    GetFVarPatchesValues() --> GetFVarValues()