### PR TITLE
Fix FindPTex.cmake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,7 @@ if(NOT NO_OPENGL AND NOT ANDROID AND NOT IOS)
 endif()
 if(NOT NO_PTEX)
    find_package(PTex 2.0)
+   find_package(Zlib 1.2)
 endif()
 if (OPENGL_FOUND AND NOT IOS)
     add_definitions(
@@ -520,6 +521,7 @@ endif()
 if(PTEX_FOUND)
     add_definitions(
         -DOPENSUBDIV_HAS_PTEX
+        -DPTEX_STATIC
     )
 else()
     if(NOT NO_PTEX)

--- a/cmake/FindPTex.cmake
+++ b/cmake/FindPTex.cmake
@@ -101,15 +101,21 @@ else ()
             DOC "The Ptex library")
 endif ()
 
-if (PTEX_INCLUDE_DIR AND EXISTS "${PTEX_INCLUDE_DIR}/Ptexture.h" )
+if (PTEX_INCLUDE_DIR AND EXISTS "${PTEX_INCLUDE_DIR}/PtexVersion.h")
+    set (PTEX_VERSION_FILE "${PTEX_INCLUDE_DIR}/PtexVersion.h")
+elseif (PTEX_INCLUDE_DIR AND EXISTS "${PTEX_INCLUDE_DIR}/Ptexture.h")    
+    set (PTEX_VERSION_FILE "${PTEX_INCLUDE_DIR}/Ptexture.h")
+endif()
 
-    file(STRINGS "${PTEX_INCLUDE_DIR}/Ptexture.h" TMP REGEX "^#define PtexAPIVersion.*$")
+if (PTEX_VERSION_FILE)
+
+    file(STRINGS "${PTEX_VERSION_FILE}" TMP REGEX "^#define PtexAPIVersion.*$")
     string(REGEX MATCHALL "[0-9]+" API ${TMP})
     
-    file(STRINGS "${PTEX_INCLUDE_DIR}/Ptexture.h" TMP REGEX "^#define PtexFileMajorVersion.*$")
+    file(STRINGS "${PTEX_VERSION_FILE}" TMP REGEX "^#define PtexFileMajorVersion.*$")
     string(REGEX MATCHALL "[0-9]+" MAJOR ${TMP})
 
-    file(STRINGS "${PTEX_INCLUDE_DIR}/Ptexture.h" TMP REGEX "^#define PtexFileMinorVersion.*$")
+    file(STRINGS "${PTEX_VERSION_FILE}" TMP REGEX "^#define PtexFileMinorVersion.*$")
     string(REGEX MATCHALL "[0-9]+" MINOR ${TMP})
 
     set(PTEX_VERSION ${API}.${MAJOR}.${MINOR})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,7 +39,7 @@ if (NOT NO_OPENGL)
             add_subdirectory(glPaintTest)
         endif()
 
-        if (PTEX_FOUND)
+        if (PTEX_FOUND AND ZLIB_FOUND)
             add_subdirectory(glPtexViewer)
         endif()
 
@@ -73,7 +73,7 @@ if (DXSDK_FOUND AND NOT NO_DX)
 
    add_subdirectory(dxViewer)
 
-   if (PTEX_FOUND)
+   if (PTEX_FOUND AND ZLIB_FOUND)
        add_subdirectory(dxPtexViewer)
    endif()
 

--- a/examples/common/d3d11PtexMipmapTexture.h
+++ b/examples/common/d3d11PtexMipmapTexture.h
@@ -27,7 +27,8 @@
 
 #include <osd/nonCopyable.h>
 
-class PtexTexture;
+#include <Ptexture.h>
+
 struct ID3D11Buffer;
 struct ID3D11Texture2D;
 struct ID3D11DeviceContext;
@@ -37,7 +38,8 @@ class D3D11PtexMipmapTexture : OpenSubdiv::Osd::NonCopyable<D3D11PtexMipmapTextu
 public:
     static D3D11PtexMipmapTexture * Create(ID3D11DeviceContext *deviceContext,
                                               PtexTexture * reader,
-                                              int maxLevels=10);
+                                              int maxLevels=10,
+                                              size_t targetMemory=0);
 
     /// Returns GLSL shader snippet to fetch ptex
     static const char *GetShaderSource();

--- a/examples/common/glPtexMipmapTexture.cpp
+++ b/examples/common/glPtexMipmapTexture.cpp
@@ -27,8 +27,6 @@
 
 #include <osd/opengl.h>
 
