### PR TITLE
Made channel argument non-optional for internal face-varying methods

### DIFF
--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -352,22 +352,22 @@ private:
     struct FVarPatchChannel;
     typedef std::vector<FVarPatchChannel> FVarPatchChannelVector;
 
-    FVarPatchChannel & getFVarPatchChannel(int channel = 0);
-    FVarPatchChannel const & getFVarPatchChannel(int channel = 0) const;
+    FVarPatchChannel & getFVarPatchChannel(int channel);
+    FVarPatchChannel const & getFVarPatchChannel(int channel) const;
 
     void allocateFVarPatchChannels(int numChannels);
     void allocateFVarPatchChannelValues(
-        int numPatches, int numVerticesTotal, int channel = 0);
+        int numPatches, int numVerticesTotal, int channel);
 
     void setFVarPatchChannelLinearInterpolation(
-        Sdc::Options::FVarLinearInterpolation interpolation, int channel = 0);
+        Sdc::Options::FVarLinearInterpolation interpolation, int channel);
 
 
-    PatchDescriptor::Type getFVarPatchType(int patch, int channel = 0) const;
-    Vtr::Array<PatchDescriptor::Type> getFVarPatchTypes(int channel = 0);
+    PatchDescriptor::Type getFVarPatchType(int patch, int channel) const;
+    Vtr::Array<PatchDescriptor::Type> getFVarPatchTypes(int channel);
 
-    IndexArray getFVarValues(int channel = 0);
-    ConstIndexArray getPatchFVarValues(int patch, int channel = 0) const;
+    IndexArray getFVarValues(int channel);
+    ConstIndexArray getPatchFVarValues(int patch, int channel) const;
 
 
 private:

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -948,10 +948,10 @@ Level::gatherQuadRegularCornerPatchPoints(
         intFacePoints  = level.getFaceVertices(intFace);
         nextFacePoints = level.getFaceVertices(nextFace);
     } else {
-        thisFacePoints = level.getFaceFVarValues(face);
-        prevFacePoints = level.getFaceFVarValues(prevFace);
-        intFacePoints  = level.getFaceFVarValues(intFace);
-        nextFacePoints = level.getFaceFVarValues(nextFace);
+        thisFacePoints = level.getFaceFVarValues(face, fvarChannel);
+        prevFacePoints = level.getFaceFVarValues(prevFace, fvarChannel);
+        intFacePoints  = level.getFaceFVarValues(intFace, fvarChannel);
+        nextFacePoints = level.getFaceFVarValues(nextFace, fvarChannel);
     }
 
     patchPoints[0] = thisFacePoints[         cornerVertInFace];

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -205,13 +205,13 @@ public:
     bool isFaceHole(Index faceIndex) const;
 
     // Face-varying
-    Sdc::Options getFVarOptions(int channel = 0) const; 
+    Sdc::Options getFVarOptions(int channel) const; 
     int getNumFVarChannels() const { return (int) _fvarChannels.size(); }
-    int getNumFVarValues(int channel = 0) const;
-    ConstIndexArray getFaceFVarValues(Index faceIndex, int channel = 0) const;
+    int getNumFVarValues(int channel) const;
+    ConstIndexArray getFaceFVarValues(Index faceIndex, int channel) const;
 
-    FVarLevel & getFVarLevel(int channel = 0) { return *_fvarChannels[channel]; }
-    FVarLevel const & getFVarLevel(int channel = 0) const { return *_fvarChannels[channel]; }
+    FVarLevel & getFVarLevel(int channel) { return *_fvarChannels[channel]; }
+    FVarLevel const & getFVarLevel(int channel) const { return *_fvarChannels[channel]; }
 
     //  Manifold/non-manifold tags:
     void setEdgeNonManifold(Index edgeIndex, bool b);
@@ -327,9 +327,9 @@ public:
 
     //  Create, destroy and populate face-varying channels:
     int  createFVarChannel(int fvarValueCount, Sdc::Options const& options);
-    void destroyFVarChannel(int channel = 0);
+    void destroyFVarChannel(int channel);
 
-    IndexArray getFaceFVarValues(Index faceIndex, int channel = 0);
+    IndexArray getFaceFVarValues(Index faceIndex, int channel);
 
     void completeFVarChannelTopology(int channel, int regBoundaryValence);
 


### PR DESCRIPTION
The use of Class::FVarMethod(..., channel = 0) is convenient for users, but not for internal development.  We've run into a couple of places where the channel argument wasn't properly propagated to another method because of the default value, so I have removed it from internal methods.  In doing so I found one bug that we would have hit with the face-varying patches.