### PR TITLE
Ptex fixes:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,7 @@ if(NOT NO_OPENGL AND NOT ANDROID AND NOT IOS)
 endif()
 if(NOT NO_PTEX)
    find_package(PTex 2.0)
+   find_package(Zlib 1.2)
 endif()
 if (OPENGL_FOUND AND NOT IOS)
     add_definitions(
@@ -520,6 +521,7 @@ endif()
 if(PTEX_FOUND)
     add_definitions(
         -DOPENSUBDIV_HAS_PTEX
+        -DPTEX_STATIC
     )
 else()
     if(NOT NO_PTEX)

--- a/cmake/FindPTex.cmake
+++ b/cmake/FindPTex.cmake
@@ -101,15 +101,21 @@ else ()
             DOC "The Ptex library")
 endif ()
 
-if (PTEX_INCLUDE_DIR AND EXISTS "${PTEX_INCLUDE_DIR}/Ptexture.h" )
+if (PTEX_INCLUDE_DIR AND EXISTS "${PTEX_INCLUDE_DIR}/PtexVersion.h")
+    set (PTEX_VERSION_FILE "${PTEX_INCLUDE_DIR}/PtexVersion.h")
+elseif (PTEX_INCLUDE_DIR AND EXISTS "${PTEX_INCLUDE_DIR}/Ptexture.h")    
+    set (PTEX_VERSION_FILE "${PTEX_INCLUDE_DIR}/Ptexture.h")
+endif()
 
-    file(STRINGS "${PTEX_INCLUDE_DIR}/Ptexture.h" TMP REGEX "^#define PtexAPIVersion.*$")
+if (PTEX_VERSION_FILE)
+
+    file(STRINGS "${PTEX_VERSION_FILE}" TMP REGEX "^#define PtexAPIVersion.*$")
     string(REGEX MATCHALL "[0-9]+" API ${TMP})
     
-    file(STRINGS "${PTEX_INCLUDE_DIR}/Ptexture.h" TMP REGEX "^#define PtexFileMajorVersion.*$")
+    file(STRINGS "${PTEX_VERSION_FILE}" TMP REGEX "^#define PtexFileMajorVersion.*$")
     string(REGEX MATCHALL "[0-9]+" MAJOR ${TMP})
 
-    file(STRINGS "${PTEX_INCLUDE_DIR}/Ptexture.h" TMP REGEX "^#define PtexFileMinorVersion.*$")
+    file(STRINGS "${PTEX_VERSION_FILE}" TMP REGEX "^#define PtexFileMinorVersion.*$")
     string(REGEX MATCHALL "[0-9]+" MINOR ${TMP})
 
     set(PTEX_VERSION ${API}.${MAJOR}.${MINOR})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,7 +39,7 @@ if (NOT NO_OPENGL)
             add_subdirectory(glPaintTest)
         endif()
 
-        if (PTEX_FOUND)
+        if (PTEX_FOUND AND ZLIB_FOUND)
             add_subdirectory(glPtexViewer)
         endif()
 
@@ -73,7 +73,7 @@ if (DXSDK_FOUND AND NOT NO_DX)
 
    add_subdirectory(dxViewer)
 
-   if (PTEX_FOUND)
+   if (PTEX_FOUND AND ZLIB_FOUND)
        add_subdirectory(dxPtexViewer)
    endif()
 

--- a/examples/common/d3d11PtexMipmapTexture.cpp
+++ b/examples/common/d3d11PtexMipmapTexture.cpp
@@ -32,7 +32,8 @@
 D3D11PtexMipmapTexture::D3D11PtexMipmapTexture()
     : _width(0), _height(0), _depth(0),
       _layout(0), _texels(0),
-      _layoutSRV(0), _texelsSRV(0)
+      _layoutSRV(0), _texelsSRV(0),
+      _memoryUsage(0)
 {
 }
 
@@ -225,6 +226,7 @@ D3D11PtexMipmapTexture::Create(ID3D11DeviceContext *deviceContext,
 
     result->_layoutSRV = layoutSRV;
     result->_texelsSRV = texelsSRV;
+    result->_memoryUsage = loader.GetMemoryUsage();
 
     return result;
 }

