### PR TITLE
Remove all unused references to AddVaryingWithWeight

### DIFF
--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -188,8 +188,6 @@ struct Vertex {
         _pos[2]+=weight*src._pos[2];
     }
 
-    void AddVaryingWithWeight(Vertex const & , float) { }
-
     void Clear( void * =0 ) { _pos[0]=_pos[1]=_pos[2]=0.0f; }
 
     void SetPosition(float x, float y, float z) { _pos[0]=x; _pos[1]=y; _pos[2]=z; }

--- a/examples/mayaPolySmooth/mayaPolySmooth.cpp
+++ b/examples/mayaPolySmooth/mayaPolySmooth.cpp
@@ -568,8 +568,6 @@ struct Vertex {
         position[2]+=weight*src.position[2];
     }
 
-    void AddVaryingWithWeight(Vertex const &, float) { }
-
     float position[3];
 };
 

--- a/tutorials/far/tutorial_0/far_tutorial_0.cpp
+++ b/tutorials/far/tutorial_0/far_tutorial_0.cpp
@@ -59,8 +59,6 @@ struct Vertex {
         _position[2]+=weight*src._position[2];
     }
 
-    void AddVaryingWithWeight(Vertex const &, float) { }
-
     // Public interface ------------------------------------
     void SetPosition(float x, float y, float z) {
         _position[0]=x;

--- a/tutorials/far/tutorial_1/far_tutorial_1.cpp
+++ b/tutorials/far/tutorial_1/far_tutorial_1.cpp
@@ -403,8 +403,6 @@ struct Vertex {
         _position[2]+=weight*src._position[2];
     }
 
-    void AddVaryingWithWeight(Vertex const &, float) { }
-
     // Public interface ------------------------------------
     void SetPosition(float x, float y, float z) {
         _position[0]=x;

--- a/tutorials/far/tutorial_4/far_tutorial_4.cpp
+++ b/tutorials/far/tutorial_4/far_tutorial_4.cpp
@@ -61,8 +61,6 @@ struct Vertex {
         _position[2]+=weight*src._position[2];
     }
 
-    void AddVaryingWithWeight(Vertex const &, float) { }
-
     // Public interface ------------------------------------
     void SetPosition(float x, float y, float z) {
         _position[0]=x;

--- a/tutorials/far/tutorial_6/far_tutorial_6.cpp
+++ b/tutorials/far/tutorial_6/far_tutorial_6.cpp
@@ -96,8 +96,6 @@ struct Vertex {
         point[2] += weight * src.point[2];
     }
 
-    void AddVaryingWithWeight(Vertex const &, float) { }
-
     float point[3];
 };
 

--- a/tutorials/far/tutorial_7/far_tutorial_7.cpp
+++ b/tutorials/far/tutorial_7/far_tutorial_7.cpp
@@ -72,8 +72,6 @@ struct Vertex {
         _position[2]+=weight*src._position[2];
     }
 
-    void AddVaryingWithWeight(Vertex const &, float) { }
-
     // Public interface ------------------------------------
     void SetPosition(float x, float y, float z) {
         _position[0]=x;


### PR DESCRIPTION
Far no longer supports this method, so the existing functions were pure noise.
Hbr, however still requires it, so there are still a couple instances of it in
the hbr tutorial files.