### PR TITLE
More revisions to documentation pages

### DIFF
--- a/documentation/roadmap.rst
+++ b/documentation/roadmap.rst
@@ -46,40 +46,63 @@ For more details, please see the `Release Notes <release_notes.html>`_.
 3.0 Master Release (Q2 2015)
 
     * freeze subdivision 'specification' (enforce backward compatibility)
-    * add support for bi-cubic face-varying interpolation (discrete & limit)
     * add support for Loop limit evaluation & draw
 
+3.1 Supplemental Release (Q3/Q4 2015)
 
-To Infinity & Beyond
-====================
+    * include any noteworthy omissions arising from 3.0
+    * add support for bi-cubic face-varying limit patches
+    * add support for higher order differentiation of limit patches
 
-The following is a list of pending projects and future directions for
-OpenSubdiv.
+3.2 Future Release (2016)
 
-Optimize Draw
-+++++++++++++
-  OSD specializes topological patch configurations by configuring GPU shader
-  source code. This causes back-end APIs to have to bind many shaders and
-  burdens the drivers with many "draw" calls for each primitive, which does
-  not scale well. Our goal is to ultimately try to reduce this burden back to
-  a single shader bind operation per primitive.
+    * TBD
 
-    - Reduce GPU shader variants:
 
-        + Merge regular / boundary / corner cases with vertex mirroring
-        + Merge transition cases with degenerate patches
-        + Merge rotations cases with run-time conditionals
+Near Term
+=========
 
-  Note: this project has been started at Pixar.
+The following is a short list of topics already expressed as priorities and
+receiving ongoing attention -- some being actively prototyped to varying
+degrees.
+
+Feature parity for Loop subdivision
++++++++++++++++++++++++++++++++++++
+
+  The more popular Catmark scheme has long received more attention and effort
+  than the Loop scheme.  Given OpenSubdiv claims to support both, additional
+  effort is required to bring Loop to the same level of functionality as
+  Catmark.  With the feature-adaptive analysis now scheme-independent, the
+  addition of triangular patches to the PatchTables will go a long way towards
+  that goal.  Prototype patch gathering and evaluation methods have already
+  been tested within the existing code base and discussions on extending the
+  internal patch infra-structure are underway.
+
+Improved support for infinitely sharp features
+++++++++++++++++++++++++++++++++++++++++++++++
+
+  The current implementation of adaptive feature isolation requires infinitely
+  sharp creases to be pushed to the highest level of isolation -- eventually
+  representing the result with a regular patch. The surface is therefore both
+  inefficient and incorrect. Patches with a single infinitely sharp edge can be
+  represented exactly with regular boundary patches and could be isolated at a
+  much higher level.  Continuity with dart patches is necessary in such cases,
+  and approximating more sharp irregular regions with alternate patch types
+  (e.g. Gregory or Bezier) will help this goal and others.
 
 Dynamic feature adaptive isolation (DFAS)
 +++++++++++++++++++++++++++++++++++++++++
 
   Adaptive feature isolation can produce a large number of patches, especially
   when the model contains a lot of semi-sharp creases. We need a LOD solution
-  that can dynamically isolate features based on distance to view-point.
+  that can dynamically isolate features based on distance to view-point.  (Note:
+  paper from Matthias Niessner & Henry Schafer)
 
-  Note: paper from Matthias Niessner & Henry Schafer
+Longer Term
+===========
+
+The following is a list of pending projects and future directions for
+OpenSubdiv.
 
 Implement a "high-level" API layer
 ++++++++++++++++++++++++++++++++++
@@ -95,14 +118,11 @@ Implement a "high-level" API layer
 
   Note: this document drafting has been started at Pixar with partners.
 
-Support for infinitely sharp creases
-++++++++++++++++++++++++++++++++++++
+"Next-gen" back-ends
+++++++++++++++++++++
 
