### PR TITLE
Fixed potential crash in Far::StencilTableFactory

### DIFF
--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -212,7 +212,8 @@ StencilTableFactory::AppendLocalPointStencilTable(
 
     // factorize and append.
     if (baseStencilTable == NULL or
-        localPointStencilTable == NULL) return NULL;
+        localPointStencilTable == NULL or
+        localPointStencilTable->GetNumStencils() == 0) return NULL;
 
     // baseStencilTable can be built with or without singular stencils
     // (single weight of 1.0f) as place-holders for coarse mesh vertices.


### PR DESCRIPTION
Now StencilTableFactory::AppendLocalPointStencilTable() does
nothing when the localPointStencilTable is empty. This avoids
a potential crash (failed assertion) when both the baseStencilTable
and the localPointStencilTable are empty, as is the case for
simple geometry like the all-quads torus regression test shape.