### PR TITLE
Fixing linking errors on both Linux and WIndows

### DIFF
--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -539,10 +539,6 @@ TopologyRefinerFactory<MESH>::getBaseFaceFVarValues(TopologyRefiner & newRefiner
 }
 
 
-
-// XXXX manuelk MSVC specializes these templated functions which creates duplicated symbols
-#ifndef _MSC_VER
-
 template <class MESH>
 bool
 TopologyRefinerFactory<MESH>::resizeComponentTopology(TopologyRefiner& /* refiner */, MESH const& /* mesh */) {
@@ -679,8 +675,6 @@ TopologyRefinerFactory<MESH>::reportInvalidTopology(
     //  errors. By default, nothing is reported
     //
 }
-
-#endif
 
 } // end namespace Far
 

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -124,7 +124,7 @@ convertToCompatibleStencilTable(
 }
 
 template <>
-Far::StencilTable const *
+inline Far::StencilTable const *
 convertToCompatibleStencilTable<Far::StencilTable, Far::StencilTable, void>(
     Far::StencilTable const *table, void *  /*context*/) {
     // no need for conversion
@@ -134,7 +134,7 @@ convertToCompatibleStencilTable<Far::StencilTable, Far::StencilTable, void>(
 }
 
 template <>
-Far::LimitStencilTable const *
+inline Far::LimitStencilTable const *
 convertToCompatibleStencilTable<Far::LimitStencilTable, Far::LimitStencilTable, void>(
     Far::LimitStencilTable const *table, void *  /*context*/) {
     // no need for conversion
@@ -144,7 +144,7 @@ convertToCompatibleStencilTable<Far::LimitStencilTable, Far::LimitStencilTable, 
 }
 
 template <>
-Far::StencilTable const *
+inline Far::StencilTable const *
 convertToCompatibleStencilTable<Far::StencilTable, Far::StencilTable, ID3D11DeviceContext>(
     Far::StencilTable const *table, ID3D11DeviceContext *  /*context*/) {
     // no need for conversion


### PR DESCRIPTION
This pull request contains fixes which we needed to apply on the sources in order to make OpenSubdiv linking finely with Blender. Using gcc 4.9 on Linux and MSVC 2013 on Windows.

This is so called "works for us" and extra checks on whether it causes regressions for someone wouldn't hurt.