### PR TITLE
Teach the LimitStencilTable to compute 2nd partial derivatives

### DIFF
--- a/opensubdiv/far/patchBasis.cpp
+++ b/opensubdiv/far/patchBasis.cpp
@@ -208,7 +208,7 @@ inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParam const & param,
         derivT[2] =   s * dScale;
         derivT[3] =  sC * dScale;
 
-        if (derivSS and derivST and derivTT) {
+        if (derivSS && derivST && derivTT) {
             float d2Scale = dScale * dScale;
 
             for(int i=0;i<4;i++) {
@@ -291,7 +291,7 @@ void Spline<BASIS>::GetPatchWeights(PatchParam const & param,
             }
         }
 
-        if (derivSS and derivST and derivTT) {
+        if (derivSS && derivST && derivTT) {
             // Compute the tensor product weight of appropriate differentiated
             // (s,t) basis functions for each control vertex (scaled accordingly):
         

--- a/opensubdiv/far/patchBasis.cpp
+++ b/opensubdiv/far/patchBasis.cpp
@@ -46,14 +46,14 @@ class Spline {
 public:
 
     // curve weights
-    static void GetWeights(float t, float point[], float deriv[]);
+    static void GetWeights(float t, float point[], float deriv[], float deriv2[]);
 
     // box-spline weights
     static void GetWeights(float v, float w, float point[]);
 
     // patch weights
     static void GetPatchWeights(PatchParam const & param,
-        float s, float t, float point[], float deriv1[], float deriv2[]);
+        float s, float t, float point[], float deriv1[], float deriv2[], float deriv11[], float deriv12[], float deriv22[]);
 
     // adjust patch weights for boundary (and corner) edges
     static void AdjustBoundaryWeights(PatchParam const & param,
@@ -62,7 +62,7 @@ public:
 
 template <>
 inline void Spline<BASIS_BEZIER>::GetWeights(
-    float t, float point[4], float deriv[4]) {
+    float t, float point[4], float deriv[4], float deriv2[4]) {
 
     // The four uniform cubic Bezier basis functions (in terms of t and its
     // complement tC) evaluated at t:
@@ -83,11 +83,19 @@ inline void Spline<BASIS_BEZIER>::GetWeights(
        deriv[2] = -9.0f * t2 +  6.0f * t;
        deriv[3] =  3.0f * t2;
     }
+
+    // Second derivatives of the basis functions at t:
+    if (deriv2) {
+        deriv2[0] =   6.0f * tC;
+        deriv2[1] =  18.0f * t - 12.0f;
+        deriv2[2] = -18.0f * t +  6.0f;
+        deriv2[3] =   6.0f * t;
+    }
 }
 
 template <>
 inline void Spline<BASIS_BSPLINE>::GetWeights(
-    float t, float point[4], float deriv[4]) {
+    float t, float point[4], float deriv[4], float deriv2[4]) {
 
     // The four uniform cubic B-Spline basis functions evaluated at t:
     float const one6th = 1.0f / 6.0f;
@@ -107,6 +115,14 @@ inline void Spline<BASIS_BSPLINE>::GetWeights(
         deriv[1] =  1.5f*t2 - 2.0f*t;
         deriv[2] = -1.5f*t2 +      t + 0.5f;
         deriv[3] =  0.5f*t2;
+    }
+
+    // Second derivatives of the basis functions at t:
+    if (deriv2) {
+        deriv2[0] = -       t + 1.0f;
+        deriv2[1] =  3.0f * t - 2.0f;
+        deriv2[2] = -3.0f * t + 1.0f;
+        deriv2[3] =         t;
     }
 }
 
@@ -165,7 +181,7 @@ inline void Spline<BASIS_BOX_SPLINE>::GetWeights(
 
 template <>
 inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParam const & param,
-    float s, float t, float point[4], float derivS[4], float derivT[4]) {
+    float s, float t, float point[4], float derivS[4], float derivT[4], float derivSS[4], float derivST[4], float derivTT[4]) {
 
     param.Normalize(s,t);
 
@@ -191,6 +207,20 @@ inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParam const & param,
         derivT[1] =  -s * dScale;
         derivT[2] =   s * dScale;
         derivT[3] =  sC * dScale;
+
+        if (derivSS and derivST and derivTT) {
+            float d2Scale = dScale * dScale;
+
+            for(int i=0;i<4;i++) {
+                derivSS[i] = 0;
+                derivTT[i] = 0;
+            }
+            
+            derivST[0] =  d2Scale;
+            derivST[1] = -d2Scale;
+            derivST[2] = -d2Scale;
+            derivST[3] =  d2Scale;
+        }
     }
 }
 
@@ -224,14 +254,14 @@ void Spline<BASIS>::AdjustBoundaryWeights(PatchParam const & param,
 
 template <SplineBasis BASIS>
 void Spline<BASIS>::GetPatchWeights(PatchParam const & param,
-    float s, float t, float point[16], float derivS[16], float derivT[16]) {
+    float s, float t, float point[16], float derivS[16], float derivT[16], float derivSS[16], float derivST[16], float derivTT[16]) {
 
-    float sWeights[4], tWeights[4], dsWeights[4], dtWeights[4];
+    float sWeights[4], tWeights[4], dsWeights[4], dtWeights[4], dssWeights[4], dttWeights[4];
 
     param.Normalize(s,t);
 
-    Spline<BASIS>::GetWeights(s, point ? sWeights : 0, derivS ? dsWeights : 0);
-    Spline<BASIS>::GetWeights(t, point ? tWeights : 0, derivT ? dtWeights : 0);
+    Spline<BASIS>::GetWeights(s, point ? sWeights : 0, derivS ? dsWeights : 0, derivSS ? dssWeights : 0);
+    Spline<BASIS>::GetWeights(t, point ? tWeights : 0, derivT ? dtWeights : 0, derivTT ? dttWeights : 0);
 
     if (point) {
         // Compute the tensor product weight of the (s,t) basis function
@@ -260,30 +290,43 @@ void Spline<BASIS>::GetPatchWeights(PatchParam const & param,
                 derivT[4*i+j] = sWeights[j] * dtWeights[i] * dScale;
             }
         }
+
+        if (derivSS and derivST and derivTT) {
+            // Compute the tensor product weight of appropriate differentiated
+            // (s,t) basis functions for each control vertex (scaled accordingly):
+        
+            float d2Scale = dScale * dScale;
+
+            AdjustBoundaryWeights(param, dssWeights, dttWeights);
+
+            for (int i = 0; i < 4; ++i) {
+                for (int j = 0; j < 4; ++j) {
+                    derivSS[4*i+j] = dssWeights[j] * tWeights[i] * d2Scale;
+                    derivST[4*i+j] = dsWeights[j] * dtWeights[i] * d2Scale;
+                    derivTT[4*i+j] = sWeights[j] * dttWeights[i] * d2Scale;
+                }
+            }
+        }
     }
 }
 
 void GetBilinearWeights(PatchParam const & param,
-    float s, float t, float point[4], float deriv1[4], float deriv2[4]) {
-
-    Spline<BASIS_BILINEAR>::GetPatchWeights(param, s, t, point, deriv1, deriv2);
+    float s, float t, float point[4], float deriv1[4], float deriv2[4], float deriv11[4], float deriv12[4], float deriv22[4]) {
+    Spline<BASIS_BILINEAR>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
 void GetBezierWeights(PatchParam const param,
-    float s, float t, float point[16], float deriv1[16], float deriv2[16]) {
-
-    Spline<BASIS_BEZIER>::GetPatchWeights(param, s, t, point, deriv1, deriv2);
+    float s, float t, float point[16], float deriv1[16], float deriv2[16], float deriv11[16], float deriv12[16], float deriv22[16]) {
+    Spline<BASIS_BEZIER>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
 void GetBSplineWeights(PatchParam const & param,
-    float s, float t, float point[16], float deriv1[16], float deriv2[16]) {
-
-    Spline<BASIS_BSPLINE>::GetPatchWeights(param, s, t, point, deriv1, deriv2);
+    float s, float t, float point[16], float deriv1[16], float deriv2[16], float deriv11[16], float deriv12[16], float deriv22[16]) {
+    Spline<BASIS_BSPLINE>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
 void GetGregoryWeights(PatchParam const & param,
-    float s, float t, float point[20], float deriv1[20], float deriv2[20]) {
-
+    float s, float t, float point[20], float deriv1[20], float deriv2[20], float deriv11[20], float deriv12[20], float deriv22[20]) {
     //
     //  P3         e3-      e2+         P2
     //     15------17-------11--------10
@@ -321,13 +364,13 @@ void GetGregoryWeights(PatchParam const & param,
     //  interior points will be denoted G -- so we have B(s), B(t) and G(s,t):
     //
     //  Directional Bezier basis functions B at s and t:
-    float Bs[4], Bds[4];
-    float Bt[4], Bdt[4];
+    float Bs[4], Bds[4], Bdss[4];
+    float Bt[4], Bdt[4], Bdtt[4];
 
     param.Normalize(s,t);
 
-    Spline<BASIS_BEZIER>::GetWeights(s, Bs, deriv1 ? Bds : 0);
-    Spline<BASIS_BEZIER>::GetWeights(t, Bt, deriv2 ? Bdt : 0);
+    Spline<BASIS_BEZIER>::GetWeights(s, Bs, deriv1 ? Bds : 0, deriv11 ? Bdss : 0);
+    Spline<BASIS_BEZIER>::GetWeights(t, Bt, deriv2 ? Bdt : 0, deriv22 ? Bdtt : 0);
 
     //  Rational multipliers G at s and t:
     float sC = 1.0f - s;
@@ -361,8 +404,10 @@ void GetGregoryWeights(PatchParam const & param,
     //  order differentiation.
     //
     if (deriv1 and deriv2) {
+        bool find_second_partials = deriv1 and deriv12 and deriv22;
         //  Remember to include derivative scaling in all assignments below:
         float dScale = (float)(1 << param.GetDepth());
+        float d2Scale = dScale * dScale;
 
         //  Combined weights for boundary points -- simple (scaled) tensor products:
         for (int i = 0; i < 12; ++i) {
@@ -372,9 +417,17 @@ void GetGregoryWeights(PatchParam const & param,
 
             deriv1[iDst] = Bds[sCol] * Bt[tRow] * dScale;
             deriv2[iDst] = Bdt[tRow] * Bs[sCol] * dScale;
+
+            if (find_second_partials) {
+                deriv11[iDst] = Bdss[sCol] * Bt[tRow] * d2Scale;
+                deriv12[iDst] = Bds[sCol] * Bdt[tRow] * d2Scale;
+                deriv22[iDst] = Bs[sCol] * Bdtt[tRow] * d2Scale;
+            }
         }
 
-#define _USE_BEZIER_PSEUDO_DERIVATIVES
+//#define _USE_BEZIER_PSEUDO_DERIVATIVES
+        // dclyde's note: skipping half of the product rule like this does seem to change the result a lot in my tests.
+        // This is not a runtime bottleneck for cloth sims anyway so I'm just using the accurate version.
 #ifdef _USE_BEZIER_PSEUDO_DERIVATIVES
         //  Approximation to the true Gregory derivatives by differentiating the Bezier patch
         //  unique to the given (s,t), i.e. having F = (g^+ * f^+) + (g^- * f^-) as its four
@@ -388,6 +441,12 @@ void GetGregoryWeights(PatchParam const & param,
 
             deriv1[iDst] = Bds[sCol] * Bt[tRow] * G[i] * dScale;
             deriv2[iDst] = Bdt[tRow] * Bs[sCol] * G[i] * dScale;
+
+            if (find_second_partials) {
+                deriv11[iDst] = Bdss[sCol] * Bt[tRow] * G[i] * d2Scale;
+                deriv12[iDst] = Bds[sCol] * Bdt[tRow] * G[i] * d2Scale;
+                deriv22[iDst] = Bs[sCol] * Bdtt[tRow] * G[i] * d2Scale;
+            }
         }
 #else
         //  True Gregory derivatives using appropriate differentiation of composite functions:
@@ -422,6 +481,18 @@ void GetGregoryWeights(PatchParam const & param,
             //  Product rule combining B and B' with G and G' (and scaled):
             deriv1[iDst] = (Bds[sCol] * G[i] + Bs[sCol] * Gds) * Bt[tRow] * dScale;
             deriv2[iDst] = (Bdt[tRow] * G[i] + Bt[tRow] * Gdt) * Bs[sCol] * dScale;
+
+            if (find_second_partials) {
+                float Dsqr_inv = D[i]*D[i];
+
+                float Gdss = 2.0f * Dds[i] * Dsqr_inv * (G[i] * Dds[i] - Nds[i]);
+                float Gdst = Dsqr_inv * (2.0f * G[i] * Dds[i] * Ddt[i] - Nds[i] * Ddt[i] - Ndt[i] * Dds[i]);
+                float Gdtt = 2.0f * Ddt[i] * Dsqr_inv * (G[i] * Ddt[i] - Ndt[i]);
+
+                deriv11[iDst] = (Bdss[sCol] * G[i] + 2.0f * Bds[sCol] * Gds + Bs[sCol] * Gdss) * Bt[tRow] * d2Scale;
+                deriv12[iDst] = (Bt[tRow] * (Bs[sCol] * Gdst + Bds[sCol] * Gdt) + Bdt[tRow] * (Bds[sCol] * G[i] + Bs[sCol] * Gds)) * d2Scale;
+                deriv22[iDst] = (Bdtt[tRow] * G[i] + 2.0f * Bdt[tRow] * Gdt + Bt[tRow] * Gdtt) * Bs[sCol] * d2Scale;
+            }
         }
 #endif
     }

--- a/opensubdiv/far/patchBasis.h
+++ b/opensubdiv/far/patchBasis.h
@@ -46,16 +46,16 @@ namespace internal {
 //
 
 void GetBilinearWeights(PatchParam const & patchParam,
-    float s, float t, float wP[4], float wDs[4], float wDt[4]);
+    float s, float t, float wP[4], float wDs[4], float wDt[4], float wDss[4] = 0, float wDst[4] = 0, float wDtt[4] = 0);
 
 void GetBezierWeights(PatchParam const & patchParam,
-    float s, float t, float wP[16], float wDs[16], float wDt[16]);
+    float s, float t, float wP[16], float wDs[16], float wDt[16], float wDss[16] = 0, float wDst[16] = 0, float wDtt[16] = 0);
 
 void GetBSplineWeights(PatchParam const & patchParam,
-    float s, float t, float wP[16], float wDs[16], float wDt[16]);
+    float s, float t, float wP[16], float wDs[16], float wDt[16], float wDss[16] = 0, float wDst[16] = 0, float wDtt[16] = 0);
 
 void GetGregoryWeights(PatchParam const & patchParam,
-    float s, float t, float wP[20], float wDs[20], float wDt[20]);
+    float s, float t, float wP[20], float wDs[20], float wDt[20], float wDss[20] = 0, float wDst[20] = 0, float wDtt[20] = 0);
 
 
 } // end namespace internal

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -424,17 +424,17 @@ PatchTable::print() const {
 //
 void
 PatchTable::EvaluateBasis(PatchHandle const & handle, float s, float t,
-    float wP[], float wDs[], float wDt[]) const {
+    float wP[], float wDs[], float wDt[], float wDss[], float wDst[], float wDtt[]) const {
 
     PatchDescriptor::Type patchType = GetPatchArrayDescriptor(handle.arrayIndex).GetType();
     PatchParam const & param = _paramTable[handle.patchIndex];
 
     if (patchType == PatchDescriptor::REGULAR) {
-        internal::GetBSplineWeights(param, s, t, wP, wDs, wDt);
+        internal::GetBSplineWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
     } else if (patchType == PatchDescriptor::GREGORY_BASIS) {
-        internal::GetGregoryWeights(param, s, t, wP, wDs, wDt);
+        internal::GetGregoryWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
     } else if (patchType == PatchDescriptor::QUADS) {
-        internal::GetBilinearWeights(param, s, t, wP, wDs, wDt);
+        internal::GetBilinearWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
     } else {
         assert(0);
     }

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -306,7 +306,7 @@ public:
     /// @param wDt     Weights (evaluated basis functions) for derivative wrt t
     ///
     void EvaluateBasis(PatchHandle const & handle, float s, float t,
-        float wP[], float wDs[], float wDt[], float wDss[] = 0, float wDst[] = 0, float wDtt[] = 0) const;
+        float wP[], float wDs[] = 0, float wDt[] = 0, float wDss[] = 0, float wDst[] = 0, float wDtt[] = 0) const;
 
     //@}
 

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -306,7 +306,7 @@ public:
     /// @param wDt     Weights (evaluated basis functions) for derivative wrt t
     ///
     void EvaluateBasis(PatchHandle const & handle, float s, float t,
-        float wP[], float wDs[], float wDt[]) const;
+        float wP[], float wDs[], float wDt[], float wDss[] = 0, float wDst[] = 0, float wDtt[] = 0) const;
 
     //@}
 

--- a/opensubdiv/far/stencilBuilder.h
+++ b/opensubdiv/far/stencilBuilder.h
@@ -66,6 +66,9 @@ public:
     std::vector<float> const& GetStencilWeights() const;
     std::vector<float> const& GetStencilDuWeights() const;
     std::vector<float> const& GetStencilDvWeights() const;
+    std::vector<float> const& GetStencilDuuWeights() const;
+    std::vector<float> const& GetStencilDuvWeights() const;
+    std::vector<float> const& GetStencilDvvWeights() const;
 
     // Vertex Facade.
     class Index {
@@ -82,6 +85,10 @@ public:
         // Add with first derivative.
         void AddWithWeight(Stencil const& src,
                                      float weight, float du, float dv);
+
+        // Add with first and second derivatives.
+        void AddWithWeight(Stencil const& src,
+            float weight, float du, float dv, float duu, float duv, float dvv);
 
         Index operator[](int index) const {
             return Index(_owner, index+_index);

--- a/opensubdiv/far/stencilTable.cpp
+++ b/opensubdiv/far/stencilTable.cpp
@@ -47,7 +47,13 @@ namespace {
                     std::vector<float> const*  duWeights=NULL,
                     std::vector<float> *      _duWeights=NULL,
                     std::vector<float> const*  dvWeights=NULL,
-                    std::vector<float> *      _dvWeights=NULL) {
+                    std::vector<float> *      _dvWeights=NULL,
+                    std::vector<float> const*  duuWeights=NULL,
+                    std::vector<float> *      _duuWeights=NULL,
+                    std::vector<float> const*  duvWeights=NULL,
+                    std::vector<float> *      _duvWeights=NULL,
+                    std::vector<float> const*  dvvWeights=NULL,
+                    std::vector<float> *      _dvvWeights=NULL) {
         size_t start = includeCoarseVerts ? 0 : firstOffset;
 
         _offsets->resize(offsets->size());
@@ -58,6 +64,12 @@ namespace {
             _duWeights->resize(duWeights->size());
         if (_dvWeights)
             _dvWeights->resize(dvWeights->size());
+        if (_duuWeights)
+            _duuWeights->resize(duuWeights->size());
+        if (_duvWeights)
+            _duvWeights->resize(duvWeights->size());
+        if (_dvvWeights)
+            _dvvWeights->resize(dvvWeights->size());
 
         // The stencils are probably not in order, so we must copy/sort them.
         // Note here that loop index 'i' represents stencil_i for vertex_i.
@@ -93,6 +105,19 @@ namespace {
                         &(*dvWeights)[off], sz*sizeof(float));
             }
 
+            if (_duuWeights) {
+                std::memcpy(&(*_duuWeights)[curOffset],
+                        &(*duuWeights)[off], sz*sizeof(float));
+            }
+            if (_duvWeights) {
+                std::memcpy(&(*_duvWeights)[curOffset],
+                        &(*duvWeights)[off], sz*sizeof(float));
+            }
+            if (_dvvWeights) {
+                std::memcpy(&(*_dvvWeights)[curOffset],
+                        &(*dvvWeights)[off], sz*sizeof(float));
+            }
+
             curOffset += sz;
             stencilCount++;
             weightCount += sz;
@@ -106,6 +131,13 @@ namespace {
             _duWeights->resize(weightCount);
         if (_dvWeights)
             _dvWeights->resize(weightCount);
+
+        if (_duuWeights)
+            _duuWeights->resize(weightCount);
+        if (_duvWeights)
+            _duvWeights->resize(weightCount);
+        if (_dvvWeights)
+            _dvvWeights->resize(weightCount);
     }
 };
 
@@ -142,6 +174,9 @@ LimitStencilTable::LimitStencilTable(int numControlVerts,
                                      std::vector<float> const& weights,
                                      std::vector<float> const& duWeights,
                                      std::vector<float> const& dvWeights,
+                                     std::vector<float> const& duuWeights,
+                                     std::vector<float> const& duvWeights,
+                                     std::vector<float> const& dvvWeights,
                                      bool includeCoarseVerts,
                                      size_t firstOffset)
     : StencilTable(numControlVerts) {
@@ -153,7 +188,10 @@ LimitStencilTable::LimitStencilTable(int numControlVerts,
                     &sources, &_indices,
                     &weights, &_weights,
                     &duWeights, &_duWeights,
-                    &dvWeights, &_dvWeights);
+                    &dvWeights, &_dvWeights,
+                    &duuWeights, &_duuWeights,
+                    &duvWeights, &_duvWeights,
+                    &dvvWeights, &_dvvWeights);
 }
 
 void
@@ -161,6 +199,9 @@ LimitStencilTable::Clear() {
     StencilTable::Clear();
     _duWeights.clear();
     _dvWeights.clear();
+    _duuWeights.clear();
+    _duvWeights.clear();
+    _dvvWeights.clear();
 }
 
 

--- a/opensubdiv/far/stencilTable.h
+++ b/opensubdiv/far/stencilTable.h
@@ -299,6 +299,9 @@ class LimitStencilTable : public StencilTable {
                     std::vector<float> const& weights,
                     std::vector<float> const& duWeights,
                     std::vector<float> const& dvWeights,
+                    std::vector<float> const& duuWeights,
+                    std::vector<float> const& duvWeights,
+                    std::vector<float> const& dvvWeights,
                     bool includeCoarseVerts,
                     size_t firstOffset);
 
@@ -320,6 +323,21 @@ public:
         return _dvWeights;
     }
 
+    /// \brief Returns the 'uu' derivative stencil interpolation weights
+    std::vector<float> const & GetDuuWeights() const {
+        return _duuWeights;
+    }
+
+    /// \brief Returns the 'uv' derivative stencil interpolation weights
+    std::vector<float> const & GetDuvWeights() const {
+        return _duvWeights;
+    }
+
+    /// \brief Returns the 'vv' derivative stencil interpolation weights
+    std::vector<float> const & GetDvvWeights() const {
+        return _dvvWeights;
+    }
+
     /// \brief Updates derivative values based on the control values
     ///
     /// \note The destination buffers ('uderivs' & 'vderivs') are assumed to
@@ -331,6 +349,15 @@ public:
     ///                       derivative primvar data
     ///
     /// @param vderivs        Destination buffer for the interpolated 'v'
+    ///                       derivative primvar data
+    ///
+    /// @param uuderivs       Destination buffer for the interpolated 'uu'
+    ///                       derivative primvar data
+    ///
+    /// @param uvderivs       Destination buffer for the interpolated 'uv'
+    ///                       derivative primvar data
+    ///
+    /// @param vvderivs       Destination buffer for the interpolated 'vv'
     ///                       derivative primvar data
     ///
     /// @param start          (skip to )index of first value to update
@@ -345,6 +372,15 @@ public:
         update(controlValues, vderivs, _dvWeights, start, end);
     }
 
+    template <class T>
+    void Update2ndPartials(T const *controlValues, T *uuderivs, T *uvderivs, T *vvderivs,
+        int start=-1, int end=-1) const {
+
+        update(controlValues, uuderivs, _duuWeights, start, end);
+        update(controlValues, uvderivs, _duvWeights, start, end);
+        update(controlValues, vvderivs, _dvvWeights, start, end);
+    }
+
     /// \brief Clears the stencils from the table
     void Clear();
 
@@ -355,8 +391,11 @@ private:
     void resize(int nstencils, int nelems);
 
 private:
-    std::vector<float>  _duWeights,  // u derivative limit stencil weights
-                        _dvWeights;  // v derivative limit stencil weights
+    std::vector<float>  _duWeights,   // u  derivative limit stencil weights
+                        _dvWeights,   // v  derivative limit stencil weights
+                        _duuWeights,  // uu derivative limit stencil weights
+                        _duvWeights,  // uv derivative limit stencil weights
+                        _dvvWeights;  // vv derivative limit stencil weights
 };
 
 

--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -371,7 +371,7 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
         options.generateOffsets = true;
 
         // PERFORMANCE: We could potentially save some mem-copies by not
-        // instanciating the stencil tables and work directly off the source
+        // instantiating the stencil tables and work directly off the source
         // data.
         cvstencils = StencilTableFactory::Create(refiner, options);
     } else {

--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -438,29 +438,29 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
     internal::StencilBuilder::Index origin(&builder, 0);
     internal::StencilBuilder::Index dst = origin;
 
-    float wP[20], wDs[20], wDt[20];
+    float wP[20], wDs[20], wDt[20], wDss[20], wDst[20], wDtt[20];
 
     for (size_t i=0; i<locationArrays.size(); ++i) {
         LocationArray const & array = locationArrays[i];
         assert(array.ptexIdx>=0);
 
-        for (int j=0; j<array.numLocations; ++j) {
+        for (int j=0; j<array.numLocations; ++j) { // for each face we're working on
             float s = array.s[j],
-                  t = array.t[j];
+                  t = array.t[j]; // for each target (s,t) point on that face
 
             PatchMap::Handle const * handle = 
                                         patchmap.FindPatch(array.ptexIdx, s, t);
             if (handle) {
                 ConstIndexArray cvs = patchtable->GetPatchVertices(*handle);
 
-                patchtable->EvaluateBasis(*handle, s, t, wP, wDs, wDt);
+                patchtable->EvaluateBasis(*handle, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
 
                 StencilTable const & src = *cvstencils;
                 dst = origin[numLimitStencils];
 
                 dst.Clear();
                 for (int k = 0; k < cvs.size(); ++k) {
-                    dst.AddWithWeight(src[cvs[k]], wP[k], wDs[k], wDt[k]);
+                    dst.AddWithWeight(src[cvs[k]], wP[k], wDs[k], wDt[k], wDss[k], wDst[k], wDtt[k]);
                 }
 
                 ++numLimitStencils;
@@ -487,6 +487,9 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
                                           builder.GetStencilWeights(),
                                           builder.GetStencilDuWeights(),
                                           builder.GetStencilDvWeights(),
+                                          builder.GetStencilDuuWeights(),
+                                          builder.GetStencilDuvWeights(),
+                                          builder.GetStencilDvvWeights(),
                                           /*ctrlVerts*/false,
                                           /*fristOffset*/0);
     return result;

--- a/opensubdiv/far/stencilTableFactory.h
+++ b/opensubdiv/far/stencilTableFactory.h
@@ -168,11 +168,11 @@ public:
     ///
     /// @param cvStencils       A set of StencilTable generated from the
     ///                         TopologyRefiner (optional: prevents redundant
-    ///                         instanciation of the table if available)
+    ///                         instantiation of the table if available)
     ///
     /// @param patchTable       A set of PatchTable generated from the
     ///                         TopologyRefiner (optional: prevents redundant
-    ///                         instanciation of the table if available)
+    ///                         instantiation of the table if available)
     ///
     static LimitStencilTable const * Create(TopologyRefiner const & refiner,
         LocationArrayVec const & locationArrays,

--- a/opensubdiv/far/topologyLevel.h
+++ b/opensubdiv/far/topologyLevel.h
@@ -100,10 +100,10 @@ public:
     ConstIndexArray GetEdgeFaces(Index e) const    { return _level->getEdgeFaces(e); }
 
     /// \brief Access the faces incident a given vertex
-    ConstIndexArray GetVertexFaces( Index v) const { return _level->getVertexFaces(v); }
+    ConstIndexArray GetVertexFaces(Index v) const  { return _level->getVertexFaces(v); }
 
     /// \brief Access the edges incident a given vertex
-    ConstIndexArray GetVertexEdges( Index v) const { return _level->getVertexEdges(v); }
+    ConstIndexArray GetVertexEdges(Index v) const  { return _level->getVertexEdges(v); }
 
     /// \brief Access the local indices of a vertex with respect to its incident faces
     ConstLocalIndexArray GetVertexFaceLocalIndices(Index v) const { return _level->getVertexFaceLocalIndices(v); }

--- a/opensubdiv/vtr/types.h
+++ b/opensubdiv/vtr/types.h
@@ -70,7 +70,7 @@ static const int VALENCE_LIMIT = ((1 << 16) - 1);  // std::numeric_limits<LocalI
 
 //
 //  Collections if integer types in variable or fixed sized arrays.  Note that the use
-//  of "vector" in the name indicates a class that wraps an std:;vector (typically a
+//  of "vector" in the name indicates a class that wraps an std::vector (typically a
 //  member variable) which is fully resizable and owns its own storage, whereas "array"
 //  wraps a vtr::Array which uses a fixed block of pre-allocated memory.
 //

--- a/regression/common/far_utils.h
+++ b/regression/common/far_utils.h
@@ -241,7 +241,7 @@ inline bool
 TopologyRefinerFactory<Shape>::assignFaceVaryingTopology(
     Far::TopologyRefiner & refiner, Shape const & shape) {
 
-    // UV layyout (we only parse 1 channel)
+    // UV layout (we only parse 1 channel)
     if (not shape.faceuvs.empty()) {
 
         int nfaces = getNumBaseFaces(refiner),


### PR DESCRIPTION
When doing cloth simulations the 2nd partials are needed to describe the curvature.