### PR TITLE
Disabled fractional spacing w/o screen space tess

### DIFF
--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -72,6 +72,12 @@
 //         mix(input[c].var, input[d].var, UV.x), UV.y)
 #endif
 
+// For now, fractional spacing is supported only with screen space tessellation
+#ifndef OSD_ENABLE_SCREENSPACE_TESSELLATION
+#undef OSD_FRACTIONAL_EVEN_SPACING
+#undef OSD_FRACTIONAL_ODD_SPACING
+#endif
+
 #if defined OSD_FRACTIONAL_EVEN_SPACING
   #define OSD_SPACING fractional_even_spacing
 #elif defined OSD_FRACTIONAL_ODD_SPACING

--- a/opensubdiv/osd/hlslPatchCommon.hlsl
+++ b/opensubdiv/osd/hlslPatchCommon.hlsl
@@ -26,6 +26,12 @@
 // Patches.Common
 //----------------------------------------------------------
 
+// For now, fractional spacing is supported only with screen space tessellation
+#ifndef OSD_ENABLE_SCREENSPACE_TESSELLATION
+#undef OSD_FRACTIONAL_EVEN_SPACING
+#undef OSD_FRACTIONAL_ODD_SPACING
+#endif
+
 #if defined OSD_FRACTIONAL_EVEN_SPACING
   #define OSD_PARTITIONING "fractional_even"
 #elif defined OSD_FRACTIONAL_ODD_SPACING


### PR DESCRIPTION
For now, the common patch shader code supports fractional spacing
modes only when screen-space tessellation is also enabled.

It's possible to relax this restriction, but that requires changing
the client shader interface.