### PR TITLE
Reduce the transient memory consumption in endcap construction.

### DIFF
--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.h
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.h
@@ -51,11 +51,19 @@ public:
     ///
     /// @param refiner                TopologyRefiner from which to generate patches
     ///
+    /// @param vertexStencils         Output stencil table for the patch points
+    ///                               (vertex interpolation)
+    ///
+    /// @param varyingStencils        Output stencil table for the patch points
+    ///                               (varying interpolation)
+    ///
     /// @param shareBoundaryVertices  Use same boundary vertices for neighboring
     ///                               patches. It reduces the number of stencils
     ///                               to be used.
     ///
-    EndCapBSplineBasisPatchFactory(TopologyRefiner const & refiner);
+    EndCapBSplineBasisPatchFactory(TopologyRefiner const & refiner,
+                                   StencilTable * vertexStencils,
+                                   StencilTable * varyingStencils);
 
     /// \brief Returns end patch point indices for \a faceIndex of \a level.
     ///        Note that end patch points are not included in the vertices in
@@ -75,21 +83,6 @@ public:
         PatchTableFactory::PatchFaceTag const * levelPatchTags,
         int levelVertOffset);
 
-    /// \brief Create a StencilTable for end patch points, relative to the max
-    ///        subdivision level.
-    ///
-    StencilTable* CreateVertexStencilTable() const {
-        return GregoryBasis::CreateStencilTable(_vertexStencils);
-    }
-
-    /// \brief Create a StencilTable for end patch varying primvar.
-    ///        This table is used as a convenient way to get varying primvars
-    ///        populated on end patch points along with positions.
-    ///
-    StencilTable* CreateVaryingStencilTable() const {
-        return GregoryBasis::CreateStencilTable(_varyingStencils);
-    }
-
 private:
     ConstIndexArray getPatchPointsFromGregoryBasis(
         Vtr::internal::Level const * level, Index thisFace,
@@ -106,10 +99,10 @@ private:
         ConstIndexArray facePoints, int vid,
         GregoryBasis::Point *P, GregoryBasis::Point *Ep, GregoryBasis::Point *Em);
 
+    StencilTable * _vertexStencils;
+    StencilTable * _varyingStencils;
 
     TopologyRefiner const *_refiner;
-    GregoryBasis::PointsVector _vertexStencils;
-    GregoryBasis::PointsVector _varyingStencils;
     int _numVertices;
     int _numPatches;
     std::vector<Index> _patchPoints;

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.h
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.h
@@ -27,6 +27,7 @@
 
 #include "../far/patchTableFactory.h"
 #include "../far/gregoryBasis.h"
+#include "../far/stencilTable.h"
 #include "../vtr/level.h"
 
 namespace OpenSubdiv {
@@ -74,11 +75,19 @@ public:
     ///
     /// @param refiner                TopologyRefiner from which to generate patches
     ///
+    /// @param vertexStencils         Output stencil table for the patch points
+    ///                               (vertex interpolation)
+    ///
+    /// @param varyingStencils        Output stencil table for the patch points
+    ///                               (varying interpolation)
+    ///
     /// @param shareBoundaryVertices  Use same boundary vertices for neighboring
     ///                               patches. It reduces the number of stencils
     ///                               to be used.
     ///
     EndCapGregoryBasisPatchFactory(TopologyRefiner const & refiner,
+                                   StencilTable *vertexStencils,
+                                   StencilTable *varyingStencils,
                                    bool shareBoundaryVertices=true);
 
     /// \brief Returns end patch point indices for \a faceIndex of \a level.
@@ -99,21 +108,6 @@ public:
         PatchTableFactory::PatchFaceTag const * levelPatchTags,
         int levelVertOffset);
 
-    /// \brief Create a StencilTable for end patch points, relative to the max
-    ///        subdivision level.
-    ///
-    StencilTable* CreateVertexStencilTable() const {
-        return GregoryBasis::CreateStencilTable(_vertexStencils);
-    }
-
-    /// \brief Create a StencilTable for end patch varying primvar.
-    ///        This table is used as a convenient way to get varying primvars
-    ///        populated on end patch points along with positions.
-    ///
-    StencilTable* CreateVaryingStencilTable() const {
-        return GregoryBasis::CreateStencilTable(_varyingStencils);
-    }
-
 private:
 
     /// Creates a basis for the vertices specified in mask on the face and
