### PR TITLE
Fix a bug in limit stencil table creation

### DIFF
--- a/opensubdiv/far/stencilTable.cpp
+++ b/opensubdiv/far/stencilTable.cpp
@@ -69,7 +69,7 @@ namespace {
         for ( size_t i=start; i<offsets->size(); i++ ) {
             // Once we've copied out all the control verts, jump to the offset
             // where the actual stencils begin.
-            if ((int)i == numControlVerts)
+            if (includeCoarseVerts and (int)i == numControlVerts)
                 i = firstOffset;
 
             // Copy the stencil.

--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -453,8 +453,6 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
     //
     // Copy the proto-stencils into the limit stencil table
     //
-    size_t firstOffset = refiner.GetLevel(0).GetNumVertices();
-
     LimitStencilTable * result = new LimitStencilTable(
                                           refiner.GetLevel(0).GetNumVertices(),
                                           builder.GetStencilOffsets(),
@@ -464,7 +462,7 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
                                           builder.GetStencilDuWeights(),
                                           builder.GetStencilDvWeights(),
                                           /*ctrlVerts*/false,
-                                          firstOffset);
+                                          /*fristOffset*/0);
     return result;
 }
 


### PR DESCRIPTION
LimitStencilTableFactory::Create was returning fewer number of
stencils, off by the number of coarse vertices.