### PR TITLE
Fix a bug in PatchTableFactory of uniform refinement containing all-levels

### DIFF
--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -502,18 +502,25 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level) {
     Far::StencilTable const * vertexStencils = NULL;
     Far::StencilTable const * varyingStencils = NULL;
     int nverts=0;
+
     {
-        // Apply feature adaptive refinement to the mesh so that we can use the
-        // limit evaluation API features.
-        Far::TopologyRefiner::AdaptiveOptions options(level);
-        topologyRefiner->RefineAdaptive(options);
+        bool adaptive = (sdctype == OpenSubdiv::Sdc::SCHEME_CATMARK);
+        if (adaptive) {
+            // Apply feature adaptive refinement to the mesh so that we can use the
+            // limit evaluation API features.
+            Far::TopologyRefiner::AdaptiveOptions options(level);
+            topologyRefiner->RefineAdaptive(options);
+        } else {
+            Far::TopologyRefiner::UniformOptions options(level);
+            topologyRefiner->RefineUniform(options);
+        }
 
         // Generate stencil table to update the bi-cubic patches control
         // vertices after they have been re-posed (both for vertex & varying
         // interpolation)
         Far::StencilTableFactory::Options soptions;
         soptions.generateOffsets=true;
-        soptions.generateIntermediateLevels=true;
+        soptions.generateIntermediateLevels=adaptive;
 
         vertexStencils =
             Far::StencilTableFactory::Create(*topologyRefiner, soptions);

--- a/examples/glEvalLimit/init_shapes.h
+++ b/examples/glEvalLimit/init_shapes.h
@@ -40,8 +40,6 @@ static std::vector<ShapeDesc> g_defaultShapes;
 
 //------------------------------------------------------------------------------
 static void initShapes() {
-//    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear) );
-
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner0",     catmark_cube_corner0,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner1",     catmark_cube_corner1,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner2",     catmark_cube_corner2,     kCatmark ) );
@@ -87,5 +85,7 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_helmet",           catmark_helmet,           kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pawn",             catmark_pawn,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_rook",             catmark_rook,             kCatmark ) );
+
+    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear) );
 }
 //------------------------------------------------------------------------------


### PR DESCRIPTION
There's a bug when PatchTableFactory::Options::generateAllLevels is set, resulting
incorrect patch vert indices.
We exclude the vertices of control cage for uniform refinement, even the flag is set.

Note that when we use stencil table and patch table together, they need to be constructed in a consistent way, especially in uniform refinement. If the stencil table includes intermediate levels,
the patch table indexing the vertices generated by the stencil table also takes into account the
number of vertices in the intermediate levels.

The legitimate combinations of uniform refinement are
1. you only need the finest refinement
   StencilTableFactory::Options.generateIntermediateLevels = false
   PatchTableFactory::Options.generateAllLevels = false
2. you need all levels
   StencilTableFactory::Options.generateIntermediateLevels = true
   PatchTableFactory::Options.generateAllLevels = true
3. you need the intermediate levels only in the stencil table (for hierarchical edits etc)
   StencilTableFactory::Options.generateIntermediateLevels = true
   PatchTableFactory::Options.generateAllLevels = false
   (however, this is currently not supported in 3.0)

In adaptive refinement, generateIntermediateLevels has to be true and generateAllLevels is ignored.

These options are indeed confusing. We're hoping to fix it in a future release when we add uniform bi-cubic patches and DFAS.