### PR TITLE
Fixed Far::PatchParam encoding of refinement level

### DIFF
--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -571,7 +571,7 @@ createPtexNumbers(OpenSubdiv::Far::PatchTable const & patchTable,
                 center.AddWithWeight(vertexBuffer[cvs[remap[k]]], 0.25f);
             }
 
-            snprintf(buf, 16, "%d", patchTable.GetPatchParam(array, patch).faceIndex);
+            snprintf(buf, 16, "%d", patchTable.GetPatchParam(array, patch).GetFaceId());
             g_font->Print3D(center.GetPos(), buf, 1);
         }
     }

--- a/examples/glShareTopology/sceneBase.cpp
+++ b/examples/glShareTopology/sceneBase.cpp
@@ -242,8 +242,8 @@ SceneBase::CreateIndexBuffer() {
             // XXX: needs sharpness interface for patcharray or put sharpness into patchParam.
             for (int k = 0; k < patchParams.size(); ++k) {
                 float sharpness = 0.0;
-                ppBuffer.push_back(patchParams[k].faceIndex);
-                ppBuffer.push_back(patchParams[k].bitField.field);
+                ppBuffer.push_back(patchParams[k].field0);
+                ppBuffer.push_back(patchParams[k].field1);
                 ppBuffer.push_back(*((unsigned int *)&sharpness));
             }
         }

