### PR TITLE
use WIN32_LEAN_AND_MEAN properly

### DIFF
--- a/examples/common/clDeviceContext.cpp
+++ b/examples/common/clDeviceContext.cpp
@@ -27,6 +27,7 @@
 #include "clDeviceContext.h"
 
 #if defined(_WIN32)
+    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
 #elif defined(__APPLE__)
     #include <OpenGL/OpenGL.h>

--- a/examples/common/cudaDeviceContext.cpp
+++ b/examples/common/cudaDeviceContext.cpp
@@ -25,6 +25,7 @@
 #include "cudaDeviceContext.h"
 
 #if defined(_WIN32)
+    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
 #elif defined(__APPLE__)
     #include <OpenGL/OpenGL.h>

--- a/opensubdiv/osd/opengl.h
+++ b/opensubdiv/osd/opengl.h
@@ -40,7 +40,7 @@
     #include <GLES2/gl2.h>
 #else
     #if defined(_WIN32)
-        #define W32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
         #include <windows.h>
     #endif
     #if defined(OSD_USES_GLEW)


### PR DESCRIPTION
Misspelled W32_LEAN_AND_MEAN in osd/opengl.h had no effect on windows.h.

Also added to example code wherever windows.h is included.