--- a/examples/common/d3d11PtexMipmapTexture.h
+++ b/examples/common/d3d11PtexMipmapTexture.h
@@ -55,6 +55,9 @@ public:
 
     ID3D11ShaderResourceView **GetTexelsSRV() { return &_texelsSRV; }
 
+    /// Returns the amount of allocated memory (in byte)
+    size_t GetMemoryUsage() const { return _memoryUsage; }
+
     ~D3D11PtexMipmapTexture();
 
 private:
@@ -70,6 +73,8 @@ private:
     ID3D11Texture2D *_texels;  // texel data
     ID3D11ShaderResourceView *_layoutSRV;
     ID3D11ShaderResourceView *_texelsSRV;
+
+    size_t _memoryUsage;  // total amount of memory used (estimate)
 };
 
 #endif  // OPENSUBDIV_EXAMPLES_D3D11_PTEX_TEXTURE_H

--- a/examples/common/d3d11PtexMipmapTexture.h
+++ b/examples/common/d3d11PtexMipmapTexture.h
@@ -27,7 +27,8 @@
 
 #include <osd/nonCopyable.h>
 
-class PtexTexture;
+#include <Ptexture.h>
+
 struct ID3D11Buffer;
 struct ID3D11Texture2D;
 struct ID3D11DeviceContext;
@@ -37,7 +38,8 @@ class D3D11PtexMipmapTexture : OpenSubdiv::Osd::NonCopyable<D3D11PtexMipmapTextu
 public:
     static D3D11PtexMipmapTexture * Create(ID3D11DeviceContext *deviceContext,
                                               PtexTexture * reader,
-                                              int maxLevels=10);
+                                              int maxLevels=10,
+                                              size_t targetMemory=0);
 
     /// Returns GLSL shader snippet to fetch ptex
     static const char *GetShaderSource();

--- a/examples/common/glPtexMipmapTexture.cpp
+++ b/examples/common/glPtexMipmapTexture.cpp
@@ -27,8 +27,6 @@
 
 #include <osd/opengl.h>
 
