### PR TITLE
Code tweak to prevent build failure in iOS with XCode7

### DIFF
--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -152,7 +152,7 @@ Level::getTopologyErrorString(TopologyError errCode) {
     if (callback) { \
         char const * errStr = getTopologyErrorString(code); \
         char msg[1024]; \
-        snprintf(msg, 1024, "%s - "format, errStr, ##__VA_ARGS__); \
+        snprintf(msg, 1024, "%s - " format, errStr, ##__VA_ARGS__); \
         callback(code, msg, clientData); \
     }
 


### PR DESCRIPTION
According to issue #648 (closed as it related to another problem) a missing space between literal strings is causing a compilation error with XCode7 on iOS.  This should be a harmless fix.