### PR TITLE
Clean up compiler warnings.

### DIFF
--- a/examples/common/stb_image_write.h
+++ b/examples/common/stb_image_write.h
@@ -249,7 +249,7 @@ void stbiw__write_hdr_scanline(FILE *f, int width, int comp, unsigned char *scra
 {
    unsigned char scanlineheader[4] = { 2, 2, 0, 0 };
    unsigned char rgbe[4];
-   float linear[3];
+   float linear[3] = {0.0, 0.0, 0.0};
    int x;
 
    scanlineheader[2] = (width&0xff00)>>8;

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -442,6 +442,7 @@ createFVarPatches(OpenSubdiv::Far::TopologyRefiner const & refiner,
         std::vector<Vertex> verts(nverts);
         memset(&verts[0], 0, verts.size()*sizeof(Vertex));
 
+        /*
         OpenSubdiv::Far::PatchTable::PatchHandle handle;
 
         Vertex * vert = &verts[0];
@@ -454,6 +455,7 @@ createFVarPatches(OpenSubdiv::Far::TopologyRefiner const & refiner,
                 }
             }
         }
+        */
 
         GLMesh::Options options;
         options.edgeColorMode = GLMesh::EDGECOLOR_BY_PATCHTYPE;

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -218,7 +218,9 @@ class FVarChannelCursor {
 public:
 
     FVarChannelCursor(TopologyRefiner const & refiner,
-                      PatchTableFactory::Options options) {
+                      PatchTableFactory::Options options)
+        : _channelIndices(0)
+    {
         if (options.generateFVarTables) {
             // If client-code does not select specific channels, default to all
             // the channels in the refiner.

--- a/opensubdiv/vtr/fvarLevel.cpp
+++ b/opensubdiv/vtr/fvarLevel.cpp
@@ -268,7 +268,7 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
 
                 int   vertInEdge = vInEdge[i];
                 bool  markEdgeDiscts = false;
-                Index valueIndexInFace0;
+                Index valueIndexInFace0 = 0;
                 for (int j = 0; !markEdgeDiscts && (j < eFaces.size()); ++j) {
                     Index           fIndex  = eFaces[j];
                     ConstIndexArray fVerts  = _level.getFaceVertices(fIndex);


### PR DESCRIPTION
stb - potential use of uninitialized variable (this may have been safe)
farViewer - unused variable
patchTableFactory - _channelIndices potentially used uninitialized
FVarLevel - valueIndexInFace0 potentially used used uninitialized (was safe)