### PR TITLE
Improve OpenCL/DX interop configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,23 @@ if(OPENCL_FOUND)
                 "will not be portable to systems without OpenCL installed.")
         endif()
     endif()
+
+    if (DXSDK_FOUND AND NOT NO_DX)
+        if (OPENCL_CL_D3D11_H_FOUND)
+            set(OPENCL_D3D11_INTEROP_FOUND "YES")
+            add_definitions(
+                -DOPENSUBDIV_HAS_OPENCL_DX_INTEROP
+                -DOPENSUBDIV_HAS_CL_D3D11_H
+            )
+        endif()
+        if (OPENCL_CL_D3D11_EXT_H_FOUND)
+            set(OPENCL_D3D11_INTEROP_FOUND "YES")
+            add_definitions(
+                -DOPENSUBDIV_HAS_OPENCL_DX_INTEROP
+                -DOPENSUBDIV_HAS_CL_D3D11_EXT_H
+            )
+        endif()
+    endif()
 else()
     if (NOT NO_OPENCL)
         message(WARNING

--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -93,6 +93,39 @@ elseif (WIN32)
             ENV OpenCL_INCPATH
     )
 
+    # AMD APP SDK
+    find_file(_OPENCL_DX_INTEROP_CL_D3D11_H
+        NAMES
+            CL/cl_d3d11.h
+        PATHS
+            "${_OPENCL_INC_CAND}"
+            "${OPENCL_INCLUDE_DIRS}"
+            ENV OpenCL_INCPATH
+    )
+    if (_OPENCL_DX_INTEROP_CL_D3D11_H)
+        set(OPENCL_CL_D3D11_H_FOUND "YES")
+        message("OpenCL DX11 interop found ${_OPENCL_DX_INTEROP_CL_D3D11_H}")
+    endif()
+
+    # NVIDIA GPU Computing ToolKit
+    find_file(_OPENCL_DX_INTEROP_CL_D3D11_EXT_H
+        NAMES
+            CL/cl_d3d11_ext.h
+        PATHS
+            "${_OPENCL_INC_CAND}"
+            "${OPENCL_INCLUDE_DIRS}"
+            ENV OpenCL_INCPATH
+    )
+
+    if (_OPENCL_DX_INTEROP_CL_D3D11_EXT_H)
+        set(OPENCL_CL_D3D11_EXT_H_FOUND "YES")
+        message("OpenCL DX11 interop found ${_OPENCL_DX_INTEROP_CL_D3D11_EXT_H}")
+    endif()
+
+    if (NOT _OPENCL_DX_INTEROP_CL_D3D11_H AND NOT _OPENCL_DX_INTEROP_CL_D3D11_EXT_H)
+        message("OpenCL DX11 interop not found")
+    endif()
+
 elseif (UNIX)
 
     find_library( OPENCL_LIBRARIES

--- a/examples/common/clDeviceContext.cpp
+++ b/examples/common/clDeviceContext.cpp
@@ -40,7 +40,13 @@
 
 #if defined(OPENSUBDIV_HAS_DX11SDK)
 #include <D3D11.h>
+
+#if defined(OPENSUBDIV_HAS_CL_D3D11_H)
 #include <CL/cl_d3d11.h>
+#elif defined(OPENSUBDIV_HAS_CL_D3D11_EXT_H)
+#include <CL/cl_d3d11_ext.h>
+#endif
+
 #endif
 
 
@@ -272,7 +278,9 @@ CLDeviceContext::Initialize() {
 bool
 CLD3D11DeviceContext::Initialize(ID3D11DeviceContext *d3dDeviceContext) {
 
-#if defined(OPENSUBDIV_HAS_DX11SDK)
+#if defined(OPENSUBDIV_HAS_DX11SDK) && \
+    (defined(OPENSUBDIV_HAS_CL_D3D11_H) || defined(OPENSUBDIV_HAS_CL_D3D11_EXT_H))
+
     _d3dDeviceContext = d3dDeviceContext;
 
     cl_int ciErrNum;
@@ -281,11 +289,19 @@ CLD3D11DeviceContext::Initialize(ID3D11DeviceContext *d3dDeviceContext) {
     ID3D11Device *device;
     d3dDeviceContext->GetDevice(&device);
 
+#if defined(OPENSUBDIV_HAS_CL_D3D11_H)
     cl_context_properties props[] = {
         CL_CONTEXT_D3D11_DEVICE_KHR, (cl_context_properties)device,
         CL_CONTEXT_PLATFORM, (cl_context_properties)cpPlatform,
         0
     };
+#elif defined(OPENSUBDIV_HAS_CL_D3D11_EXT_H)
+    cl_context_properties props[] = {
+        CL_CONTEXT_D3D11_DEVICE_NV, (cl_context_properties)device,
+        CL_CONTEXT_PLATFORM, (cl_context_properties)cpPlatform,
+        0
+    };
+#endif
 
     // get the number of GPU devices available to the platform
     cl_uint numDevices = 0;

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -38,7 +38,7 @@
     #include <osd/tbbEvaluator.h>
 #endif
 
-#ifdef OPENSUBDIV_HAS_OPENCL
+#ifdef OPENSUBDIV_HAS_OPENCL_DX_INTEROP
     #include <osd/clD3D11VertexBuffer.h>
     #include <osd/clEvaluator.h>
     #include "../common/clDeviceContext.h"
@@ -344,7 +344,7 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level, int kernel, Scheme scheme=
                                    numVaryingElements,
                                    level, bits, NULL, g_pd3dDeviceContext);
 #endif
-#ifdef OPENSUBDIV_HAS_OPENCL
+#ifdef OPENSUBDIV_HAS_OPENCL_DX_INTEROP
     } else if(kernel == kCL) {
         static Osd::EvaluatorCacheT<Osd::CLEvaluator> clEvaluatorCache;
         g_mesh = new Osd::Mesh<Osd::CLD3D11VertexBuffer,
@@ -1053,7 +1053,7 @@ callbackKernel(int k) {
 
     g_kernel = k;
 
-#ifdef OPENSUBDIV_HAS_OPENCL
+#ifdef OPENSUBDIV_HAS_OPENCL_DX_INTEROP
     if (g_kernel == kCL and (not g_clDeviceContext.IsInitialized())) {
         if (g_clDeviceContext.Initialize(g_pd3dDeviceContext) == false) {
             printf("Error in initializing OpenCL\n");
@@ -1182,7 +1182,7 @@ initHUD() {
 #ifdef OPENSUBDIV_HAS_CUDA
     g_hud->AddPullDownButton(compute_pulldown, "CUDA", kCUDA);
 #endif
-#ifdef OPENSUBDIV_HAS_OPENCL
+#ifdef OPENSUBDIV_HAS_OPENCL_DX_INTEROP
     if (CLDeviceContext::HAS_CL_VERSION_1_1()) {
         g_hud->AddPullDownButton(compute_pulldown, "OpenCL", kCL);
     }

--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -242,7 +242,7 @@ if ( OPENCL_FOUND )
         list(APPEND PUBLIC_HEADER_FILES clGLVertexBuffer.h)
     endif()
 
-    if ( DXSDK_FOUND )
+    if ( OPENCL_D3D11_INTEROP_FOUND )
         list(APPEND GPU_SOURCE_FILES
              clD3D11VertexBuffer.cpp
         )

--- a/opensubdiv/osd/clD3D11VertexBuffer.cpp
+++ b/opensubdiv/osd/clD3D11VertexBuffer.cpp
@@ -26,7 +26,13 @@
 
 #include <cassert>
 #include <D3D11.h>
+#if defined(OPENSUBDIV_HAS_CL_D3D11_H)
 #include <CL/cl_d3d11.h>
+#elif defined(OPENSUBDIV_HAS_CL_D3D11_EXT_H)
+#include <CL/cl_d3d11_ext.h>
+#else
+#error "d3d11.h or d3d11_ext.h must be found in cmake"
+#endif
 
 #include "../far/error.h"
 
@@ -35,9 +41,19 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Osd {
 
-static clCreateFromD3D11BufferKHR_fn clCreateFromD3D11Buffer = NULL;
-static clEnqueueAcquireD3D11ObjectsKHR_fn clEnqueueAcquireD3D11Objects = NULL;
-static clEnqueueReleaseD3D11ObjectsKHR_fn clEnqueueReleaseD3D11Objects = NULL;
+#if defined(OPENSUBDIV_HAS_CL_D3D11_H)
+typedef clCreateFromD3D11BufferKHR_fn clCreateFromD3D11Buffer_fn;
+typedef clEnqueueAcquireD3D11ObjectsKHR_fn clEnqueueAcquireD3D11Objects_fn;
+typedef clEnqueueReleaseD3D11ObjectsKHR_fn clEnqueueReleaseD3D11Objects_fn;
+#else
+typedef clCreateFromD3D11BufferNV_fn clCreateFromD3D11Buffer_fn;
+typedef clEnqueueAcquireD3D11ObjectsNV_fn clEnqueueAcquireD3D11Objects_fn;
+typedef clEnqueueReleaseD3D11ObjectsNV_fn clEnqueueReleaseD3D11Objects_fn;
+#endif
+
+static clCreateFromD3D11Buffer_fn clCreateFromD3D11Buffer = NULL;
+static clEnqueueAcquireD3D11Objects_fn clEnqueueAcquireD3D11Objects = NULL;
+static clEnqueueReleaseD3D11Objects_fn clEnqueueReleaseD3D11Objects = NULL;
 
 // XXX: clGetExtensionFunctionAddress is marked as deprecated and
 //      clGetExtensionFunctionAddressForPlatform should be used,
@@ -52,30 +68,30 @@ static void resolveInteropFunctions() {
 
     if (not clCreateFromD3D11Buffer) {
         clCreateFromD3D11Buffer =
-            (clCreateFromD3D11BufferKHR_fn)
+            (clCreateFromD3D11Buffer_fn)
             clGetExtensionFunctionAddress("clCreateFromD3D11BufferKHR");
     }
     if (not clCreateFromD3D11Buffer) {
         clCreateFromD3D11Buffer =
-            (clCreateFromD3D11BufferKHR_fn)
+            (clCreateFromD3D11Buffer_fn)
             clGetExtensionFunctionAddress("clCreateFromD3D11BufferNV");
     }
 
     if (not clEnqueueAcquireD3D11Objects) {
-        clEnqueueAcquireD3D11Objects = (clEnqueueAcquireD3D11ObjectsKHR_fn)
+        clEnqueueAcquireD3D11Objects = (clEnqueueAcquireD3D11Objects_fn)
             clGetExtensionFunctionAddress("clEnqueueAcquireD3D11ObjectsKHR");
     }
     if (not clEnqueueAcquireD3D11Objects) {
-        clEnqueueAcquireD3D11Objects = (clEnqueueAcquireD3D11ObjectsKHR_fn)
+        clEnqueueAcquireD3D11Objects = (clEnqueueAcquireD3D11Objects_fn)
             clGetExtensionFunctionAddress("clEnqueueAcquireD3D11ObjectsNV");
     }
 
     if (not clEnqueueReleaseD3D11Objects) {
-        clEnqueueReleaseD3D11Objects = (clEnqueueReleaseD3D11ObjectsKHR_fn)
+        clEnqueueReleaseD3D11Objects = (clEnqueueReleaseD3D11Objects_fn)
             clGetExtensionFunctionAddress("clEnqueueReleaseD3D11ObjectsKHR");
     }
     if (not clEnqueueReleaseD3D11Objects) {
-        clEnqueueReleaseD3D11Objects = (clEnqueueReleaseD3D11ObjectsKHR_fn)
+        clEnqueueReleaseD3D11Objects = (clEnqueueReleaseD3D11Objects_fn)
             clGetExtensionFunctionAddress("clEnqueueReleaseD3D11ObjectsNV");
     }
 }


### PR DESCRIPTION
Build DX/CL interop classes in osd and examples only if cmake finds
cl_d3d11.h or cl_d3d11_ext.h.
Also add some defines to works with both KHR and NV version of extensions.
