### PR TITLE
Added Xinerama as a link dependency for GLFW

### DIFF
--- a/cmake/FindGLFW.cmake
+++ b/cmake/FindGLFW.cmake
@@ -154,7 +154,11 @@ else ()
             message(FATAL_ERROR "Xcursor library not found - required for GLFW")
         endif()
 
-        list(APPEND GLFW_x11_LIBRARY "${X11_Xrandr_LIB}" "${X11_Xxf86vm_LIB}" "${X11_Xcursor_LIB}" "${CMAKE_THREAD_LIBS_INIT}" -lrt -lXi)
+        if(NOT X11_Xinerama_FOUND)
+            message(FATAL_ERROR "Xinerama library not found - required for GLFW")
+        endif()
+
+        list(APPEND GLFW_x11_LIBRARY "${X11_Xrandr_LIB}" "${X11_Xxf86vm_LIB}" "${X11_Xcursor_LIB}" "${X11_Xinerama_LIB}" "${CMAKE_THREAD_LIBS_INIT}" -lrt -lXi)
 
         find_library( GLFW_glfw_LIBRARY
             NAMES 


### PR DESCRIPTION
This is a recently introduced dependency in GLFW 3.1.x

Since Xinerama is widely supported, simply adding this as a required
dependency for now. If this turns out to be a problem then we can
make this dependency optional when using older versions of GLFW.