### PR TITLE
update documents.

### DIFF
--- a/documentation/api_overview.rst
+++ b/documentation/api_overview.rst
@@ -59,12 +59,12 @@ API Layers
 From a top-down point of view, OpenSubdiv is comprised of several layers, some
 public, and some private.
 
-Layers list in descending order:
+Layers list:
 
-  * **Osd** (OpenSubdiv)
-  * **Far** (Feature Adaptive Representation)
-  * **Vtr** (Vectorized Topological Representation)
   * **Sdc** (Subdivision Core)
+  * **Vtr** (Vectorized Topological Representation)
+  * **Far** (Feature Adaptive Representation)
+  * **Osd** (OpenSubdiv cross platform)
 
 Client mesh data enters the API through the Far layer. Typically, results will
 be collected from the Osd layer. However, it is possible to use
@@ -78,34 +78,6 @@ See `Using the Right Tools`_ for more in-depth coverage.
 
 .. image:: images/api_layers_3_0.png
    :align: center
-
-----
-
-Representation vs. Implementation Layers
-========================================
-
-One of the core performance goals of our subdivision algorithms is to leverage
-interactive performance out of massively parallel code execution wherever 
-possible. In order to support a large diversity of compute architectures
-it is critical to stream the geometric data to the compute kernels in the
-most optimal way.
-
-Data structures that are efficient for topology analysis during the pre-computation
-stage are not very good candidates for parallel processing. Our layered structure
-reflects this requirement: topology analysis and other pre-computation tasks are
-delegated to "representation" layers, while the actual execution of computations
-has been moved to an "implementation" layer.
-
-.. image:: images/api_representations.png
-
-**Representation** layers are for general purpose algorithms and differentiated by
-the requirements placed on data represenation. See `Multiple Representations`_ for
-more details.
-
-The **Implementation** layer contains hardware and API-specific implementations.
-In order to minimize code redundancy and bugs, we strive to reduce device-specific
-computation logic to the most simplistic expression possible (in many cases as
-simple as series of multiply-ads).
 
 ----
 

--- a/documentation/nav_template.txt
+++ b/documentation/nav_template.txt
@@ -66,18 +66,18 @@
             <li><a href="using_osd.html">OpenSubdiv</a>
                 <ul>
                     <li><a href="api_overview.html">API Overview</a>
-                        <li><a href="osd_overview.html">Osd</a></li>
-                        <ul>
-                            <li><a href="osd_shader_interface.html">Shader Interface</a></li>
-                        </ul>
+                        <li><a href="sdc_overview.html">Sdc</a></li>
+                        <li><a href="vtr_overview.html">Vtr</a></li>
                         <li><a href="far_overview.html">Far</a></li>
                         <ul>
                             <li><a href="far_overview.html#far-topologyrefiner">Topology Refiner</a></li>
                             <li><a href="far_overview.html#far-patchtable">Patch Table</a></li>
                             <li><a href="far_overview.html#far-stenciltable">Stencil Table</a></li>
                         </ul>
-                        <li><a href="vtr_overview.html">Vtr</a></li>
-                        <li><a href="sdc_overview.html">Sdc</a></li>
+                        <li><a href="osd_overview.html">Osd</a></li>
+                        <ul>
+                            <li><a href="osd_shader_interface.html">Shader Interface</a></li>
+                        </ul>
                     </li>
                     <p></p>
                     <li><a href="tutorials.html">Tutorials</a>

--- a/documentation/osd_overview.rst
+++ b/documentation/osd_overview.rst
@@ -40,17 +40,17 @@ OpenSubdiv (Osd)
 available on various backends such as TBB, CUDA, OpenCL, GLSL etc.
 The main roles of **Osd** are:
 
-Refinement
+ - **Refinement**
     Compute stencil-based uniform/adaptive subdivision on CPU/GPU backends
-Limit Stencil Evaluation
+ - **Limit Stencil Evaluation**
     Compute limit surfaces by limit stencils on CPU/GPU backends
-Limit Evaluation with PatchTable
+ - **Limit Evaluation with PatchTable**
     Compute limit surfaces by patch evaluation on CPU/GPU backends
-OpenGL/DX11 Drawing with hardware tessellation
+ - **OpenGL/DX11 Drawing with hardware tessellation**
     Provide GLSL/HLSL tessellation functions for patch table
-Interleaved/Batched buffer configuration
+ - **Interleaved/Batched buffer configuration**
     Provide consistent buffer descriptor to deal with arbitrary buffer layout.
-Cross-Platform Implementation
+ - **Cross-Platform Implementation**
     Provide convenient classes to interop between compute and draw APIs
 
 They are independently used by client. For example, a client can use only

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -72,38 +72,10 @@ Release 3.0.0 RC1
 
 **Changes**
     - Far::TopologyRefiner was split into several classes to clarify and focus
-      the API.  Specifically, all level-related methods were moved to a new
-      class Far::TopologyLevel for inspection of a level in the hierarchy.
-      Similarly, all methods related to client "primvar" data, i.e. the suite
-      of Interpolate<T>() and Limit<T>() methods, were moved to a new class
-      Far::PrimvarRefiner.
-    
+      the API.
     - Interpolation of Vertex and Varying primvars in a single pass is no longer
-      supported. As a result, AddVaryingWithWeight() is no longer required and 
-      InterpolateVarying() must be called explicitly, which calls 
-      AddWithWeight(), instead of AddVaryingWithWeight().
-   
-    - The Osd layer was largely refactored to remove old designs that were
-      originally required to support large numbers of kernel and shader
-      configurations (thanks to stencils and unified shading).
-
-
-Release 3.0.0 Beta 
-==================
-
-Our intentions as open-source developers is to give as much access to our code,
-as early as possible, because we value and welcome the feedback from the
-community.
-
-With the 'Beta' release cycle, we hope to give stake-holders a time-window to
-provide feedback on decisions made and changes in the code that may impact
-them. Our Beta code is likely not feature-complete yet, but the general
-structure and architectures will be sufficiently locked in place for early
-adopters to start building upon these releases.
-
-Within 'Master' releases, we expect APIs to be backward compatible so that
-existing client code can seamlessly build against newer releases. Changes
-may include bug fixes as well as new features.
+      supported.
+    - The Osd layer was largely refactored.
 
 Previous 2.x Release Notes
 ==========================

--- a/documentation/using_osd.rst
+++ b/documentation/using_osd.rst
@@ -41,11 +41,10 @@ OpenSubdiv APIs
    :widths: 50 50
    
    * - | `Overview <api_overview.html>`_
-     - | `Osd API <osd_overview.html>`_
-       | `Far API <far_overview.html>`_
+     - | `Sdc API <sdc_overview.html>`_
        | `Vtr API <vtr_overview.html>`_
-       | `Sdc API <sdc_overview.html>`_
-       | 
+       | `Far API <far_overview.html>`_
+       | `Osd API <osd_overview.html>`_
 
 
 


### PR DESCRIPTION
- flip the order of API layers as  sdc > vtr > far > osd
- remove the paragraph of representation vs implementation.
- fix a layout issue in osd_overview
- simplify the release note as previous releases