### PR TITLE
Moved the Hbr and Hierarchical Edits documents

### DIFF
--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -81,6 +81,7 @@ if (DOCUTILS_FOUND AND PYTHONINTERP_FOUND)
         glsharetopology.rst
         glstencilviewer.rst
         glviewer.rst
+        hedits.rst
         hbr_overview.rst
         intro.rst
         intro_30.rst

--- a/documentation/hedits.rst
+++ b/documentation/hedits.rst
@@ -179,5 +179,3 @@ Modifiable properties include:
    :align: center
    :height: 300
    :target: images/hedit_example5.png
-
-----

--- a/documentation/nav_template.txt
+++ b/documentation/nav_template.txt
@@ -80,9 +80,13 @@
                     <p></p>
                     <li><a href="tutorials.html">Tutorials</a>
                     <p></p>
-                    <li><a href="hbr_overview.html">(Hbr)</a></li>
+                    <li><a href="hbr_overview.html">Historical But Relevant</a></li>
                     <ul>
-                        <li><a href="using_osd_hbr.html">(Using Hbr)</a></li>
+                        <li><a href="hbr_overview.html">Hbr</a></li>
+                        <ul>
+                            <li><a href="using_osd_hbr.html">Using Hbr</a></li>
+                        </ul>
+                        <li><a href="hedits.html">Hierarchical Edits</a></li>
                     </ul>
                 </ul>
             </li>


### PR DESCRIPTION
The Hbr and Hierarchical Edits documents are now clearly marked in a
deprecated section.