### PR TITLE
Improved fix for stencil table construction

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1303,10 +1303,19 @@ PatchTableFactory::populateAdaptivePatches(
     }
 
     // finalize end patches
-    if (localPointStencils)
+    if (localPointStencils and localPointStencils->GetNumStencils() > 0) {
         localPointStencils->generateOffsets();
-    if (localPointVaryingStencils)
+    } else {
+        delete localPointStencils;
+        localPointStencils = NULL;
+    }
+
+    if (localPointVaryingStencils and localPointVaryingStencils->GetNumStencils() > 0) {
         localPointVaryingStencils->generateOffsets();
+    } else {
+        delete localPointVaryingStencils;
+        localPointVaryingStencils = NULL;
+    }
 
     switch(context.options.GetEndCapType()) {
     case Options::ENDCAP_GREGORY_BASIS:


### PR DESCRIPTION
My previous fix added some defensive logic in case the
local point stencil table was empty when attempting to
append local point stencils to an existing stencil table.

This change fixes Far::PatchTableFactory to not return
empty local point stencil tables when there are no local
point stencils. This behavior is now more consistent with
earlier releases.

We will leave the earlier defensive logic in place as well.