### PR TITLE
Fixed residual memory consumed by end cap stencils

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1304,14 +1304,14 @@ PatchTableFactory::populateAdaptivePatches(
 
     // finalize end patches
     if (localPointStencils and localPointStencils->GetNumStencils() > 0) {
-        localPointStencils->generateOffsets();
+        localPointStencils->finalize();
     } else {
         delete localPointStencils;
         localPointStencils = NULL;
     }
 
     if (localPointVaryingStencils and localPointVaryingStencils->GetNumStencils() > 0) {
-        localPointVaryingStencils->generateOffsets();
+        localPointVaryingStencils->finalize();
     } else {
         delete localPointVaryingStencils;
         localPointVaryingStencils = NULL;

--- a/opensubdiv/far/stencilTable.h
+++ b/opensubdiv/far/stencilTable.h
@@ -208,6 +208,12 @@ protected:
     // Reserves the table arrays (factory helper)
     void reserve(int nstencils, int nelems);
 
+    // Reallocates the table arrays to remove excess capacity (factory helper)
+    void shrinkToFit();
+
+    // Performs any final operations on internal tables (factory helper)
+    void finalize();
+
 protected:
     StencilTable() : _numControlVertices(0) {}
     StencilTable(int numControlVerts)
@@ -417,6 +423,19 @@ StencilTable::reserve(int nstencils, int nelems) {
     _sizes.reserve(nstencils);
     _indices.reserve(nelems);
     _weights.reserve(nelems);
+}
+
+inline void
+StencilTable::shrinkToFit() {
+    std::vector<int>(_sizes).swap(_sizes);
+    std::vector<Index>(_indices).swap(_indices);
+    std::vector<float>(_weights).swap(_weights);
+}
+
+inline void
+StencilTable::finalize() {
+    shrinkToFit();
+    generateOffsets();
 }
 
 // Returns a Stencil at index i in the table


### PR DESCRIPTION
An earlier change improved transient memory usage during the construction
of end cap stencil tables but could leave unused capacity in the internal
containers of the resulting tables. This change adds an additional
internal factory helper method which trims this storage.