### PR TITLE
Tess shader performance fix

### DIFF
--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -1120,7 +1120,10 @@ OsdComputePerPatchVertexBSpline(ivec3 patchParam, int ID, vec3 cv[16],
 
 #if defined OSD_PATCH_ENABLE_SINGLE_CREASE
 
-    mat4 Mj, Ms;
+    vec3 P  = vec3(0); // 0 to 1-2^(-Sf)
+    vec3 P1 = vec3(0); // 1-2^(-Sf) to 1-2^(-Sc)
+    vec3 P2 = vec3(0); // 1-2^(-Sc) to 1
+
     float sharpness = OsdGetPatchSharpness(patchParam);
     if (sharpness > 0) {
         float Sf = floor(sharpness);
@@ -1128,60 +1131,86 @@ OsdComputePerPatchVertexBSpline(ivec3 patchParam, int ID, vec3 cv[16],
         float Sr = fract(sharpness);
         mat4 Mf = OsdComputeMs(Sf);
         mat4 Mc = OsdComputeMs(Sc);
-        Mj = (1-Sr) * Mf + Sr * Mi;
-        Ms = (1-Sr) * Mf + Sr * Mc;
+        mat4 Mj = (1-Sr) * Mf + Sr * Mi;
+        mat4 Ms = (1-Sr) * Mf + Sr * Mc;
         float s0 = 1 - pow(2, -floor(sharpness));
         float s1 = 1 - pow(2, -ceil(sharpness));
         result.vSegments = vec2(s0, s1);
-    } else {
-        Mj = Ms = Mi;
-        result.vSegments = vec2(0);
-    }
-    result.P  = vec3(0); // 0 to 1-2^(-Sf)
-    result.P1 = vec3(0); // 1-2^(-Sf) to 1-2^(-Sc)
-    result.P2 = vec3(0); // 1-2^(-Sc) to 1
 
-    mat4 MUi, MUj, MUs;
-    mat4 MVi, MVj, MVs;
-    MUi = MUj = MUs = Q;
-    MVi = MVj = MVs = Q;
+        mat4 MUi = Q, MUj = Q, MUs = Q;
+        mat4 MVi = Q, MVj = Q, MVs = Q;
 
-    int boundaryMask = OsdGetPatchBoundaryMask(patchParam);
-    if ((boundaryMask & 1) != 0) {
-        MVi = OsdFlipMatrix(Mi);
-        MVj = OsdFlipMatrix(Mj);
-        MVs = OsdFlipMatrix(Ms);
-    }
-    if ((boundaryMask & 2) != 0) {
-        MUi = Mi;
-        MUj = Mj;
-        MUs = Ms;
-    }
-    if ((boundaryMask & 4) != 0) {
-        MVi = Mi;
-        MVj = Mj;
-        MVs = Ms;
-    }
-    if ((boundaryMask & 8) != 0) {
-        MUi = OsdFlipMatrix(Mi);
-        MUj = OsdFlipMatrix(Mj);
-        MUs = OsdFlipMatrix(Ms);
-    }
+        int boundaryMask = OsdGetPatchBoundaryMask(patchParam);
+        if ((boundaryMask & 1) != 0) {
+            MVi = OsdFlipMatrix(Mi);
+            MVj = OsdFlipMatrix(Mj);
+            MVs = OsdFlipMatrix(Ms);
+        }
+        if ((boundaryMask & 2) != 0) {
+            MUi = Mi;
+            MUj = Mj;
+            MUs = Ms;
+        }
+        if ((boundaryMask & 4) != 0) {
+            MVi = Mi;
+            MVj = Mj;
+            MVs = Ms;
+        }
+        if ((boundaryMask & 8) != 0) {
+            MUi = OsdFlipMatrix(Mi);
+            MUj = OsdFlipMatrix(Mj);
+            MUs = OsdFlipMatrix(Ms);
+        }
 
-    vec3 Hi[4], Hj[4], Hs[4];
-    for (int l=0; l<4; ++l) {
-        Hi[l] = Hj[l] = Hs[l] = vec3(0);
+        vec3 Hi[4], Hj[4], Hs[4];
+        for (int l=0; l<4; ++l) {
+            Hi[l] = Hj[l] = Hs[l] = vec3(0);
+            for (int k=0; k<4; ++k) {
+                Hi[l] += MUi[i][k] * cv[l*4 + k];
+                Hj[l] += MUj[i][k] * cv[l*4 + k];
+                Hs[l] += MUs[i][k] * cv[l*4 + k];
+            }
+        }
         for (int k=0; k<4; ++k) {
-            Hi[l] += MUi[i][k] * cv[l*4 + k];
-            Hj[l] += MUj[i][k] * cv[l*4 + k];
-            Hs[l] += MUs[i][k] * cv[l*4 + k];
+            P  += MVi[j][k]*Hi[k];
+            P1 += MVj[j][k]*Hj[k];
+            P2 += MVs[j][k]*Hs[k];
+        }
+    } else {
+        result.vSegments = vec2(0);
+
+        mat4 MUi = Q;
+        mat4 MVi = Q;
+
+        int boundaryMask = OsdGetPatchBoundaryMask(patchParam);
+        if ((boundaryMask & 1) != 0) {
+            MVi = OsdFlipMatrix(Mi);
+        }
+        if ((boundaryMask & 2) != 0) {
+            MUi = Mi;
+        }
+        if ((boundaryMask & 4) != 0) {
+            MVi = Mi;
+        }
+        if ((boundaryMask & 8) != 0) {
+            MUi = OsdFlipMatrix(Mi);
+        }
+
+        vec3 Hi[4], Hj[4], Hs[4];
+        for (int l=0; l<4; ++l) {
+            Hi[l] = Hj[l] = Hs[l] = vec3(0);
+            for (int k=0; k<4; ++k) {
+                Hi[l] += MUi[i][k] * cv[l*4 + k];
+            }
+        }
+        for (int k=0; k<4; ++k) {
+            P += MVi[j][k]*Hi[k];
         }
     }
-    for (int k=0; k<4; ++k) {
-        result.P  += MVi[j][k]*Hi[k];
-        result.P1 += MVj[j][k]*Hj[k];
-        result.P2 += MVs[j][k]*Hs[k];
-    }
+
+    result.P  = P;
+    result.P1 = P1;
+    result.P2 = P2;
 #else
     OsdComputeBSplineBoundaryPoints(cv, patchParam);
 

--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -1176,41 +1176,30 @@ OsdComputePerPatchVertexBSpline(ivec3 patchParam, int ID, vec3 cv[16],
             P1 += MVj[j][k]*Hj[k];
             P2 += MVs[j][k]*Hs[k];
         }
+
+        result.P  = P;
+        result.P1 = P1;
+        result.P2 = P2;
     } else {
         result.vSegments = vec2(0);
 
-        mat4 MUi = Q;
-        mat4 MVi = Q;
+        OsdComputeBSplineBoundaryPoints(cv, patchParam);
 
-        int boundaryMask = OsdGetPatchBoundaryMask(patchParam);
-        if ((boundaryMask & 1) != 0) {
-            MVi = OsdFlipMatrix(Mi);
-        }
-        if ((boundaryMask & 2) != 0) {
-            MUi = Mi;
-        }
-        if ((boundaryMask & 4) != 0) {
-            MVi = Mi;
-        }
-        if ((boundaryMask & 8) != 0) {
-            MUi = OsdFlipMatrix(Mi);
-        }
-
-        vec3 Hi[4], Hj[4], Hs[4];
+        vec3 Hi[4];
         for (int l=0; l<4; ++l) {
-            Hi[l] = Hj[l] = Hs[l] = vec3(0);
+            Hi[l] = vec3(0);
             for (int k=0; k<4; ++k) {
-                Hi[l] += MUi[i][k] * cv[l*4 + k];
+                Hi[l] += Q[i][k] * cv[l*4 + k];
             }
         }
         for (int k=0; k<4; ++k) {
-            P += MVi[j][k]*Hi[k];
+            P += Q[j][k]*Hi[k];
         }
-    }
 
-    result.P  = P;
-    result.P1 = P1;
-    result.P2 = P2;
+        result.P  = P;
+        result.P1 = P;
+        result.P2 = P;
+    }
 #else
     OsdComputeBSplineBoundaryPoints(cv, patchParam);
 

