### PR TITLE
Fixes cmake projects for non-gpu use case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,8 @@ option(NO_DX "Disable DirectX support")
 option(NO_TESTS "Disable all tests")
 option(NO_GLTESTS "Disable GL tests")
 
+set(OSD_GPU FALSE)
+
 # Check for dependencies
 if(NOT NO_OMP)
     find_package(OpenMP)
@@ -338,7 +340,7 @@ endif()
 if(NOT NO_CUDA)
     find_package(CUDA 4.0)
 endif()
-if(NOT ANDROID AND NOT IOS)
+if(NOT NO_OPENGL AND NOT ANDROID AND NOT IOS)
     find_package(GLFW 3.0.0)
 endif()
 if(NOT NO_PTEX)
@@ -406,6 +408,10 @@ else()
     endif()
 endif()
 
+if( OPENGL_FOUND AND NOT NO_OPENGL)
+    set(OSD_GPU TRUE)
+endif()
+
 if(GLFW_FOUND AND (GLFW_VERSION VERSION_EQUAL 3.0 OR GLFW_VERSION VERSION_GREATER 3.0))
     add_definitions( -DGLFW_VERSION_3 )
 endif()
@@ -449,6 +455,7 @@ if(OPENGLES_FOUND)
     add_definitions(
         -DOPENSUBDIV_HAS_OPENGLES
     )
+    set(OSD_GPU TRUE)
 endif()
 
 if(OPENCL_FOUND)
@@ -486,6 +493,7 @@ if(OPENCL_FOUND)
             )
         endif()
     endif()
