### PR TITLE
Squashed commit for #610.

### DIFF
--- a/examples/glViewer/CMakeLists.txt
+++ b/examples/glViewer/CMakeLists.txt
@@ -67,3 +67,5 @@ target_link_libraries(glViewer
 )
 
 install(TARGETS glViewer DESTINATION "${CMAKE_BINDIR_BASE}")
+
+

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -1613,6 +1613,10 @@ int main(int argc, char ** argv) {
     std::string str;
     std::vector<char const *> animobjs;
 
+
+
+    bool disable_glew_experimental = false;
+
     for (int i = 1; i < argc; ++i) {
         if (strstr(argv[i], ".obj")) {
             animobjs.push_back(argv[i]);
@@ -1628,6 +1632,10 @@ int main(int argc, char ** argv) {
         }
         else if (!strcmp(argv[i], "-f")) {
             fullscreen = true;
+        }
+        else if (strcmp(argv[i], "-x") == 0){
+            //disable it at runtime for certain buggy drivers
+            disable_glew_experimental = true;
         }
         else {
             std::ifstream ifs(argv[1]);
@@ -1709,8 +1717,12 @@ int main(int argc, char ** argv) {
 #if defined(OSD_USES_GLEW)
 #ifdef CORE_PROFILE
     // this is the only way to initialize glew correctly under core profile context.
-    glewExperimental = true;
+    if (!disable_glew_experimental)
+        glewExperimental = true;
 #endif
+#endif
+
+#if defined(OSD_USES_GLEW)
     if (GLenum r = glewInit() != GLEW_OK) {
         printf("Failed to initialize glew. Error = %s\n", glewGetErrorString(r));
         exit(1);


### PR DESCRIPTION
commit 10ab13ff84c0da1d595697e38206ab359d12e4b9
Merge: f816a43 e7e1acc
Author: Ignacio Lillo ignacio.lillo.razeto@gmail.com
Date:   Tue Jun 9 21:30:54 2015 -0300

```
Merge branch 'upstream-dev' into 358
```

commit f816a43f6bc0e5769462c11ed0e5971e1453c85d
Author: Ignacio Lillo ignacio.lillo.razeto@gmail.com
Date:   Mon Jun 8 21:36:28 2015 -0300

```
Refs #358. Converted tabs to spaces and removed extra whitepace.
```

commit acac924edc88ea078d367c31e8e5295b29a12b8a
Author: Ignacio Lillo ignacio.lillo.razeto@gmail.com
Date:   Sat Jun 6 12:31:58 2015 -0300

```
Refs #358. Renamed flag to disable glewExperimental.

The old name was -disable_glew_experimental, the new name is -x.
```

commit 46746c7cbbf9d475477816d94a63dc866f28d296
Author: Ignacio Lillo ignacio.lillo.razeto@gmail.com
Date:   Sat Jun 6 12:30:13 2015 -0300

```
Refs #358. Removed DISABLE_GLEW_EXPERIMENTAL cmake flag.
```

commit 7c32f6b3a58654c2516946dc8825fc5353c0a9df
Merge: e3d8749 5e5da32
Author: Ignacio Lillo ignacio.lillo.razeto@gmail.com
Date:   Sat Jun 6 12:16:13 2015 -0300

```
Merge branch 'dev' into 358
```

commit e3d87492981ea00eaf273a1918d4c19e012eb520
Author: Ignacio Lillo ignacio.lillo.razeto@gmail.com
Date:   Fri Jun 5 00:00:40 2015 -0300

```
Refs #358. Added runtime flag to disable glewExperimental flag
```

commit 267e9c553b89654b29b8dab5e4891388387d4ff2
Merge: 875b18c 2587f6e
Author: Ignacio Lillo ignacio.lillo.razeto@gmail.com
Date:   Thu Jun 4 23:38:15 2015 -0300

```
Merge branch 'dev' into 358
```

commit 875b18c28f9393b3de9c079b7c8ba293d53a86a7
Author: Ignacio Lillo ignacio.lillo.razeto@gmail.com
Date:   Tue Jun 2 00:06:42 2015 -0300

```
Refs #358. Added compilation flag to disable glewExperimental.
```
