### PR TITLE
Fixed initialization of unconnected vertices in FVar channels

### DIFF
--- a/opensubdiv/vtr/fvarLevel.cpp
+++ b/opensubdiv/vtr/fvarLevel.cpp
@@ -249,7 +249,7 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
                     eTag._linear = (ETag::ETagSize) _hasLinearBoundaries;
                 }
             }
-        } else {
+        } else if (vFaces.size() > 0) {
             //
             //  Unfortunately for non-manifold cases we can't make as much use of the
             //  retrieved face-values as there is no correlation between the incident
@@ -308,7 +308,7 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
         //  boundary vertices that have not already been tagged.
         //
         if (vIsBoundary && !vertexMismatch[vIndex]) {
-            if (_hasLinearBoundaries) {
+            if (_hasLinearBoundaries && (vFaces.size() > 0)) {
                 vertexMismatch[vIndex] = true;
 
                 if (vIsManifold) {
@@ -411,8 +411,6 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
         ConstIndexArray       vFaces  = _level.getVertexFaces(vIndex);
         ConstLocalIndexArray  vInFace = _level.getVertexFaceLocalIndices(vIndex);
 
-        if ( vFaces.empty() || vInFace.empty() )
-            continue;
         //
         //  First step is to assign the values associated with the faces by retrieving them
         //  from the faces.  If the face-varying topology around this vertex matches the vertex
@@ -421,7 +419,11 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
         //
         IndexArray vValues = getVertexValues(vIndex);
 
-        vValues[0] = _faceVertValues[_level.getOffsetOfFaceVertices(vFaces[0]) + vInFace[0]];
+        if (vFaces.size() > 0) {
+            vValues[0] = _faceVertValues[_level.getOffsetOfFaceVertices(vFaces[0]) + vInFace[0]];
+        } else {
+            vValues[0] = 0;
+        }
         if (!vertexMismatch[vIndex]) {
             continue;
         }

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -614,23 +614,27 @@ Level::getEdgeVertices(Index edgeIndex) {
 //
 inline ConstIndexArray
 Level::getEdgeFaces(Index edgeIndex) const {
-    return ConstIndexArray(&_edgeFaceIndices[_edgeFaceCountsAndOffsets[edgeIndex*2+1]],
-                          _edgeFaceCountsAndOffsets[edgeIndex*2]);
+    return ConstIndexArray(&_edgeFaceIndices[0] + 
+                           _edgeFaceCountsAndOffsets[edgeIndex*2+1],
+                           _edgeFaceCountsAndOffsets[edgeIndex*2]);
 }
 inline IndexArray
 Level::getEdgeFaces(Index edgeIndex) {
-    return IndexArray(&_edgeFaceIndices[_edgeFaceCountsAndOffsets[edgeIndex*2+1]],
-                          _edgeFaceCountsAndOffsets[edgeIndex*2]);
+    return IndexArray(&_edgeFaceIndices[0] +
+                      _edgeFaceCountsAndOffsets[edgeIndex*2+1],
+                      _edgeFaceCountsAndOffsets[edgeIndex*2]);
 }
 
 inline ConstLocalIndexArray
 Level::getEdgeFaceLocalIndices(Index edgeIndex) const {
-    return ConstLocalIndexArray(&_edgeFaceLocalIndices[_edgeFaceCountsAndOffsets[edgeIndex*2+1]],
-                               _edgeFaceCountsAndOffsets[edgeIndex*2]);
+    return ConstLocalIndexArray(&_edgeFaceLocalIndices[0] +
+                                _edgeFaceCountsAndOffsets[edgeIndex*2+1],
+                                _edgeFaceCountsAndOffsets[edgeIndex*2]);
 }
 inline LocalIndexArray
 Level::getEdgeFaceLocalIndices(Index edgeIndex) {
-    return LocalIndexArray(&_edgeFaceLocalIndices[_edgeFaceCountsAndOffsets[edgeIndex*2+1]],
+    return LocalIndexArray(&_edgeFaceLocalIndices[0] +
+                           _edgeFaceCountsAndOffsets[edgeIndex*2+1],
                            _edgeFaceCountsAndOffsets[edgeIndex*2]);
 }
 

--- a/regression/shapes/catmark_nonman_bareverts.h
+++ b/regression/shapes/catmark_nonman_bareverts.h
@@ -1,0 +1,91 @@
+//
+//   Copyright 2015 DreamWorks Animation LLC.
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+static const std::string catmark_nonman_bareverts =
+"# 4x4 grid of quads -- 25 vertices:\n"
+"v  0.00 0.00 0.00\n"
+"v  0.25 0.00 0.00\n"
+"v  0.50 0.00 0.00\n"
+"v  0.75 0.00 0.00\n"
+"v  1.00 0.00 0.00\n"
+"v  0.00 0.25 0.00\n"
+"v  0.25 0.25 0.20\n"
+"v  0.50 0.25 0.20\n"
+"v  0.75 0.25 0.20\n"
+"v  1.00 0.25 0.00\n"
+"v  0.00 0.50 0.00\n"
+"v  0.25 0.50 0.20\n"
+"v  0.50 0.50 0.30\n"
+"v  0.75 0.50 0.20\n"
+"v  1.00 0.50 0.00\n"
+"v  0.00 0.75 0.00\n"
+"v  0.25 0.75 0.20\n"
+"v  0.50 0.75 0.20\n"
+"v  0.75 0.75 0.20\n"
+"v  1.00 0.75 0.00\n"
+"v  0.00 1.00 0.00\n"
+"v  0.25 1.00 0.00\n"
+"v  0.50 1.00 0.00\n"
+"v  0.75 1.00 0.00\n"
+"v  1.00 1.00 0.00\n"
+"vt 0.00 0.00\n"
+"vt 0.25 0.00\n"
+"vt 0.50 0.00\n"
+"vt 0.75 0.00\n"
+"vt 1.00 0.00\n"
+"vt 0.00 0.20\n"
+"vt 0.25 0.20\n"
+"vt 0.50 0.10\n"
+"vt 0.75 0.20\n"
+"vt 1.00 0.20\n"
+"vt 0.00 0.40\n"
+"vt 0.25 0.40\n"
+"vt 0.50 0.20\n"
+"vt 0.75 0.40\n"
+"vt 1.00 0.40\n"
+"vt 0.00 0.60\n"
+"vt 0.25 0.60\n"
+"vt 0.50 0.40\n"
+"vt 0.75 0.60\n"
+"vt 1.00 0.60\n"
+"vt 0.00 0.80\n"
+"vt 0.25 0.80\n"
+"vt 0.50 0.65\n"
+"vt 0.75 0.80\n"
+"vt 1.00 0.80\n"
+"vt 0.00 1.00\n"
+"vt 0.25 1.00\n"
+"vt 0.40 1.00\n"
+"vt 0.75 1.00\n"
+"vt 1.00 1.00\n"
+"vt 0.60 1.00\n"
+"f  6/6  7/7  12/12 11/11\n"
+"f  7/7  8/8  13/13 12/12\n"
+"f  8/8  9/9  14/14 13/13\n"
+"f  9/9 10/10 15/15 14/14\n"
+"f 11/16 12/17 17/22 16/21\n"
+"f 12/17 13/18 18/23 17/22\n"
+"f 13/18 14/19 19/24 18/23\n"
+"f 14/19 15/20 20/25 19/24\n"
+;


### PR DESCRIPTION
Vertices in FVar channels were presumed to have at least one incident face.  This lead to some array bounds errors that were recently corrected (#695) but left the vertex uninitialized within the FVar channel.  This change corrects the initialization.

A regression shape with unconnected (bare) vertices was also added for future use.  Like other non-manifold cases, it cannot be included in the far_regression as Hbr will reject it.

Note that unconnected vertices will be implicitly filtered from any feature-adaptive refinement, so these cases are currently only relevant to uniform subdivision.