### PR TITLE
Fixed GLSL Compute Kernel buffer layout

### DIFF
--- a/opensubdiv/osd/glslComputeKernel.glsl
+++ b/opensubdiv/osd/glslComputeKernel.glsl
@@ -26,6 +26,7 @@
 
 
 layout(local_size_x=WORK_GROUP_SIZE, local_size_y=1, local_size_z=1) in;
+layout(std430) buffer;
 
 // source and destination buffers
 


### PR DESCRIPTION
For improved portability, we need to declare std430 buffer layout
for buffer resources used by the GLSL Compute Kernel.