--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -1092,33 +1092,33 @@ OsdFlipMatrix(mat4 m)
                 m[0][3], m[0][2], m[0][1], m[0][0]);
 }
 
+// Regular BSpline to Bezier
+uniform mat4 Q = mat4(
+    1.f/6.f, 4.f/6.f, 1.f/6.f, 0.f,
+    0.f,     4.f/6.f, 2.f/6.f, 0.f,
+    0.f,     2.f/6.f, 4.f/6.f, 0.f,
+    0.f,     1.f/6.f, 4.f/6.f, 1.f/6.f
+);
+
+// Infinitely Sharp (boundary)
+uniform mat4 Mi = mat4(
+    1.f/6.f, 4.f/6.f, 1.f/6.f, 0.f,
+    0.f,     4.f/6.f, 2.f/6.f, 0.f,
+    0.f,     2.f/6.f, 4.f/6.f, 0.f,
+    0.f,     0.f,     1.f,     0.f
+);
+
 // convert BSpline cv to Bezier cv
 void
 OsdComputePerPatchVertexBSpline(ivec3 patchParam, int ID, vec3 cv[16],
                                 out OsdPerPatchVertexBezier result)
 {
-    // Regular BSpline to Bezier
-    mat4 Q = mat4(
-        1.f/6.f, 4.f/6.f, 1.f/6.f, 0.f,
-        0.f,     4.f/6.f, 2.f/6.f, 0.f,
-        0.f,     2.f/6.f, 4.f/6.f, 0.f,
-        0.f,     1.f/6.f, 4.f/6.f, 1.f/6.f
-    );
-
     result.patchParam = patchParam;
 
     int i = ID%4;
     int j = ID/4;
 
 #if defined OSD_PATCH_ENABLE_SINGLE_CREASE
-
-    // Infinitely Sharp (boundary)
-    mat4 Mi = mat4(
-        1.f/6.f, 4.f/6.f, 1.f/6.f, 0.f,
-        0.f,     4.f/6.f, 2.f/6.f, 0.f,
-        0.f,     2.f/6.f, 4.f/6.f, 0.f,
-        0.f,     0.f,     1.f,     0.f
-    );
 
     mat4 Mj, Ms;
     float sharpness = OsdGetPatchSharpness(patchParam);

--- a/opensubdiv/osd/hlslPatchCommon.hlsl
+++ b/opensubdiv/osd/hlslPatchCommon.hlsl
@@ -1051,41 +1051,29 @@ OsdComputePerPatchVertexBSpline(int3 patchParam, int ID, float3 cv[16],
             P2 += MVs[j][k]*Hs[k];
         }
 
+        result.P  = P;
+        result.P1 = P1;
+        result.P2 = P2;
     } else {
         result.vSegments = float2(0, 0);
 
-        float4x4 MUi = Q;
-        float4x4 MVi = Q;
+        OsdComputeBSplineBoundaryPoints(cv, patchParam);
 
-        int boundaryMask = OsdGetPatchBoundaryMask(patchParam);
-        if ((boundaryMask & 1) != 0) {
-            MVi = OsdFlipMatrix(Mi);
-        }
-        if ((boundaryMask & 2) != 0) {
-            MUi = Mi;
-        }
-        if ((boundaryMask & 4) != 0) {
-            MVi = Mi;
-        }
-        if ((boundaryMask & 8) != 0) {
-            MUi = OsdFlipMatrix(Mi);
-        }
-
-        float3 Hi[4], Hj[4], Hs[4];
+        float3 Hi[4];
         for (int l=0; l<4; ++l) {
-            Hi[l] = Hj[l] = Hs[l] = float3(0,0,0);
+            Hi[l] = float3(0,0,0);
             for (int k=0; k<4; ++k) {
-                Hi[l] += MUi[i][k] * cv[l*4 + k];
+                Hi[l] += Q[i][k] * cv[l*4 + k];
             }
         }
         for (int k=0; k<4; ++k) {
-            P += MVi[j][k]*Hi[k];
+            P += Q[j][k]*Hi[k];
         }
-    }
 
