### PR TITLE
Prepare to defer face-varying bicubic patches

### DIFF
--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -400,7 +400,9 @@ createFVarPatchNumbers(OpenSubdiv::Far::PatchTable const & patchTable,
             g_font->Print3D(fvarBuffer[cvs[i]].GetPos(), buf, 2);
         }
 
+#ifdef FAR_FVAR_SMOOTH_PATCH
         g_currentFVarPatchType = patchTable.GetFVarPatchType(handle, channel);
+#endif
     }
 }
 

--- a/examples/farViewer/gl_mesh.cpp
+++ b/examples/farViewer/gl_mesh.cpp
@@ -457,7 +457,8 @@ GLMesh::InitializeFVar(Options options, TopologyRefiner const & refiner,
 
         // default to solid color
 
-        float const * color=0;
+        static float quadColor[3] = { 1.0f, 1.0f, 0.0f };
+        float const * color = quadColor;
 
         // wireframe indices
         int * basisedges = (int *)alloca(2*nedgesperpatch*sizeof(int)),
@@ -480,10 +481,11 @@ GLMesh::InitializeFVar(Options options, TopologyRefiner const & refiner,
             *ptr++ = tessFactor * (tessFactor-1) + i+1;
         }
 
-        OpenSubdiv::Far::PatchTable::PatchHandle handle;
         for (int patch=0, offset=0; patch<npatches; ++patch) {
 
+#ifdef FAR_FVAR_SMOOTH_PATCH
             if (options.edgeColorMode==EDGECOLOR_BY_PATCHTYPE) {
+                OpenSubdiv::Far::PatchTable::PatchHandle handle;
 
                 handle.patchIndex = patch;
                 OpenSubdiv::Far::PatchDescriptor::Type type =
@@ -493,10 +495,10 @@ GLMesh::InitializeFVar(Options options, TopologyRefiner const & refiner,
                     color = getAdaptivePatchColor(
                         OpenSubdiv::Far::PatchDescriptor(type));
                 } else {
-                    static float quadColor[3] = { 1.0f, 1.0f, 0.0f };
                     color = quadColor;
                 }
             }
+#endif
             assert(color);
 
             for (int edge=0; edge<nedgesperpatch; ++edge) {

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -41,6 +41,12 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Far {
 
+// XXXdyu We're going to postpone support for smooth interpolation of
+// face-varying patches until after the version 3.0 release. We've cordoned
+// off the related code with the following macro and will restore this
+// code after we cut the release.
+#undef FAR_FVAR_SMOOTH_PATCH
+
 /// \brief Container for arrays of parametric patches
 ///
 /// PatchTable contain topology and parametric information about the patches
@@ -239,6 +245,7 @@ public:
     Sdc::Options::FVarLinearInterpolation GetFVarChannelLinearInterpolation(int channel = 0) const;
 
 
+#ifdef FAR_FVAR_SMOOTH_PATCH
     /// \brief Returns a descriptor for a given patch in a channel
     PatchDescriptor::Type GetFVarPatchType(PatchHandle const & handle, int channel = 0) const;
 
@@ -247,6 +254,7 @@ public:
 
     /// \brief Returns an array of descriptors for the patches in a channel
     Vtr::ConstArray<PatchDescriptor::Type> GetFVarPatchTypes(int channel = 0) const;
+#endif
 
 
     /// \brief Returns the value indices for a given patch in a channel
@@ -372,7 +380,9 @@ private:
     void setFVarPatchChannelLinearInterpolation(
         Sdc::Options::FVarLinearInterpolation interpolation, int channel = 0);
 
+#ifdef FAR_FVAR_SMOOTH_PATCH
     void setFVarPatchChannelPatchesType(PatchDescriptor::Type type, int channel = 0);
+#endif
 
     PatchDescriptor::Type getFVarPatchType(int patch, int channel = 0) const;
     Vtr::Array<PatchDescriptor::Type> getFVarPatchTypes(int channel = 0);
@@ -380,7 +390,9 @@ private:
     IndexArray getFVarValues(int channel = 0);
     ConstIndexArray getPatchFVarValues(int patch, int channel = 0) const;
 
-    void setBicubicFVarPatchChannelValues(int patchSize, std::vector<Index> const & values, int channel = 0);
+#ifdef FAR_FVAR_SMOOTH_PATCH
+    void setBicubicFVarPatchChannelValues(int patchSize, std::vector<Index> const & values, int channel =0);
+#endif
 
 private:
 

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -94,7 +94,9 @@ public:
              endCapType(ENDCAP_GREGORY_BASIS),
              shareEndCapPatchPoints(true),
              generateFVarTables(false),
+#ifdef FAR_FVAR_SMOOTH_PATCH
              useFVarQuadEndCaps(true), // XXXX change to false when FVar Gregory is ready
+#endif
              numFVarChannels(-1),
              fvarChannelIndices(0)
         { }
@@ -116,8 +118,10 @@ public:
                                                   ///< currently only work with GregoryBasis.
 
                      // face-varying
-                     generateFVarTables   : 1, ///< Generate face-varying patch tables
-                     useFVarQuadEndCaps   : 1; ///< Use bilinear quads as end-caps around extraordinary vertices
+                     generateFVarTables   : 1;///< Generate face-varying patch tables
+#ifdef FAR_FVAR_SMOOTH_PATCH
+        unsigned int useFVarQuadEndCaps   : 1; ///< Use bilinear quads as end-caps around extraordinary vertices
+#endif
 
         int          numFVarChannels;          ///< Number of channel indices and interpolation modes passed
         int const *  fvarChannelIndices;       ///< List containing the indices of the channels selected for the factory


### PR DESCRIPTION
There's a lot of good foundational work here to eventually support
smooth interpolation of face-varying patches. Unfortunately, this
is not quite ready to release. Therefore, we've decided to defer this
feature until a later release.

This change hides this code behind the FAR_FVAR_SMOOTH_PATCH macro.