### PR TITLE
Rename and, or and not to &&, || and ! etc. Ref #779

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,35 +204,40 @@ elseif(MSVC)
     # Turn on all warnings
     list(APPEND OSD_COMPILER_FLAGS /Wall)
 
-    # MSVC is unfortunately not standard conforming with regards to
-    # the alternative names for logical and bitwise operators:
-    # http://stackoverflow.com/questions/555505/c-alternative-tokens
-    # http://stackoverflow.com/questions/6006526/c-writing-or-instead-of
-    #
-    # This can be solved by including iso646.h, but that is a rather
-    # unsatisfactory solution since we then always have to remember to
-    # include this header file.  Instead we define these operators
-    # ourselves as command line arguments to cl.exe.
-    #
-    # An alternative would be to compile with the /Za option
-    # (but unfortunately that breaks other code):
-    # http://msdn.microsoft.com/en-us/library/0k0w269d.aspx
-    list(APPEND OSD_COMPILER_FLAGS
-                    /Dand=&&
-                    /Dand_eq=&=
-                    /Dbitand=&
-                    /Dbitor=|
-                    /Dcompl=~
-                    /Dnot=!
-                    /Dnot_eq=!=
-                    /Dor=||
-                    /Dor_eq=|=
-                    # nvcc does not seem to like a caret being the last character
-                    # in a command line defined preprocessor symbol, so add an
-                    # empty trailing comment to avoid this.
-                    /Dxor=^/**/
-                    /Dxor_eq=^=
-    )
+    # Temporary option to assist in the refactoring to avoid the need for these.
+    # https://github.com/PixarAnimationStudios/OpenSubdiv/issues/779#
+    option(NO_ISO646 "Disable MSVC iso646.h macros" OFF)
+    if(NOT NO_ISO646)
+        # MSVC is unfortunately not standard conforming with regards to
+        # the alternative names for logical and bitwise operators:
+        # http://stackoverflow.com/questions/555505/c-alternative-tokens
+        # http://stackoverflow.com/questions/6006526/c-writing-or-instead-of
+        #
+        # This can be solved by including iso646.h, but that is a rather
+        # unsatisfactory solution since we then always have to remember to
+        # include this header file.  Instead we define these operators
+        # ourselves as command line arguments to cl.exe.
+        #
+        # An alternative would be to compile with the /Za option
+        # (but unfortunately that breaks other code):
+        # http://msdn.microsoft.com/en-us/library/0k0w269d.aspx
+        list(APPEND OSD_COMPILER_FLAGS
+                        /Dand=&&
+                        /Dand_eq=&=
+                        /Dbitand=&
+                        /Dbitor=|
+                        /Dcompl=~
+                        /Dnot=!
+                        /Dnot_eq=!=
+                        /Dor=||
+                        /Dor_eq=|=
+                        # nvcc does not seem to like a caret being the last character
+                        # in a command line defined preprocessor symbol, so add an
+                        # empty trailing comment to avoid this.
+                        /Dxor=^/**/
+                        /Dxor_eq=^=
+        )
+    endif()
 
 
     list(APPEND OSD_COMPILER_FLAGS

--- a/examples/common/hdr_reader.cpp
+++ b/examples/common/hdr_reader.cpp
@@ -79,7 +79,7 @@ unsigned char *loadHdr(const char *filename, HdrInfo *info, bool convertToFloat)
 
     // read header
     while(true) {
-        if (not fgets(buffer, MAXLINE, fp)) goto error;
+        if (! fgets(buffer, MAXLINE, fp)) goto error;
         if (buffer[0] == '\n') break;
         if (buffer[0] == '\r' && buffer[0] == '\n') break;
         if (strncmp(buffer, "#?", 2) == 0) {
@@ -92,16 +92,16 @@ unsigned char *loadHdr(const char *filename, HdrInfo *info, bool convertToFloat)
     if (strncmp(info->format, "32-bit_rle_rgbe", 15)) goto error;
 
     // resolution
-    if (not fgets(buffer, MAXLINE, fp)) goto error;
+    if (! fgets(buffer, MAXLINE, fp)) goto error;
     {
         int n = (int)strlen(buffer);
         for (int i = 1; i < n; ++i) {
             if (buffer[i] == 'X') {
-                if (not (info->flag & HDR_Y_MAJOR)) info->flag |= HDR_X_MAJOR;
+                if (! (info->flag & HDR_Y_MAJOR)) info->flag |= HDR_X_MAJOR;
                 info->flag |= (char)((buffer[i-1] == '-') ? HDR_X_DEC : 0);
                 info->width = atoi(&buffer[i+1]);
             } else if (buffer[i] == 'Y') {
-                if (not (info->flag & HDR_X_MAJOR)) info->flag |= HDR_Y_MAJOR;
+                if (! (info->flag & HDR_X_MAJOR)) info->flag |= HDR_Y_MAJOR;
                 info->flag |= (char)((buffer[i-1] == '-') ? HDR_Y_DEC : 0);
                 info->height = atoi(&buffer[i+1]);
             }
@@ -128,7 +128,7 @@ unsigned char *loadHdr(const char *filename, HdrInfo *info, bool convertToFloat)
     line = (unsigned char *)malloc(info->scanLength*4);
 
     for (int y = info->scanWidth-1; y >= 0; --y) {
-        if (not readLine(line, info->scanLength, fp)) goto error;
+        if (! readLine(line, info->scanLength, fp)) goto error;
         for (int x = 0; x < info->scanLength; ++x) {
             if (convertToFloat) {
                 float scale = powf(2.0f, float(line[x*4+3] - 128))/255.0f;

--- a/examples/common/stopwatch.h
+++ b/examples/common/stopwatch.h
@@ -25,7 +25,7 @@
 #ifndef STOPWATCH_H
 #define STOPWATCH_H
 
-#if (_WIN32 or _WIN64)
+#if (_WIN32 || _WIN64)
     #include <windows.h>
 #else
     #include <sys/types.h>

--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
@@ -56,7 +56,7 @@ EndCapBSplineBasisPatchFactory::EndCapBSplineBasisPatchFactory(
     _refiner(&refiner), _numVertices(0), _numPatches(0) {
 
     // Sanity check: the mesh must be adaptively refined
-    assert(not refiner.IsUniform());
+    assert(! refiner.IsUniform());
 
     // Reserve the patch point stencils. Ideally topology refiner
     // would have an API to return how many endcap patches will be required.

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
@@ -50,7 +50,7 @@ EndCapGregoryBasisPatchFactory::EndCapGregoryBasisPatchFactory(
     _numGregoryBasisVertices(0), _numGregoryBasisPatches(0) {
 
     // Sanity check: the mesh must be adaptively refined
-    assert(not refiner.IsUniform());
+    assert(! refiner.IsUniform());
 
     // Reserve the patch point stencils. Ideally topology refiner
     // would have an API to return how many endcap patches will be required.
@@ -164,8 +164,8 @@ EndCapGregoryBasisPatchFactory::GetPatchPoints(
             // - exist (no boundary)
             // - have already been processed (known CV indices)
             // - are also Gregory basis patches
-            if (adjface!=Vtr::INDEX_INVALID and (adjface < faceIndex) and
-                (not levelPatchTags[adjface]._isRegular)) {
+            if (adjface!=Vtr::INDEX_INVALID && (adjface < faceIndex) &&
+                (! levelPatchTags[adjface]._isRegular)) {
 
                 ConstIndexArray aedges = level->getFaceEdges(adjface);
                 int aedge = aedges.FindIndexIn4Tuple(edge);
@@ -190,8 +190,8 @@ EndCapGregoryBasisPatchFactory::GetPatchPoints(
                     break;
                 }
                 assert(ptr
-                       and srcBasisIdx>=0
-                       and srcBasisIdx<(int)_faceIndices.size());
+                       && srcBasisIdx>=0
+                       && srcBasisIdx<(int)_faceIndices.size());
 
                 // Copy the indices of CVs from the face on the other side of the
                 // shared edge

--- a/opensubdiv/far/patchBasis.cpp
+++ b/opensubdiv/far/patchBasis.cpp
@@ -179,7 +179,7 @@ inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParam const & param,
         point[3] = sC * t;
     }
     
-    if (derivS and derivT) {
+    if (derivS && derivT) {
         float dScale = (float)(1 << param.GetDepth());
 
         derivS[0] = -tC * dScale;
@@ -246,7 +246,7 @@ void Spline<BASIS>::GetPatchWeights(PatchParam const & param,
         }
     }
 
-    if (derivS and derivT) {
+    if (derivS && derivT) {
         // Compute the tensor product weight of the differentiated (s,t) basis
         // function corresponding to each control vertex (scaled accordingly):
 
@@ -360,7 +360,7 @@ void GetGregoryWeights(PatchParam const & param,
     //  unclear if the approximations will hold up under surface analysis involving higher
     //  order differentiation.
     //
-    if (deriv1 and deriv2) {
+    if (deriv1 && deriv2) {
         //  Remember to include derivative scaling in all assignments below:
         float dScale = (float)(1 << param.GetDepth());
 

--- a/opensubdiv/far/patchDescriptor.h
+++ b/opensubdiv/far/patchDescriptor.h
@@ -95,7 +95,7 @@ public:
 
     /// \brief Returns true if the type is an adaptive patch
     static inline bool IsAdaptive(Type type) {
-        return (type>=LOOP and type<=GREGORY_BASIS);
+        return (type>=LOOP && type<=GREGORY_BASIS);
     }
 
     /// \brief Returns true if the type is an adaptive patch

--- a/opensubdiv/far/patchMap.cpp
+++ b/opensubdiv/far/patchMap.cpp
@@ -71,7 +71,7 @@ PatchMap::initialize( PatchTable const & patchTable ) {
         narrays = (int)patchTable.GetNumPatchArrays(),
         npatches = (int)patchTable.GetNumPatchesTotal();
 
-    if (not narrays or not npatches)
+    if (! narrays || ! npatches)
         return;
 
     // populate subpatch handles vector
@@ -141,12 +141,12 @@ PatchMap::initialize( PatchTable const & patchTable ) {
 
                 if (j==pdepth) {
                    // we have reached the depth of the sub-patch : add a leaf
-                   assert( not node->children[quadrant].isSet );
+                   assert( ! node->children[quadrant].isSet );
                    node->SetChild(quadrant, handleIndex, true);
                    break;
                 } else {
                     // travel down the child node of the corresponding quadrant
-                    if (not node->children[quadrant].isSet) {
+                    if (! node->children[quadrant].isSet) {
                         // create a new branch in the quadrant
                         node = addChild(quadtree, node, quadrant);
                     } else {

--- a/opensubdiv/far/patchMap.h
+++ b/opensubdiv/far/patchMap.h
@@ -151,7 +151,7 @@ PatchMap::FindPatch( int faceid, float u, float v ) const {
     if (faceid>=(int)_quadtree.size())
         return NULL;
 
-    assert( (u>=0.0f) and (u<=1.0f) and (v>=0.0f) and (v<=1.0f) );
+    assert( (u>=0.0f) && (u<=1.0f) && (v>=0.0f) && (v<=1.0f) );
 
     QuadNode const * node = &_quadtree[faceid];
 
@@ -166,7 +166,7 @@ PatchMap::FindPatch( int faceid, float u, float v ) const {
         assert(quadrant>=0);
 
         // is the quadrant a hole ?
-        if (not node->children[quadrant].isSet)
+        if (! node->children[quadrant].isSet)
             return 0;
 
         if (node->children[quadrant].isLeaf) {

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -357,7 +357,7 @@ PatchTable::IsFeatureAdaptive() const {
 
     for (int i=0; i<GetNumPatchArrays(); ++i) {
         PatchDescriptor const & desc = _patchArrays[i].desc;
-        if (desc.GetType()>=PatchDescriptor::REGULAR and
+        if (desc.GetType()>=PatchDescriptor::REGULAR &&
             desc.GetType()<=PatchDescriptor::GREGORY_BASIS) {
             return true;
         }
@@ -393,7 +393,7 @@ PatchTable::getPatchFVarValues(int patch, int channel) const {
         int ncvs = PatchDescriptor::GetNumFVarControlVertices(c.patchesType);
         return ConstIndexArray(&c.patchValues[patch * ncvs], ncvs);
     } else {
-        assert(patch<(int)c.patchValuesOffsets.size() and
+        assert(patch<(int)c.patchValuesOffsets.size() &&
             patch<(int)c.patchTypes.size());
         return ConstIndexArray(&c.patchValues[c.patchValuesOffsets[patch]],
             PatchDescriptor::GetNumFVarControlVertices(c.patchTypes[patch]));

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -350,7 +350,7 @@ PatchTableFactory::allocateVertexTables(PatchTable * table, int /* nlevels */, b
         ncvs += table->GetNumControlVertices(i);
     }
 
-    if (ncvs==0 or npatches==0)
+    if (ncvs==0 || npatches==0)
         return;
 
     table->_patchVerts.resize( ncvs );
@@ -369,8 +369,8 @@ void
 PatchTableFactory::allocateFVarChannels(TopologyRefiner const & refiner,
     Options options, int npatches, PatchTable * table) {
 
-    assert(options.generateFVarTables and
-        refiner.GetNumFVarChannels()>0 and npatches>0 and table);
+    assert(options.generateFVarTables &&
+        refiner.GetNumFVarChannels()>0 && npatches>0 && table);
 
     // Create a channel cursor to iterate over client-selected channels or
     // default to the channels found in the TopologyRefiner
@@ -411,7 +411,7 @@ PatchTableFactory::gatherFVarData(AdaptiveContext & context, int level,
     (void)levelFaceOffset;  // not used
     (void)fofss;  // not used
 
-    if (not context.RequiresFVarPatches()) {
+    if (! context.RequiresFVarPatches()) {
         return 0;
     }
 
@@ -542,7 +542,7 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
     assert(refiner.IsUniform());
 
     // ensure that triangulateQuads is only set for quadrilateral schemes
-    options.triangulateQuads &= (refiner.GetSchemeType()==Sdc::SCHEME_BILINEAR or
+    options.triangulateQuads &= (refiner.GetSchemeType()==Sdc::SCHEME_BILINEAR ||
                                  refiner.GetSchemeType()==Sdc::SCHEME_CATMARK);
 
     // level=0 may contain n-gons, which are not supported in PatchTable.
@@ -601,7 +601,7 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
     allocateVertexTables( table, 0, /*hasSharpness=*/false );
 
     FVarChannelCursor fvc(refiner, options);
-    bool generateFVarPatches = (options.generateFVarTables and fvc.size()>0);
+    bool generateFVarPatches = (options.generateFVarTables && fvc.size()>0);
     if (generateFVarPatches) {
         int npatches = table->GetNumPatchesTotal();
         allocateFVarChannels(refiner, options, npatches, table);
@@ -639,7 +639,7 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
         if (level>=firstlevel) {
             for (int face=0; face<nfaces; ++face) {
 
-                if (refiner.HasHoles() and refLevel.IsFaceHole(face)) {
+                if (refiner.HasHoles() && refLevel.IsFaceHole(face)) {
                     continue;
                 }
 
@@ -696,7 +696,7 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
 PatchTable *
 PatchTableFactory::createAdaptive(TopologyRefiner const & refiner, Options options) {
 
-    assert(not refiner.IsUniform());
+    assert(! refiner.IsUniform());
 
     PtexIndices ptexIndices(refiner);
 
@@ -872,16 +872,16 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
             bool hasXOrdinaryVertex   = compFaceVertTag._xordinary;
 
             patchTag._hasPatch  = true;
-            patchTag._isRegular = not hasXOrdinaryVertex or hasNonManifoldVertex;
+            patchTag._isRegular = ! hasXOrdinaryVertex || hasNonManifoldVertex;
 
             // single crease patch optimization
-            if (context.options.useSingleCreasePatch and
-                not hasXOrdinaryVertex and not hasBoundaryVertex and not hasNonManifoldVertex) {
+            if (context.options.useSingleCreasePatch &&
+                ! hasXOrdinaryVertex && ! hasBoundaryVertex && ! hasNonManifoldVertex) {
 
                 Vtr::ConstIndexArray fEdges = level->getFaceEdges(faceIndex);
                 Vtr::internal::Level::ETag compFaceETag = level->getFaceCompositeETag(fEdges);
 
-                if (compFaceETag._semiSharp or compFaceETag._infSharp) {
+                if (compFaceETag._semiSharp || compFaceETag._infSharp) {
                     float sharpness = 0;
                     int rotation = 0;
                     if (level->isSingleCreasePatch(faceIndex, &sharpness, &rotation)) {
@@ -902,7 +902,7 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
             //  for regular patches, though an irregular patch or extrapolated boundary patch
             //  is really necessary in future for some non-manifold cases.
             //
-            if (hasBoundaryVertex or hasNonManifoldVertex) {
+            if (hasBoundaryVertex || hasNonManifoldVertex) {
                 Vtr::ConstIndexArray fEdges = level->getFaceEdges(faceIndex);
 
                 int boundaryEdgeMask = ((level->getEdgeTag(fEdges[0])._boundary) << 0) |
@@ -971,7 +971,7 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
             bool approxSmoothCornerWithRegularPatch = true;
 
             if (approxSmoothCornerWithRegularPatch) {
-                if (!patchTag._isRegular and (patchTag._boundaryCount == 2)) {
+                if (!patchTag._isRegular && (patchTag._boundaryCount == 2)) {
                     //  We may have a sharp corner opposite/adjacent an xordinary vertex --
                     //  need to make sure there is only one xordinary vertex and that it
                     //  is the corner vertex.
@@ -987,7 +987,7 @@ PatchTableFactory::identifyAdaptivePatches(AdaptiveContext & context) {
 
                         if (xordCount == 1) {
                             //  We require the vertex opposite the xordinary vertex be interior:
-                            if (not level->getVertexTag(fVerts[(xordVertex + 2) % 4])._boundary) {
+                            if (! level->getVertexTag(fVerts[(xordVertex + 2) % 4])._boundary) {
                                 patchTag._isRegular = true;
                             }
                         }
@@ -1162,7 +1162,7 @@ PatchTableFactory::populateAdaptivePatches(
             }
 
             const PatchFaceTag& patchTag = levelPatchTags[faceIndex];
-            if (not patchTag._hasPatch) {
+            if (! patchTag._hasPatch) {
                 continue;
             }
 
@@ -1303,14 +1303,14 @@ PatchTableFactory::populateAdaptivePatches(
     }
 
     // finalize end patches
-    if (localPointStencils and localPointStencils->GetNumStencils() > 0) {
+    if (localPointStencils && localPointStencils->GetNumStencils() > 0) {
         localPointStencils->generateOffsets();
     } else {
         delete localPointStencils;
         localPointStencils = NULL;
     }
 
-    if (localPointVaryingStencils and localPointVaryingStencils->GetNumStencils() > 0) {
+    if (localPointVaryingStencils && localPointVaryingStencils->GetNumStencils() > 0) {
         localPointVaryingStencils->generateOffsets();
     } else {
         delete localPointVaryingStencils;

--- a/opensubdiv/far/primvarRefiner.h
+++ b/opensubdiv/far/primvarRefiner.h
@@ -265,7 +265,7 @@ template <class T, class U>
 inline void
 PrimvarRefiner::Interpolate(int level, T const & src, U & dst) const {
 
-    assert(level>0 and level<=(int)_refiner._refinements.size());
+    assert(level>0 && level<=(int)_refiner._refinements.size());
 
     switch (_refiner._subdivType) {
     case Sdc::SCHEME_CATMARK:
@@ -290,7 +290,7 @@ template <class T, class U>
 inline void
 PrimvarRefiner::InterpolateFaceVarying(int level, T const & src, U & dst, int channel) const {
 
-    assert(level>0 and level<=(int)_refiner._refinements.size());
+    assert(level>0 && level<=(int)_refiner._refinements.size());
 
     switch (_refiner._subdivType) {
     case Sdc::SCHEME_CATMARK:
@@ -387,7 +387,7 @@ template <class T, class U>
 inline void
 PrimvarRefiner::InterpolateFaceUniform(int level, T const & src, U & dst) const {
 
-    assert(level>0 and level<=(int)_refiner._refinements.size());
+    assert(level>0 && level<=(int)_refiner._refinements.size());
 
     Vtr::internal::Refinement const & refinement = _refiner.getRefinement(level-1);
     Vtr::internal::Level const & child = refinement.child();
@@ -404,7 +404,7 @@ template <class T, class U>
 inline void
 PrimvarRefiner::InterpolateVarying(int level, T const & src, U & dst) const {
 
-    assert(level>0 and level<=(int)_refiner._refinements.size());
+    assert(level>0 && level<=(int)_refiner._refinements.size());
 
     Vtr::internal::Refinement const & refinement = _refiner.getRefinement(level-1);
     Vtr::internal::Level const &      parent     = refinement.parent();

--- a/opensubdiv/far/ptexIndices.cpp
+++ b/opensubdiv/far/ptexIndices.cpp
@@ -150,7 +150,7 @@ PtexIndices::GetAdjacency(
         //  o----------o----------o
         // v0                     v1
         */
-        assert(quadrant>=0 and quadrant<fedges.size());
+        assert(quadrant>=0 && quadrant<fedges.size());
 
         int nextQuadrant = (quadrant+1) % fedges.size(),
             prevQuadrant = (quadrant+fedges.size()-1) % fedges.size();

--- a/opensubdiv/far/stencilBuilder.cpp
+++ b/opensubdiv/far/stencilBuilder.cpp
@@ -239,7 +239,7 @@ private:
         //
         // Additionally, if the client does not want the resulting verts
         // compacted, do not attempt to combine weights.
-        if (_compactWeights and !_dests.empty() and _dests[lastOffset] == dst) {
+        if (_compactWeights && !_dests.empty() && _dests[lastOffset] == dst) {
 
             // tableSize is exactly _sources.size(), but using tableSize is
             // significantly faster.
@@ -267,7 +267,7 @@ private:
         // a way that the current stencil being built is always at the end of
         // the array, so if the dests array is empty or back() doesn't match
         // dst, then we just started building a new stencil.
-        if (_dests.empty() or dst != _dests.back()) {
+        if (_dests.empty() || dst != _dests.back()) {
             // _indices and _sizes always have num(stencils) elements so that
             // stencils can be directly looked up by their index in these
             // arrays. So here, ensure that they are large enough to hold the
@@ -426,7 +426,7 @@ void
 StencilBuilder::Index::AddWithWeight(Stencil const& src,
                                      float weight, float du, float dv)
 {
-    if (isWeightZero(weight) and isWeightZero(du) and isWeightZero(dv)) {
+    if (isWeightZero(weight) && isWeightZero(du) && isWeightZero(dv)) {
         return;
     }
 

--- a/opensubdiv/far/stencilTable.cpp
+++ b/opensubdiv/far/stencilTable.cpp
@@ -69,7 +69,7 @@ namespace {
         for ( size_t i=start; i<offsets->size(); i++ ) {
             // Once we've copied out all the control verts, jump to the offset
             // where the actual stencils begin.
-            if (includeCoarseVerts and (int)i == numControlVerts)
+            if (includeCoarseVerts && (int)i == numControlVerts)
                 i = firstOffset;
 
             // Copy the stencil.

--- a/opensubdiv/far/stencilTable.h
+++ b/opensubdiv/far/stencilTable.h
@@ -422,7 +422,7 @@ StencilTable::reserve(int nstencils, int nelems) {
 // Returns a Stencil at index i in the table
 inline Stencil
 StencilTable::GetStencil(Index i) const {
-    assert((not _offsets.empty()) and i<(int)_offsets.size());
+    assert((! _offsets.empty()) && i<(int)_offsets.size());
 
     Index ofs = _offsets[i];
 
@@ -446,7 +446,7 @@ LimitStencilTable::resize(int nstencils, int nelems) {
 // Returns a LimitStencil at index i in the table
 inline LimitStencil
 LimitStencilTable::GetLimitStencil(Index i) const {
-    assert((not GetOffsets().empty()) and i<(int)GetOffsets().size());
+    assert((! GetOffsets().empty()) && i<(int)GetOffsets().size());
 
     Index ofs = GetOffsets()[i];
 

--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -76,7 +76,7 @@ StencilTableFactory::Create(TopologyRefiner const & refiner,
     Options options) {
 
     int maxlevel = std::min(int(options.maxLevel), refiner.GetMaxLevel());
-    if (maxlevel==0 and (not options.generateControlVerts)) {
+    if (maxlevel==0 && (! options.generateControlVerts)) {
         StencilTable * result = new StencilTable;
         result->_numControlVertices = refiner.GetLevel(0).GetNumVertices();
         return result;
@@ -98,7 +98,7 @@ StencilTableFactory::Create(TopologyRefiner const & refiner,
                                     refiner.GetLevel(0).GetNumVertices());
 
     for (int level=1; level<=maxlevel; ++level) {
-        if (not interpolateVarying) {
+        if (! interpolateVarying) {
             primvarRefiner.Interpolate(level, srcIndex, dstIndex);
         } else {
             primvarRefiner.InterpolateVarying(level, srcIndex, dstIndex);
@@ -110,7 +110,7 @@ StencilTableFactory::Create(TopologyRefiner const & refiner,
 
         dstIndex = dstIndex[refiner.GetLevel(level).GetNumVertices()];
 
-        if (not options.factorizeIntermediateLevels) {
+        if (! options.factorizeIntermediateLevels) {
             // All previous verts are considered as coarse verts, as a
             // result, we don't update the srcIndex and update the coarse
             // vertex count.
@@ -119,7 +119,7 @@ StencilTableFactory::Create(TopologyRefiner const & refiner,
     }
 
     size_t firstOffset = refiner.GetLevel(0).GetNumVertices();
-    if (not options.generateIntermediateLevels)
+    if (! options.generateIntermediateLevels)
         firstOffset = srcIndex.GetOffset();
  
     // Copy stencils from the StencilBuilder into the StencilTable.
@@ -146,7 +146,7 @@ StencilTableFactory::Create(int numTables, StencilTable const ** tables) {
     // other Create() API returns an empty stencil instead of NULL.
     // They need to be consistent.
 
-    if ( (numTables<=0) or (not tables)) {
+    if ( (numTables<=0) || (! tables)) {
         return NULL;
     }
 
@@ -160,7 +160,7 @@ StencilTableFactory::Create(int numTables, StencilTable const ** tables) {
         // allow the tables could have a null entry.
         if (!st) continue;
 
-        if (ncvs >= 0 and st->GetNumControlVertices() != ncvs) {
+        if (ncvs >= 0 && st->GetNumControlVertices() != ncvs) {
             return NULL;
         }
         ncvs = st->GetNumControlVertices();
@@ -211,8 +211,8 @@ StencilTableFactory::AppendLocalPointStencilTable(
     bool factorize) {
 
     // factorize and append.
-    if (baseStencilTable == NULL or
-        localPointStencilTable == NULL or
+    if (baseStencilTable == NULL ||
+        localPointStencilTable == NULL ||
         localPointStencilTable->GetNumStencils() == 0) return NULL;
 
     // baseStencilTable can be built with or without singular stencils
@@ -360,7 +360,7 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
     int maxlevel = refiner.GetMaxLevel();
 
     StencilTable const * cvstencils = cvStencilsIn;
-    if (not cvstencils) {
+    if (! cvstencils) {
         // Generate stencils for the control vertices - this is necessary to
         // properly factorize patches with control vertices at level 0 (natural
         // regular patches, such as in a torus)
@@ -390,7 +390,7 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
     // If a stencil table was given, use it, otherwise, create a new one
     PatchTable const * patchtable = patchTableIn;
 
-    if (not patchtable) {
+    if (! patchtable) {
         // XXXX (manuelk) If no patch-table was passed, we should be able to
         // infer the patches fairly easily from the refiner. Once more tags
         // have been added to the refiner, maybe we can remove the need for the
@@ -402,7 +402,7 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
 
         patchtable = PatchTableFactory::Create(refiner, options);
 
-        if (not cvStencilsIn) {
+        if (! cvStencilsIn) {
             // if cvstencils is just created above, append endcap stencils
             if (StencilTable const *localPointStencilTable =
                 patchtable->GetLocalPointStencilTable()) {
@@ -416,15 +416,15 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
     } else {
         // Sanity checks
         if (patchtable->IsFeatureAdaptive()==uniform) {
-            if (not cvStencilsIn) {
-                assert(cvstencils and cvstencils!=cvStencilsIn);
+            if (! cvStencilsIn) {
+                assert(cvstencils && cvstencils!=cvStencilsIn);
                 delete cvstencils;
             }
             return 0;
         }
     }
 
-    assert(patchtable and cvstencils);
+    assert(patchtable && cvstencils);
 
     // Create a patch-map to locate sub-patches faster
     PatchMap patchmap( *patchtable );
@@ -469,11 +469,11 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
         }
     }
 
-    if (not cvStencilsIn) {
+    if (! cvStencilsIn) {
         delete cvstencils;
     }
 
-    if (not patchTableIn) {
+    if (! patchTableIn) {
         delete patchtable;
     }
 

--- a/opensubdiv/far/topologyDescriptor.cpp
+++ b/opensubdiv/far/topologyDescriptor.cpp
@@ -95,7 +95,7 @@ bool
 TopologyRefinerFactory<TopologyDescriptor>::assignComponentTags(
     TopologyRefiner & refiner, TopologyDescriptor const & desc) {
 
-    if ((desc.numCreases>0) and desc.creaseVertexIndexPairs and desc.creaseWeights) {
+    if ((desc.numCreases>0) && desc.creaseVertexIndexPairs && desc.creaseWeights) {
 
         int const * vertIndexPairs = desc.creaseVertexIndexPairs;
         for (int edge=0; edge<desc.numCreases; ++edge, vertIndexPairs+=2) {
@@ -113,13 +113,13 @@ TopologyRefinerFactory<TopologyDescriptor>::assignComponentTags(
         }
     }
 
-    if ((desc.numCorners>0) and desc.cornerVertexIndices and desc.cornerWeights) {
+    if ((desc.numCorners>0) && desc.cornerVertexIndices && desc.cornerWeights) {
 
         for (int vert=0; vert<desc.numCorners; ++vert) {
 
             int idx = desc.cornerVertexIndices[vert];
 
-            if (idx >= 0 and idx < getNumBaseVertices(refiner)) {
+            if (idx >= 0 && idx < getNumBaseVertices(refiner)) {
                 setBaseVertexSharpness(refiner, idx, desc.cornerWeights[vert]);
             } else {
                 char msg[1024];

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -360,7 +360,7 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
         considerFVarChannels = false;
 
         for (int channel = 0; channel < numFVarChannels; ++channel) {
-            if (not level.getFVarLevel(channel).isLinear()) {
+            if (! level.getFVarLevel(channel).isLinear()) {
                 considerFVarChannels = true;
                 break;
             }
@@ -425,7 +425,7 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
         } else if (compFaceVTag._rule & Sdc::Crease::RULE_DART) {
             //  Any occurrence of a Dart vertex requires isolation
             selectFace = true;
-        } else if (not (compFaceVTag._rule & Sdc::Crease::RULE_SMOOTH)) {
+        } else if (! (compFaceVTag._rule & Sdc::Crease::RULE_SMOOTH)) {
             //  None of the vertices is Smooth, so we have all vertices either Crease or Corner.
             //  Though some may be regular patches, this currently warrants isolation as we only
             //  support regular patches with one corner or one boundary, i.e. with one or more
@@ -435,12 +435,12 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
             //  Any semi-sharp feature at or around the vertex warrants isolation -- unless we
             //  optimize for the single-crease patch, i.e. only edge sharpness of a constant value
             //  along the entire regular patch boundary (quickly exclude the Corner case first):
-            if (considerSingleCreasePatch && not (compFaceVTag._rule & Sdc::Crease::RULE_CORNER)) {
-                selectFace = not level.isSingleCreasePatch(face);
+            if (considerSingleCreasePatch && ! (compFaceVTag._rule & Sdc::Crease::RULE_CORNER)) {
+                selectFace = ! level.isSingleCreasePatch(face);
             } else {
                 selectFace = true;
             }
-        } else if (not compFaceVTag._boundary) {
+        } else if (! compFaceVTag._boundary) {
             //  At this point we are left with a mix of smooth and inf-sharp features.  If not
             //  on a boundary, the interior inf-sharp features need isolation -- unless we are
             //  again optimizing for the single-crease patch, infinitely sharp in this case.
@@ -449,12 +449,12 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
             //  is kept separate for the inf-sharp case:  a separate and much more efficient
             //  test can be made for the inf-sharp case, and there are other opportunities here
             //  to optimize for regular patches at infinitely sharp corners.
-            if (considerSingleCreasePatch && not (compFaceVTag._rule & Sdc::Crease::RULE_CORNER)) {
-                selectFace = not level.isSingleCreasePatch(face);
+            if (considerSingleCreasePatch && ! (compFaceVTag._rule & Sdc::Crease::RULE_CORNER)) {
+                selectFace = ! level.isSingleCreasePatch(face);
             } else {
                 selectFace = true;
             }
-        } else if (not (compFaceVTag._rule & Sdc::Crease::RULE_CORNER)) {
+        } else if (! (compFaceVTag._rule & Sdc::Crease::RULE_CORNER)) {
             //  We are now left with boundary faces -- if no Corner vertex, we have a mix of both
             //  regular Smooth and Crease vertices on a boundary face, which can only be a regular
             //  boundary patch, so don't isolate.
@@ -462,7 +462,7 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
         } else {
             //  The last case with at least one Corner vertex and one Smooth (interior) vertex --
             //  distinguish the regular corner case from others:
-            if (not compFaceVTag._corner) {
+            if (! compFaceVTag._corner) {
                 //  We may consider interior sharp corners as regular in future, but for now we
                 //  only accept a topological corner for the regular corner case:
                 selectFace = true;
@@ -485,8 +485,8 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
         //  If still not selected, inspect the face-varying channels (when present) for similar
         //  irregular features requiring isolation:
         //
-        if (not selectFace and considerFVarChannels) {
-            for (int channel = 0; not selectFace && (channel < numFVarChannels); ++channel) {
+        if (! selectFace && considerFVarChannels) {
+            for (int channel = 0; ! selectFace && (channel < numFVarChannels); ++channel) {
                 Vtr::internal::FVarLevel const & fvarLevel = level.getFVarLevel(channel);
 
                 //
@@ -501,7 +501,7 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
                         fvarLevel.getFaceCompositeValueTag(faceValues, faceVerts);
 
                 //  No mismatch in topology -> no need to further isolate...
-                if (not compFVarFaceTag._mismatch) continue;
+                if (! compFVarFaceTag._mismatch) continue;
 
                 if (compFVarFaceTag._xordinary) {
                     //  An xordinary boundary value always requires isolation:
@@ -514,10 +514,10 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
                     Vtr::internal::Level::VTag compFVarVTag =
                             fvarLevel.getFaceCompositeValueAndVTag(faceValues, faceVerts, fvarVTags);
 
-                    if (not (compFVarVTag._rule & Sdc::Crease::RULE_SMOOTH)) {
+                    if (! (compFVarVTag._rule & Sdc::Crease::RULE_SMOOTH)) {
                         //  No Smooth corners so too many boundaries/corners -- need to isolate:
                         selectFace = true;
-                    } else if (not (compFVarVTag._rule & Sdc::Crease::RULE_CORNER)) {
+                    } else if (! (compFVarVTag._rule & Sdc::Crease::RULE_CORNER)) {
                         //  A mix of Smooth and Crease corners -- must be regular so don't isolate:
                         selectFace = false;
                     } else {
@@ -537,7 +537,7 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
                         //  (the topological corner tag catches this above).  Verify that the corner
                         //  vertex is opposite the smooth vertex (and consider doing this above)...
                         //
-                        if (not selectFace && (level.getDepth() == 0)) {
+                        if (! selectFace && (level.getDepth() == 0)) {
                             if (fvarVTags[0]._infSharp && fvarVTags[2]._boundary) selectFace = true;
                             if (fvarVTags[1]._infSharp && fvarVTags[3]._boundary) selectFace = true;
                             if (fvarVTags[2]._infSharp && fvarVTags[0]._boundary) selectFace = true;

--- a/opensubdiv/far/topologyRefinerFactory.cpp
+++ b/opensubdiv/far/topologyRefinerFactory.cpp
@@ -125,7 +125,7 @@ TopologyRefinerFactoryBase::prepareComponentTopologyAssignment(TopologyRefiner& 
 
     bool completeMissingTopology = (baseLevel.getNumEdges() == 0);
     if (completeMissingTopology) {
-        if (not baseLevel.completeTopologyFromFaceVertices()) {
+        if (! baseLevel.completeTopologyFromFaceVertices()) {
             char msg[1024];
             snprintf(msg, 1024, "Failure in TopologyRefinerFactory<>::Create() -- "
                     "vertex with valence %d > %d max.",
@@ -142,7 +142,7 @@ TopologyRefinerFactoryBase::prepareComponentTopologyAssignment(TopologyRefiner& 
     }
 
     if (fullValidation) {
-        if (not baseLevel.validateTopology(callback, callbackData)) {
+        if (! baseLevel.validateTopology(callback, callbackData)) {
             if (completeMissingTopology) {
                 Error(FAR_RUNTIME_ERROR, "Failure in TopologyRefinerFactory<>::Create() -- "
                     "invalid topology detected from partial specification.");
@@ -240,7 +240,7 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
             //  more than two incident faces.  In these cases there are more incident
             //  faces than edges (1 more for each additional "fin") and no boundaries.
             //
-            if (not ((nonManifoldEdgeCount == 2) && (boundaryEdgeCount == 0) && (vFaces.size() > vEdges.size()))) {
+            if (! ((nonManifoldEdgeCount == 2) && (boundaryEdgeCount == 0) && (vFaces.size() > vEdges.size()))) {
                 vSharpness = Sdc::Crease::SHARPNESS_INFINITE;
             }
         }

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -319,7 +319,7 @@ TopologyRefinerFactory<MESH>::Create(MESH const& mesh, Options options) {
 
     TopologyRefiner * refiner = new TopologyRefiner(options.schemeType, options.schemeOptions);
 
-    if (not populateBaseLevel(*refiner, mesh, options)) {
+    if (! populateBaseLevel(*refiner, mesh, options)) {
         delete refiner;
         return 0;
     }
@@ -349,8 +349,8 @@ TopologyRefinerFactory<MESH>::populateBaseLevel(TopologyRefiner& refiner, MESH c
     //  an inventory of all components and their relations that is used to allocate buffers
     //  to be efficiently populated in the subsequent topology assignment step.
     //
-    if (not resizeComponentTopology(refiner, mesh)) return false;
-    if (not prepareComponentTopologySizing(refiner)) return false;
+    if (! resizeComponentTopology(refiner, mesh)) return false;
+    if (! prepareComponentTopologySizing(refiner)) return false;
 
     //
     //  Assignment of the topology -- this is a required specialization for MESH.  If edges
@@ -361,21 +361,21 @@ TopologyRefinerFactory<MESH>::populateBaseLevel(TopologyRefiner& refiner, MESH c
     TopologyCallback callback = reinterpret_cast<TopologyCallback>(reportInvalidTopology);
     void const *     userData = &mesh;
         
-    if (not assignComponentTopology(refiner, mesh)) return false;
-    if (not prepareComponentTopologyAssignment(refiner, validate, callback, userData)) return false;
+    if (! assignComponentTopology(refiner, mesh)) return false;
+    if (! prepareComponentTopologyAssignment(refiner, validate, callback, userData)) return false;
 
     //
     //  User assigned and internal tagging of components -- an optional specialization for
     //  MESH.  Allows the specification of sharpness values, holes, etc.
     //
-    if (not assignComponentTags(refiner, mesh)) return false;
-    if (not prepareComponentTagsAndSharpness(refiner)) return false;
+    if (! assignComponentTags(refiner, mesh)) return false;
+    if (! prepareComponentTagsAndSharpness(refiner)) return false;
 
     //
     //  Defining channels of face-varying primvar data -- an optional specialization for MESH.
     //
-    if (not assignFaceVaryingTopology(refiner, mesh)) return false;
-    if (not prepareFaceVaryingChannels(refiner)) return false;
+    if (! assignFaceVaryingTopology(refiner, mesh)) return false;
+    if (! prepareFaceVaryingChannels(refiner)) return false;
 
     return true;
 }

--- a/opensubdiv/osd/bufferDescriptor.h
+++ b/opensubdiv/osd/bufferDescriptor.h
@@ -84,8 +84,8 @@ struct BufferDescriptor {
 
     /// True if the descriptors are identical
     bool operator == (BufferDescriptor const &other) const {
-        return (offset == other.offset and
-                length == other.length and
+        return (offset == other.offset &&
+                length == other.length &&
                 stride == other.stride);
     }
 

--- a/opensubdiv/osd/cpuKernel.cpp
+++ b/opensubdiv/osd/cpuKernel.cpp
@@ -52,7 +52,7 @@ static inline void
 addWithWeight(float *dst, const float *src, int srcIndex, float weight,
               BufferDescriptor const &desc) {
 
-    assert(src and dst);
+    assert(src && dst);
     src = elementAtIndex(src, srcIndex, desc);
     for (int k = 0; k < desc.length; ++k) {
         dst[k] += src[k] * weight;
@@ -62,7 +62,7 @@ addWithWeight(float *dst, const float *src, int srcIndex, float weight,
 static inline void
 copy(float *dst, int dstIndex, const float *src, BufferDescriptor const &desc) {
 
-    assert(src and dst);
+    assert(src && dst);
 
     dst = elementAtIndex(dst, dstIndex, desc);
     memcpy(dst, src, desc.length*sizeof(float));
@@ -77,7 +77,7 @@ CpuEvalStencils(float const * src, BufferDescriptor const &srcDesc,
                 float const * weights,
                 int start, int end) {
 
-    assert(start>=0 and start<end);
+    assert(start>=0 && start<end);
 
     if (start>0) {
         sizes += start;
@@ -88,15 +88,15 @@ CpuEvalStencils(float const * src, BufferDescriptor const &srcDesc,
     src += srcDesc.offset;
     dst += dstDesc.offset;
 
-    if (srcDesc.length == 4 and dstDesc.length == 4 and
-        srcDesc.stride == 4 and dstDesc.stride == 4) {
+    if (srcDesc.length == 4 && dstDesc.length == 4 &&
+        srcDesc.stride == 4 && dstDesc.stride == 4) {
 
         // SIMD fast path for aligned primvar data (4 floats)
         ComputeStencilKernel<4>(src, dst,
             sizes, indices, weights, start,  end);
 
-    } else if (srcDesc.length == 8 and dstDesc.length == 8 and
-               srcDesc.stride == 8 and dstDesc.stride == 8) {
+    } else if (srcDesc.length == 8 && dstDesc.length == 8 &&
+               srcDesc.stride == 8 && dstDesc.stride == 8) {
 
         // SIMD fast path for aligned primvar data (8 floats)
         ComputeStencilKernel<8>(src, dst,

--- a/opensubdiv/osd/cpuKernel.h
+++ b/opensubdiv/osd/cpuKernel.h
@@ -61,7 +61,7 @@ CpuEvalStencils(float const * src, BufferDescriptor const &srcDesc,
 // SIMD ICC optimization of the stencil kernel
 //
 
-#if defined ( __INTEL_COMPILER ) or defined ( __ICC )
+#if defined ( __INTEL_COMPILER ) || defined ( __ICC )
     #define __ALIGN_DATA __declspec(align(32))
 #else
     #define __ALIGN_DATA
@@ -86,7 +86,7 @@ ComputeStencilKernel(float const * vertexSrc,
     for (int i=start; i<end; ++i) {
 
         // Clear
-#if defined ( __INTEL_COMPILER ) or defined ( __ICC )
+#if defined ( __INTEL_COMPILER ) || defined ( __ICC )
     #pragma simd
     #pragma vector aligned
 #endif
@@ -99,7 +99,7 @@ ComputeStencilKernel(float const * vertexSrc,
             weight = *weights;
 
             // AddWithWeight
-#if defined ( __INTEL_COMPILER ) or defined ( __ICC )
+#if defined ( __INTEL_COMPILER ) || defined ( __ICC )
     #pragma simd
     #pragma vector aligned
 #endif
@@ -108,7 +108,7 @@ ComputeStencilKernel(float const * vertexSrc,
             }
         }
 
-#if defined ( __INTEL_COMPILER ) or defined ( __ICC )
+#if defined ( __INTEL_COMPILER ) || defined ( __ICC )
     #pragma simd
     #pragma vector aligned
 #endif

--- a/opensubdiv/osd/d3d11LegacyGregoryPatchTable.cpp
+++ b/opensubdiv/osd/d3d11LegacyGregoryPatchTable.cpp
@@ -59,7 +59,7 @@ D3D11LegacyGregoryPatchTable::Create(Far::PatchTable const *farPatchTable,
     Far::PatchTable::QuadOffsetsTable const &
         quadOffsetsTable = farPatchTable->GetQuadOffsetsTable();
 
-    if (not valenceTable.empty()) {
+    if (! valenceTable.empty()) {
         D3D11_BUFFER_DESC bd;
         bd.ByteWidth = UINT(valenceTable.size() * sizeof(unsigned int));
         bd.Usage = D3D11_USAGE_DEFAULT;
@@ -91,7 +91,7 @@ D3D11LegacyGregoryPatchTable::Create(Far::PatchTable const *farPatchTable,
         }
     }
 
-    if (not quadOffsetsTable.empty()) {
+    if (! quadOffsetsTable.empty()) {
         D3D11_BUFFER_DESC bd;
         bd.ByteWidth = UINT(quadOffsetsTable.size() * sizeof(unsigned int));
         bd.Usage = D3D11_USAGE_DEFAULT;

--- a/opensubdiv/sdc/catmarkScheme.h
+++ b/opensubdiv/sdc/catmarkScheme.h
@@ -104,7 +104,7 @@ Scheme<SCHEME_CATMARK>::assignSmoothMaskForEdge(EDGE const& edge, MASK& mask) co
         }
     }
 
-    if (not useTriangleOption) {
+    if (! useTriangleOption) {
         mask.VertexWeight(0) = 0.25f;
         mask.VertexWeight(1) = 0.25f;
 

--- a/opensubdiv/tools/stringify/main.cpp
+++ b/opensubdiv/tools/stringify/main.cpp
@@ -41,13 +41,13 @@ std::string stringify( std::string const & line ) {
             inconstant = inconstant ? false : true;
         }
 
-        if (line[i]=='\\' and line[i+1]=='\0') {
+        if (line[i]=='\\' && line[i+1]=='\0') {
             s << "\"";
             return s.str();
         }
 
         // escape backslash
-        if (inconstant and line[i]=='\\')
+        if (inconstant && line[i]=='\\')
            s << '\\' ;
 
         s << line[i];
@@ -67,21 +67,21 @@ int main(int argc, char **argv) {
 
     std::ifstream input;
     input.open(argv[1]);
-    if (not input.is_open()) {
+    if (! input.is_open()) {
         std::cerr << "Can not read from: " << argv[1] << std::endl;
         return 1;
     }
 
     std::ofstream output;
     output.open(argv[2]);
-    if (not output.is_open()) {
+    if (! output.is_open()) {
         std::cerr << "Can not write to: " << argv[2] << std::endl;
         return 1;
     }
 
     std::string line;
 
-    while (not input.eof()) {
+    while (! input.eof()) {
         std::getline(input, line);
         output << "\"" << stringify(line) << std::endl;
     }

--- a/opensubdiv/vtr/fvarLevel.cpp
+++ b/opensubdiv/vtr/fvarLevel.cpp
@@ -861,7 +861,7 @@ FVarLevel::getVertexEdgeValues(Index vIndex, Index valuesPerEdge[]) const {
     ConstLocalIndexArray vInFace = _level.getVertexFaceLocalIndices(vIndex);
 
     bool vIsBoundary = _level.getVertexTag(vIndex)._boundary;
-    bool vIsManifold = not _level.getVertexTag(vIndex)._nonManifold;
+    bool vIsManifold = ! _level.getVertexTag(vIndex)._nonManifold;
 
     bool isBaseLevel = (_level.getDepth() == 0);
 

--- a/opensubdiv/vtr/fvarLevel.h
+++ b/opensubdiv/vtr/fvarLevel.h
@@ -167,7 +167,7 @@ public:
 
     bool isLinear() const            { return _isLinear; }
     bool hasLinearBoundaries() const { return _hasLinearBoundaries; }
-    bool hasSmoothBoundaries() const { return not _hasLinearBoundaries; }
+    bool hasSmoothBoundaries() const { return ! _hasLinearBoundaries; }
 
     Sdc::Options getOptions() const { return _options; }
 

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -1305,7 +1305,7 @@ Level::isSingleCreasePatch(Index face, float *sharpnessOut, int *rotationOut) co
             }
         }
         // sharpnesses have to be [0, x, 0, x] or [x, 0, x, 0]
-        if (!isSharpnessEqual(sharpnesses[0], sharpnesses[2]) or
+        if (!isSharpnessEqual(sharpnesses[0], sharpnesses[2]) ||
             !isSharpnessEqual(sharpnesses[1], sharpnesses[3])) {
             return false;
         }

--- a/opensubdiv/vtr/refinement.cpp
+++ b/opensubdiv/vtr/refinement.cpp
@@ -907,7 +907,7 @@ Refinement::subdivideEdgeSharpness() {
                 cSharpness = creasing.SubdivideEdgeSharpnessAtVertex(pSharpness, pVertEdges.size(),
                                                                          pVertEdgeSharpness);
             }
-            if (not Sdc::Crease::IsSharp(cSharpness)) {
+            if (! Sdc::Crease::IsSharp(cSharpness)) {
                 cEdgeTag._semiSharp = false;
             }
         }
@@ -941,7 +941,7 @@ Refinement::subdivideVertexSharpness() {
             float pSharpness = _parent->_vertSharpness[pVert];
 
             cSharpness = creasing.SubdivideVertexSharpness(pSharpness);
-            if (not Sdc::Crease::IsSharp(cSharpness)) {
+            if (! Sdc::Crease::IsSharp(cSharpness)) {
                 cVertTag._semiSharp = false;
             }
         }

--- a/opensubdiv/vtr/refinement.h
+++ b/opensubdiv/vtr/refinement.h
@@ -150,7 +150,7 @@ public:
     ConstIndexArray  getEdgeChildEdges(Index parentEdge) const;
 
     //  Child-to-parent relationships
-    bool isChildVertexComplete(Index v) const       { return not _childVertexTag[v]._incomplete; }
+    bool isChildVertexComplete(Index v) const       { return ! _childVertexTag[v]._incomplete; }
 
     Index getChildFaceParentFace(Index f) const     { return _childFaceParentIndex[f]; }
     int   getChildFaceInParentFace(Index f) const   { return _childFaceTag[f]._indexInParent; }

--- a/regression/common/cmp_utils.h
+++ b/regression/common/cmp_utils.h
@@ -95,7 +95,7 @@ GetReorderedHbrVertexData(
                                   * v1 = hmesh.GetVertex(farVerts[1]);
 
                     Hhalfedge * e = v0->GetEdge(v1);
-                    if (not e) {
+                    if (! e) {
                         e = v1->GetEdge(v0);
                     }
                     assert(e);
@@ -164,10 +164,10 @@ GetReorderedHbrVertexData(
 
                     Hvertex const * v0 = current.verts[farVerts[0]],
                                   * v1 = current.verts[farVerts[1]];
-                    assert(v0 and v1);
+                    assert(v0 && v1);
 
                     Hhalfedge * e= v0->GetEdge(v1);
-                    if (not e) {
+                    if (! e) {
                         e = v1->GetEdge(v0);
                     }
                     assert(e);

--- a/regression/common/far_utils.cpp
+++ b/regression/common/far_utils.cpp
@@ -49,7 +49,7 @@ InterpolateFVarData(OpenSubdiv::Far::TopologyRefiner & refiner,
         numValuesM = refiner.GetLevel(maxlevel).GetNumFVarValues(channel),
         numValuesTotal = refiner.GetNumFVarValuesTotal(channel);
 
-    if (shape.uvs.empty() or numValuesTotal<=0) {
+    if (shape.uvs.empty() || numValuesTotal<=0) {
         return;
     }
 

--- a/regression/common/far_utils.h
+++ b/regression/common/far_utils.h
@@ -242,7 +242,7 @@ TopologyRefinerFactory<Shape>::assignFaceVaryingTopology(
     Far::TopologyRefiner & refiner, Shape const & shape) {
 
     // UV layyout (we only parse 1 channel)
-    if (not shape.faceuvs.empty()) {
+    if (! shape.faceuvs.empty()) {
 
         int nfaces = getNumBaseFaces(refiner),
            channel = createBaseFVarChannel(refiner, (int)shape.uvs.size()/2 );
@@ -295,7 +295,7 @@ TopologyRefinerFactory<Shape>::assignComponentTags(
 
             for (int j=0; j<(int)t->intargs.size(); ++j) {
                 int vertex = t->intargs[j];
-                if (vertex<0 or vertex>=getNumBaseVertices(refiner)) {
+                if (vertex<0 || vertex>=getNumBaseVertices(refiner)) {
                     printf("cannot find vertex for corner tag (%d)\n", vertex );
                     return false;
                 } else {

--- a/regression/common/hbr_utils.h
+++ b/regression/common/hbr_utils.h
@@ -113,7 +113,7 @@ void applyTags( OpenSubdiv::HbrMesh<T> * mesh, Shape const * sh ) {
             OpenSubdiv::HbrCatmarkSubdivision<T> * scheme =
                 dynamic_cast<OpenSubdiv::HbrCatmarkSubdivision<T> *>( mesh->GetSubdivision() );
 
-            if (not scheme) {
+            if (! scheme) {
                 printf("the \"smoothtriangles\" tag can only be applied to Catmark meshes\n");
                 continue;
             }
@@ -152,7 +152,7 @@ void applyTags( OpenSubdiv::HbrMesh<T> * mesh, Shape const * sh ) {
             else
                 printf("the \"creasemethod\" tag only accepts \"normal\" or \"chaikin\" as value (%s)\n", t->stringargs[0].c_str());
 
-        } else if (t->name=="vertexedit" or t->name=="edgeedit") {
+        } else if (t->name=="vertexedit" || t->name=="edgeedit") {
             int nops = 0;
             int floatstride = 0;
             int maxfloatwidth = 0;
@@ -468,7 +468,7 @@ createTopology( Shape const * sh, OpenSubdiv::HbrMesh<T> * mesh, Scheme scheme) 
 
         int nv = sh->nvertsPerFace[f];
 
-        if ((scheme==kLoop) and (nv!=3)) {
+        if ((scheme==kLoop) && (nv!=3)) {
             printf("Trying to create a Loop subd with non-triangle face\n");
             exit(1);
         }
@@ -512,7 +512,7 @@ createTopology( Shape const * sh, OpenSubdiv::HbrMesh<T> * mesh, Scheme scheme) 
 
             face->SetPtexIndex(ptxidx);
 
-            if ( (scheme==kCatmark or scheme==kBilinear) and nv != 4 ) {
+            if ( (scheme==kCatmark || scheme==kBilinear) && nv != 4 ) {
                 ptxidx+=nv;
             } else {
                 ptxidx++;
@@ -549,7 +549,7 @@ createTopology( Shape const * sh, OpenSubdiv::HbrMesh<T> * mesh, Scheme scheme) 
 template <class T> void
 createFaceVaryingUV( Shape const * sh, OpenSubdiv::HbrMesh<T> * mesh) {
 
-    if (not sh->HasUV())
+    if (! sh->HasUV())
         return;
 
     for (int i=0, idx=0; i<sh->GetNumFaces(); ++i ) {
@@ -566,9 +566,9 @@ createFaceVaryingUV( Shape const * sh, OpenSubdiv::HbrMesh<T> * mesh) {
 
             float const * fvdata = &sh->uvs[ sh->faceuvs[idx++]*2 ];
 
-            if (not fvt.IsInitialized()) {
+            if (! fvt.IsInitialized()) {
                 fvt.SetAllData(2, fvdata);
-            } else if (not fvt.CompareAll(2, fvdata)) {
+            } else if (! fvt.CompareAll(2, fvdata)) {
                 OpenSubdiv::HbrFVarData<T> & nfvt = e->GetOrgVertex()->NewFVarData(f);
                 nfvt.SetAllData(2, fvdata);
             }
@@ -582,7 +582,7 @@ simpleHbr(char const * Shapestr, Scheme scheme, std::vector<float> * verts=0, bo
 
     Shape * sh = Shape::parseObj( Shapestr, scheme );
 
-    int fvarwidth = fvar and sh->HasUV() ? 2 : 0;
+    int fvarwidth = fvar && sh->HasUV() ? 2 : 0;
 
     OpenSubdiv::HbrMesh<T> * mesh = createMesh<T>(scheme, fvarwidth);
 
@@ -607,7 +607,7 @@ simpleHbr(char const * Shapestr, Scheme scheme, std::vector<float> & verts, bool
 
     Shape * sh = Shape::parseObj( Shapestr, scheme );
 
-    int fvarwidth = fvar and sh->HasUV() ? 2 : 0;
+    int fvarwidth = fvar && sh->HasUV() ? 2 : 0;
 
     OpenSubdiv::HbrMesh<T> * mesh = createMesh<T>(scheme, fvarwidth);
 
@@ -641,7 +641,7 @@ interpolateHbrVertexData(char const * Shapestr, Scheme scheme, int maxlevel) {
 
             OpenSubdiv::HbrFace<T> * f = hmesh->GetFace(i);
             assert(f->GetDepth()==level);
-            if (not f->IsHole()) {
+            if (! f->IsHole()) {
                 f->Refine();
             }
         }
@@ -660,7 +660,7 @@ template <class T>
 bool
 hbrVertexOnBoundary(const OpenSubdiv::HbrVertex<T> *v)
 {
-    if (not v)
+    if (! v)
         return false;
 
     if (v->OnBoundary())
@@ -672,7 +672,7 @@ hbrVertexOnBoundary(const OpenSubdiv::HbrVertex<T> *v)
     else {
         OpenSubdiv::HbrHalfedge<T> const * pe = v->GetParentEdge();
         if (pe) {
-              return hbrVertexOnBoundary(pe->GetOrgVertex()) or
+              return hbrVertexOnBoundary(pe->GetOrgVertex()) ||
                      hbrVertexOnBoundary(pe->GetDestVertex());
         } else {
             OpenSubdiv::HbrFace<T> const * pf = v->GetParentFace(), * rootf = pf;

--- a/regression/common/shape_utils.cpp
+++ b/regression/common/shape_utils.cpp
@@ -35,7 +35,7 @@
 //------------------------------------------------------------------------------
 static char const * sgets( char * s, int size, char ** stream ) {
     for (int i=0; i<size; ++i) {
-        if ( (*stream)[i]=='\n' or (*stream)[i]=='\0') {
+        if ( (*stream)[i]=='\n' || (*stream)[i]=='\0') {
 
             memcpy(s, *stream, i);
             s[i]='\0';
@@ -71,7 +71,7 @@ Shape * Shape::parseObj(char const * shapestr, Scheme shapescheme,
 
     char * str=const_cast<char *>(shapestr), line[256], buf[256], usemtl=-1;
     bool done = false;
-    while (not done) {
+    while (! done) {
         done = sgets(line, sizeof(line), &str)==0;
         char* end = &line[strlen(line)-1];
         if (*end == '\n') *end = '\0'; // strip trailing nl
@@ -111,7 +111,7 @@ Shape * Shape::parseObj(char const * shapestr, Scheme shapescheme,
                               while (*cp == ' ') cp++;
                           }
                           s->nvertsPerFace.push_back(nverts);
-                          if (not s->mtls.empty()) {
+                          if (! s->mtls.empty()) {
                               s->mtlbind.push_back(usemtl);
                           }
                       } break;
@@ -120,10 +120,10 @@ Shape * Shape::parseObj(char const * shapestr, Scheme shapescheme,
                            if (t)
                                s->tags.push_back(t);
                        } break;
-            case 'u' : if (parsemtl and sscanf(line, "usemtl %s", buf)==1) {
+            case 'u' : if (parsemtl && sscanf(line, "usemtl %s", buf)==1) {
                            usemtl = s->FindMaterial(buf);
                        } break;
-            case 'm' : if (parsemtl and sscanf(line, "mtllib %s", buf)==1) {
+            case 'm' : if (parsemtl && sscanf(line, "mtllib %s", buf)==1) {
                            std::ifstream ifs(buf);
                            if (ifs) {
                                std::stringstream ss;
@@ -210,7 +210,7 @@ void Shape::parseMtllib(char const * mtlstr) {
 
     bool done = false;
     float r, g, b, a;
-    while (not done) {
+    while (! done) {
         done = sgets(line, sizeof(line), &str)==0;
         char* end = &line[strlen(line)-1];
         if (*end == '\n') *end = '\0'; // strip trailing nl

--- a/regression/common/shape_utils.h
+++ b/regression/common/shape_utils.h
@@ -89,7 +89,7 @@ struct Shape {
 
     int GetNumFaces() const { return (int)nvertsPerFace.size(); }
 
-    bool HasUV() const { return not (uvs.empty() or faceuvs.empty()); }
+    bool HasUV() const { return ! (uvs.empty() || faceuvs.empty()); }
 
     int GetFVarWidth() const { return HasUV() ? 2 : 0; }
 

--- a/regression/far_regression/far_regression.cpp
+++ b/regression/far_regression/far_regression.cpp
@@ -99,8 +99,8 @@ struct xyzVV {
     const float * GetPos() const { return _pos; }
 
     bool operator==(xyzVV const & other) const {
-        if (_pos[0]==other._pos[0] and
-            _pos[1]==other._pos[1] and
+        if (_pos[0]==other._pos[0] &&
+            _pos[1]==other._pos[1] &&
             _pos[2]==other._pos[2]) {
             return true;
         }
@@ -189,7 +189,7 @@ checkMesh(ShapeDesc const & desc, int maxlevel) {
 
         float dist = sqrtf( delta[0]*delta[0]+delta[1]*delta[1]+delta[2]*delta[2]);
         if ( dist > PRECISION ) {
-            if (not g_debugmode)
+            if (! g_debugmode)
                 printf("// HbrVertex<T> %d fails : dist=%.10f (%.10f %.10f %.10f)"
                        " (%.10f %.10f %.10f)\n", i, dist, hbrVert.GetPos()[0],
                                                           hbrVert.GetPos()[1],
@@ -208,7 +208,7 @@ checkMesh(ShapeDesc const & desc, int maxlevel) {
     if (deltaCnt[2])
         deltaAvg[2]/=deltaCnt[2];
 
-    if (not g_debugmode) {
+    if (! g_debugmode) {
         printf("  delta ratio : (%d/%d %d/%d %d/%d)\n", (int)deltaCnt[0], nverts,
                                                         (int)deltaCnt[1], nverts,
                                                         (int)deltaCnt[2], nverts );

--- a/regression/hbr_regression/baseline.cpp
+++ b/regression/hbr_regression/baseline.cpp
@@ -121,8 +121,8 @@ static void generate( char const * shapeStr, char const * name, int levels, Sche
         printf("    writing \"%s\"\n", fname.str().c_str());
 
         FILE * handle = fopen( fname.str().c_str(), "w" );
-        if (not handle) {
-            printf("Could not open \"%s\" - aborting.\n", fname.str().c_str());
+        if (! handle) {
+            printf("Could ! open \"%s\" - aborting.\n", fname.str().c_str());
             exit(0);
         }
 
@@ -194,25 +194,25 @@ static void parseArgs(int argc, char ** argv) {
         usage(argv[0]);
 
     for (int i=1; i<argc; ++i) {
-        if (not strcmp(argv[i],"-shape")) {
+        if (! strcmp(argv[i],"-shape")) {
             if (i<(argc-1))
                 g_shapeindex =  atoi( argv[++i] );
-            if ( g_shapeindex<0 or g_shapeindex>(int)g_shapes.size()) {
+            if ( g_shapeindex<0 || g_shapeindex>(int)g_shapes.size()) {
                 printf("-shape : index must be within [%ld %ld]\n", 0L, (long int)g_shapes.size());
                 exit(0);
             }
-        } else if (not strcmp(argv[i],"-scheme")) {
+        } else if (! strcmp(argv[i],"-scheme")) {
 
             const char * scheme = NULL;
 
             if (i<(argc-1))
                 scheme = argv[++i];
 
-            if (not strcmp(scheme,"bilinear"))
+            if (! strcmp(scheme,"bilinear"))
                 g_scheme = kBilinear;
-            else if (not strcmp(scheme,"catmark"))
+            else if (! strcmp(scheme,"catmark"))
                 g_scheme = kCatmark;
-            else if (not strcmp(scheme,"loop"))
+            else if (! strcmp(scheme,"loop"))
                 g_scheme = kLoop;
             else {
                 printf("-scheme : must be one of (\"bilinear\", \"catmark\", \"loop\")\n");
@@ -239,7 +239,7 @@ int main(int argc, char ** argv) {
     if ( g_objfile.size() ) {
 
         FILE * handle = fopen( g_objfile.c_str(), "rt" );
-        if (not handle) {
+        if (! handle) {
             printf("Could not open \"%s\" - aborting.\n", g_objfile.c_str());
             exit(0);
         }

--- a/regression/hbr_regression/main.cpp
+++ b/regression/hbr_regression/main.cpp
@@ -109,7 +109,7 @@ typedef OpenSubdiv::HbrVertexOperator<xyzVV> xyzVertexOperator;
 static Shape * readShape( char const * fname, Scheme scheme ) {
 
     FILE * handle = fopen( fname, "rt" );
-    if (not handle) {
+    if (! handle) {
         printf("Could not open \"%s\" - aborting.\n", fname);
         exit(0);
     }
@@ -145,7 +145,7 @@ static void writeObj( const char * fname, xyzmesh const * mesh,
     int firstface, int lastface, int firstvert, int lastvert ) {
 
     FILE * handle = fopen( fname, "w" );
-    if (not handle) {
+    if (! handle) {
         printf("Could not open \"%s\" - aborting.\n", fname);
         exit(0);
     }
@@ -242,7 +242,7 @@ static int checkMesh( shaperec const & r, int levels ) {
 
             float dist = sqrtf( delta[0]*delta[0]+delta[1]*delta[1]+delta[2]*delta[2]);
             if ( dist > STRICT_PRECISION ) {
-                if(dist < WEAK_PRECISION and g_allowWeakRegression) {
+                if(dist < WEAK_PRECISION && g_allowWeakRegression) {
                     g_strictRegressionFailure=true;
                 } else {
                     if (g_verbose) {
@@ -310,9 +310,9 @@ int main(int argc, char ** argv) {
     int levels=5, total=0;
 
     for (int i=1; i<argc; ++i) {
-        if ((not strcmp(argv[i],"-s")) or (not strcmp(argv[i],"-strict"))) {
+        if ((! strcmp(argv[i],"-s")) || (! strcmp(argv[i],"-strict"))) {
             g_allowWeakRegression=false;
-        } else if ((not strcmp(argv[i],"-v")) or (not strcmp(argv[i],"-verbose"))) {
+        } else if ((! strcmp(argv[i],"-v")) || (! strcmp(argv[i],"-verbose"))) {
             g_verbose=true;
         } else {
             usage( argv[1] );


### PR DESCRIPTION
This isn't a complete refactor. Given how many files need to be touched this is probably better done incrementally. 

I added a temporary CMake option to prevent the MSVC compatibility macros from being added to the solution. This can be all removed once the refactor is complete.

I have more fixes related to this, for DX and OpenGL - but I was going to submit PR separately so it's easier to review and test. With so many changes all over the place it's easy to introduce typo regressions so please review carefully.

Tested using the following config:

```
cmake ^
  -G "Visual Studio 12 2013 Win64" ^
  -D NO_EXAMPLES=1 ^
  -D NO_TUTORIALS=1 ^
  -D NO_REGRESSION=1 ^
  -D NO_MAYA=1 ^
  -D NO_PTEX=1 ^
  -D NO_DOC=1 ^
  -D NO_OMP=1 ^
  -D NO_TBB=1 ^
  -D NO_CUDA=1 ^
  -D NO_OPENCL=1 ^
  -D NO_OPENGL=1 ^
  -D NO_DX=1 ^
  -D NO_CLEW=1 ^
  -D NO_ISO646=1 ^
  ..
```