-#include <Ptexture.h>
-
 GLPtexMipmapTexture::GLPtexMipmapTexture()
     : _width(0), _height(0), _depth(0), _layout(0), _texels(0), _memoryUsage(0)
 {

--- a/examples/common/glPtexMipmapTexture.h
+++ b/examples/common/glPtexMipmapTexture.h
@@ -28,9 +28,8 @@
 #include <osd/nonCopyable.h>
 #include <osd/opengl.h>
 
+#include <Ptexture.h>
 #include <stdlib.h>
-
-class PtexTexture;
 
 class GLPtexMipmapTexture : OpenSubdiv::Osd::NonCopyable<GLPtexMipmapTexture> {
 public:

--- a/examples/common/ptexMipmapTextureLoader.h
+++ b/examples/common/ptexMipmapTextureLoader.h
@@ -25,11 +25,11 @@
 #ifndef OPENSUBDIV_EXAMPLES_PTEX_MIPMAP_TEXTURE_LOADER_H
 #define OPENSUBDIV_EXAMPLES_PTEX_MIPMAP_TEXTURE_LOADER_H
 
+#include <Ptexture.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <vector>
 
-class PtexTexture;
 
 class PtexMipmapTextureLoader {
 public:
@@ -37,7 +37,8 @@ public:
                                int maxNumPages,
                                int maxLevels = -1,
                                size_t targetMemory = 0,
-                               bool seamlessMipmap = true);
+                               bool seamlessMipmap = true,
+                               bool padAlpha = false);
 
     ~PtexMipmapTextureLoader();
 
@@ -136,6 +137,7 @@ private:
     int  resampleBorder(int face, int edgeId, unsigned char *result,
                         int dstLength, int bpp,
                         float srcStart = 0.0f, float srcEnd = 1.0f);
+    void addAlphaChannel();
 
     std::vector<Block> _blocks;
     std::vector<Page *> _pages;
@@ -144,6 +146,8 @@ private:
     int _maxLevels;
     int _bpp;
     int _pageWidth, _pageHeight;
+
+    bool _padAlpha;
 
     unsigned char *_texelBuffer;
     unsigned char *_layoutBuffer;

--- a/examples/dxPtexViewer/CMakeLists.txt
+++ b/examples/dxPtexViewer/CMakeLists.txt
@@ -26,6 +26,7 @@
 
 set(SHADER_FILES
      shader.hlsl
+     skyshader.hlsl
 )
 
 set(PLATFORM_LIBRARIES
@@ -56,6 +57,7 @@ endif()
 
 set(SOURCE_FILES
     dxPtexViewer.cpp
+    sky.cpp
 )
 
 _stringify("${SHADER_FILES}" INC_FILES)

--- a/examples/dxPtexViewer/CMakeLists.txt
+++ b/examples/dxPtexViewer/CMakeLists.txt
@@ -32,6 +32,7 @@ set(PLATFORM_LIBRARIES
     "${OSD_LINK_TARGET}"
     "${DXSDK_LIBRARIES}"
     "${PTEX_LIBRARY}"
+    "${ZLIB_LIBRARY}"
 )
 
 include_directories(

--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -644,7 +644,7 @@ ShaderCache g_shaderCache;
 
 //------------------------------------------------------------------------------
 D3D11PtexMipmapTexture *
-createPtex(const char *filename) {
+createPtex(const char *filename, int memLimit) {
 
     Ptex::String ptexError;
     printf("Loading ptex : %s\n", filename);
@@ -663,8 +663,11 @@ createPtex(const char *filename) {
         printf("Error in reading %s\n", filename);
         exit(1);
     }
+
+    size_t targetMemory = memLimit * 1024 * 1024; // MB
+
     D3D11PtexMipmapTexture *osdPtex = D3D11PtexMipmapTexture::Create(
-        g_pd3dDeviceContext, ptex, g_maxMipmapLevels);
+        g_pd3dDeviceContext, ptex, g_maxMipmapLevels, targetMemory);
 
     ptex->release();
 
@@ -1735,6 +1738,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmd
     const char *diffuseEnvironmentMap = NULL, *specularEnvironmentMap = NULL;
     const char *colorFilename = NULL, *displacementFilename = NULL,
         *occlusionFilename = NULL, *specularFilename = NULL;
+    int memLimit;
 
     for (int i = 0; i < (int)argv.size(); ++i) {
         if (strstr(argv[i].c_str(), ".obj"))
@@ -1751,6 +1755,8 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmd
             g_yup = true;
         else if (argv[i] == "-m")
             g_maxMipmapLevels = atoi(argv[++i].c_str());
+        else if (argv[i] == "-x")
+            memLimit = atoi(argv[++i].c_str());
         else if (argv[i] == "--disp")
             g_displacementScale = (float)atof(argv[++i].c_str());
         else if (colorFilename == NULL)
@@ -1781,13 +1787,13 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmd
     createOsdMesh(g_level, g_kernel);
 
     // load ptex files
-    g_osdPTexImage = createPtex(colorFilename);
+    g_osdPTexImage = createPtex(colorFilename, memLimit);
     if (displacementFilename)
-        g_osdPTexDisplacement = createPtex(displacementFilename);
+        g_osdPTexDisplacement = createPtex(displacementFilename, memLimit);
     if (occlusionFilename)
-        g_osdPTexOcclusion = createPtex(occlusionFilename);
+        g_osdPTexOcclusion = createPtex(occlusionFilename, memLimit);
     if (specularFilename)
-        g_osdPTexSpecular = createPtex(specularFilename);
+        g_osdPTexSpecular = createPtex(specularFilename, memLimit);
 
     initHUD();
 

--- a/examples/dxPtexViewer/shader.hlsl
+++ b/examples/dxPtexViewer/shader.hlsl
@@ -30,6 +30,7 @@ cbuffer Transform : register( b0 ) {
     float4x4 ModelViewMatrix;
     float4x4 ProjectionMatrix;
     float4x4 ModelViewProjectionMatrix;
+    float4x4 ModelViewInverseMatrix;
 };
 
 cbuffer Tessellation : register( b1 ) {
@@ -287,6 +288,31 @@ void gs_main( triangle OutputVertex input[3],
 }
 
 #endif
+
+
+// ---------------------------------------------------------------------------
+//  IBL lighting
+// ---------------------------------------------------------------------------
+
+Texture2D diffuseEnvironmentMap : register(t12);
+Texture2D specularEnvironmentMap : register(t13);
+
+SamplerState iblSampler : register(s0);
+
+#define M_PI 3.14159265358
+
+float4
+gamma(float4 value, float g) {
+    return float4(pow(value.xyz, float3(g,g,g)), 1);
+}
+
+float4
+getEnvironmentHDR(Texture2D tx, SamplerState sm, float3 dir)
+{
+    dir = mul(ModelViewInverseMatrix, float4(dir, 0)).xyz;
+    float2 uv = float2((atan2(dir.x,dir.z)/M_PI+1)*0.5, (1-dir.y)*0.5);
+    return tx.Sample(sm, uv);
+}
 
 
 // ---------------------------------------------------------------------------
@@ -559,8 +585,38 @@ ps_main(in OutputVertex input,
 #else
     float specular = 1.0;
 #endif
+
     // ------------ lighting ---------------
+#ifdef USE_IBL
+    // non-plausible BRDF
+    float4 a = float4(0, 0, 0, 1); //ambientColor;
+    float4 d = getEnvironmentHDR(diffuseEnvironmentMap, iblSampler, normal);
+
+    float3 eye = normalize(input.position.xyz - float3(0,0,0));
+    float3 r = reflect(eye, normal);
+    float4 s = getEnvironmentHDR(specularEnvironmentMap, iblSampler, r);
+
+    const float fresnelBias = 0.01;
+    const float fresnelScale = 1.0;
+    const float fresnelPower = 3.5;
+    float F = fresnelBias + fresnelScale * pow(1.0+dot(normal,eye), fresnelPower);
+
+    // Geometric attenuation term (
+    float NoV = dot(normal, -eye);
+    float alpha = 0.75 * 0.75; // roughness ^ 2
+    float k = alpha * 0.5;
+    float G = NoV/(NoV*(1-k)+k);
+
+    a *= (1-occ);
+    d *= (1-occ);
+    s *= min(specular, (1-occ)) * (F*G);
+
+    float4 Cf = (a+d)*texColor*(1-F)/M_PI + s;
+    //Cf = gamma(Cf, 2.2);
+
+#else
     float4 Cf = lighting(texColor, input.position.xyz, normal, occ);
+#endif
 
     // ------------ wireframe ---------------
     outColor = edgeColor(Cf, input.edgeDistance);

--- a/examples/dxPtexViewer/sky.cpp
+++ b/examples/dxPtexViewer/sky.cpp
@@ -1,0 +1,257 @@
+//
+//   Copyright 2013 Nvidia
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+
+#include "./sky.h"
+
+#include "../common/d3d11Utils.h"
+
+#include <cassert>
+#include <vector>
+
+static const char *g_skyShaderSource =
+#include "skyshader.gen.h"
+;
+
+#define SAFE_RELEASE(p) { if(p) { (p)->Release(); (p)=NULL; } }
+
+// shader constants
+__declspec(align(16)) struct CB_CONSTANTS {
+        float ModelViewMatrix[16];
+};
+
+
+Sky::Sky(ID3D11Device * device, ID3D11Texture2D * environmentMap) :
+    numIndices(0), 
+    vertexShader(0),
+    pixelShader(0),
+    shaderConstants(0),
+    texture(environmentMap), // we do not own this - we do not release it !
+    textureSRV(0),
+    textureSS(0),
+    inputLayout(0),
+    rasterizerState(0),
+    depthStencilState(0),
+    sphere(0),
+    sphereIndices(0) { 
+
+    initialize(device);
+}
+
+Sky::~Sky() {
+    SAFE_RELEASE(vertexShader);
+    SAFE_RELEASE(pixelShader);
+    SAFE_RELEASE(shaderConstants);
+    SAFE_RELEASE(inputLayout);
+    SAFE_RELEASE(rasterizerState);
+    SAFE_RELEASE(depthStencilState);
+    SAFE_RELEASE(textureSS);
+    SAFE_RELEASE(textureSRV);
+    SAFE_RELEASE(sphere);
+    SAFE_RELEASE(sphereIndices);
+}
+
+void
+Sky::initialize(ID3D11Device * device) {
+
+    // compile shaders
+    ID3DBlob * pVSBlob = D3D11Utils::CompileShader(g_skyShaderSource, "vs_main", "vs_5_0"),
+             * pPSBlob = D3D11Utils::CompileShader(g_skyShaderSource, "ps_main", "ps_5_0");
+    assert(pVSBlob && pPSBlob);
+
+    device->CreateVertexShader(pVSBlob->GetBufferPointer(),
+        pVSBlob->GetBufferSize(), NULL, &vertexShader);
+    assert(vertexShader);
+
+    device->CreatePixelShader(pPSBlob->GetBufferPointer(),
+        pPSBlob->GetBufferSize(), NULL, &pixelShader);
+    assert(pixelShader);
+
+    // VBO layout
+    D3D11_INPUT_ELEMENT_DESC inputElementDesc[] = {
+        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, sizeof(float)*3, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+    };
+    device->CreateInputLayout(inputElementDesc, ARRAYSIZE(inputElementDesc),
+        pVSBlob->GetBufferPointer(), pVSBlob->GetBufferSize(), &inputLayout);
+    assert(inputLayout);
+
+    // shader constants
+    D3D11_BUFFER_DESC cbDesc;
+    ZeroMemory(&cbDesc, sizeof(cbDesc));
+    cbDesc.Usage = D3D11_USAGE_DYNAMIC;
+    cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+    cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+    cbDesc.MiscFlags = 0;
+    cbDesc.ByteWidth = sizeof(CB_CONSTANTS);
+    device->CreateBuffer(&cbDesc, NULL, &shaderConstants);
+    assert(shaderConstants);
+
+    // texture SRV
+    assert(texture);
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
+    ZeroMemory(&srvDesc, sizeof(srvDesc));
+    srvDesc.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+    srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+    srvDesc.Texture2D.MostDetailedMip = 0;
+    srvDesc.Texture2D.MipLevels = 1;
+    device->CreateShaderResourceView(texture, &srvDesc, &textureSRV);
+    assert(textureSRV);
+
+    // texture sampler
+    D3D11_SAMPLER_DESC samplerDesc;
+    ZeroMemory(&samplerDesc, sizeof(samplerDesc));
+    samplerDesc.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
+    samplerDesc.AddressU = samplerDesc.AddressV = samplerDesc.AddressW = D3D11_TEXTURE_ADDRESS_WRAP;
+    samplerDesc.MaxAnisotropy = 0;
+    samplerDesc.ComparisonFunc = D3D11_COMPARISON_NEVER;
+    samplerDesc.MinLOD = 0;
+    samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
+    samplerDesc.BorderColor[0] = samplerDesc.BorderColor[1] = samplerDesc.BorderColor[2] = samplerDesc.BorderColor[3] = 0.0f;
+    device->CreateSamplerState(&samplerDesc, &textureSS);
+
+    // depth stencil state
+    D3D11_DEPTH_STENCIL_DESC depthStencilDesc;
+    ZeroMemory(&depthStencilDesc, sizeof(depthStencilDesc));
+    depthStencilDesc.DepthEnable = true;
+    depthStencilDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;
+    depthStencilDesc.DepthFunc = D3D11_COMPARISON_LESS_EQUAL;
+    depthStencilDesc.StencilEnable = false;
+    device->CreateDepthStencilState(&depthStencilDesc, &depthStencilState);
+
+    // rasterizer state
+    D3D11_RASTERIZER_DESC rasDesc;
+    rasDesc.FillMode = D3D11_FILL_SOLID;
+    rasDesc.CullMode = D3D11_CULL_NONE;
+    rasDesc.FrontCounterClockwise = FALSE;
+    rasDesc.DepthBias = 0;
+    rasDesc.DepthBiasClamp = 0;
+    rasDesc.DepthClipEnable = FALSE;
+    rasDesc.SlopeScaledDepthBias = 0.0f;
+    rasDesc.ScissorEnable = FALSE;
+    rasDesc.MultisampleEnable = FALSE;
+    rasDesc.AntialiasedLineEnable = FALSE;
+    device->CreateRasterizerState(&rasDesc, &rasterizerState);
+    assert(rasterizerState);
+
+    const int U_DIV = 20,
+              V_DIV = 20;
+
+    std::vector<float> vbo;
+    std::vector<int> indices;
+    for (int u = 0; u <= U_DIV; ++u) {
+        for (int v = 0; v < V_DIV; ++v) {
+            float s = float(2*M_PI*float(u)/U_DIV);
+            float t = float(M_PI*float(v)/(V_DIV-1));
+            vbo.push_back(-sin(t)*sin(s));
+            vbo.push_back(cos(t));
+            vbo.push_back(-sin(t)*cos(s));
+            vbo.push_back(u/float(U_DIV));
+            vbo.push_back(v/float(V_DIV));
+
+            if (v > 0 && u > 0) {
+                indices.push_back((u-1)*V_DIV+v-1);
+                indices.push_back(u*V_DIV+v-1);
+                indices.push_back((u-1)*V_DIV+v);
+                indices.push_back((u-1)*V_DIV+v);
+                indices.push_back(u*V_DIV+v-1);
+                indices.push_back(u*V_DIV+v);
+            }
+        }
+    }
+
+    D3D11_BUFFER_DESC bufferDesc;
+    D3D11_SUBRESOURCE_DATA subData;
+
+    // topology indices
+    ZeroMemory(&bufferDesc, sizeof(bufferDesc));
+    bufferDesc.ByteWidth = (int)indices.size() * sizeof(int);
+    bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+    bufferDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
+    bufferDesc.CPUAccessFlags = 0;
+    bufferDesc.MiscFlags = 0;
+    bufferDesc.StructureByteStride = sizeof(int);
+
+    ZeroMemory(&subData, sizeof(subData));
+    subData.pSysMem = &indices[0];
+    subData.SysMemPitch = 0;
+    subData.SysMemSlicePitch = 0;
+    device->CreateBuffer(&bufferDesc, &subData, &sphereIndices);
+    assert(sphereIndices);
+
+    // VBO
+    ZeroMemory(&bufferDesc, sizeof(bufferDesc));
+    bufferDesc.ByteWidth = (int)vbo.size() * sizeof(float);
+    bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+    bufferDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+    bufferDesc.CPUAccessFlags = 0;
+    bufferDesc.MiscFlags = 0;
+
+    ZeroMemory(&subData, sizeof(subData));
+    subData.pSysMem = &vbo[0];
+    device->CreateBuffer(&bufferDesc, &subData, &sphere);
+    assert(sphere);
+
+    numIndices = (int)indices.size();
+}
+
+void
+Sky::Draw(ID3D11DeviceContext * deviceContext, float const mvp[16]) {
+
+    if (vertexShader==0 || pixelShader==0 || shaderConstants==0) return;
+
+    if (texture==0 || textureSRV==0 || textureSS==0) return;
+
+    if (sphere==0 || sphereIndices==0) return;
+
+    // update shader constants
+    D3D11_MAPPED_SUBRESOURCE MappedResource;
+    deviceContext->Map(shaderConstants, 0, D3D11_MAP_WRITE_DISCARD, 0, &MappedResource);
+    CB_CONSTANTS* pData = (CB_CONSTANTS*)MappedResource.pData;
+
+    memcpy(pData->ModelViewMatrix, mvp, 16*sizeof(float));
+
+    deviceContext->Unmap(shaderConstants, 0);
+
+    // draw
+    deviceContext->RSSetState(rasterizerState);
+    deviceContext->OMSetDepthStencilState(depthStencilState, 1);
+
+    deviceContext->VSSetShader(vertexShader, NULL, 0);
+    deviceContext->VSSetConstantBuffers(0, 1, &shaderConstants);
+
+    deviceContext->PSSetShader(pixelShader, NULL, 0);
+    deviceContext->PSSetShaderResources(0, 1, &textureSRV);
+    deviceContext->PSSetSamplers(0, 1, &textureSS);
+
+    UINT hStrides = 5*sizeof(float);
+    UINT hOffsets = 0;
+    deviceContext->IASetVertexBuffers(0, 1, &sphere, &hStrides, &hOffsets);
+    deviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    deviceContext->IASetInputLayout(inputLayout);
+
+    deviceContext->IASetIndexBuffer(sphereIndices, DXGI_FORMAT_R32_UINT, 0);
+
+    deviceContext->DrawIndexed(numIndices, 0, 0);
+}

--- a/examples/dxPtexViewer/sky.h
+++ b/examples/dxPtexViewer/sky.h
@@ -1,0 +1,65 @@
+//
+//   Copyright 2013 Nvidia
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#include <D3D11.h>
+#include <D3Dcompiler.h>
+
+//
+// Draws an environment sphere centered on the camera w/ a texture
+//
+class Sky {
+
+public:
+
+    // Constructor (Sky does not own the texture asset)
+    Sky(ID3D11Device * device, ID3D11Texture2D * environmentMap);
+
+    ~Sky();
+
+    void Draw(ID3D11DeviceContext * deviceContext, float const mvp[16]);
+
+private:
+
+    void initialize(ID3D11Device * device);
+
+private:
+
+    int numIndices;
+
+    ID3D11VertexShader * vertexShader;
+    ID3D11PixelShader * pixelShader;
+    ID3D11Buffer * shaderConstants;
+
+    ID3D11InputLayout * inputLayout;
+    ID3D11RasterizerState * rasterizerState;
+    ID3D11DepthStencilState * depthStencilState;
+
+    ID3D11Texture2D * texture;
+    ID3D11ShaderResourceView * textureSRV;
+    ID3D11SamplerState * textureSS;
+
+    ID3D11Buffer * sphere;
+    ID3D11Buffer * sphereIndices;
+};
+

--- a/examples/dxPtexViewer/skyshader.hlsl
+++ b/examples/dxPtexViewer/skyshader.hlsl
@@ -1,0 +1,80 @@
+//
+//   Copyright 2013 Nvidia
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+struct VS_InputVertex {
+    float3 position : POSITION0;
+    float2 texCoord : TEXCOORD0;
+};
+
+struct VS_OutputVertex {
+    float4 position : SV_POSITION0;
+    float2 texCoord : TEXCOORD0;
+};
+
+cbuffer Transform : register( b0 ) {
+    float4x4 ModelViewMatrix;
+};
+
+//--------------------------------------------------------------
+// sky vertex shader
+//--------------------------------------------------------------
+
+
+void vs_main(in VS_InputVertex input,
+             out VS_OutputVertex output) {
+
+    output.position = mul(ModelViewMatrix, float4(input.position,1));
+    output.texCoord = input.texCoord;
+}
+
+//--------------------------------------------------------------
+// sky pixel shader
+//--------------------------------------------------------------
+
+struct PS_InputVertex {
+    float4 position : SV_POSITION0;
+    float2 texCoord : TEXCOORD0;
+};
+
+Texture2D tx : register(t0);
+
+SamplerState sm : register(s0);
+
+float4
+gamma(float4 value, float g) {
+    return float4(pow(value.xyz, float3(g,g,g)), 1);
+}
+
+
+float4
+ps_main(in PS_InputVertex input) : SV_Target {
+
+    float4 tex = tx.Sample(sm, input.texCoord.xy);
+
+    //float4 outColor = gamma(tex,0.4545);
+    float4 outColor = tex;
+
+    return outColor;
+}
+

--- a/examples/glPtexViewer/CMakeLists.txt
+++ b/examples/glPtexViewer/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND PLATFORM_LIBRARIES
     "${OPENGL_LIBRARY}"
     "${GLFW_LIBRARIES}"
     "${PTEX_LIBRARY}"
+    "${ZLIB_LIBRARY}"
 )
 
 include_directories(


### PR DESCRIPTION
- fix build compiling & linking to accomodate recent code churn in Ptex
- fix FindPTex.cmake module to correctly extract version number
- fix dxPtexViewer & glPtexViewer source to compile with new Ptex namespace changes
- add alpha channel padding function to ptexMipmapLoader as a workaround to the absence of 3-channel DXGI formats
- mirror ptex memory limit function from glPtexViewer to dxPtexViewer

Sorry - the previous PR was messed up : hopefully this will work better...
