### PR TITLE
Minor revision to one of the regression/shapes

### DIFF
--- a/regression/shapes/catmark_fvar_bound0.h
+++ b/regression/shapes/catmark_fvar_bound0.h
@@ -71,7 +71,7 @@ static const std::string catmark_fvar_bound0 =
 "vt 1.00 0.60\n"
 "vt 0.00 0.80\n"
 "vt 0.25 0.80\n"
-"vt 0.50 0.80\n"
+"vt 0.50 0.65\n"
 "vt 0.75 0.80\n"
 "vt 1.00 0.80\n"
 "vt 0.00 1.00\n"


### PR DESCRIPTION
The intent of regression/shapes/catmark_fvar_bound0 and bound1 was to show the side effects resulting from splitting the lower UV region.  At some point the dart was exaggerated in the bound1 shape but not bound0, so I've corrected bound0 to match.  The documentation will be citing this pair as an illustration of the side effects mentioned (and so a motivation for the new "corners only" mode).