@@ -121,8 +115,8 @@ private:
     bool addPatchBasis(Index faceIndex, bool newVerticesMask[4][5],
                        int levelVertOffset);
 
-    GregoryBasis::PointsVector _vertexStencils;
-    GregoryBasis::PointsVector _varyingStencils;
+    StencilTable *_vertexStencils;
+    StencilTable *_varyingStencils;
 
     TopologyRefiner const *_refiner;
     bool _shareBoundaryVertices;

--- a/opensubdiv/far/gregoryBasis.cpp
+++ b/opensubdiv/far/gregoryBasis.cpp
@@ -126,7 +126,6 @@ GregoryBasis::ProtoBasis::ProtoBasis(
         P[i].Clear(stencilCapacity);
         e0[i].Clear(stencilCapacity);
         e1[i].Clear(stencilCapacity);
-        V[i].Clear(1);
     }
 
     Vtr::internal::StackBuffer<Index, 40> manifoldRings[4];
@@ -142,7 +141,7 @@ GregoryBasis::ProtoBasis::ProtoBasis(
 
     for (int vid=0; vid<4; ++vid) {
         // save for varying stencils
-        V[vid].AddWithWeight(facePoints[vid], 1.0f);
+        varyingIndex[vid] = facePoints[vid] + levelVertOffset;
 
         int ringSize =
             level.gatherQuadRegularRingAroundVertex(
@@ -445,39 +444,7 @@ GregoryBasis::ProtoBasis::ProtoBasis(
         Em[i].OffsetIndices(levelVertOffset);
         Fp[i].OffsetIndices(levelVertOffset);
         Fm[i].OffsetIndices(levelVertOffset);
-        V[i].OffsetIndices(levelVertOffset);
     }
-}
-
-/*static*/
-StencilTable *
-GregoryBasis::CreateStencilTable(PointsVector const &stencils) {
-
-    int nStencils = (int)stencils.size();
-    if (nStencils == 0) return NULL;
-
-    int nElements = 0;
-    for (int i = 0; i < nStencils; ++i) {
-        nElements += stencils[i].GetSize();
-    }
-
-    // allocate destination
-    StencilTable *stencilTable = new StencilTable();
-
-    // XXX: do we need numControlVertices in stencilTable?
-    stencilTable->_numControlVertices = 0;
-    stencilTable->resize(nStencils, nElements);
-
-    int * sizes = &stencilTable->_sizes[0];
-    Index * indices = &stencilTable->_indices[0];
-    float * weights = &stencilTable->_weights[0];
-
-    for (int i = 0; i < nStencils; ++i) {
-        stencils[i].Copy(&sizes, &indices, &weights);
-    }
-    stencilTable->generateOffsets();
-
-    return stencilTable;
 }
 
 } // end namespace Far

--- a/opensubdiv/far/gregoryBasis.h
+++ b/opensubdiv/far/gregoryBasis.h
@@ -161,8 +161,14 @@ public:
             ++(*size);
         }
 
-    private:
+        Vtr::Index GetStencilIndex(int index) const {
+            return _stencils[index].index;
+        }
+        float GetStencilWeight(int index) const {
+            return _stencils[index].weight;
+        }
 
+    private:
         int _size;
 
         struct Stencil {
@@ -219,12 +225,28 @@ public:
         Point P[4], Ep[4], Em[4], Fp[4], Fm[4];
 
         // for varying interpolation
-        Point V[4];
+        Vtr::Index varyingIndex[4];
     };
 
     typedef std::vector<GregoryBasis::Point> PointsVector;
 
