### PR TITLE
Index out of Range Issues

### DIFF
--- a/opensubdiv/vtr/fvarLevel.cpp
+++ b/opensubdiv/vtr/fvarLevel.cpp
@@ -411,6 +411,8 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
         ConstIndexArray       vFaces  = _level.getVertexFaces(vIndex);
         ConstLocalIndexArray  vInFace = _level.getVertexFaceLocalIndices(vIndex);
 
+        if ( vFaces.empty() || vInFace.empty() )
+            continue;
         //
         //  First step is to assign the values associated with the faces by retrieving them
         //  from the faces.  If the face-varying topology around this vertex matches the vertex

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -521,23 +521,23 @@ Level::getFaceEdges(Index faceIndex) {
 //
 inline ConstIndexArray
 Level::getVertexFaces(Index vertIndex) const {
-    return ConstIndexArray(&_vertFaceIndices[_vertFaceCountsAndOffsets[vertIndex*2+1]],
+    return ConstIndexArray( (&_vertFaceIndices[0]) + _vertFaceCountsAndOffsets[vertIndex*2+1],
                           _vertFaceCountsAndOffsets[vertIndex*2]);
 }
 inline IndexArray
 Level::getVertexFaces(Index vertIndex) {
-    return IndexArray(&_vertFaceIndices[_vertFaceCountsAndOffsets[vertIndex*2+1]],
+    return IndexArray( (&_vertFaceIndices[0]) + _vertFaceCountsAndOffsets[vertIndex*2+1],
                           _vertFaceCountsAndOffsets[vertIndex*2]);
 }
 
 inline ConstLocalIndexArray
 Level::getVertexFaceLocalIndices(Index vertIndex) const {
-    return ConstLocalIndexArray(&_vertFaceLocalIndices[_vertFaceCountsAndOffsets[vertIndex*2+1]],
+    return ConstLocalIndexArray( (&_vertFaceLocalIndices[0]) + _vertFaceCountsAndOffsets[vertIndex*2+1],
                                _vertFaceCountsAndOffsets[vertIndex*2]);
 }
 inline LocalIndexArray
 Level::getVertexFaceLocalIndices(Index vertIndex) {
-    return LocalIndexArray(&_vertFaceLocalIndices[_vertFaceCountsAndOffsets[vertIndex*2+1]],
+    return LocalIndexArray( (&_vertFaceLocalIndices[0]) + _vertFaceCountsAndOffsets[vertIndex*2+1],
                                _vertFaceCountsAndOffsets[vertIndex*2]);
 }
 
@@ -558,23 +558,23 @@ Level::trimVertexFaces(Index vertIndex, int count) {
 //
 inline ConstIndexArray
 Level::getVertexEdges(Index vertIndex) const {
-    return ConstIndexArray(&_vertEdgeIndices[_vertEdgeCountsAndOffsets[vertIndex*2+1]],
+    return ConstIndexArray( (&_vertEdgeIndices[0]) +_vertEdgeCountsAndOffsets[vertIndex*2+1],
                           _vertEdgeCountsAndOffsets[vertIndex*2]);
 }
 inline IndexArray
 Level::getVertexEdges(Index vertIndex) {
-    return IndexArray(&_vertEdgeIndices[_vertEdgeCountsAndOffsets[vertIndex*2+1]],
+    return IndexArray( (&_vertEdgeIndices[0]) +_vertEdgeCountsAndOffsets[vertIndex*2+1],
                           _vertEdgeCountsAndOffsets[vertIndex*2]);
 }
 
 inline ConstLocalIndexArray
 Level::getVertexEdgeLocalIndices(Index vertIndex) const {
-    return ConstLocalIndexArray(&_vertEdgeLocalIndices[_vertEdgeCountsAndOffsets[vertIndex*2+1]],
+    return ConstLocalIndexArray( (&_vertEdgeLocalIndices[0]) + _vertEdgeCountsAndOffsets[vertIndex*2+1],
                                _vertEdgeCountsAndOffsets[vertIndex*2]);
 }
 inline LocalIndexArray
 Level::getVertexEdgeLocalIndices(Index vertIndex) {
-    return LocalIndexArray(&_vertEdgeLocalIndices[_vertEdgeCountsAndOffsets[vertIndex*2+1]],
+    return LocalIndexArray( (&_vertEdgeLocalIndices[0]) + _vertEdgeCountsAndOffsets[vertIndex*2+1],
                                _vertEdgeCountsAndOffsets[vertIndex*2]);
 }
 


### PR DESCRIPTION
These changes fix some out range issue I ran into.  

The ones in "level.h" make it so on  windows debug the code does not assert and abort when there are unconnected vertices at the end of the list.

The change in "fvarLevel.cpp" fixes an index out or range when there is face varying data and unconnected vertices.