-    result.P  = P;
-    result.P1 = P1;
-    result.P2 = P2;
+        result.P  = P;
+        result.P1 = P;
+        result.P2 = P;
+    }
 #else
     OsdComputeBSplineBoundaryPoints(cv, patchParam);
 

--- a/opensubdiv/osd/hlslPatchCommon.hlsl
+++ b/opensubdiv/osd/hlslPatchCommon.hlsl
@@ -966,33 +966,33 @@ OsdFlipMatrix(float4x4 m)
                     m[0][3], m[0][2], m[0][1], m[0][0]);
 }
 
+// Regular BSpline to Bezier
+static float4x4 Q = {
+    1.f/6.f, 4.f/6.f, 1.f/6.f, 0.f,
+    0.f,     4.f/6.f, 2.f/6.f, 0.f,
+    0.f,     2.f/6.f, 4.f/6.f, 0.f,
+    0.f,     1.f/6.f, 4.f/6.f, 1.f/6.f
+};
+
+// Infinitely Sharp (boundary)
+static float4x4 Mi = {
+    1.f/6.f, 4.f/6.f, 1.f/6.f, 0.f,
+    0.f,     4.f/6.f, 2.f/6.f, 0.f,
+    0.f,     2.f/6.f, 4.f/6.f, 0.f,
+    0.f,     0.f,     1.f,     0.f
+};
+
 // convert BSpline cv to Bezier cv
 void
 OsdComputePerPatchVertexBSpline(int3 patchParam, int ID, float3 cv[16],
                                 out OsdPerPatchVertexBezier result)
 {
-    // Regular BSpline to Bezier
-    float4x4 Q = {
-        1.f/6.f, 4.f/6.f, 1.f/6.f, 0.f,
-        0.f,     4.f/6.f, 2.f/6.f, 0.f,
-        0.f,     2.f/6.f, 4.f/6.f, 0.f,
-        0.f,     1.f/6.f, 4.f/6.f, 1.f/6.f
-    };
-
     result.patchParam = patchParam;
 
     int i = ID%4;
     int j = ID/4;
 
 #if defined OSD_PATCH_ENABLE_SINGLE_CREASE
-
-    // Infinitely Sharp (boundary)
-    float4x4 Mi = {
-        1.f/6.f, 4.f/6.f, 1.f/6.f, 0.f,
-        0.f,     4.f/6.f, 2.f/6.f, 0.f,
-        0.f,     2.f/6.f, 4.f/6.f, 0.f,
-        0.f,     0.f,     1.f,     0.f
-    };
 
     float4x4 Mj, Ms;
     float sharpness = OsdGetPatchSharpness(patchParam);


### PR DESCRIPTION
These changes help improve the measured performance of the
GL tessellation control shader code and mitigate some performance
regressions we've seen since v3_0_0_RC1

Equivalent changes have been made to both the GLSL and HLSL
code paths. Performance is improved somewhat on DX11 but the
differences there are much less than GL.