### PR TITLE
Fixed the tessellation metrics calculations

### DIFF
--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -603,6 +603,8 @@ OsdComputeBSplineBoundaryPoints(inout vec3 cpt[16], ivec3 patchParam)
 // (0,0)                                         (1,0)
 //
 
+#define OSD_MAX_TESS_LEVEL gl_MaxTessGenLevel
+
 float OsdComputePostProjectionSphereExtent(vec3 center, float diameter)
 {
     vec4 p = OsdProjectionMatrix() * vec4(center, 1.0);
@@ -619,15 +621,28 @@ float OsdComputeTessLevel(vec3 p0, vec3 p1)
     vec3 center = (p0 + p1) / 2.0;
     float diameter = distance(p0, p1);
     float projLength = OsdComputePostProjectionSphereExtent(center, diameter);
-    return round(max(1.0, OsdTessLevel() * projLength));
+    float tessLevel = round(max(1.0, OsdTessLevel() * projLength));
+
+    // We restrict adaptive tessellation levels to half of the device
+    // supported maximum because transition edges are split into two
+    // halfs and the sum of the two corresponding levels must not exceed
+    // the device maximum. We impose this limit even for non-transition
+    // edges because a non-transition edge must be able to match up with
+    // one half of the transition edge of an adjacent transition patch.
+    return min(tessLevel, OSD_MAX_TESS_LEVEL / 2);
 }
 
 void
 OsdGetTessLevelsUniform(ivec3 patchParam,
                         out vec4 tessOuterLo, out vec4 tessOuterHi)
 {
+    // Uniform factors are simple powers of two for each level.
+    // The maximum here can be increased if we know the maximum
+    // refinement level of the mesh:
+    //     min(OSD_MAX_TESS_LEVEL, pow(2, MaximumRefinementLevel-1)
     int refinementLevel = OsdGetPatchRefinementLevel(patchParam);
-    float tessLevel = OsdTessLevel() / pow(2, refinementLevel-1);
+    float tessLevel = min(OsdTessLevel(), OSD_MAX_TESS_LEVEL) /
+                        pow(2, refinementLevel-1);
 
     // tessLevels of transition edge should be clamped to 2.
     int transitionMask = OsdGetPatchTransitionMask(patchParam);


### PR DESCRIPTION
Unified transition patch drawing affects the calculation of
tessellation level metrics. Because a single edge of a shader
patch might be split into two halfs along a transition edge,
the effective maximum number of spans along any adaptive edge
is limited to half of the device maximum.