### PR TITLE
Some minor compiler warning fixes

### DIFF
--- a/opensubdiv/far/primvarRefiner.h
+++ b/opensubdiv/far/primvarRefiner.h
@@ -214,7 +214,12 @@ private:
         typedef float Weight;  //  Also part of the expected interface
 
     public:
-        Mask(Weight* v, Weight* e, Weight* f) : _vertWeights(v), _edgeWeights(e), _faceWeights(f) { }
+        Mask(Weight* v, Weight* e, Weight* f) : 
+            _vertWeights(v), _edgeWeights(e), _faceWeights(f),
+            _vertCount(0), _edgeCount(0), _faceCount(0), 
+            _faceWeightsForFaceCenters(false)
+        { }
+
         ~Mask() { }
 
     public:  //  Generic interface expected of <typename MASK>:

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -220,7 +220,7 @@ TopologyRefiner::RefineUniform(UniformOptions options) {
 
     for (int i = 1; i <= (int)options.refinementLevel; ++i) {
         refineOptions._minimalTopology =
-            options.fullTopologyInLastLevel ? false : (i == options.refinementLevel);
+            options.fullTopologyInLastLevel ? false : (i == (int)options.refinementLevel);
 
         Vtr::internal::Level& parentLevel = getLevel(i-1);
         Vtr::internal::Level& childLevel  = *(new Vtr::internal::Level);


### PR DESCRIPTION
In one case, we were comparing int and unsigned int.

In primvarRefiner, some values were safely uninitialized, but older compilers
(GCC 4.1) were complaining.