--- a/opensubdiv/far/patchBasis.h
+++ b/opensubdiv/far/patchBasis.h
@@ -45,16 +45,16 @@ namespace internal {
 // So this interface will be changing in future.
 //
 
-void GetBilinearWeights(PatchParam::BitField bits,
+void GetBilinearWeights(PatchParam const & patchParam,
     float s, float t, float wP[4], float wDs[4], float wDt[4]);
 
-void GetBezierWeights(PatchParam::BitField bits,
+void GetBezierWeights(PatchParam const & patchParam,
     float s, float t, float wP[16], float wDs[16], float wDt[16]);
 
-void GetBSplineWeights(PatchParam::BitField bits,
+void GetBSplineWeights(PatchParam const & patchParam,
     float s, float t, float wP[16], float wDs[16], float wDt[16]);
 
-void GetGregoryWeights(PatchParam::BitField bits,
+void GetGregoryWeights(PatchParam const & patchParam,
     float s, float t, float wP[20], float wDs[20], float wDt[20]);
 
 

--- a/opensubdiv/far/patchMap.cpp
+++ b/opensubdiv/far/patchMap.cpp
@@ -91,7 +91,7 @@ PatchMap::initialize( PatchTable const & patchTable ) {
             h.patchIndex = current;
             h.vertIndex  = j * ringsize;
 
-            nfaces = std::max(nfaces, (int)params[j].faceIndex);
+            nfaces = std::max(nfaces, (int)params[j].GetFaceId());
 
             ++current;
         }
@@ -113,21 +113,21 @@ PatchMap::initialize( PatchTable const & patchTable ) {
 
         for (int i=0; i < patchTable.GetNumPatches(parray); ++i, ++handleIndex) {
 
-            PatchParam::BitField bits = params[i].bitField;
+            PatchParam const & param = params[i];
 
-            unsigned char depth = bits.GetDepth();
+            unsigned short depth = param.GetDepth();
 
-            QuadNode * node = &quadtree[ params[i].faceIndex ];
+            QuadNode * node = &quadtree[ params[i].GetFaceId() ];
 
-            if (depth==(bits.NonQuadRoot() ? 1 : 0)) {
+            if (depth==(param.NonQuadRoot() ? 1 : 0)) {
                 // special case : regular BSpline face w/ no sub-patches
                 node->SetChild( handleIndex );
                 continue;
             }
 
-            int u = bits.GetU(),
-                v = bits.GetV(),
-                pdepth = bits.NonQuadRoot() ? depth-2 : depth-1,
+            int u = param.GetU(),
+                v = param.GetV(),
+                pdepth = param.NonQuadRoot() ? depth-2 : depth-1,
                 half = 1 << pdepth;
 
             for (unsigned char j=0; j<depth; ++j) {

--- a/opensubdiv/far/patchParam.h
+++ b/opensubdiv/far/patchParam.h
@@ -44,12 +44,17 @@ namespace Far {
 ///
 /// Bitfield layout :
 ///
-///  Field      | Bits | Content
+///  Field0     | Bits | Content
 ///  -----------|:----:|------------------------------------------------------
-///  level      | 3    | the subdivision level of the patch
-///  nonquad    | 1    | whether the patch is the child of a non-quad face
-///  boundary   | 4    | boundary edge mask encoding
+///  faceId     | 28   | the faceId of the patch
 ///  transition | 4    | transition edge mask encoding
+///
+///  Field1     | Bits | Content
+///  -----------|:----:|------------------------------------------------------
+///  level      | 4    | the subdivision level of the patch
+///  nonquad    | 1    | whether the patch is the child of a non-quad face
+///  unused     | 3    | transition edge mask encoding
+///  boundary   | 4    | boundary edge mask encoding
 ///  v          | 10   | log2 value of u parameter at first patch corner
 ///  u          | 10   | log2 value of v parameter at first patch corner
 ///
@@ -57,62 +62,9 @@ namespace Far {
 ///        GPU & CPU compilers pack bit-fields and endian-ness.
 ///
 struct PatchParam {
-    Index faceIndex:32; // Ptex face index
-
-    struct BitField {
-        unsigned int field:32;
-
-        /// \brief Sets the values of the bit fields
-        ///
-        /// @param u value of the u parameter for the first corner of the face
-        /// @param v value of the v parameter for the first corner of the face
-        ///
-        /// @param rots rotations required to reproduce CCW face-winding
-        /// @param depth subdivision level of the patch
-        /// @param nonquad true if the root face is not a quad
-        ///
-        void Set( short u, short v, unsigned char depth, bool nonquad,
-                  unsigned short boundary, unsigned short transition );
-
-        /// \brief Returns the log2 value of the u parameter at the top left corner of
-        /// the patch
-        unsigned short GetU() const { return (unsigned short)((field >> 22) & 0x3ff); }
-
-        /// \brief Returns the log2 value of the v parameter at the top left corner of
-        /// the patch
-        unsigned short GetV() const { return (unsigned short)((field >> 12) & 0x3ff); }
-
-        /// \brief Returns the transition edge encoding for the patch.
-        unsigned short GetTransition() const { return (unsigned short)((field >> 8) & 0xf); }
-
-        /// \brief Returns the boundary edge encoding for the patch.
-        unsigned short GetBoundary() const { return (unsigned short)((field >> 4) & 0xf); }
-
-        /// \brief True if the parent coarse face is a non-quad
-        bool NonQuadRoot() const { return (field >> 3) & 0x1; }
-
-        /// \brief Returns the fratcion of normalized parametric space covered by the
-        /// sub-patch.
-        float GetParamFraction() const;
-
-        /// \brief Returns the level of subdivision of the patch
-        unsigned char GetDepth() const { return  (unsigned char)(field & 0x7); }
-
-        /// The (u,v) pair is normalized to this sub-parametric space.
-        ///
-        /// @param u  u parameter
-        /// @param v  v parameter
-        ///
-        void Normalize( float & u, float & v ) const;
-
-        /// \brief Resets the values to 0
-        void Clear() { field = 0; }
-
-    } bitField;
-
     /// \brief Sets the values of the bit fields
     ///
-    /// @param faceid ptex face index
+    /// @param faceid face index
     ///
     /// @param u value of the u parameter for the first corner of the face
     /// @param v value of the v parameter for the first corner of the face
@@ -121,11 +73,49 @@ struct PatchParam {
     /// @param depth subdivision level of the patch
     /// @param nonquad true if the root face is not a quad
     ///
-    void Set( Index faceid, short u, short v, unsigned char depth, bool nonquad ,
+    void Set( Index faceid, short u, short v,
+              unsigned short depth, bool nonquad ,
               unsigned short boundary, unsigned short transition );
 
     /// \brief Resets everything to 0
-    void Clear();
+    void Clear() { field0 = field1 = 0; }
+
+    /// \brief Retuns the faceid
+    Index GetFaceId() const { return Index(field0 & 0xfffffff); }
+
+    /// \brief Returns the log2 value of the u parameter at the top left corner of
+    /// the patch
+    unsigned short GetU() const { return (unsigned short)((field1 >> 22) & 0x3ff); }
+
+    /// \brief Returns the log2 value of the v parameter at the top left corner of
+    /// the patch
+    unsigned short GetV() const { return (unsigned short)((field1 >> 12) & 0x3ff); }
+
+    /// \brief Returns the transition edge encoding for the patch.
+    unsigned short GetTransition() const { return (unsigned short)((field0 >> 28) & 0xf); }
+
+    /// \brief Returns the boundary edge encoding for the patch.
+    unsigned short GetBoundary() const { return (unsigned short)((field1 >> 8) & 0xf); }
+
+    /// \brief True if the parent coarse face is a non-quad
+    bool NonQuadRoot() const { return (field1 >> 4) & 0x1; }
+
+    /// \brief Returns the fraction of normalized parametric space covered by the
+    /// sub-patch.
+    float GetParamFraction() const;
+
+    /// \brief Returns the level of subdivision of the patch
+    unsigned short GetDepth() const { return  (unsigned short)(field1 & 0xf); }
+
+    /// The (u,v) pair is normalized to this sub-parametric space.
+    ///
+    /// @param u  u parameter
+    /// @param v  v parameter
+    ///
+    void Normalize( float & u, float & v ) const;
+
+    unsigned int field0:32;
+    unsigned int field1:32;
 };
 
 typedef std::vector<PatchParam> PatchParamTable;
@@ -134,19 +124,20 @@ typedef Vtr::Array<PatchParam> PatchParamArray;
 typedef Vtr::ConstArray<PatchParam> ConstPatchParamArray;
 
 inline void
-PatchParam::BitField::Set( short u, short v, unsigned char depth, bool nonquad,
-                           unsigned short boundary, unsigned short transition ) {
-    field = (u << 22) |
-            (v << 12) |
-            (transition << 8) |
-            (boundary << 4) |
-            ((nonquad ? 1:0) << 3) |
-            (nonquad ? depth+1 : depth);
+PatchParam::Set( Index faceid, short u, short v,
+                 unsigned short depth, bool nonquad,
+                 unsigned short boundary, unsigned short transition ) {
+    field0 = (((unsigned int)faceid) & 0xfffffff) |
+             ((transition & 0xf) << 28);
+    field1 = ((u & 0x3ff) << 22) |
+             ((v & 0x3ff) << 12) |
+             ((boundary & 0xf) << 8) |
+             ((nonquad ? 1:0) << 4) |
+             (nonquad ? depth+1 : depth);
 }
 
-
 inline float
-PatchParam::BitField::GetParamFraction( ) const {
+PatchParam::GetParamFraction( ) const {
     if (NonQuadRoot()) {
         return 1.0f / float( 1 << (GetDepth()-1) );
     } else {
@@ -155,7 +146,7 @@ PatchParam::BitField::GetParamFraction( ) const {
 }
 
 inline void
-PatchParam::BitField::Normalize( float & u, float & v ) const {
+PatchParam::Normalize( float & u, float & v ) const {
 
     float frac = GetParamFraction();
 
@@ -166,19 +157,6 @@ PatchParam::BitField::Normalize( float & u, float & v ) const {
     // normalize u,v coordinates
     u = (u - pu) / frac,
     v = (v - pv) / frac;
-}
-
-inline void
-PatchParam::Set( Index faceid, short u, short v, unsigned char depth, bool nonquad,
-                 unsigned short boundary, unsigned short transition ) {
-    faceIndex = faceid;
-    bitField.Set(u,v,depth,nonquad,boundary,transition);
-}
-
-inline void
-PatchParam::Clear() {
-    faceIndex = 0;
-    bitField.Clear();
 }
 
 } // end namespace Far

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -427,14 +427,14 @@ PatchTable::EvaluateBasis(PatchHandle const & handle, float s, float t,
     float wP[], float wDs[], float wDt[]) const {
 
     PatchDescriptor::Type patchType = GetPatchArrayDescriptor(handle.arrayIndex).GetType();
-    PatchParam::BitField const & patchBits = _paramTable[handle.patchIndex].bitField;
+    PatchParam const & param = _paramTable[handle.patchIndex];
 
     if (patchType == PatchDescriptor::REGULAR) {
-        internal::GetBSplineWeights(patchBits, s, t, wP, wDs, wDt);
+        internal::GetBSplineWeights(param, s, t, wP, wDs, wDt);
     } else if (patchType == PatchDescriptor::GREGORY_BASIS) {
-        internal::GetGregoryWeights(patchBits, s, t, wP, wDs, wDt);
+        internal::GetGregoryWeights(param, s, t, wP, wDs, wDt);
     } else if (patchType == PatchDescriptor::QUADS) {
-        internal::GetBilinearWeights(patchBits, s, t, wP, wDs, wDt);
+        internal::GetBilinearWeights(param, s, t, wP, wDs, wDt);
     } else {
         assert(0);
     }

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -440,16 +440,16 @@ PatchTableFactory::gatherFVarData(AdaptiveContext & context, int level,
 }
 
 //
-//  Populates the face-varying data buffer 'coord' for the given face, returning
-//  a pointer to the next descriptor
+//  Populates the PatchParam for the given face, returning
+//  a pointer to the next entry
 //
 PatchParam *
 PatchTableFactory::computePatchParam(
     TopologyRefiner const & refiner, PtexIndices const &ptexIndices,
     int depth, Vtr::Index faceIndex, int boundaryMask, 
-    int transitionMask, PatchParam *coord) {
+    int transitionMask, PatchParam *param) {
 
-    if (coord == NULL) return NULL;
+    if (param == NULL) return NULL;
 
     // Move up the hierarchy accumulating u,v indices to the coarse level:
     int childIndexInParent = 0,
@@ -497,10 +497,10 @@ PatchTableFactory::computePatchParam(
         --depth;
     }
 
-    coord->Set(ptexIndex, (short)u, (short)v, (unsigned char) depth, nonquad,
+    param->Set(ptexIndex, (short)u, (short)v, (unsigned short) depth, nonquad,
                (unsigned short) boundaryMask, (unsigned short) transitionMask);
 
-    return ++coord;
+    return ++param;
 }
 
 

--- a/opensubdiv/osd/clKernel.cl
+++ b/opensubdiv/osd/clKernel.cl
@@ -157,8 +157,8 @@ struct PatchCoord {
 };
 
 struct PatchParam {
-    int faceIndex;
-    uint patchBits;
+    uint field0;
+    uint field1;
     float sharpness;
 };
 
@@ -182,7 +182,7 @@ static void getBSplineWeights(float t, float *point, float *deriv) {
 }
 
 static void adjustBoundaryWeights(uint bits, float *sWeights, float *tWeights) {
-    int boundary = ((bits >> 4) & 0xf);
+    int boundary = ((bits >> 8) & 0xf);
 
     if (boundary & 1) {
         tWeights[2] -= tWeights[0];
@@ -207,11 +207,11 @@ static void adjustBoundaryWeights(uint bits, float *sWeights, float *tWeights) {
 }
 
 static int getDepth(uint patchBits) {
-    return (patchBits & 0x7);
+    return (patchBits & 0xf);
 }
 
 static float getParamFraction(uint patchBits) {
-    bool nonQuadRoot = (patchBits >> 3) & 0x1;
+    bool nonQuadRoot = (patchBits >> 4) & 0x1;
     int depth = getDepth(patchBits);
     if (nonQuadRoot) {
         return 1.0f / (float)( 1 << (depth-1) );
@@ -255,7 +255,7 @@ __kernel void computePatches(__global float *src, int srcOffset,
 
     int patchType = 6; // array.patchType XXX: REGULAR only for now.
     int numControlVertices = 16;
-    uint patchBits = patchParamBuffer[coord.patchIndex].patchBits;
+    uint patchBits = patchParamBuffer[coord.patchIndex].field1;
 
     float uv[2] = {coord.s, coord.t};
     normalizePatchCoord(patchBits, uv);

--- a/opensubdiv/osd/cpuEvaluator.cpp
+++ b/opensubdiv/osd/cpuEvaluator.cpp
@@ -145,20 +145,20 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         // XXX: patchIndex is absolute. not sure it's consistent.
         //      (should be offsetted by array.primitiveIdBase?)
         //    patchParamBuffer[array.primitiveIdBase + coord.handle.patchIndex]
-        Far::PatchParam::BitField patchBits = *(Far::PatchParam::BitField*)
-            &patchParamBuffer[coord.handle.patchIndex].patchBits;
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
-            Far::internal::GetBSplineWeights(patchBits,
+            Far::internal::GetBSplineWeights(param,
                                              coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 16;
         } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-            Far::internal::GetGregoryWeights(patchBits,
+            Far::internal::GetGregoryWeights(param,
                                              coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 20;
         } else if (patchType == Far::PatchDescriptor::QUADS) {
-            Far::internal::GetBilinearWeights(patchBits,
+            Far::internal::GetBilinearWeights(param,
                                               coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 4;
         } else {
@@ -218,20 +218,20 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
         int patchType = array.GetPatchType();
-        Far::PatchParam::BitField patchBits = *(Far::PatchParam::BitField*)
-            &patchParamBuffer[coord.handle.patchIndex].patchBits;
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
-            Far::internal::GetBSplineWeights(patchBits,
+            Far::internal::GetBSplineWeights(param,
                                              coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 16;
         } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-            Far::internal::GetGregoryWeights(patchBits,
+            Far::internal::GetGregoryWeights(param,
                                              coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 20;
         } else if (patchType == Far::PatchDescriptor::QUADS) {
-            Far::internal::GetBilinearWeights(patchBits,
+            Far::internal::GetBilinearWeights(param,
                                               coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 4;
         } else {

--- a/opensubdiv/osd/cpuPatchTable.cpp
+++ b/opensubdiv/osd/cpuPatchTable.cpp
@@ -69,8 +69,8 @@ CpuPatchTable::CpuPatchTable(const Far::PatchTable *farPatchTable) {
             farPatchTable->GetPatchParams(j);
         for (int k = 0; k < patchParams.size(); ++k) {
             float sharpness = 0.0;
-            _patchParamBuffer.push_back(patchParams[k].faceIndex);
-            _patchParamBuffer.push_back(patchParams[k].bitField.field);
+            _patchParamBuffer.push_back(patchParams[k].field0);
+            _patchParamBuffer.push_back(patchParams[k].field1);
             _patchParamBuffer.push_back(*((unsigned int *)&sharpness));
         }
 #else
@@ -90,8 +90,8 @@ CpuPatchTable::CpuPatchTable(const Far::PatchTable *farPatchTable) {
             }
             PatchParam param;
             //param.patchParam = patchParamTable[patchIndex];
-            param.faceIndex = patchParamTable[patchIndex].faceIndex;
-            param.patchBits = patchParamTable[patchIndex].bitField.field;
+            param.field0 = patchParamTable[patchIndex].field0;
+            param.field1 = patchParamTable[patchIndex].field1;
             param.sharpness = sharpness;
             _patchParamBuffer.push_back(param);
         }

--- a/opensubdiv/osd/cudaKernel.cu
+++ b/opensubdiv/osd/cudaKernel.cu
@@ -253,8 +253,8 @@ struct PatchArray {
     int primitiveIdBase;  // offset in the patch param buffer
 };
 struct PatchParam {
-    int faceIndex;
-    unsigned int bitField;
+    unsigned int field0;
+    unsigned int field1;
     float sharpness;
 };
 
@@ -282,7 +282,7 @@ getBSplineWeights(float t, float point[4], float deriv[4]) {
 
 __device__ void
 adjustBoundaryWeights(unsigned int bits, float sWeights[4], float tWeights[4]) {
-    int boundary = ((bits >> 4) & 0xf);  // far/patchParam.h
+    int boundary = ((bits >> 8) & 0xf);  // far/patchParam.h
 
     if (boundary & 1) {
         tWeights[2] -= tWeights[0];
@@ -308,12 +308,12 @@ adjustBoundaryWeights(unsigned int bits, float sWeights[4], float tWeights[4]) {
 
 __device__
 int getDepth(unsigned int patchBits) {
-    return (patchBits & 0x7);
+    return (patchBits & 0xf);
 }
 
 __device__
 float getParamFraction(unsigned int patchBits) {
-    bool nonQuadRoot = (patchBits >> 3) & 0x1;
+    bool nonQuadRoot = (patchBits >> 4) & 0x1;
     int depth = getDepth(patchBits);
     if (nonQuadRoot) {
         return 1.0f / float( 1 << (depth-1) );
@@ -360,7 +360,7 @@ computePatches(const float *src, float *dst, float *dstDu, float *dstDv,
         int patchType = 6; // array.patchType XXX: REGULAR only for now.
         int numControlVertices = 16;
         // note: patchIndex is absolute.
-        unsigned int patchBits = patchParamBuffer[coord.patchIndex].bitField;
+        unsigned int patchBits = patchParamBuffer[coord.patchIndex].field1;
 
         // normalize
         float s = coord.s;

--- a/opensubdiv/osd/glPatchTable.cpp
+++ b/opensubdiv/osd/glPatchTable.cpp
@@ -66,8 +66,7 @@ GLPatchTable::allocate(Far::PatchTable const *farPatchTable) {
     GLsizei patchParamSize = (GLsizei)patchTable.GetPatchParamSize();
 
     // copy patch array
-    _patchArrays.insert(_patchArrays.end(),
-                        patchTable.GetPatchArrayBuffer(),
+    _patchArrays.assign(patchTable.GetPatchArrayBuffer(),
                         patchTable.GetPatchArrayBuffer() + numPatchArrays);
 
     // copy index buffer

--- a/opensubdiv/osd/glslComputeKernel.glsl
+++ b/opensubdiv/osd/glslComputeKernel.glsl
@@ -73,8 +73,8 @@ struct PatchCoord {
    float t;
 };
 struct PatchParam {
-    int faceIndex;
-    uint patchBits;
+    uint field0;
+    uint field1;
     float sharpness;
 };
 uniform ivec4 patchArray[2];
@@ -214,11 +214,11 @@ void getBSplineWeights(float t, inout vec4 point, inout vec4 deriv) {
 }
 
 uint getDepth(uint patchBits) {
-    return (patchBits & 0x7);
+    return (patchBits & 0xf);
 }
 
 float getParamFraction(uint patchBits) {
-    uint nonQuadRoot = (patchBits >> 3) & 0x1;
+    uint nonQuadRoot = (patchBits >> 4) & 0x1;
     uint depth = getDepth(patchBits);
     if (nonQuadRoot == 1) {
         return 1.0f / float( 1 << (depth-1) );
@@ -242,7 +242,7 @@ vec2 normalizePatchCoord(uint patchBits, vec2 uv) {
 }
 
 void adjustBoundaryWeights(uint bits, inout vec4 sWeights, inout vec4 tWeights) {
-    uint boundary = ((bits >> 4) & 0xf);
+    uint boundary = ((bits >> 8) & 0xf);
 
     if ((boundary & 1) != 0) {
         tWeights[2] -= tWeights[0];
@@ -277,7 +277,7 @@ void main() {
     int patchType = 6; // array.x XXX: REGULAR only for now.
     int numControlVertices = 16;
 
-    uint patchBits = patchParamBuffer[patchIndex].patchBits;
+    uint patchBits = patchParamBuffer[patchIndex].field1;
     vec2 uv = normalizePatchCoord(patchBits, vec2(coord.s, coord.t));
     float dScale = float(1 << getDepth(patchBits));
 

--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -155,27 +155,27 @@ ivec3 OsdGetPatchParam(int patchIndex)
 
 int OsdGetPatchFaceId(ivec3 patchParam)
 {
-    return patchParam.x;
+    return (patchParam.x & 0xfffffff);
 }
 
 int OsdGetPatchFaceLevel(ivec3 patchParam)
 {
-    return (1 << ((patchParam.y & 0x7) - ((patchParam.y >> 3) & 1)));
+    return (1 << ((patchParam.y & 0xf) - ((patchParam.y >> 4) & 1)));
 }
 
 int OsdGetPatchRefinementLevel(ivec3 patchParam)
 {
-    return (patchParam.y & 0x7);
+    return (patchParam.y & 0xf);
 }
 
 int OsdGetPatchBoundaryMask(ivec3 patchParam)
 {
-    return ((patchParam.y >> 4) & 0xf);
+    return ((patchParam.y >> 8) & 0xf);
 }
 
 int OsdGetPatchTransitionMask(ivec3 patchParam)
 {
-    return ((patchParam.y >> 8) & 0xf);
+    return ((patchParam.x >> 28) & 0xf);
 }
 
 ivec2 OsdGetPatchFaceUV(ivec3 patchParam)

--- a/opensubdiv/osd/glslXFBKernel.glsl
+++ b/opensubdiv/osd/glslXFBKernel.glsl
@@ -173,11 +173,11 @@ void getBSplineWeights(float t, inout vec4 point, inout vec4 deriv) {
 }
 
 uint getDepth(uint patchBits) {
-    return (patchBits & 0x7U);
+    return (patchBits & 0xfU);
 }
 
 float getParamFraction(uint patchBits) {
-    uint nonQuadRoot = (patchBits >> 3) & 0x1U;
+    uint nonQuadRoot = (patchBits >> 4) & 0x1U;
     uint depth = getDepth(patchBits);
     if (nonQuadRoot == 1) {
         return 1.0f / float( 1 << (depth-1) );
@@ -201,7 +201,7 @@ vec2 normalizePatchCoord(uint patchBits, vec2 uv) {
 }
 
 void adjustBoundaryWeights(uint bits, inout vec4 sWeights, inout vec4 tWeights) {
-    uint boundary = ((bits >> 4) & 0xfU);
+    uint boundary = ((bits >> 8) & 0xfU);
 
     if ((boundary & 1U) != 0) {
         tWeights[2] -= tWeights[0];

--- a/opensubdiv/osd/hlslPatchCommon.hlsl
+++ b/opensubdiv/osd/hlslPatchCommon.hlsl
@@ -130,27 +130,27 @@ int3 OsdGetPatchParam(int patchIndex)
 
 int OsdGetPatchFaceId(int3 patchParam)
 {
-    return patchParam.x;
+    return (patchParam.x & 0xfffffff);
 }
 
 int OsdGetPatchFaceLevel(int3 patchParam)
 {
-    return (1 << ((patchParam.y & 0x7) - ((patchParam.y >> 3) & 1)));
+    return (1 << ((patchParam.y & 0xf) - ((patchParam.y >> 4) & 1)));
 }
 
 int OsdGetPatchRefinementLevel(int3 patchParam)
 {
-    return (patchParam.y & 0x7);
+    return (patchParam.y & 0xf);
 }
 
 int OsdGetPatchBoundaryMask(int3 patchParam)
 {
-    return ((patchParam.y >> 4) & 0xf);
+    return ((patchParam.y >> 8) & 0xf);
 }
 
 int OsdGetPatchTransitionMask(int3 patchParam)
 {
-    return ((patchParam.y >> 8) & 0xf);
+    return ((patchParam.x >> 28) & 0xf);
 }
 
 int2 OsdGetPatchFaceUV(int3 patchParam)

--- a/opensubdiv/osd/ompEvaluator.cpp
+++ b/opensubdiv/osd/ompEvaluator.cpp
@@ -142,20 +142,20 @@ OmpEvaluator::EvalPatches(
         // XXX: patchIndex is absolute. not sure it's consistent.
         //      (should be offsetted by array.primitiveIdBase?)
         //    patchParamBuffer[array.primitiveIdBase + coord.handle.patchIndex]
-        Far::PatchParam::BitField patchBits = *(Far::PatchParam::BitField*)
-            &patchParamBuffer[coord.handle.patchIndex].patchBits;
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
-            Far::internal::GetBSplineWeights(patchBits,
+            Far::internal::GetBSplineWeights(param,
                                              coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 16;
         } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-            Far::internal::GetGregoryWeights(patchBits,
+            Far::internal::GetGregoryWeights(param,
                                              coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 20;
         } else if (patchType == Far::PatchDescriptor::QUADS) {
-            Far::internal::GetBilinearWeights(patchBits,
+            Far::internal::GetBilinearWeights(param,
                                               coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 4;
         } else {
@@ -203,20 +203,20 @@ OmpEvaluator::EvalPatches(
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
         int patchType = array.GetPatchType();
-        Far::PatchParam::BitField patchBits = *(Far::PatchParam::BitField*)
-            &patchParamBuffer[coord.handle.patchIndex].patchBits;
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
-            Far::internal::GetBSplineWeights(patchBits,
+            Far::internal::GetBSplineWeights(param,
                                              coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 16;
         } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-            Far::internal::GetGregoryWeights(patchBits,
+            Far::internal::GetGregoryWeights(param,
                                              coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 20;
         } else if (patchType == Far::PatchDescriptor::QUADS) {
-            Far::internal::GetBilinearWeights(patchBits,
+            Far::internal::GetBilinearWeights(param,
                                               coord.s, coord.t, wP, wDs, wDt);
             numControlVertices = 4;
         } else {

--- a/opensubdiv/osd/tbbKernel.cpp
+++ b/opensubdiv/osd/tbbKernel.cpp
@@ -329,20 +329,20 @@ public:
             PatchArray const &array = _patchArrayBuffer[coord.handle.arrayIndex];
 
             int patchType = array.GetPatchType();
-            Far::PatchParam::BitField patchBits = *(Far::PatchParam::BitField*)
-                &_patchParamBuffer[coord.handle.patchIndex].patchBits;
+            Far::PatchParam const & param =
+                _patchParamBuffer[coord.handle.patchIndex];
 
             int numControlVertices = 0;
             if (patchType == Far::PatchDescriptor::REGULAR) {
-                Far::internal::GetBSplineWeights(patchBits,
+                Far::internal::GetBSplineWeights(param,
                                                  coord.s, coord.t, wP, wDs, wDt);
                 numControlVertices = 16;
             } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-                Far::internal::GetGregoryWeights(patchBits,
+                Far::internal::GetGregoryWeights(param,
                                                  coord.s, coord.t, wP, wDs, wDt);
                 numControlVertices = 20;
             } else if (patchType == Far::PatchDescriptor::QUADS) {
-                Far::internal::GetBilinearWeights(patchBits,
+                Far::internal::GetBilinearWeights(param,
                                                   coord.s, coord.t, wP, wDs, wDt);
                 numControlVertices = 4;
             } else {
@@ -383,20 +383,20 @@ public:
             PatchArray const &array = _patchArrayBuffer[coord.handle.arrayIndex];
 
             int patchType = array.GetPatchType();
-            Far::PatchParam::BitField patchBits = *(Far::PatchParam::BitField*)
-                &_patchParamBuffer[coord.handle.patchIndex].patchBits;
+            Far::PatchParam const & param =
+                _patchParamBuffer[coord.handle.patchIndex];
 
             int numControlVertices = 0;
             if (patchType == Far::PatchDescriptor::REGULAR) {
-                Far::internal::GetBSplineWeights(patchBits,
+                Far::internal::GetBSplineWeights(param,
                                                  coord.s, coord.t, wP, wDs, wDt);
                 numControlVertices = 16;
             } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-                Far::internal::GetGregoryWeights(patchBits,
+                Far::internal::GetGregoryWeights(param,
                                                  coord.s, coord.t, wP, wDs, wDt);
                 numControlVertices = 20;
             } else if (patchType == Far::PatchDescriptor::QUADS) {
-                Far::internal::GetBilinearWeights(patchBits,
+                Far::internal::GetBilinearWeights(param,
                                                   coord.s, coord.t, wP, wDs, wDt);
                 numControlVertices = 4;
             } else {

--- a/opensubdiv/osd/types.h
+++ b/opensubdiv/osd/types.h
@@ -90,10 +90,8 @@ struct PatchArray {
     int primitiveIdBase;  // an offset within the patch param buffer
 };
 
-struct PatchParam {
+struct PatchParam : public Far::PatchParam {
     // int3 struct.
-    int faceIndex;
-    unsigned int patchBits;
     float sharpness;
 };
 


### PR DESCRIPTION
This change restores the use of 4-bits in Far::PatchParam to
encode the refinement level of a patch. This restores one bit
that was stolen to allow for more general encoding of boundary
edge and transition edge masks. In order to accommodate all
of the bits that are required, the transition edge mask bits
are now stored along with the faceId bits.

Also, accessors are now exposed directly as members of Far::PatchParam
and the internal bitfield class is no longer directly exposed.