### PR TITLE
Reduced warnings resulting from GCC's -Wshadow option

### DIFF
--- a/opensubdiv/osd/cpuPatchTable.cpp
+++ b/opensubdiv/osd/cpuPatchTable.cpp
@@ -79,8 +79,8 @@ CpuPatchTable::CpuPatchTable(const Far::PatchTable *farPatchTable) {
             farPatchTable->GetPatchParamTable();
         std::vector<Far::Index> const &sharpnessIndexTable =
             farPatchTable->GetSharpnessIndexTable();
-        int numPatches = farPatchTable->GetNumPatches(j);
-        for (int k = 0; k < numPatches; ++k) {
+        int numPatchesJ = farPatchTable->GetNumPatches(j);
+        for (int k = 0; k < numPatchesJ; ++k) {
             float sharpness = 0.0;
             int patchIndex = (int)_patchParamBuffer.size();
             if (patchIndex < (int)sharpnessIndexTable.size()) {

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -173,12 +173,12 @@ public:
 
     // XXX: FIXME, linear search
     struct Entry {
-        Entry(BufferDescriptor const &srcDesc,
-              BufferDescriptor const &dstDesc,
-              BufferDescriptor const &duDesc,
-              BufferDescriptor const &dvDesc,
-              EVALUATOR *e) : srcDesc(srcDesc), dstDesc(dstDesc),
-                              duDesc(duDesc), dvDesc(dvDesc), evaluator(e) {}
+        Entry(BufferDescriptor const &srcDescArg,
+              BufferDescriptor const &dstDescArg,
+              BufferDescriptor const &duDescArg,
+              BufferDescriptor const &dvDescArg,
+              EVALUATOR *evalArg) : srcDesc(srcDescArg), dstDesc(dstDescArg),
+                              duDesc(duDescArg), dvDesc(dvDescArg), evaluator(evalArg) {}
         BufferDescriptor srcDesc, dstDesc, duDesc, dvDesc;
         EVALUATOR *evaluator;
     };
@@ -420,24 +420,24 @@ public:
                                 instance, _deviceContext);
 
         if (_varyingDesc.length > 0) {
-            BufferDescriptor srcDesc = _varyingDesc;
-            BufferDescriptor dstDesc(srcDesc);
-            dstDesc.offset += numControlVertices * dstDesc.stride;
+            BufferDescriptor vSrcDesc = _varyingDesc;
+            BufferDescriptor vDstDesc(vSrcDesc);
+            vDstDesc.offset += numControlVertices * vDstDesc.stride;
 
             instance = GetEvaluator<Evaluator>(
-                _evaluatorCache, srcDesc, dstDesc,
+                _evaluatorCache, vSrcDesc, vDstDesc,
                 _deviceContext);
 
             if (_varyingBuffer) {
                 // non-interleaved
-                Evaluator::EvalStencils(_varyingBuffer, srcDesc,
-                                        _varyingBuffer, dstDesc,
+                Evaluator::EvalStencils(_varyingBuffer, vSrcDesc,
+                                        _varyingBuffer, vDstDesc,
                                         _varyingStencilTable,
                                         instance, _deviceContext);
             } else {
                 // interleaved
-                Evaluator::EvalStencils(_vertexBuffer, srcDesc,
-                                        _vertexBuffer, dstDesc,
+                Evaluator::EvalStencils(_vertexBuffer, vSrcDesc,
+                                        _vertexBuffer, vDstDesc,
                                         _varyingStencilTable,
                                         instance, _deviceContext);
             }

--- a/opensubdiv/osd/types.h
+++ b/opensubdiv/osd/types.h
@@ -42,14 +42,14 @@ struct PatchCoord {
 
     /// \brief Constructor
     ///
-    /// @param handle    patch handle
+    /// @param handleArg    patch handle
     ///
-    /// @param s         parametric location on the patch
+    /// @param sArg         parametric location on the patch
     ///
-    /// @param t         parametric location on the patch
+    /// @param tArg         parametric location on the patch
     ///
-    PatchCoord(Far::PatchTable::PatchHandle handle, float s, float t) :
-        handle(handle), s(s), t(t) { }
+    PatchCoord(Far::PatchTable::PatchHandle handleArg, float sArg, float tArg) :
+        handle(handleArg), s(sArg), t(tArg) { }
 
     PatchCoord() : s(0), t(0) {
         handle.arrayIndex = 0;

--- a/opensubdiv/vtr/quadRefinement.cpp
+++ b/opensubdiv/vtr/quadRefinement.cpp
@@ -40,8 +40,8 @@ namespace internal {
 //
 //  Simple constructor, destructor and basic initializers:
 //
-QuadRefinement::QuadRefinement(Level const & parent, Level & child, Sdc::Options const & options) :
-    Refinement(parent, child, options) {
+QuadRefinement::QuadRefinement(Level const & parentArg, Level & childArg, Sdc::Options const & optionsArg) :
+    Refinement(parentArg, childArg, optionsArg) {
 
     _splitType   = Sdc::SPLIT_TO_QUADS;
     _regFaceSize = 4;
@@ -344,9 +344,6 @@ QuadRefinement::populateEdgeVerticesFromParentEdges() {
 void
 QuadRefinement::populateEdgeFaceRelation() {
 
-    const Level& parent = *_parent;
-          Level& child  = *_child;
-
     //
     //  Notes on allocating/initializing the edge-face counts/offsets vector:
     //
@@ -367,27 +364,27 @@ QuadRefinement::populateEdgeFaceRelation() {
     //      - could at least make a quick traversal of components and use the above
     //        two points to get much closer estimate than what is used for uniform
     //
-    int childEdgeFaceIndexSizeEstimate = (int)parent._faceVertIndices.size() * 2 +
-                                         (int)parent._edgeFaceIndices.size() * 2;
+    int childEdgeFaceIndexSizeEstimate = (int)_parent->_faceVertIndices.size() * 2 +
+                                         (int)_parent->_edgeFaceIndices.size() * 2;
 
-    child._edgeFaceCountsAndOffsets.resize(child.getNumEdges() * 2);
-    child._edgeFaceIndices.resize(     childEdgeFaceIndexSizeEstimate);
-    child._edgeFaceLocalIndices.resize(childEdgeFaceIndexSizeEstimate);
+    _child->_edgeFaceCountsAndOffsets.resize(_child->getNumEdges() * 2);
+    _child->_edgeFaceIndices.resize(     childEdgeFaceIndexSizeEstimate);
+    _child->_edgeFaceLocalIndices.resize(childEdgeFaceIndexSizeEstimate);
 
     // Update _maxEdgeFaces from the parent level before calling the 
     // populateEdgeFacesFromParent methods below, as these may further
     // update _maxEdgeFaces.
-    child._maxEdgeFaces = parent._maxEdgeFaces;
+    _child->_maxEdgeFaces = _parent->_maxEdgeFaces;
 
     populateEdgeFacesFromParentFaces();
     populateEdgeFacesFromParentEdges();
 
     //  Revise the over-allocated estimate based on what is used (as indicated in the
     //  count/offset for the last vertex) and trim the index vector accordingly:
-    childEdgeFaceIndexSizeEstimate = child.getNumEdgeFaces(child.getNumEdges()-1) +
-                                     child.getOffsetOfEdgeFaces(child.getNumEdges()-1);
-    child._edgeFaceIndices.resize(     childEdgeFaceIndexSizeEstimate);
-    child._edgeFaceLocalIndices.resize(childEdgeFaceIndexSizeEstimate);
+    childEdgeFaceIndexSizeEstimate = _child->getNumEdgeFaces(_child->getNumEdges()-1) +
+                                     _child->getOffsetOfEdgeFaces(_child->getNumEdges()-1);
+    _child->_edgeFaceIndices.resize(     childEdgeFaceIndexSizeEstimate);
+    _child->_edgeFaceLocalIndices.resize(childEdgeFaceIndexSizeEstimate);
 }
 
 void
@@ -516,9 +513,6 @@ QuadRefinement::populateEdgeFacesFromParentEdges() {
 void
 QuadRefinement::populateVertexFaceRelation() {
 
-    const Level& parent = *_parent;
-          Level& child  = *_child;
-
     //
     //  Notes on allocating/initializing the vertex-face counts/offsets vector:
     //
@@ -537,13 +531,13 @@ QuadRefinement::populateVertexFaceRelation() {
     //          - where the 1 or 2 is number of child edges of parent edge
     //      - same as parent vert for verts from parent verts (catmark)
     //
-    int childVertFaceIndexSizeEstimate = (int)parent._faceVertIndices.size()
-                                       + (int)parent._edgeFaceIndices.size() * 2
-                                       + (int)parent._vertFaceIndices.size();
+    int childVertFaceIndexSizeEstimate = (int)_parent->_faceVertIndices.size()
+                                       + (int)_parent->_edgeFaceIndices.size() * 2
+                                       + (int)_parent->_vertFaceIndices.size();
 
-    child._vertFaceCountsAndOffsets.resize(child.getNumVertices() * 2);
-    child._vertFaceIndices.resize(         childVertFaceIndexSizeEstimate);
-    child._vertFaceLocalIndices.resize(    childVertFaceIndexSizeEstimate);
+    _child->_vertFaceCountsAndOffsets.resize(_child->getNumVertices() * 2);
+    _child->_vertFaceIndices.resize(         childVertFaceIndexSizeEstimate);
+    _child->_vertFaceLocalIndices.resize(    childVertFaceIndexSizeEstimate);
 
     if (getFirstChildVertexFromVertices() == 0) {
         populateVertexFacesFromParentVertices();
@@ -557,10 +551,10 @@ QuadRefinement::populateVertexFaceRelation() {
 
     //  Revise the over-allocated estimate based on what is used (as indicated in the
     //  count/offset for the last vertex) and trim the index vectors accordingly:
-    childVertFaceIndexSizeEstimate = child.getNumVertexFaces(child.getNumVertices()-1) +
-                                     child.getOffsetOfVertexFaces(child.getNumVertices()-1);
-    child._vertFaceIndices.resize(     childVertFaceIndexSizeEstimate);
-    child._vertFaceLocalIndices.resize(childVertFaceIndexSizeEstimate);
+    childVertFaceIndexSizeEstimate = _child->getNumVertexFaces(_child->getNumVertices()-1) +
+                                     _child->getOffsetOfVertexFaces(_child->getNumVertices()-1);
+    _child->_vertFaceIndices.resize(     childVertFaceIndexSizeEstimate);
+    _child->_vertFaceLocalIndices.resize(childVertFaceIndexSizeEstimate);
 }
 
 void
@@ -702,9 +696,6 @@ QuadRefinement::populateVertexFacesFromParentVertices() {
 void
 QuadRefinement::populateVertexEdgeRelation() {
 
-    const Level& parent = *_parent;
-          Level& child  = *_child;
-
     //
     //  Notes on allocating/initializing the vertex-edge counts/offsets vector:
     //
@@ -727,13 +718,13 @@ QuadRefinement::populateVertexEdgeRelation() {
     //          - any end vertex will require all N child faces (catmark)
     //      - same as parent vert for verts from parent verts (catmark)
     //
-    int childVertEdgeIndexSizeEstimate = (int)parent._faceVertIndices.size()
-                                       + (int)parent._edgeFaceIndices.size() + parent.getNumEdges() * 2
-                                       + (int)parent._vertEdgeIndices.size();
+    int childVertEdgeIndexSizeEstimate = (int)_parent->_faceVertIndices.size()
+                                       + (int)_parent->_edgeFaceIndices.size() + _parent->getNumEdges() * 2
+                                       + (int)_parent->_vertEdgeIndices.size();
 
-    child._vertEdgeCountsAndOffsets.resize(child.getNumVertices() * 2);
-    child._vertEdgeIndices.resize(         childVertEdgeIndexSizeEstimate);
-    child._vertEdgeLocalIndices.resize(    childVertEdgeIndexSizeEstimate);
+    _child->_vertEdgeCountsAndOffsets.resize(_child->getNumVertices() * 2);
+    _child->_vertEdgeIndices.resize(         childVertEdgeIndexSizeEstimate);
+    _child->_vertEdgeLocalIndices.resize(    childVertEdgeIndexSizeEstimate);
 
     if (getFirstChildVertexFromVertices() == 0) {
         populateVertexEdgesFromParentVertices();
@@ -747,10 +738,10 @@ QuadRefinement::populateVertexEdgeRelation() {
 
     //  Revise the over-allocated estimate based on what is used (as indicated in the
     //  count/offset for the last vertex) and trim the index vectors accordingly:
-    childVertEdgeIndexSizeEstimate = child.getNumVertexEdges(child.getNumVertices()-1) +
-                                     child.getOffsetOfVertexEdges(child.getNumVertices()-1);
-    child._vertEdgeIndices.resize(     childVertEdgeIndexSizeEstimate);
-    child._vertEdgeLocalIndices.resize(childVertEdgeIndexSizeEstimate);
+    childVertEdgeIndexSizeEstimate = _child->getNumVertexEdges(_child->getNumVertices()-1) +
+                                     _child->getOffsetOfVertexEdges(_child->getNumVertices()-1);
+    _child->_vertEdgeIndices.resize(     childVertEdgeIndexSizeEstimate);
+    _child->_vertEdgeLocalIndices.resize(childVertEdgeIndexSizeEstimate);
 }
 
 void

--- a/opensubdiv/vtr/refinement.cpp
+++ b/opensubdiv/vtr/refinement.cpp
@@ -45,9 +45,9 @@ namespace internal {
 //
 //  Simple constructor, destructor and basic initializers:
 //
-Refinement::Refinement(Level const & parent, Level & child, Sdc::Options const& options) :
-    _parent(&parent),
-    _child(&child),
+Refinement::Refinement(Level const & parentArg, Level & childArg, Sdc::Options const& options) :
+    _parent(&parentArg),
+    _child(&childArg),
     _options(options),
     _regFaceSize(-1),
     _uniform(false),
@@ -65,8 +65,8 @@ Refinement::Refinement(Level const & parent, Level & child, Sdc::Options const& 
     _firstChildVertFromEdge(0),
     _firstChildVertFromVert(0) {
 
-    assert((child.getDepth() == 0) && (child.getNumVertices() == 0));
-    child._depth = 1 + parent.getDepth();
+    assert((childArg.getDepth() == 0) && (childArg.getNumVertices() == 0));
+    childArg._depth = 1 + parentArg.getDepth();
 }
 
 Refinement::~Refinement() {

--- a/opensubdiv/vtr/triRefinement.cpp
+++ b/opensubdiv/vtr/triRefinement.cpp
@@ -40,8 +40,8 @@ namespace internal {
 //
 //  Simple constructor, destructor and basic initializers:
 //
-TriRefinement::TriRefinement(Level const & parent, Level & child, Sdc::Options const & options) :
-    Refinement(parent, child, options) {
+TriRefinement::TriRefinement(Level const & parentArg, Level & childArg, Sdc::Options const & optionsArg) :
+    Refinement(parentArg, childArg, optionsArg) {
 
     _splitType   = Sdc::SPLIT_TO_TRIS;
     _regFaceSize = 3;

--- a/regression/common/cmp_utils.h
+++ b/regression/common/cmp_utils.h
@@ -47,8 +47,8 @@ namespace {
 template<class T>
 void
 GetReorderedHbrVertexData(
-    const OpenSubdiv::Far::TopologyRefiner &refiner,
-    const OpenSubdiv::HbrMesh<T> &hmesh,
+    const OpenSubdiv::Far::TopologyRefiner &farRefiner,
+    const OpenSubdiv::HbrMesh<T> &hbrMesh,
     std::vector<T> *hbrVertexData,
     std::vector<bool> *hbrVertexOnBoundaryData = NULL)
 {
@@ -178,14 +178,14 @@ GetReorderedHbrVertexData(
         }
     };
 
-    Mapper mapper(refiner, hmesh);
+    Mapper mapper(farRefiner, hbrMesh);
 
-    int nverts = hmesh.GetNumVertices();
-    assert( nverts==refiner.GetNumVerticesTotal() );
+    int nverts = hbrMesh.GetNumVertices();
+    assert( nverts==farRefiner.GetNumVerticesTotal() );
 
     hbrVertexData->resize(nverts);
 
-    for (int level=0, ofs=0; level<(refiner.GetMaxLevel()+1); ++level) {
+    for (int level=0, ofs=0; level<(farRefiner.GetMaxLevel()+1); ++level) {
 
        typename Mapper::LevelMap & map = mapper.maps[level];
        for (int i=0; i<(int)map.verts.size(); ++i) {

--- a/regression/common/shape_utils.cpp
+++ b/regression/common/shape_utils.cpp
@@ -129,8 +129,8 @@ Shape * Shape::parseObj(char const * shapestr, Scheme shapescheme,
                                std::stringstream ss;
                                ss << ifs.rdbuf();
                                ifs.close();
-                               std::string str = ss.str();
-                               s->parseMtllib(str.c_str());
+                               std::string tmpStr = ss.str();
+                               s->parseMtllib(tmpStr.c_str());
                                s->mtllib = buf;
                            }
                        } break;

--- a/regression/osd_regression/main.cpp
+++ b/regression/osd_regression/main.cpp
@@ -585,13 +585,13 @@ usage(char ** argv) {
 static void 
 parseArgs(int argc, char ** argv) {
 
-    for (int i=1; i<argc; ++i) {
-        if (not strcmp(argv[i],"-compute")) {
+    for (int argi=1; argi<argc; ++argi) {
+        if (not strcmp(argv[argi],"-compute")) {
         
             const char * backend = NULL;
             
-            if (i<(argc-1))
-                backend = argv[++i];
+            if (argi<(argc-1))
+                backend = argv[++argi];
 
             if (not strcmp(backend, "all")) {
               g_Backend = -1;
@@ -612,8 +612,8 @@ parseArgs(int argc, char ** argv) {
                 exit(0);
               }
             }
-        } else if ( (not strcmp(argv[i],"-help")) or
-                    (not strcmp(argv[i],"-h")) ) {
+        } else if ( (not strcmp(argv[argi],"-help")) or
+                    (not strcmp(argv[argi],"-h")) ) {
             usage(argv);
             exit(1);
         } else {


### PR DESCRIPTION
GCC is far stricter about its symbol shadowing warnings than ICC --for example, being triggered by simple constructors whose argument names match members (a common practice).  They've been reduced in the core libraries and the regression code in this set of changes.  So at least no public headers of the core library will trigger anything if clients turn on -Wshadow.

Unfortunately Hbr triggers a lot of these warnings, so regressions and other examples or tutorials using Hbr will emit a lot of noise if we try to enable -Wshadow by default.