### PR TITLE
Removed link to incomplete 'Textures' doc.

### DIFF
--- a/documentation/nav_template.txt
+++ b/documentation/nav_template.txt
@@ -81,7 +81,6 @@
                     <p></p>
                     <li><a href="tutorials.html">Tutorials</a>
                     <li><a href="using_osd_compile.html#compiling-linking">Compiling & Linking</a></li>
-                    <li><a href="using_osd_textures.html">Textures</a></li>
                     <p></p>
                     <li><a href="hbr_overview.html">(Hbr)</a></li>
                     <ul>


### PR DESCRIPTION
Removed the link to the 'Textures' document because it is incomplete.
Still keep the texture document (in the tree and in the CMakeLists.txt to one day revive.