### PR TITLE
Remove the 'Next' link in getting_started.

### DIFF
--- a/documentation/getting_started.rst
+++ b/documentation/getting_started.rst
@@ -166,7 +166,3 @@ The OpenSubdiv code base contains the following main areas:
 |                      | our APIs. If GPU SDKs are detected, some tests will attempt to run computations       |
 |                      | on those GPUs.                                                                        |
 +----------------------+---------------------------------------------------------------------------------------+
-
-----
-
-Next : `Building OpenSubdiv <cmake_build.html>`__


### PR DESCRIPTION
It was the only document that had such a next link.  Also that became no longer true when we put the contributing doc between it and the building doc.