### PR TITLE
Fixed single crease patch classification

### DIFF
--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -115,6 +115,8 @@ public:
         ss << "#define OSD_ENABLE_PATCH_CULL\n";
         ss << "#define GEOMETRY_OUT_LINE\n";
 
+        ss << "#define OSD_PATCH_ENABLE_SINGLE_CREASE\n";
+
         // include osd PatchCommon
         ss << Osd::GLSLPatchShaderSource::GetCommonShaderSource();
         std::string common = ss.str();

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -1305,8 +1305,8 @@ Level::isSingleCreasePatch(Index face, float *sharpnessOut, int *rotationOut) co
             }
         }
         // sharpnesses have to be [0, x, 0, x] or [x, 0, x, 0]
-        if (isSharpnessEqual(sharpnesses[0], sharpnesses[2]) or
-            isSharpnessEqual(sharpnesses[1], sharpnesses[3])) {
+        if (!isSharpnessEqual(sharpnesses[0], sharpnesses[2]) or
+            !isSharpnessEqual(sharpnesses[1], sharpnesses[3])) {
             return false;
         }
     }


### PR DESCRIPTION
This fixes a regression in the function used to identify single crease
patches. This also updates the patch color values used by the glImaging
regression test to match the colors used in other example viewers so
that patch types can be more easily identified during automated testing.