### PR TITLE
cmake fix: specify the destination file name for the maya script

### DIFF
--- a/examples/mayaPolySmooth/CMakeLists.txt
+++ b/examples/mayaPolySmooth/CMakeLists.txt
@@ -109,7 +109,9 @@ install(TARGETS maya_polySmoothNode DESTINATION "${CMAKE_PLUGINDIR_BASE}")
 
 add_custom_target(maya_polySmoothNode_melScripts
         COMMAND
-            ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/mayaPolySmooth.mel" "${CMAKE_BINARY_DIR}/${CMAKE_LIBDIR_BASE}"
+            ${CMAKE_COMMAND} -E copy
+            "${CMAKE_CURRENT_SOURCE_DIR}/mayaPolySmooth.mel"
+            "${CMAKE_BINARY_DIR}/${CMAKE_LIBDIR_BASE}/mayaPolySmooth.mel"
         DEPENDS
             "${CMAKE_CURRENT_SOURCE_DIR}/mayaPolySmooth.mel"
 )


### PR DESCRIPTION
This change fixes a cmake build issue on windows, which fails to create lib
directory when maya example plugin is configured to build.