### PR TITLE
Updated Far::StencilTable evaluation API

### DIFF
--- a/documentation/far_overview.rst
+++ b/documentation/far_overview.rst
@@ -647,11 +647,9 @@ series of coarse control vertices:
                              utan,
                              vtan;
 
-    // Update points by applying stencils
-    controlStencils.UpdateValues<StencilType>( reinterpret_cast<StencilType const *>(
-        &controlPoints[0]), &points[0] );
+    // Evaluate points by applying stencils
+    stencils.Evaluate( &controlPoints[0], &points[0] );
 
-    // Update tangents by applying derivative stencils
-    controlStencils.UpdateDerivs<StencilType>( reinterpret_cast<StencilType const *>(
-        &controlPoints[0]), &utan[0], &vtan[0] );
+    // Evaluate points and tangents by applying stencils
+    limitStencils.Evaluate( &controlPoints[0], &points[0], &utan[0], &vtan[0] );
 

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -698,7 +698,7 @@ createFarGLMesh(Shape * shape, int maxlevel) {
         //
         // apply stencils
         //
-        stencilTable->UpdateValues(verts, verts + ncoarseverts);
+        stencilTable->Evaluate(verts, verts + ncoarseverts);
 
         delete stencilTable;
     } else {

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -414,7 +414,7 @@ template <class T>
 inline void
 PatchTable::ComputeLocalPointValues(T const *src, T *dst) const {
     if (_localPointStencils) {
-        _localPointStencils->UpdateValues(src, dst);
+        _localPointStencils->Evaluate(src, dst);
     }
 };
 

--- a/opensubdiv/far/stencilTable.h
+++ b/opensubdiv/far/stencilTable.h
@@ -169,7 +169,7 @@ public:
     /// \brief Returns the stencil at index i in the table
     Stencil operator[] (Index index) const;
 
-    /// \brief Updates point values based on the control values
+    /// \brief Evaluates primvar values.
     ///
     /// \note The destination buffers are assumed to have allocated at least
     ///       \c GetNumStencils() elements.
@@ -184,7 +184,7 @@ public:
     /// @param end            Index of last value to update
     ///
     template <class T>
-    void UpdateValues(T const *controlValues, T *values, Index start=-1, Index end=-1) const {
+    void Evaluate(T const *controlValues, T *values, Index start=-1, Index end=-1) const {
         update(controlValues, values, _weights, start, end);
     }
 
@@ -305,12 +305,15 @@ public:
         return _dvWeights;
     }
 
-    /// \brief Updates derivative values based on the control values
+    /// \brief Evaluates limit surface primvar values and first derivatives.
     ///
     /// \note The destination buffers ('uderivs' & 'vderivs') are assumed to
     ///       have allocated at least \c GetNumStencils() elements.
     ///
     /// @param controlValues  Buffer with primvar data for the control vertices
+    ///
+    /// @param values         Destination buffer for the interpolated primvar
+    ///                       data
     ///
     /// @param uderivs        Destination buffer for the interpolated 'u'
     ///                       derivative primvar data
@@ -323,9 +326,10 @@ public:
     /// @param end            Index of last value to update
     ///
     template <class T>
-    void UpdateDerivs(T const *controlValues, T *uderivs, T *vderivs,
+    void Evaluate(T const *controlValues, T *values, T *uderivs, T *vderivs,
         int start=-1, int end=-1) const {
 
+        update(controlValues, values, _weights, start, end);
         update(controlValues, uderivs, _duWeights, start, end);
         update(controlValues, vderivs, _dvWeights, start, end);
     }

--- a/tutorials/far/tutorial_4/far_tutorial_4.cpp
+++ b/tutorials/far/tutorial_4/far_tutorial_4.cpp
@@ -141,7 +141,7 @@ int main(int, char **) {
 
         // Apply stencils on the control vertex data to update the primvar data
         // of the refined vertices.
-        stencilTable->UpdateValues(controlValues, &vertexBuffer[0]);
+        stencilTable->Evaluate(controlValues, &vertexBuffer[0]);
     }
 
     { // Visualization with Maya : print a MEL script that generates particles

--- a/tutorials/far/tutorial_5/far_tutorial_5.cpp
+++ b/tutorials/far/tutorial_5/far_tutorial_5.cpp
@@ -174,9 +174,9 @@ int main(int, char **) {
         // Apply stencils on the control vertex data to update the primvar data
         // of the refined vertices.
 
-        vertexStencils->UpdateValues(vertexCVs, &vertexBuffer[0]);
+        vertexStencils->Evaluate(vertexCVs, &vertexBuffer[0]);
 
-        varyingStencils->UpdateValues(varyingCVs, &varyingBuffer[0]);
+        varyingStencils->Evaluate(varyingCVs, &varyingBuffer[0]);
     }
 
     { // Visualization with Maya : print a MEL script that generates particles

--- a/tutorials/far/tutorial_7/far_tutorial_7.cpp
+++ b/tutorials/far/tutorial_7/far_tutorial_7.cpp
@@ -160,7 +160,7 @@ int main(int, char **) {
         start = end;
         end += nverts;
 
-        stencilTable->UpdateValues(srcVerts, destVerts, start, end);
+        stencilTable->Evaluate(srcVerts, destVerts, start, end);
         
         // apply 2 hierarchical edits on level 1 vertices
         if (level==1) {


### PR DESCRIPTION
The methods which evaluate primvar data and limit derivatives have
been updated to conform to conventions used elsewhere in the Far
and Osd APIs:

    Far::StencilTable::Update and
    Far::LimitStencilTable::UpdateDerivs

are now

    Far::StencilTable::Evaluate and
    Far::LimitStencilTable::Evaluate

respectively. The second method is now an overloaded method
which evaluates primvar data along with first derivative tangents.