### PR TITLE
Fix a bug in LimitStencilTableFactory

### DIFF
--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -353,7 +353,10 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
         cvstencils = StencilTableFactory::Create(refiner, options);
     } else {
         // Sanity checks
-        if (cvstencils->GetNumStencils() != (uniform ?
+        //
+        // Note that the input cvStencils could be larger than the number of
+        // refiner's vertices, due to the existence of the end cap stencils.
+        if (cvstencils->GetNumStencils() < (uniform ?
             refiner.GetLevel(maxlevel).GetNumVertices() :
                 refiner.GetNumVerticesTotal())) {
                 return 0;


### PR DESCRIPTION
If the input cv stencil is given and it includes the local point stencils for endcaps, LimitStencilTableFactory::Create failed because of incorrect sanity checking.