-  The current implementation of adaptive feature isolation requires infinitely
-  sharp creases to be pushed to the highest level of isolation. The resulting
-  surface is both incorrect and inefficient. We want to correctly support
-  infinitely sharp creases with discontinuous patches that do not require to
-  be isolated to the highest level of subdivision.
+  Implement Osd::Draw Context & Controllers for next-gen GPU APIs such as
+  Mantle, Metal, DX12, Vulkan.
 
 A means to control edge curvature
 +++++++++++++++++++++++++++++++++
@@ -114,11 +134,12 @@ A means to control edge curvature
   This will likely require the introduction of non-uniform rational splines
   (NURCCS ?) in OpenSubdiv.
 
-"Next-gen" back-ends
-++++++++++++++++++++
 
-  Implement Osd::Draw Context & Controllers for next-gen GPU APIs such as
-  Mantle, Metal, DX12, Vulkan.
+Always in Need of Improvement
+=============================
+
+And finally, a few topics that always benefit fron continual improvement.
+Any and all contributions in this area are greatly appreciated.
 
 Regression testing
 ++++++++++++++++++

--- a/documentation/subdivision_surfaces.rst
+++ b/documentation/subdivision_surfaces.rst
@@ -86,63 +86,6 @@ connectivity.
 
 ----
 
-Manifold vs Non-Manifold Geometry
-*********************************
-
-Continuous limit surfaces generally require that the topology be a
-two-dimensional manifold for the limit surface to be unambiguous.  It is
-possible (and sometimes useful, if only temporarily) to model non-manifold
-geometry and so create surfaces whose limit is not as well-defined.
-
-The following examples show typical cases of non-manifold topological
-configurations.
-
-----
-
-Non-Manifold Fan
-++++++++++++++++
-
-This "fan" configuration shows an edge shared by 3 distinct faces.
-
-.. image:: images/nonmanifold_fan.png
-   :align: center
-   :target: images/nonmanifold_fan.png
-
-With this configuration, it is unclear which face should contribute to the
-limit surface (assuming it is singular) as three of them share the same edge.
-Fan configurations are not limited to three incident faces: any configuration
-where an edge is shared by more than two faces incurs the same problem.
-
-These and other regions involving non-manifold edges are dealt with by
-considering regions that are "locally manifold".  Rather than a single limit
-surface through this problematic edge with its many incident faces, the edge
-locally partitions a single limit surface into more than one.  So each of the
-three faces here will have their own (locally manifold) limit surface -- all
-of which meet at the shared edge.
-
-----
-
-Non-Manifold Disconnected Vertex
-++++++++++++++++++++++++++++++++
-
-A vertex is disconnected from any edge and face.
-
-.. image:: images/nonmanifold_vert.png
-   :align: center
-   :target: images/nonmanifold_vert.png
-
-This case is fairly trivial: there is a very clear limit surface for the four
-vertices and the face they define, but no possible way to exact a limit surface
-from the disconnected vertex.
-
-While the vertex does not contribute to any
-limit surface, it may not be completely irrelevant though.  Such vertices may
-be worth retaining during subdivision (if for no other reason than to preserve
-certain vertex ordering) and simply ignored when it comes time to consider
-the limit surface.
-
-----
-
 Boundary Interpolation Rules
 ============================
 
@@ -212,34 +155,6 @@ Unwrapped cube example:
 
 ----
 
-"Triangle Subdivision" Rule
-===========================
-
-The triangle subdivision rule is a rule added to the Catmull-Clark scheme that
-can be applied to all triangular faces; this rule was empirically determined to
-make triangles subdivide more smoothly. However, this rule breaks the nice
-property that two separate meshes can be joined seamlessly by overlapping their
-boundaries; i.e. when there are triangles at either boundary, it is impossible
-to join the meshes seamlessly
-
-+---------------------+---------------------------------------------+
-| Mode                | Behavior                                    |
-+=====================+=============================================+
-| **TRI_SUB_CATMARK** | Default Catmark scheme weights              |
-+---------------------+---------------------------------------------+
-| **TRI_SUB_SMOOTH**  | "Smooth triangle" weights                   |
-+---------------------+---------------------------------------------+
-
-Cylinder example :
-
-.. image:: images/smoothtriangles.png
-   :align: center
-   :height: 300
-   :target: images/smoothtriangles.png
-
-
-----
-
 Semi-Sharp Creases
 ==================
 
