### PR TITLE
Improved patch approximations around non-manifold features

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -898,7 +898,10 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
             }
 
             //  Identify boundaries for both regular and xordinary patches -- non-manifold
-            //  edges and vertices are interpreted as boundaries for regular patches
+            //  (infinitely sharp) edges and vertices are currently interpreted as boundaries
+            //  for regular patches, though an irregular patch or extrapolated boundary patch
+            //  is really necessary in future for some non-manifold cases.
+            //
             if (hasBoundaryVertex or hasNonManifoldVertex) {
                 Vtr::ConstIndexArray fEdges = level->getFaceEdges(faceIndex);
 
@@ -911,6 +914,27 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
                                          ((level->getEdgeTag(fEdges[1])._nonManifold) << 1) |
                                          ((level->getEdgeTag(fEdges[2])._nonManifold) << 2) |
                                          ((level->getEdgeTag(fEdges[3])._nonManifold) << 3);
+
+                    //  Other than non-manifold edges, non-manifold vertices that were made
+                    //  sharp should also trigger new "boundary" edges for the sharp corner
+                    //  patches introduced in these cases.
+                    //
+                    if (level->getVertexTag(fVerts[0])._nonManifold &&
+                        level->getVertexTag(fVerts[0])._infSharp) {
+                        nonManEdgeMask |= (1 << 0) | (1 << 3);
+                    }
+                    if (level->getVertexTag(fVerts[1])._nonManifold &&
+                        level->getVertexTag(fVerts[1])._infSharp) {
+                        nonManEdgeMask |= (1 << 1) | (1 << 0);
+                    }
+                    if (level->getVertexTag(fVerts[2])._nonManifold &&
+                        level->getVertexTag(fVerts[2])._infSharp) {
+                        nonManEdgeMask |= (1 << 2) | (1 << 1);
+                    }
+                    if (level->getVertexTag(fVerts[3])._nonManifold &&
+                        level->getVertexTag(fVerts[3])._infSharp) {
+                        nonManEdgeMask |= (1 << 3) | (1 << 2);
+                    }
                     boundaryEdgeMask |= nonManEdgeMask;
                 }
 


### PR DESCRIPTION
Patches around non-manifold vertices are currently approximated with regular patches, which works well in some cases but not all.  Ultimately we need irregular patches (or at least some kind of extrapolated regular patch) to represent these without cracks, which is planned for the future.

Until then, this change uses regular corner patches around non-manifold vertices that are sharpened to interpolate the vertex and reduce cracks between the patches around it.  This does not eliminate cracks with the adjacent interior patches, but it is hoped the isolation level is deep enough to make them negligible until the longer term solution is in place.