### PR TITLE
Minor content and formatting changes to Far error strings

### DIFF
--- a/opensubdiv/far/error.cpp
+++ b/opensubdiv/far/error.cpp
@@ -33,37 +33,43 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Far {
 
+//
+//  Statics for the publicly assignable callbacks and the methods to
+//  assign them (disable static assignment warnings when doing so):
+//
 static ErrorCallbackFunc errorFunc = 0;
-
-static char const * errors[] = {
-    "FAR_NO_ERROR",
-    "FAR_FATAL_ERROR",
-    "FAR_INTERNAL_CODING_ERROR",
-    "FAR_CODING_ERROR",
-    "FAR_RUNTIME_ERROR"
-};
-
-void SetErrorCallback(ErrorCallbackFunc func) {
+static WarningCallbackFunc warningFunc = 0;
 
 #ifdef __INTEL_COMPILER
 #pragma warning disable 1711
 #endif
+
+void SetErrorCallback(ErrorCallbackFunc func) {
     errorFunc = func;
+}
+
+void SetWarningCallback(WarningCallbackFunc func) {
+    warningFunc = func;
+}
+
 #ifdef __INTEL_COMPILER
 #pragma warning enable 1711
 #endif
-}
 
-void Error(ErrorType err) {
 
-    if (errorFunc) {
-        errorFunc(err, NULL);
-    } else {
-        fprintf(stderr, "Error : %s\n",errors[err]);
-    }
-}
-
+//
+//  The default error and warning callbacks eventually belong in the
+//  internal namespace:
+//
 void Error(ErrorType err, const char *format, ...) {
+
+    static char const * errorTypeLabel[] = {
+        "No Error",
+        "Fatal Error",
+        "Coding Error (internal)",
+        "Coding Error",
+        "Error"
+    };
 
     assert(err!=FAR_NO_ERROR);
 
@@ -76,21 +82,8 @@ void Error(ErrorType err, const char *format, ...) {
     if (errorFunc) {
         errorFunc(err, message);
     } else {
-        printf("Error %s : %s\n",errors[err], message);
+        printf("%s: %s\n", errorTypeLabel[err], message);
     }
-}
-
-static WarningCallbackFunc warningFunc = 0;
-
-void SetWarningCallback(WarningCallbackFunc func) {
-
-#ifdef __INTEL_COMPILER
-#pragma warning disable 1711
-#endif
-    warningFunc = func;
-#ifdef __INTEL_COMPILER
-#pragma warning enable 1711
-#endif
 }
 
 void Warning(const char *format, ...) {
@@ -104,7 +97,7 @@ void Warning(const char *format, ...) {
     if (warningFunc) {
         warningFunc(message);
     } else {
-        fprintf(stdout, "Warning : %s\n", message);
+        fprintf(stdout, "Warning: %s\n", message);
     }
 }
 

--- a/opensubdiv/far/error.h
+++ b/opensubdiv/far/error.h
@@ -40,6 +40,8 @@ typedef enum {
     FAR_RUNTIME_ERROR           ///< Issue a generic runtime error, but continue execution.
 } ErrorType;
 
+
+/// \brief The error callback function type (default is "printf")
 typedef void (*ErrorCallbackFunc)(ErrorType err, const char *message);
 
 /// \brief Sets the error callback function (default is "printf")
@@ -50,22 +52,8 @@ typedef void (*ErrorCallbackFunc)(ErrorType err, const char *message);
 ///
 void SetErrorCallback(ErrorCallbackFunc func);
 
-/// \brief Sends an OSD error
-///
-/// @param err the error type
-///
-void Error(ErrorType err);
 
-/// \brief Sends an OSD error with a message
-///
-/// @param err     the error type
-///
-/// @param format  the format of the message (followed by arguments)
-///
-void Error(ErrorType err, const char *format, ...);
-
-
-/// \brief Sets the warning callback function (default is "printf")
+/// \brief The warning callback function type (default is "printf")
 typedef void (*WarningCallbackFunc)(const char *message);
 
 /// \brief Sets the warning callback function (default is "printf")
@@ -76,7 +64,21 @@ typedef void (*WarningCallbackFunc)(const char *message);
 ///
 void SetWarningCallback(WarningCallbackFunc func);
 
-/// \brief Sends an OSD warning message
+
+//
+//  The following are intended for internal use only (and will eventually
+//  be moved within namespace internal)
+//
+
+/// \brief Sends an OSD error with a message (internal use only)
+///
+/// @param err     the error type
+///
+/// @param format  the format of the message (followed by arguments)
+///
+void Error(ErrorType err, const char *format, ...);
+
+/// \brief Sends an OSD warning message (internal use only)
 ///
 /// @param format  the format of the message (followed by arguments)
 ///

--- a/opensubdiv/far/primvarRefiner.h
+++ b/opensubdiv/far/primvarRefiner.h
@@ -317,7 +317,8 @@ PrimvarRefiner::Limit(T const & src, U & dst) const {
 
     if (_refiner.getLevel(_refiner.GetMaxLevel()).getNumVertexEdgesTotal() == 0) {
         Error(FAR_RUNTIME_ERROR,
-            "Cannot compute limit points -- last level of refinement does not include full topology.");
+            "Failure in PrimvarRefiner::Limit() -- "
+            "last level of refinement does not include full topology.");
         return;
     }
 
@@ -340,7 +341,8 @@ PrimvarRefiner::Limit(T const & src, U & dstPos, U1 & dstTan1, U2 & dstTan2) con
 
     if (_refiner.getLevel(_refiner.GetMaxLevel()).getNumVertexEdgesTotal() == 0) {
         Error(FAR_RUNTIME_ERROR,
-            "Cannot compute limit points -- last level of refinement does not include full topology.");
+            "Failure in PrimvarRefiner::Limit() -- "
+            "last level of refinement does not include full topology.");
         return;
     }
 
@@ -363,7 +365,8 @@ PrimvarRefiner::LimitFaceVarying(T const & src, U & dst, int channel) const {
 
     if (_refiner.getLevel(_refiner.GetMaxLevel()).getNumVertexEdgesTotal() == 0) {
         Error(FAR_RUNTIME_ERROR,
-            "Cannot compute limit points -- last level of refinement does not include full topology.");
+            "Failure in PrimvarRefiner::LimitFaceVarying() -- "
+            "last level of refinement does not include full topology.");
         return;
     }
 

--- a/opensubdiv/far/ptexIndices.cpp
+++ b/opensubdiv/far/ptexIndices.cpp
@@ -94,9 +94,9 @@ PtexIndices::GetAdjacency(
 
     if (Sdc::SchemeTypeTraits::GetRegularFaceSize(
             refiner.GetSchemeType()) != 4) {
-        Far::Error(FAR_CODING_ERROR,
-            "PtexIndices::GetAdjacency() is currently only implemented for "
-            "quad schemes.");
+        Far::Error(FAR_RUNTIME_ERROR,
+                "Failure in PtexIndices::GetAdjacency() -- "
+                "currently only implemented for quad schemes.");
         return;
     }
 

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -192,12 +192,12 @@ TopologyRefiner::RefineUniform(UniformOptions options) {
 
     if (_levels[0]->getNumVertices() == 0) {
         Error(FAR_RUNTIME_ERROR,
-            "Cannot apply uniform refinement -- base level appears to be uninitialized.");
+            "Failure in TopologyRefiner::RefineUniform() -- base level is uninitialized.");
         return;
     }
     if (_refinements.size()) {
         Error(FAR_RUNTIME_ERROR,
-            "Cannot apply uniform refinement -- previous refinements already applied.");
+            "Failure in TopologyRefiner::RefineUniform() -- previous refinements already applied.");
         return;
     }
 
@@ -245,17 +245,17 @@ TopologyRefiner::RefineAdaptive(AdaptiveOptions options) {
 
     if (_levels[0]->getNumVertices() == 0) {
         Error(FAR_RUNTIME_ERROR,
-            "Cannot apply adaptive refinement -- base level appears to be uninitialized.");
+            "Failure in TopologyRefiner::RefineAdaptive() -- base level is uninitialized.");
         return;
     }
     if (_refinements.size()) {
         Error(FAR_RUNTIME_ERROR,
-            "Cannot apply adaptive refinement -- previous refinements already applied.");
+            "Failure in TopologyRefiner::RefineAdaptive() -- previous refinements already applied.");
         return;
     }
     if (_subdivType != Sdc::SCHEME_CATMARK) {
         Error(FAR_RUNTIME_ERROR,
-            "Cannot apply adaptive refinement -- currently only supported for scheme Catmark.");
+            "Failure in TopologyRefiner::RefineAdaptive() -- currently only supported for Catmark scheme.");
         return;
     }
 

