### PR TITLE
viewer example fixes

### DIFF
--- a/examples/common/glHud.cpp
+++ b/examples/common/glHud.cpp
@@ -277,6 +277,7 @@ GLhud::Flush() {
     ortho(proj, 0, 0, float(GetWidth()), float(GetHeight()));
     glUniformMatrix4fv(_mvpMatrix, 1, GL_FALSE, proj);
 
+    glDisable(GL_DEPTH_TEST);
     {
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, _fontTexture);
@@ -289,6 +290,7 @@ GLhud::Flush() {
 
         glBindTexture(GL_TEXTURE_2D, 0);
     }
+    glEnable(GL_DEPTH_TEST);
 
     return true;
 }

--- a/examples/dxViewer/init_shapes.h
+++ b/examples/dxViewer/init_shapes.h
@@ -79,7 +79,6 @@ static void initShapes() {
     g_defaultShapes.push_back(ShapeDesc("catmark_righthanded", catmark_righthanded, kCatmark));
     g_defaultShapes.push_back(ShapeDesc("catmark_pole8", catmark_pole8, kCatmark));
     g_defaultShapes.push_back(ShapeDesc("catmark_pole64", catmark_pole64, kCatmark));
-    g_defaultShapes.push_back(ShapeDesc("catmark_pole360", catmark_pole360, kCatmark));
     g_defaultShapes.push_back(ShapeDesc("catmark_nonman_quadpole8", catmark_nonman_quadpole8, kCatmark));
     g_defaultShapes.push_back(ShapeDesc("catmark_nonman_quadpole64", catmark_nonman_quadpole64, kCatmark));
     g_defaultShapes.push_back(ShapeDesc("catmark_nonman_quadpole360", catmark_nonman_quadpole360, kCatmark));

--- a/examples/glViewer/init_shapes.h
+++ b/examples/glViewer/init_shapes.h
@@ -80,7 +80,6 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_righthanded",      catmark_righthanded,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pole8",            catmark_pole8,            kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pole64",           catmark_pole64,           kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_pole360",          catmark_pole360,          kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_nonman_quadpole8",   catmark_nonman_quadpole8,   kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_nonman_quadpole64",  catmark_nonman_quadpole64,  kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_nonman_quadpole360", catmark_nonman_quadpole360, kCatmark ) );


### PR DESCRIPTION
- disable depth test for hud drawing
- remove catmark_pole360 from glViewer/dxViewer
  (until we fix the performance issue of high-valence gregory basis patch construction)