-    static StencilTable *CreateStencilTable(PointsVector const &stencils);
+    // for basis point stencil
+    static void AppendToStencilTable(GregoryBasis::Point const &p,
+                                     StencilTable *table) {
+        int size = p.GetSize();
+        table->_sizes.push_back(size);
+        for (int i = 0; i < size; ++i) {
+            table->_indices.push_back(p.GetStencilIndex(i));
+            table->_weights.push_back(p.GetStencilWeight(i));
+        }
+    }
+
+    // for varying stencil (just copy)
+    static void AppendToStencilTable(int index, StencilTable *table) {
+        table->_sizes.push_back(1);
+        table->_indices.push_back(index);
+        table->_weights.push_back(1.f);
+    }
 
 private:
 

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1122,14 +1122,26 @@ PatchTableFactory::populateAdaptivePatches(
     EndCapBSplineBasisPatchFactory *endCapBSpline = NULL;
     EndCapGregoryBasisPatchFactory *endCapGregoryBasis = NULL;
     EndCapLegacyGregoryPatchFactory *endCapLegacyGregory = NULL;
+    StencilTable *localPointStencils = NULL;
+    StencilTable *localPointVaryingStencils = NULL;
 
     switch(context.options.GetEndCapType()) {
     case Options::ENDCAP_GREGORY_BASIS:
+        localPointStencils = new StencilTable(0);
+        localPointVaryingStencils = new StencilTable(0);
         endCapGregoryBasis = new EndCapGregoryBasisPatchFactory(
-            refiner, context.options.shareEndCapPatchPoints);
+            refiner,
+            localPointStencils,
+            localPointVaryingStencils,
+            context.options.shareEndCapPatchPoints);
         break;
     case Options::ENDCAP_BSPLINE_BASIS:
-        endCapBSpline = new EndCapBSplineBasisPatchFactory(refiner);
+        localPointStencils = new StencilTable(0);
+        localPointVaryingStencils = new StencilTable(0);
+        endCapBSpline = new EndCapBSplineBasisPatchFactory(
+            refiner,
+            localPointStencils,
+            localPointVaryingStencils);
         break;
     case Options::ENDCAP_LEGACY_GREGORY:
         endCapLegacyGregory = new EndCapLegacyGregoryPatchFactory(refiner);
@@ -1291,19 +1303,20 @@ PatchTableFactory::populateAdaptivePatches(
     }
 
     // finalize end patches
+    if (localPointStencils)
+        localPointStencils->generateOffsets();
+    if (localPointVaryingStencils)
+        localPointVaryingStencils->generateOffsets();
+
     switch(context.options.GetEndCapType()) {
     case Options::ENDCAP_GREGORY_BASIS:
-        table->_localPointStencils =
-            endCapGregoryBasis->CreateVertexStencilTable();
-        table->_localPointVaryingStencils =
-            endCapGregoryBasis->CreateVaryingStencilTable();
+        table->_localPointStencils = localPointStencils;
+        table->_localPointVaryingStencils = localPointVaryingStencils;
         delete endCapGregoryBasis;
         break;
     case Options::ENDCAP_BSPLINE_BASIS:
-        table->_localPointStencils =
-            endCapBSpline->CreateVertexStencilTable();
-        table->_localPointVaryingStencils =
-            endCapBSpline->CreateVaryingStencilTable();
+        table->_localPointStencils = localPointStencils;
+        table->_localPointVaryingStencils = localPointVaryingStencils;
         delete endCapBSpline;
         break;
     case Options::ENDCAP_LEGACY_GREGORY:

--- a/opensubdiv/far/stencilTable.h
+++ b/opensubdiv/far/stencilTable.h
@@ -205,6 +205,9 @@ protected:
     // Resize the table arrays (factory helper)
     void resize(int nstencils, int nelems);
 
+    // Reserves the table arrays (factory helper)
+    void reserve(int nstencils, int nelems);
+
 protected:
     StencilTable() : _numControlVertices(0) {}
     StencilTable(int numControlVerts)
@@ -212,8 +215,12 @@ protected:
     { }
 
     friend class StencilTableFactory;
+    friend class PatchTableFactory;
     // XXX: temporarily, GregoryBasis class will go away.
     friend class GregoryBasis;
+    // XXX: needed to call reserve().
+    friend class EndCapBSplineBasisPatchFactory;
+    friend class EndCapGregoryBasisPatchFactory;
 
     int _numControlVertices;              // number of control vertices
 
@@ -397,6 +404,13 @@ StencilTable::resize(int nstencils, int nelems) {
     _sizes.resize(nstencils);
     _indices.resize(nelems);
     _weights.resize(nelems);
+}
+
+inline void
+StencilTable::reserve(int nstencils, int nelems) {
+    _sizes.reserve(nstencils);
+    _indices.reserve(nelems);
+    _weights.reserve(nelems);
 }
 
 // Returns a Stencil at index i in the table


### PR DESCRIPTION
- instead of accumulating GregoryBasis::Point (fixed size stencils
  backed by stackbuffer), pack the stencils into StencilTable as they
  are evaluated
- use single integer for varying stencils of patch points, not
  a GregoryBasis::Point
- cap the reserved stencil entry size.