-#include <Ptexture.h>
-
 GLPtexMipmapTexture::GLPtexMipmapTexture()
     : _width(0), _height(0), _depth(0), _layout(0), _texels(0), _memoryUsage(0)
 {

--- a/examples/common/glPtexMipmapTexture.h
+++ b/examples/common/glPtexMipmapTexture.h
@@ -28,9 +28,8 @@
 #include <osd/nonCopyable.h>
 #include <osd/opengl.h>
 
+#include <Ptexture.h>
 #include <stdlib.h>
-
-class PtexTexture;
 
 class GLPtexMipmapTexture : OpenSubdiv::Osd::NonCopyable<GLPtexMipmapTexture> {
 public:

--- a/examples/common/ptexMipmapTextureLoader.h
+++ b/examples/common/ptexMipmapTextureLoader.h
@@ -25,11 +25,11 @@
 #ifndef OPENSUBDIV_EXAMPLES_PTEX_MIPMAP_TEXTURE_LOADER_H
 #define OPENSUBDIV_EXAMPLES_PTEX_MIPMAP_TEXTURE_LOADER_H
 
+#include <Ptexture.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <vector>
 
-class PtexTexture;
 
 class PtexMipmapTextureLoader {
 public:
@@ -37,7 +37,8 @@ public:
                                int maxNumPages,
                                int maxLevels = -1,
                                size_t targetMemory = 0,
-                               bool seamlessMipmap = true);
+                               bool seamlessMipmap = true,
+                               bool padAlpha = false);
 
     ~PtexMipmapTextureLoader();
 
@@ -136,6 +137,7 @@ private:
     int  resampleBorder(int face, int edgeId, unsigned char *result,
                         int dstLength, int bpp,
                         float srcStart = 0.0f, float srcEnd = 1.0f);
+    void addAlphaChannel();
 
     std::vector<Block> _blocks;
     std::vector<Page *> _pages;
@@ -144,6 +146,8 @@ private:
     int _maxLevels;
     int _bpp;
     int _pageWidth, _pageHeight;
+
+    bool _padAlpha;
 
     unsigned char *_texelBuffer;
     unsigned char *_layoutBuffer;

--- a/examples/dxPtexViewer/CMakeLists.txt
+++ b/examples/dxPtexViewer/CMakeLists.txt
@@ -32,6 +32,7 @@ set(PLATFORM_LIBRARIES
     "${OSD_LINK_TARGET}"
     "${DXSDK_LIBRARIES}"
     "${PTEX_LIBRARY}"
+    "${ZLIB_LIBRARY}"
 )
 
 include_directories(

--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -644,7 +644,7 @@ ShaderCache g_shaderCache;
 
 //------------------------------------------------------------------------------
 D3D11PtexMipmapTexture *
-createPtex(const char *filename) {
+createPtex(const char *filename, int memLimit) {
 
     Ptex::String ptexError;
     printf("Loading ptex : %s\n", filename);
@@ -663,8 +663,11 @@ createPtex(const char *filename) {
         printf("Error in reading %s\n", filename);
         exit(1);
     }
+
+    size_t targetMemory = memLimit * 1024 * 1024; // MB
+
     D3D11PtexMipmapTexture *osdPtex = D3D11PtexMipmapTexture::Create(
-        g_pd3dDeviceContext, ptex, g_maxMipmapLevels);
+        g_pd3dDeviceContext, ptex, g_maxMipmapLevels, targetMemory);
 
     ptex->release();
 
@@ -1735,6 +1738,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmd
     const char *diffuseEnvironmentMap = NULL, *specularEnvironmentMap = NULL;
     const char *colorFilename = NULL, *displacementFilename = NULL,
         *occlusionFilename = NULL, *specularFilename = NULL;
+    int memLimit;
 
     for (int i = 0; i < (int)argv.size(); ++i) {
         if (strstr(argv[i].c_str(), ".obj"))
@@ -1751,6 +1755,8 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmd
             g_yup = true;
         else if (argv[i] == "-m")
             g_maxMipmapLevels = atoi(argv[++i].c_str());
+        else if (argv[i] == "-x")
+            memLimit = atoi(argv[++i].c_str());
         else if (argv[i] == "--disp")
             g_displacementScale = (float)atof(argv[++i].c_str());
         else if (colorFilename == NULL)
@@ -1781,13 +1787,13 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmd
     createOsdMesh(g_level, g_kernel);
 
     // load ptex files
-    g_osdPTexImage = createPtex(colorFilename);
+    g_osdPTexImage = createPtex(colorFilename, memLimit);
     if (displacementFilename)
-        g_osdPTexDisplacement = createPtex(displacementFilename);
+        g_osdPTexDisplacement = createPtex(displacementFilename, memLimit);
     if (occlusionFilename)
-        g_osdPTexOcclusion = createPtex(occlusionFilename);
+        g_osdPTexOcclusion = createPtex(occlusionFilename, memLimit);
     if (specularFilename)
-        g_osdPTexSpecular = createPtex(specularFilename);
+        g_osdPTexSpecular = createPtex(specularFilename, memLimit);
 
     initHUD();
 

--- a/examples/glPtexViewer/CMakeLists.txt
+++ b/examples/glPtexViewer/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND PLATFORM_LIBRARIES
     "${OPENGL_LIBRARY}"
     "${GLFW_LIBRARIES}"
     "${PTEX_LIBRARY}"
+    "${ZLIB_LIBRARY}"
 )
 
 include_directories(


### PR DESCRIPTION
Recent versions of Ptex appear to have moved the version strings from Ptexture.h into PtexVersion.h : added logic to scan for the new version file. This should fix the current CMake errors when the Ptex module does not find those strings where it expects to.
