### PR TITLE
Examples fixes: clew crash, unsupported GPU evals, MDI

### DIFF
--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -869,9 +869,18 @@ display() {
         g_hud.DrawString(10, -20,  "FPS        : %3.1f", fps);
 
         if (g_drawMode==kFACEVARYING) {
-            static char msg[] = "Face-varying interpolation not implemented yet";
-            g_hud.DrawString(g_width/2-20/2*8, g_height/2, msg);
+            static char msg[] =
+                "ERROR: Face-varying interpolation hasn't been supported yet.";
+            g_hud.DrawString(g_width/4, g_height/4, 1, 0, 0, msg);
         }
+
+        if (g_endCap != kEndCapBSplineBasis &&
+            (g_kernel != kCPU && g_kernel != kOPENMP && g_kernel != kTBB)) {
+            static char msg[] =
+                "ERROR: This kernel only supports BSpline basis patches.";
+            g_hud.DrawString(g_width/4, g_height/4+20, 1, 0, 0, msg);
+        }
+
 
         g_hud.Flush();
     }
@@ -1124,7 +1133,9 @@ initHUD() {
     g_hud.AddPullDownButton(compute_pulldown, "CUDA", kCUDA);
 #endif
 #ifdef OPENSUBDIV_HAS_OPENCL
-    g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    if (CLDeviceContext::HAS_CL_VERSION_1_1()) {
+        g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    }
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
     g_hud.AddPullDownButton(compute_pulldown, "GL XFB", kGLXFB);

--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -652,7 +652,7 @@ int main(int argc, char ** argv) {
 
         // prep GPU kernel
 #ifdef OPENSUBDIV_HAS_OPENCL
-        if (kernel == "CL") {
+        if (kernel == "CL" && CLDeviceContext::HAS_CL_VERSION_1_1()) {
             if (g_clDeviceContext.IsInitialized() == false) {
                 if (g_clDeviceContext.Initialize() == false) {
                     std::cout << "Error in initializing OpenCL\n";

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -682,6 +682,8 @@ display() {
     updateUniformBlocks();
     bindTextures();
 
+//#define ENABLE_MDI
+#if defined(ENABLE_MDI) && defined(GL_ARB_multi_draw_indirect)
     if (g_MDI && glMultiDrawElementsIndirect) {
         SceneBase::BatchVector const &batches = g_scene->GetBatches();
         for (int i = 0; i < (int)batches.size(); ++i) {
@@ -698,6 +700,9 @@ display() {
         }
         glBindBuffer(GL_DRAW_INDIRECT_BUFFER, 0);
     } else {
+#else
+    {
+#endif
         int numObjects = g_scene->GetNumObjects();
         for (int i = 0; i < numObjects; ++i) {
             SceneBase::PatchArrayVector const &patchArrays = g_scene->GetPatchArrays(i);
@@ -1093,8 +1098,10 @@ initHUD() {
                     -200, 20, 20, true, callbackSlider, 0);
 
     {
+#if defined(ENABLE_MDI) && defined(GL_ARB_multi_draw_indirect)
         g_hud.AddCheckBox("Multi Draw Indirect (m)", g_MDI != 0,
                           10, 170, callbackCheckBox, kHUD_CB_MDI, 'm');
+#endif
         g_hud.AddCheckBox("Adaptive (`)", g_options.adaptive != 0,
                           10, 190, callbackCheckBox, kHUD_CB_ADAPTIVE, '`');
 

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -960,7 +960,9 @@ initHUD() {
     g_hud.AddPullDownButton(compute_pulldown, "CUDA", kCUDA);
 #endif
 #ifdef OPENSUBDIV_HAS_OPENCL
-    g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    if (CLDeviceContext::HAS_CL_VERSION_1_1()) {
+        g_hud.AddPullDownButton(compute_pulldown, "OpenCL", kCL);
+    }
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
     g_hud.AddPullDownButton(compute_pulldown, "GL XFB", kGLXFB);


### PR DESCRIPTION
- Fix crashes on glEvalLimit and glStencilViewer with CLEW
- Currently GPU patch evaluation only supports BSpline patches.
  raise an error message in glEvalLimit for the unsupported combinations
  until GregoryBasis evaluation will be added to them.
- Add a guard for glMultiDrawElementsIndirect, and also disable it too
