### PR TITLE
Static CRT for MSVC (DON'T MERGE THIS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,10 +273,10 @@ elseif(MSVC)
     )
 
     # Turn off a duplicate LIBCMT linker warning
-    set(CMAKE_EXE_LINKER_FLAGS
-        "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:libcmt.lib")
-    set(CMAKE_SHARED_LINKER_FLAGS
-        "${CMAKE_SHARED_LINKER_FLAGS} /NODEFAULTLIB:libcmt.lib")
+    #set(CMAKE_EXE_LINKER_FLAGS
+    #    "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:libcmt.lib")
+    #set(CMAKE_SHARED_LINKER_FLAGS
+    #    "${CMAKE_SHARED_LINKER_FLAGS} /NODEFAULTLIB:libcmt.lib")
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,19 @@ option(NO_DX "Disable DirectX support")
 option(NO_TESTS "Disable all tests")
 option(NO_GLTESTS "Disable GL tests")
 
+option(STATIC_CRT "Statically link MSVC CRT" OFF)
+
+if(MSVC AND STATIC_CRT)
+    message(STATUS "Using static MSVC CRT")
+    # http://stackoverflow.com/a/32128977/486990
+    add_compile_options(
+        "$<$<CONFIG:Debug>:/MTd>"
+        "$<$<CONFIG:RelWithDebInfo>:/MT>"
+        "$<$<CONFIG:Release>:/MT>"
+        "$<$<CONFIG:MinSizeRel>:/MT>"
+    )
+endif()
+
 set(OSD_GPU FALSE)
 
 # Check for dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,10 @@ elseif(MSVC)
                     #/D_HAS_ITERATOR_DEBUGGING=0
     )
 
+    # thomthom : When enabling static CRT there are linker errors in Release
+    # referring to libcpmt (Note not libcmt). Not sure why, but removing this
+    # exclude allowed it to build, and there where no linker error in VS2013/15
+    # when building with minimal build.
     # Turn off a duplicate LIBCMT linker warning
     #set(CMAKE_EXE_LINKER_FLAGS
     #    "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:libcmt.lib")
@@ -314,16 +318,22 @@ option(NO_DX "Disable DirectX support")
 option(NO_TESTS "Disable all tests")
 option(NO_GLTESTS "Disable GL tests")
 
-option(STATIC_CRT "Statically link MSVC CRT" OFF)
+option(MSVC_STATIC_CRT_RELEASE "Statically link MSVC CRT in Release" OFF)
+option(MSVC_STATIC_CRT_DEBUG "Statically link MSVC CRT in Debug" OFF)
 
-if(MSVC AND STATIC_CRT)
-    message(STATUS "Using static MSVC CRT")
+if(MSVC AND MSVC_STATIC_CRT_RELEASE)
+    message(STATUS "Using static MSVC CRT Release")
     # http://stackoverflow.com/a/32128977/486990
     add_compile_options(
-        "$<$<CONFIG:Debug>:/MDd>"
         "$<$<CONFIG:RelWithDebInfo>:/MT>"
         "$<$<CONFIG:Release>:/MT>"
         "$<$<CONFIG:MinSizeRel>:/MT>"
+    )
+endif()
+if(MSVC AND MSVC_STATIC_CRT_DEBUG)
+    message(STATUS "Using static MSVC CRT Debug")
+    add_compile_options(
+        "$<$<CONFIG:Debug>:/MTd>"
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ if(MSVC AND STATIC_CRT)
     message(STATUS "Using static MSVC CRT")
     # http://stackoverflow.com/a/32128977/486990
     add_compile_options(
-        "$<$<CONFIG:Debug>:/MTd>"
+        "$<$<CONFIG:Debug>:/MDd>"
         "$<$<CONFIG:RelWithDebInfo>:/MT>"
         "$<$<CONFIG:Release>:/MT>"
         "$<$<CONFIG:MinSizeRel>:/MT>"


### PR DESCRIPTION
I don't intend this to be merged - but merely as a way to talk about the changes I had to do to solve issue #776. Got some questions - once resolved I'll create a new clean pull request.

Testing with this config:

```
cmake ^
  -G "Visual Studio 12 2013 Win64" ^
  -D NO_EXAMPLES=1 ^
  -D NO_TUTORIALS=1 ^
  -D NO_REGRESSION=1 ^
  -D NO_MAYA=1 ^
  -D NO_PTEX=1 ^
  -D NO_DOC=1 ^
  -D NO_OMP=1 ^
  -D NO_TBB=1 ^
  -D NO_CUDA=1 ^
  -D NO_OPENCL=1 ^
  -D NO_OPENGL=1 ^
  -D NO_DX=1 ^
  -D NO_CLEW=1 ^
  -D MSVC_STATIC_CRT_RELEASE=1 ^
  -D MSVC_STATIC_CRT_DEBUG=1 ^
  ..
```
