### PR TITLE
Fix typo in Far tutorial, GetFaceEdges() actually get face index, not edge index

### DIFF
--- a/tutorials/far/tutorial_1/far_tutorial_1.cpp
+++ b/tutorials/far/tutorial_1/far_tutorial_1.cpp
@@ -186,7 +186,7 @@ public:
 
     int const * GetFaceVerts(int face) const { return g_faceverts+getCompOffset(g_facenverts, face); }
 
-    int const * GetFaceEdges(int edge) const { return g_faceedges+getCompOffset(g_facenverts, edge); }
+    int const * GetFaceEdges(int face) const { return g_faceedges+getCompOffset(g_facenverts, face); }
 
 
     //


### PR DESCRIPTION
Seems to be a typo unless i'm mistaken.