--- a/opensubdiv/far/topologyRefinerFactory.cpp
+++ b/opensubdiv/far/topologyRefinerFactory.cpp
@@ -57,13 +57,13 @@ TopologyRefinerFactoryBase::prepareComponentTopologySizing(TopologyRefiner& refi
     int fCount = baseLevel.getNumFaces();
 
     if (vCount == 0) {
-        Error(FAR_RUNTIME_ERROR,
-                "Invalid topology detected : mesh contains no vertices.");
+        Error(FAR_RUNTIME_ERROR, "Failure in TopologyRefinerFactory<>::Create() -- "
+                "mesh contains no vertices.");
         return false;
     }
     if (fCount == 0) {
-        Error(FAR_RUNTIME_ERROR,
-                "Invalid topology detected : meshes without faces not yet supported.");
+        Error(FAR_RUNTIME_ERROR, "Failure in TopologyRefinerFactory<>::Create() -- "
+                "meshes without faces not yet supported.");
         return false;
     }
 
@@ -71,8 +71,8 @@ TopologyRefinerFactoryBase::prepareComponentTopologySizing(TopologyRefiner& refi
     //  valence has been initialized with the maximum number of face-vertices:
     if (baseLevel.getMaxValence() > Vtr::VALENCE_LIMIT) {
         char msg[1024];
-        snprintf(msg, 1024,
-                "Invalid topology specified : face with %d vertices > %d max.",
+        snprintf(msg, 1024, "Failure in TopologyRefinerFactory<>::Create() -- "
+                "face with %d vertices > %d max.",
                 baseLevel.getMaxValence(), Vtr::VALENCE_LIMIT);
         Error(FAR_RUNTIME_ERROR, msg);
         return false;
@@ -82,13 +82,13 @@ TopologyRefinerFactoryBase::prepareComponentTopologySizing(TopologyRefiner& refi
                      baseLevel.getOffsetOfFaceVertices(fCount - 1);
 
     if (fVertCount == 0) {
-        Error(FAR_RUNTIME_ERROR,
-                "Invalid topology detected : mesh contains no face-vertices.");
+        Error(FAR_RUNTIME_ERROR, "Failure in TopologyRefinerFactory<>::Create() -- "
+                "mesh contains no face-vertices.");
         return false;
     }
     if ((refiner.GetSchemeType() == Sdc::SCHEME_LOOP) && (fVertCount != (3 * fCount))) {
-        Error(FAR_RUNTIME_ERROR,
-                "Invalid topology specified : non-triangular faces not supported by Loop scheme.");
+        Error(FAR_RUNTIME_ERROR, "Failure in TopologyRefinerFactory<>::Create() -- "
+                "non-triangular faces not supported by Loop scheme.");
         return false;
     }
     baseLevel.resizeFaceVertices(fVertCount);
@@ -127,25 +127,29 @@ TopologyRefinerFactoryBase::prepareComponentTopologyAssignment(TopologyRefiner& 
     if (completeMissingTopology) {
         if (not baseLevel.completeTopologyFromFaceVertices()) {
             char msg[1024];
-            snprintf(msg, 1024,
-                    "Invalid topology detected : vertex with valence %d > %d max.",
+            snprintf(msg, 1024, "Failure in TopologyRefinerFactory<>::Create() -- "
+                    "vertex with valence %d > %d max.",
                     baseLevel.getMaxValence(), Vtr::VALENCE_LIMIT);
             Error(FAR_RUNTIME_ERROR, msg);
             return false;
         }
     } else {
         if (baseLevel.getMaxValence() == 0) {
-            Error(FAR_RUNTIME_ERROR,
-                "Invalid topology detected : maximum valence not assigned.");
+            Error(FAR_RUNTIME_ERROR, "Failure in TopologyRefinerFactory<>::Create() -- "
+                "maximum valence not assigned.");
             return false;
         }
     }
 
     if (fullValidation) {
         if (not baseLevel.validateTopology(callback, callbackData)) {
-            Error(FAR_RUNTIME_ERROR, completeMissingTopology ?
-                    "Invalid topology detected as completed from partial specification." :
-                    "Invalid topology detected as fully specified.");
+            if (completeMissingTopology) {
+                Error(FAR_RUNTIME_ERROR, "Failure in TopologyRefinerFactory<>::Create() -- "
+                    "invalid topology detected from partial specification.");
+            } else {
+                Error(FAR_RUNTIME_ERROR, "Failure in TopologyRefinerFactory<>::Create() -- "
+                    "invalid topology detected as fully specified.");
+            }
             return false;
         }
     }
@@ -289,7 +293,8 @@ TopologyRefinerFactoryBase::prepareFaceVaryingChannels(TopologyRefiner& refiner)
     for (int channel=0; channel<refiner.GetNumFVarChannels(); ++channel) {
         if (baseLevel.getNumFVarValues(channel) == 0) {
             char msg[1024];
-            snprintf(msg, 1024, "Invalid face-varying channel : channel %d has no values.", channel);
+            snprintf(msg, 1024, "Failure in TopologyRefinerFactory<>::Create() -- "
+                    "face-varying channel %d has no values.", channel);
             Error(FAR_RUNTIME_ERROR, msg);
             return false;
         }

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -547,7 +547,8 @@ template <class MESH>
 bool
 TopologyRefinerFactory<MESH>::resizeComponentTopology(TopologyRefiner& /* refiner */, MESH const& /* mesh */) {
 
-    Error(FAR_RUNTIME_ERROR, "Missing specialization for TopologyRefinerFactory<MESH>::resizeComponentTopology()");
+    Error(FAR_RUNTIME_ERROR,
+        "Failure in TopologyRefinerFactory<>::resizeComponentTopology() -- no specialization provided.");
 
     //
     //  Sizing the topology tables:
@@ -587,7 +588,8 @@ template <class MESH>
 bool
 TopologyRefinerFactory<MESH>::assignComponentTopology(TopologyRefiner& /* refiner */, MESH const& /* mesh */) {
 
-    Error(FAR_RUNTIME_ERROR, "Missing specialization for TopologyRefinerFactory<MESH>::assignComponentTopology()");
+    Error(FAR_RUNTIME_ERROR,
+        "Failure in TopologyRefinerFactory<>::assignComponentTopology() -- no specialization provided.");
 
     //
     //  Assigning the topology tables:


### PR DESCRIPTION
This change includes updates to Error() calls in Far so that their message strings are consistent.  All strings now include a specific (public) method within which the error originated along with its cause.

Minor changes to the formatting of the default message handlers were also made based on offline discussions.