### PR TITLE
Eliminate or encapsulate  recently added ICC pragmas

### DIFF
--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
@@ -37,6 +37,17 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Far {
 
+namespace {
+#ifdef __INTEL_COMPILER
+#pragma warning (push)
+#pragma warning disable 1572
+#endif
+    inline bool isWeightNonZero(float w) { return (w != 0.0f); }
+#ifdef __INTEL_COMPILER
+#pragma warning (pop)
+#endif
+}
+
 EndCapBSplineBasisPatchFactory::EndCapBSplineBasisPatchFactory(
     TopologyRefiner const & refiner) :
     _refiner(&refiner), _numVertices(0), _numPatches(0) {
@@ -86,9 +97,6 @@ EndCapBSplineBasisPatchFactory::GetPatchPoints(
     bezierCP.push_back(basis.Ep[2]);
     bezierCP.push_back(basis.P[2]);
 
-#pragma warning (push)
-#pragma warning disable 1572 //floating-point equality and inequality comparisons are unreliable
-
     // Apply basis conversion from bezier to b-spline
     float Q[4][4] = {{ 6, -7,  2, 0},
                      { 0,  2, -1, 0},
@@ -98,7 +106,7 @@ EndCapBSplineBasisPatchFactory::GetPatchPoints(
     for (int i = 0; i < 4; ++i) {
         for (int j = 0; j < 4; ++j) {
             for (int k = 0; k < 4; ++k) {            
-                if (Q[i][k] != 0.0f) H[i*4+j] += bezierCP[j+k*4] * Q[i][k];
+                if (isWeightNonZero(Q[i][k])) H[i*4+j] += bezierCP[j+k*4] * Q[i][k];
             }
         }
     }
@@ -106,12 +114,11 @@ EndCapBSplineBasisPatchFactory::GetPatchPoints(
         for (int j = 0; j < 4; ++j) {
             GregoryBasis::Point p;
             for (int k = 0; k < 4; ++k) {
-                if (Q[j][k] != 0.0f) p += H[i*4+k] * Q[j][k];
+                if (isWeightNonZero(Q[j][k])) p += H[i*4+k] * Q[j][k];
             }
             _vertexStencils.push_back(p);
         }
     }
-#pragma warning (pop)
     
     int varyingIndices[] = { 0, 0, 1, 1,
                              0, 0, 1, 1,

--- a/opensubdiv/far/stencilBuilder.cpp
+++ b/opensubdiv/far/stencilBuilder.cpp
@@ -31,6 +31,19 @@ namespace OPENSUBDIV_VERSION {
 namespace Far {
 namespace internal {
 
+namespace {
+#ifdef __INTEL_COMPILER
+#pragma warning (push)
+#pragma warning disable 1572
+#endif
+
+    inline bool isWeightZero(float w) { return (w == 0.0f); }
+
+#ifdef __INTEL_COMPILER
+#pragma warning (pop)
+#endif
+}
+
 struct PointDerivWeight {
     float p;
     float du;
@@ -363,15 +376,13 @@ StencilBuilder::GetStencilDvWeights() const {
     return _weightTable->GetDvWeights();
 }
 
-#pragma warning (push)
-#pragma warning disable 1572 //floating-point equality and inequality comparisons are unreliable
-
 void
 StencilBuilder::Index::AddWithWeight(Index const & src, float weight)
 {
     // Ignore no-op weights.
-    if (weight == 0.0f)
+    if (isWeightZero(weight)) {
         return;
+    }
     _owner->_weightTable->AddWithWeight(src._index, _index, weight,
                                 _owner->_weightTable->GetScalarAccumulator());
 }
@@ -379,7 +390,7 @@ StencilBuilder::Index::AddWithWeight(Index const & src, float weight)
 void
 StencilBuilder::Index::AddWithWeight(Stencil const& src, float weight)
 {
-    if(weight == 0.0f) {
+    if (isWeightZero(weight)) {
         return;
     }
 
@@ -389,7 +400,7 @@ StencilBuilder::Index::AddWithWeight(Stencil const& src, float weight)
 
     for (int i = 0; i < srcSize; ++i) {
         float w = srcWeights[i];
-        if (w == 0.0f) {
+        if (isWeightZero(w)) {
             continue;
         }
 
@@ -405,7 +416,7 @@ void
 StencilBuilder::Index::AddWithWeight(Stencil const& src,
                                      float weight, float du, float dv)
 {
-    if(weight == 0.0f and du == 0.0f and dv == 0.0f) {
+    if (isWeightZero(weight) and isWeightZero(du) and isWeightZero(dv)) {
         return;
     }
 
@@ -415,7 +426,7 @@ StencilBuilder::Index::AddWithWeight(Stencil const& src,
 
     for (int i = 0; i < srcSize; ++i) {
         float w = srcWeights[i];
-        if (w == 0.0f) {
+        if (isWeightZero(w)) {
             continue;
         }
 
@@ -426,8 +437,6 @@ StencilBuilder::Index::AddWithWeight(Stencil const& src,
                            _owner->_weightTable->GetPointDerivAccumulator());
     }
 }
-
-#pragma warning (pop)  
 
 } // end namespace internal
 } // end namespace Far

--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -40,6 +40,19 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Far {
 
+namespace {
+#ifdef __INTEL_COMPILER
+#pragma warning (push)
+#pragma warning disable 1572
+#endif
+
+    inline bool isWeightZero(float w) { return (w == 0.0f); }
+
+#ifdef __INTEL_COMPILER
+#pragma warning (pop)
+#endif
+}
+
 //------------------------------------------------------------------------------
 
 void
@@ -258,10 +271,7 @@ StencilTableFactory::AppendLocalPointStencilTable(
         for (int j = 0; j < src.GetSize(); ++j) {
             Index index = src.GetVertexIndices()[j];
             float weight = src.GetWeights()[j];
-#pragma warning (push)
-#pragma warning disable 1572 //floating-point equality and inequality comparisons are unreliable            
-            if (weight == 0.0f) continue;
-#pragma warning (pop)            
+            if (isWeightZero(weight)) continue;
 
             if (factorize) {
                 dst.AddWithWeight(

--- a/opensubdiv/vtr/array.h
+++ b/opensubdiv/vtr/array.h
@@ -66,8 +66,8 @@ public:
 
     ConstArray() : _begin(0), _size(0) { }
 
-    ConstArray(value_type const * ptr, size_type size) :
-        _begin(ptr), _size(size) { }
+    ConstArray(value_type const * ptr, size_type sizeArg) :
+        _begin(ptr), _size(sizeArg) { }
 
     size_type size() const { return _size; }
 
@@ -117,7 +117,7 @@ public:
 
     Array() : ConstArray<TYPE>() { }
     
-    Array(value_type * ptr, size_type size) : ConstArray<TYPE>(ptr, size) { }
+    Array(value_type * ptr, size_type sizeArg) : ConstArray<TYPE>(ptr, sizeArg) { }
 
 public:
 

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -35,7 +35,7 @@
 #include <algorithm>
 #include <vector>
 #include <map>
-   
+
 #ifdef _MSC_VER
     #define snprintf _snprintf
 #endif
@@ -380,6 +380,15 @@ namespace {
         }
         return 0;
     }
+
+#ifdef __INTEL_COMPILER
+#pragma warning (push)
+#pragma warning disable 1572
+#endif
+    inline bool isSharpnessEqual(float s1, float s2) { return (s1 == s2); }
+#ifdef __INTEL_COMPILER
+#pragma warning (pop)
+#endif
 }
 
 void
@@ -1296,13 +1305,10 @@ Level::isSingleCreasePatch(Index face, float *sharpnessOut, int *rotationOut) co
             }
         }
         // sharpnesses have to be [0, x, 0, x] or [x, 0, x, 0]
-#pragma warning (push)
-#pragma warning disable 1572 //floating-point equality and inequality comparisons are unreliable         
-        if (sharpnesses[0] != sharpnesses[2] or
-            sharpnesses[1] != sharpnesses[3]) {
+        if (isSharpnessEqual(sharpnesses[0], sharpnesses[2]) or
+            isSharpnessEqual(sharpnesses[1], sharpnesses[3])) {
             return false;
         }
-#pragma warning (pop)        
     }
     // check the edges around v[2], v[3]
     for (int i = 2; i < 4; ++i) {


### PR DESCRIPTION
This is a followup to #698 (merged separately from the pull request) which suppressed a few warnings with ICC.

Some of the pragmas that were added were eliminated through changes to the code.  Those used to suppress legitimate floating-point equality tests were encapsulated in local functions and bracketed with #ifdef __INTEL_COMPILER.