### PR TITLE
Fix GLSL program being deleted twice in GLSL Compute controller

### DIFF
--- a/opensubdiv/osd/glComputeEvaluator.cpp
+++ b/opensubdiv/osd/glComputeEvaluator.cpp
@@ -114,12 +114,6 @@ GLComputeEvaluator::GLComputeEvaluator() : _workGroupSize(64) {
 }
 
 GLComputeEvaluator::~GLComputeEvaluator() {
-    if (_stencilKernel.program) {
-        glDeleteProgram(_stencilKernel.program);
-    }
-    if (_patchKernel.program) {
-        glDeleteProgram(_patchKernel.program);
-    }
 }
 
 static GLuint


### PR DESCRIPTION
GLSL programs used by stencil and patch kernels were freed from
both GLSL Compute Evaluator and from kernel classes themselves.