### PR TITLE
Set layout to std430 for GLSL Compute kernel

### DIFF
--- a/opensubdiv/osd/glslComputeKernel.glsl
+++ b/opensubdiv/osd/glslComputeKernel.glsl
@@ -26,6 +26,7 @@
 
 
 layout(local_size_x=WORK_GROUP_SIZE, local_size_y=1, local_size_z=1) in;
+layout(std430) buffer;
 
 // source and destination buffers
 


### PR DESCRIPTION
Fixes #735, corrupted mesh issues with GLSL Compute on AMD platforms.