+    set(OSD_GPU TRUE)
 else()
     if (NOT NO_OPENCL)
         message(WARNING
@@ -499,6 +507,7 @@ if(CUDA_FOUND)
     add_definitions(
         -DOPENSUBDIV_HAS_CUDA
     )
+    set(OSD_GPU TRUE)
 else()
     if (NOT NO_CUDA)
         message(WARNING
@@ -540,21 +549,23 @@ if (NOT NO_MAYA)
 endif()
 
 # Link examples & regressions dynamically against Osd
-set( OSD_LINK_TARGET osd_dynamic_cpu osd_dynamic_gpu )
+if( OSD_GPU )
+    set( OSD_LINK_TARGET osd_dynamic_cpu osd_dynamic_gpu )
+else()
+    set( OSD_LINK_TARGET osd_dynamic_cpu )
+endif()
 
 if (WIN32)
     add_definitions(
         # Link against the static version of GLEW.
         -DGLEW_STATIC
     )
-    # Link examples & regressions statically against Osd for
-    # Windows until all the kinks can be worked out.
-    set( OSD_LINK_TARGET osd_static_cpu osd_static_gpu )
 
     if (DXSDK_FOUND AND NOT NO_DX)
         add_definitions(
             -DOPENSUBDIV_HAS_DX11SDK
         )
+        set(OSD_GPU TRUE)
     elseif(NOT NO_DX)
         message(WARNING
             "DirectX11 SDK was not found. "
@@ -565,6 +576,15 @@ if (WIN32)
             "environment variable."
         )
     endif()
+    
+    # Link examples & regressions statically against Osd for
+    # Windows until all the kinks can be worked out.
+    if( OSD_GPU )
+        set( OSD_LINK_TARGET osd_static_cpu osd_static_gpu )
+    else()
+        set( OSD_LINK_TARGET osd_static_cpu )
+    endif()
+    
 endif()
 
 

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -158,10 +158,12 @@ include_directories(
 
 set(INC_FILES )
 
+if(OPENGL_FOUND OR DXSDK_FOUND)
 _stringify("${EXAMPLES_COMMON_SHADER_FILES}" INC_FILES)
 
 source_group("Shaders" FILES ${EXAMPLES_COMMON_SHADER_FILES})
 source_group("Inc" FILES ${INC_FILES})
+endif()
 
 add_library(examples_common_obj
     OBJECT

--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -153,21 +153,23 @@ if (NOT NO_LIB)
 
     install( TARGETS osd_static_cpu DESTINATION "${CMAKE_LIBDIR_BASE}" )
 
-    # this macro uses FindCUDA.cmake to compile .cu kernel files
-    # the target then adds the other obj dependencies and include files
-    _add_possibly_cuda_library(osd_static_gpu
-        STATIC
-            version.cpp
-            $<TARGET_OBJECTS:osd_gpu_obj>
-            ${CUDA_KERNEL_FILES}
-    )
-    set_target_properties(osd_static_gpu PROPERTIES OUTPUT_NAME osdGPU CLEAN_DIRECT_OUTPUT 1)
+    if( OSD_GPU )
+        # this macro uses FindCUDA.cmake to compile .cu kernel files
+        # the target then adds the other obj dependencies and include files
+        _add_possibly_cuda_library(osd_static_gpu
+            STATIC
+                version.cpp
+                $<TARGET_OBJECTS:osd_gpu_obj>
+                ${CUDA_KERNEL_FILES}
+        )
+        set_target_properties(osd_static_gpu PROPERTIES OUTPUT_NAME osdGPU CLEAN_DIRECT_OUTPUT 1)
 
-    target_link_libraries(osd_static_gpu
-        ${PLATFORM_CPU_LIBRARIES} ${PLATFORM_GPU_LIBRARIES}
-    )
+        target_link_libraries(osd_static_gpu
+            ${PLATFORM_CPU_LIBRARIES} ${PLATFORM_GPU_LIBRARIES}
+        )
 
-    install( TARGETS osd_static_gpu DESTINATION "${CMAKE_LIBDIR_BASE}" )
+        install( TARGETS osd_static_gpu DESTINATION "${CMAKE_LIBDIR_BASE}" )
+    endif()
 
 
     # Build dynamic libs  ----------------------------------
@@ -207,34 +209,36 @@ if (NOT NO_LIB)
         install( TARGETS osd_dynamic_cpu LIBRARY DESTINATION "${CMAKE_LIBDIR_BASE}" )
 
         #---------------------------------------------------
-        _add_possibly_cuda_library(osd_dynamic_gpu
-            SHARED
-            version.cpp
-            $<TARGET_OBJECTS:osd_gpu_obj>
-            ${CUDA_KERNEL_FILES}
-        )
+        if( OSD_GPU )
+            _add_possibly_cuda_library(osd_dynamic_gpu
+                SHARED
+                version.cpp
+                $<TARGET_OBJECTS:osd_gpu_obj>
+                ${CUDA_KERNEL_FILES}
+            )
 
-        if (NOT ANDROID)
-            set_target_properties(osd_dynamic_gpu
-                PROPERTIES
-                    OUTPUT_NAME osdGPU
-                    CLEAN_DIRECT_OUTPUT 1
-                    SOVERSION ${OSD_SONAME}
-                )
-        else()
-            set_target_properties(osd_dynamic_gpu
-                PROPERTIES
-                    OUTPUT_NAME osdGPU
-                    CLEAN_DIRECT_OUTPUT 1
-                )
+            if (NOT ANDROID)
+                set_target_properties(osd_dynamic_gpu
+                    PROPERTIES
+                        OUTPUT_NAME osdGPU
+                        CLEAN_DIRECT_OUTPUT 1
+                        SOVERSION ${OSD_SONAME}
+                    )
+            else()
+                set_target_properties(osd_dynamic_gpu
+                    PROPERTIES
+                        OUTPUT_NAME osdGPU
+                        CLEAN_DIRECT_OUTPUT 1
+                    )
+            endif()
+
+            target_link_libraries(osd_dynamic_gpu
+                osd_dynamic_cpu
+                ${PLATFORM_CPU_LIBRARIES} ${PLATFORM_GPU_LIBRARIES}
+            )
+
+            install( TARGETS osd_dynamic_gpu LIBRARY DESTINATION "${CMAKE_LIBDIR_BASE}" )
         endif()
-
-        target_link_libraries(osd_dynamic_gpu
-            osd_dynamic_cpu
-            ${PLATFORM_CPU_LIBRARIES} ${PLATFORM_GPU_LIBRARIES}
-        )
-
-        install( TARGETS osd_dynamic_gpu LIBRARY DESTINATION "${CMAKE_LIBDIR_BASE}" )
 
     endif()
 

--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -317,13 +317,15 @@ add_library(osd_cpu_obj
         ${PUBLIC_HEADER_FILES}
 )
 
-add_library(osd_gpu_obj
-    OBJECT
-        ${GPU_SOURCE_FILES}
-        ${PRIVATE_HEADER_FILES}
-        ${PUBLIC_HEADER_FILES}
-        ${INC_FILES}
-)
+if( GPU_SOURCE_FILES ) 
+    add_library(osd_gpu_obj
+        OBJECT
+            ${GPU_SOURCE_FILES}
+            ${PRIVATE_HEADER_FILES}
+            ${PUBLIC_HEADER_FILES}
+            ${INC_FILES}
+    )
+endif()
 
 _add_doxy_headers( "${DOXY_HEADER_FILES}" )
 


### PR DESCRIPTION
Changes to the cmake projects so that if all the gpu options are disabled it does not try to make the gpu library.  Also made it so GLFW is not required if NO_OPENGL is specified.

Not sure if this was the best way to do this, but it seemed that the gpu build should not be required if the NO_* options don't require a gpu library.