@@ -289,6 +204,91 @@ Example of contiguous semi-sharp creases interpolation:
 .. image:: images/chaikin.png
    :align: center
    :target: images/chaikin.png
+
+----
+
+"Triangle Subdivision" Rule
+===========================
+
+The triangle subdivision rule is a rule added to the Catmull-Clark scheme that
+can be applied to all triangular faces; this rule was empirically determined to
+make triangles subdivide more smoothly. However, this rule breaks the nice
+property that two separate meshes can be joined seamlessly by overlapping their
+boundaries; i.e. when there are triangles at either boundary, it is impossible
+to join the meshes seamlessly
+
++---------------------+---------------------------------------------+
+| Mode                | Behavior                                    |
++=====================+=============================================+
+| **TRI_SUB_CATMARK** | Default Catmark scheme weights              |
++---------------------+---------------------------------------------+
+| **TRI_SUB_SMOOTH**  | "Smooth triangle" weights                   |
++---------------------+---------------------------------------------+
+
+Cylinder example :
+
+.. image:: images/smoothtriangles.png
+   :align: center
+   :height: 300
+   :target: images/smoothtriangles.png
+
+
+----
+
+Manifold vs Non-Manifold Geometry
+=================================
+
+Continuous limit surfaces generally require that the topology be a
+two-dimensional manifold for the limit surface to be unambiguous.  It is
+possible (and sometimes useful, if only temporarily) to model non-manifold
+geometry and so create surfaces whose limit is not as well-defined.
+
+The following examples show typical cases of non-manifold topological
+configurations.
+
+----
+
+Non-Manifold Fan
+****************
+
+This "fan" configuration shows an edge shared by 3 distinct faces.
+
+.. image:: images/nonmanifold_fan.png
+   :align: center
+   :target: images/nonmanifold_fan.png
+
+With this configuration, it is unclear which face should contribute to the
+limit surface (assuming it is singular) as three of them share the same edge.
+Fan configurations are not limited to three incident faces: any configuration
+where an edge is shared by more than two faces incurs the same problem.
+
+These and other regions involving non-manifold edges are dealt with by
+considering regions that are "locally manifold".  Rather than a single limit
+surface through this problematic edge with its many incident faces, the edge
+locally partitions a single limit surface into more than one.  So each of the
+three faces here will have their own (locally manifold) limit surface -- all
+of which meet at the shared edge.
+
+----
+
+Non-Manifold Disconnected Vertex
+********************************
+
+A vertex is disconnected from any edge and face.
+
+.. image:: images/nonmanifold_vert.png
+   :align: center
+   :target: images/nonmanifold_vert.png
+
+This case is fairly trivial: there is a very clear limit surface for the four
+vertices and the face they define, but no possible way to exact a limit surface
+from the disconnected vertex.
+
+While the vertex does not contribute to any
+limit surface, it may not be completely irrelevant though.  Such vertices may
+be worth retaining during subdivision (if for no other reason than to preserve
+certain vertex ordering) and simply ignored when it comes time to consider
+the limit surface.
 
 ----
 


### PR DESCRIPTION
I updated the Roadmap page as discussed to reflect more recent activity and interest.

I also re-ordered some of the topics in the Subdivision Surfaces page to de-emphasize non-manifold topology and some of the other less common features -- given that this is intended as an intro to the topic.  With the non-manifold restrictions now removed, its much less important.

Finally, I re-ordered some of the topics in the Release Notes and did some grouping that warrants review.  Most of the topics seemed to be either Performance or Topology related, so I grouped them as such -- which mainly involved items under Topology since Performance was already evolving that way.  I tried to indent each item so that the item titles stand out more, but had some issues with the RST formatting that I couldn't resolve -- indented most as expected, but a few strange exceptions.