### PR TITLE
Respect factorizeIntermediatLevels option

### DIFF
--- a/opensubdiv/far/stencilBuilder.cpp
+++ b/opensubdiv/far/stencilBuilder.cpp
@@ -215,6 +215,10 @@ public:
     std::vector<float> const&
     GetDvWeights() const { return _dvWeights; }
 
+    void SetCoarseVertCount(int numVerts) {
+        _coarseVertCount = numVerts;
+    }
+
 private:
 
     // Merge a vertex weight into the stencil table, if there is an existing
@@ -344,6 +348,12 @@ StencilBuilder::GetNumVertsInStencil(size_t stencilIndex) const
         return 0;
 
     return (int)_weightTable->GetSizes()[stencilIndex];
+}
+
+void
+StencilBuilder::SetCoarseVertCount(int numVerts)
+{
+    _weightTable->SetCoarseVertCount(numVerts);
 }
 
 std::vector<int> const&

--- a/opensubdiv/far/stencilBuilder.h
+++ b/opensubdiv/far/stencilBuilder.h
@@ -51,6 +51,8 @@ public:
 
     int GetNumVertsInStencil(size_t stencilIndex) const;
 
+    void SetCoarseVertCount(int numVerts);
+
     // Mapping from stencil[i] to it's starting offset in the sources[] and weights[] arrays;
     std::vector<int> const& GetStencilOffsets() const;
 


### PR DESCRIPTION
Previously, this option flag was being ignored during stencil table
construction. This change now respects the flag.

Fixes issue #694 
