### PR TITLE
Fixed Chaikin-related bug causing crashes in debug for MSVC and others

### DIFF
--- a/opensubdiv/sdc/crease.cpp
+++ b/opensubdiv/sdc/crease.cpp
@@ -168,7 +168,7 @@ Crease::SubdivideEdgeSharpnessesAroundVertex(int          edgeCount,
         //
         if (sharpCount == 0) {
             for (int i = 0; i < edgeCount; ++i) {
-                childSharpness[i] = Crease::SHARPNESS_SMOOTH;
+                childSharpness[i] = parentSharpness[i];
             }
         } else {
             for (int i = 0; i < edgeCount; ++i) {


### PR DESCRIPTION
This pull request addresses issue #789.

The bug occurs using the Chaikin crease method when a vertex transitions from Corner to Crease with infinitely sharp edges.  When no semi-sharp edges are present around a vertex, all child sharpness values should be inherited from their parent -- both smooth and infinitely sharp -- and not all presumed smooth.