### PR TITLE
Doxygen tweaks to prevent it mangling Far::TopologyRefinerFactory<MESH>

### DIFF
--- a/opensubdiv/far/topologyDescriptor.h
+++ b/opensubdiv/far/topologyDescriptor.h
@@ -83,8 +83,11 @@ struct TopologyDescriptor {
 
 
 //
-//  Declaration of factory method specializations (provided internally):
+//  Forward declarations of required TopologyRefinerFactory<TopologyDescriptor>
+//  specializations (defined internally):
 //
+// @cond EXCLUDE_DOXYGEN
+
 template <>
 bool
 TopologyRefinerFactory<TopologyDescriptor>::resizeComponentTopology(
@@ -108,8 +111,9 @@ TopologyRefinerFactory<TopologyDescriptor>::assignFaceVaryingTopology(
 template <>
 void
 TopologyRefinerFactory<TopologyDescriptor>::reportInvalidTopology(
-    TopologyError errCode, char const * msg, TopologyDescriptor const& /* mesh */);
+    TopologyError errCode, char const * msg, TopologyDescriptor const & desc);
 
+// @endcond
 
 } // end namespace Far
 

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -113,6 +113,8 @@ public:
     static TopologyRefiner* Create(MESH const& mesh, Options options = Options());
 
 protected:
+    typedef Vtr::internal::Level::TopologyError TopologyError;
+
     //@{
     ///  @name  Methods to be provided to complete assembly of the TopologyRefiner
     ///
@@ -142,8 +144,6 @@ protected:
 
     /// \brief  (Optional) Specify face-varying data per face
     static bool assignFaceVaryingTopology(TopologyRefiner& newRefiner, MESH const& mesh);
-
-    typedef Vtr::internal::Level::TopologyError TopologyError;
 
     /// \brief  (Optional) Control run-time topology validation and error reporting
     static void reportInvalidTopology(TopologyError errCode, char const * msg, MESH const& mesh);
@@ -324,7 +324,9 @@ TopologyRefinerFactory<MESH>::Create(MESH const& mesh, Options options) {
         return 0;
     }
 
-    // XXXX -- any state in the TopologyRefiner to update after the base level is complete?
+    //  Eventually want to move the Refiner's inventory initialization here.  Currently it
+    //  is handled after topology assignment, but if the inventory is to include additional
+    //  features (e.g. holes, etc.) it is better off deferred to here.
 
     return refiner;
 }


### PR DESCRIPTION
The Doxygen page for Far::TopologyRefinerFactory<MESH> had some erroneous mention of specializations for <TopologyDescriptor> and also incorrect ordering of the groups of methods as specified.  The combination made the page almost incomprehensible to a first-time viewer.