### PR TITLE
Suppress erroneous drawing around valence 2 interior vertex

### DIFF
--- a/examples/glViewer/init_shapes.h
+++ b/examples/glViewer/init_shapes.h
@@ -71,6 +71,7 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test5",    catmark_gregory_test5,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test6",    catmark_gregory_test6,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test7",    catmark_gregory_test7,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test8",    catmark_gregory_test8,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_hole_test1",       catmark_hole_test1,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_hole_test2",       catmark_hole_test2,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_hole_test3",       catmark_hole_test3,       kCatmark ) );

--- a/opensubdiv/far/gregoryBasis.cpp
+++ b/opensubdiv/far/gregoryBasis.cpp
@@ -350,7 +350,7 @@ GregoryBasis::ProtoBasis::ProtoBasis(
 
         Point const * rp = &r[vid*maxvalence];
 
-        if (valences[vid] > 2) {
+        if (valences[vid] >= 2) {
 
             float s1 = 3.0f - 2.0f*csf(n-3,2)-csf(np-3,2),
                   s2 = 2.0f*csf(n-3,2),

--- a/regression/shapes/all.h
+++ b/regression/shapes/all.h
@@ -56,6 +56,7 @@
 #include "catmark_gregory_test5.h"
 #include "catmark_gregory_test6.h"
 #include "catmark_gregory_test7.h"
+#include "catmark_gregory_test8.h"
 #include "catmark_helmet.h"
 #include "catmark_hole_test1.h"
 #include "catmark_hole_test2.h"

--- a/regression/shapes/catmark_gregory_test8.h
+++ b/regression/shapes/catmark_gregory_test8.h
@@ -1,0 +1,69 @@
+//
+//   Copyright 2014 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+static const std::string catmark_gregory_test8 = std::string(
+"v -1.000000 0.500000 0.500000\n"
+"v 0.000000 1.000000 1.00000\n"
+"v 1.000000 0.500000 0.500000\n"
+"v -1.000000 0.500000 -0.500000\n"
+"v 1.000000 0.500000 -0.500000\n"
+"v -1.000000 -0.500000 -0.500000\n"
+"v 1.000000 -0.500000 -0.500000\n"
+"v -1.000000 -0.500000 0.500000\n"
+"v 1.000000 -0.500000 0.500000\n"
+"vt 0.375000 0.000000 \n"
+"vt 0.500000 0.000000 \n"
+"vt 0.625000 0.000000 \n"
+"vt 0.375000 0.250000 \n"
+"vt 0.625000 0.250000 \n"
+"vt 0.375000 0.500000 \n"
+"vt 0.625000 0.500000 \n"
+"vt 0.375000 0.750000 \n"
+"vt 0.500000 0.750000 \n"
+"vt 0.625000 0.750000 \n"
+"vt 0.375000 1.000000 \n"
+"vt 0.500000 1.000000 \n"
+"vt 0.625000 1.000000 \n"
+"vt 0.875000 0.000000 \n"
+"vt 0.875000 0.250000 \n"
+"vt 0.125000 0.000000 \n"
+"vt 0.125000 0.250000 \n"
+"vn -0.528722 0.664008 0.528722\n"
+"vn 0.000000 0.707107 0.707107\n"
+"vn 0.528722 0.664008 0.528722\n"
+"vn -0.577350 0.577350 -0.577350\n"
+"vn 0.577350 0.577350 -0.577350\n"
+"vn -0.577350 -0.577350 -0.577350\n"
+"vn 0.577350 -0.577350 -0.577350\n"
+"vn -0.528722 -0.664008 0.528722\n"
+"vn 0.000000 -0.707107 0.707107\n"
+"vn 0.528722 -0.664008 0.528722\n"
+"s off\n"
+"f 4/4/4 1/1/1 2/2/2 3/3/3 5/5/5\n"
+"f 6/6/6 4/4/4 5/5/5 7/7/7\n"
+"f 8/8/8 6/6/6 7/7/7 9/9/9\n"
+"f 2/12/2 1/11/1 8/8/8 9/9/9 3/13/3\n"
+"f 3/3/3 9/14/10 7/15/7 5/5/5\n"
+"f 8/16/8 1/1/1 4/4/4 6/17/6\n"
+);


### PR DESCRIPTION
Although valence 2 gregory patch is not well supported yet, this fix
mitigates artifacts around such a vertex.
Adding a shape catmark_gregory_test8 to see this issue.