### PR TITLE
iso-646 fix for DirectX project

### DIFF
--- a/examples/common/d3d11ShaderCache.cpp
+++ b/examples/common/d3d11ShaderCache.cpp
@@ -90,7 +90,7 @@ D3D11DrawConfig::CompileVertexShader(const std::string &target,
         return false;
     }
 
-    if (ppInputLayout and !*ppInputLayout) {
+    if (ppInputLayout && !*ppInputLayout) {
         hr = pd3dDevice->CreateInputLayout(
             pInputElementDescs, numInputElements,
             pBlob->GetBufferPointer(),

--- a/examples/common/hud.cpp
+++ b/examples/common/hud.cpp
@@ -185,7 +185,7 @@ Hud::MouseClick(int x, int y)
     for (std::vector<PullDown>::iterator it = _pulldowns.begin();
          it != _pulldowns.end(); ++it) {
         if (hitTest(*it, x, y)) {
-            if (not it->open) {
+            if (! it->open) {
                 it->h = FONT_CHAR_HEIGHT;
                 it->h *= (int)it->labels.size();
                 it->open=true;
@@ -200,7 +200,7 @@ Hud::MouseClick(int x, int y)
                         it->callback(it->values[it->selected]);
                     }
                 } else {
-                    it->open=not it->open;
+                    it->open=! it->open;
                 }
             }
             _requiresRebuildStatic = true;

--- a/examples/common/hud.h
+++ b/examples/common/hud.h
@@ -146,7 +146,7 @@ protected:
         PullDownCallback callback;
 
         void SetSelected(int idx) {
-            if (idx>=0 and idx<(int)labels.size()) {
+            if (idx>=0 && idx<(int)labels.size()) {
                 selected=idx;
             }
         }

--- a/examples/common/objAnim.cpp
+++ b/examples/common/objAnim.cpp
@@ -46,7 +46,7 @@ ObjAnim::InterpolatePositions(float time, float * positions, int stride) const {
 
     assert(positions);
 
-    if ( _positions.empty() or (not _shape)) {
+    if ( _positions.empty() || (! _shape)) {
         //printf("Error: InterpolatePositions on unfit ObjAnim instance\n");
         return;
     }
@@ -94,7 +94,7 @@ ObjAnim::Create(std::vector<char const *> objFiles, bool axis) {
 
     Shape const * shape = 0;
 
-    if (not objFiles.empty()) {
+    if (! objFiles.empty()) {
 
         anim = new ObjAnim;
 
@@ -102,7 +102,7 @@ ObjAnim::Create(std::vector<char const *> objFiles, bool axis) {
 
         for (int i = 0; i < (int)objFiles.size(); ++i) {
 
-            if (not objFiles[i]) {
+            if (! objFiles[i]) {
                 continue;
             }
 

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -292,8 +292,8 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level, int kernel, Scheme scheme=
     g_scheme = scheme;
 
     // Adaptive refinement currently supported only for catmull-clark scheme
-    bool doAdaptive = (g_adaptive!=0 and g_scheme==kCatmark),
-         doSingleCreasePatch = (g_singleCreasePatch!=0 and g_scheme==kCatmark);
+    bool doAdaptive = (g_adaptive!=0 && g_scheme==kCatmark),
+         doSingleCreasePatch = (g_singleCreasePatch!=0 && g_scheme==kCatmark);
 
     Osd::MeshBitset bits;
     bits.set(Osd::MeshAdaptive, doAdaptive);
@@ -643,7 +643,7 @@ bindProgram(Effect effect, OpenSubdiv::Osd::PatchArray const & patch) {
 
     // only legacy gregory needs maxValence and numElements
     // neither legacy gregory nor gregory basis need single crease
-    if (patch.GetDescriptor().GetType() == Descriptor::GREGORY or
+    if (patch.GetDescriptor().GetType() == Descriptor::GREGORY ||
         patch.GetDescriptor().GetType() == Descriptor::GREGORY_BOUNDARY) {
         int maxValence = g_mesh->GetMaxValence();
         int numElements = 6;
@@ -668,7 +668,7 @@ bindProgram(Effect effect, OpenSubdiv::Osd::PatchArray const & patch) {
             float ModelViewInverseMatrix[16];
         };
 
-        if (not g_pcbPerFrame) {
+        if (! g_pcbPerFrame) {
             D3D11_BUFFER_DESC cbDesc;
             ZeroMemory(&cbDesc, sizeof(cbDesc));
             cbDesc.Usage = D3D11_USAGE_DYNAMIC;
@@ -711,7 +711,7 @@ bindProgram(Effect effect, OpenSubdiv::Osd::PatchArray const & patch) {
             int PrimitiveIdBase;
         };
 
-        if (not g_pcbTessellation) {
+        if (! g_pcbTessellation) {
             D3D11_BUFFER_DESC cbDesc;
             ZeroMemory(&cbDesc, sizeof(cbDesc));
             cbDesc.Usage = D3D11_USAGE_DYNAMIC;
@@ -742,7 +742,7 @@ bindProgram(Effect effect, OpenSubdiv::Osd::PatchArray const & patch) {
             float color[4];
         };
 
-        if (not g_pcbMaterial) {
+        if (! g_pcbMaterial) {
             D3D11_BUFFER_DESC cbDesc;
             ZeroMemory(&cbDesc, sizeof(cbDesc));
             cbDesc.Usage = D3D11_USAGE_DYNAMIC;
@@ -947,7 +947,7 @@ motion(int x, int y) {
         // pan
         g_pan[0] -= g_dolly*(x - g_prev_x)/g_width;
         g_pan[1] += g_dolly*(y - g_prev_y)/g_height;
-    } else if ((g_mbutton[0] && g_mbutton[1] && !g_mbutton[2]) or
+    } else if ((g_mbutton[0] && g_mbutton[1] && !g_mbutton[2]) ||
                (!g_mbutton[0] && !g_mbutton[1] && g_mbutton[2])) {
         // dolly
         g_dolly -= g_dolly*0.01f*(x - g_prev_x);
@@ -1598,7 +1598,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmd
                 TranslateMessage(&msg);
                 DispatchMessage(&msg);
             }
-            if (not g_freeze)
+            if (! g_freeze)
                 g_frame++;
 
             updateGeom();

--- a/opensubdiv/far/stencilTable.h
+++ b/opensubdiv/far/stencilTable.h
@@ -383,7 +383,7 @@ StencilTable::update(T const *controlValues, T *values,
         values += start;
     }
 
-    if (end<start or end<0) {
+    if (end<start || end<0) {
         end = GetNumStencils();
     }
 

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -119,7 +119,7 @@ template <typename STENCIL_TABLE, typename SRC_STENCIL_TABLE,
 STENCIL_TABLE const *
 convertToCompatibleStencilTable(
     SRC_STENCIL_TABLE const *table, DEVICE_CONTEXT *context) {
-    if (not table) return NULL;
+    if (! table) return NULL;
     return STENCIL_TABLE::Create(table, context);
 }
 
@@ -129,7 +129,7 @@ convertToCompatibleStencilTable<Far::StencilTable, Far::StencilTable, void>(
     Far::StencilTable const *table, void *  /*context*/) {
     // no need for conversion
     // XXX: We don't want to even copy.
-    if (not table) return NULL;
+    if (! table) return NULL;
     return new Far::StencilTable(*table);
 }
 
@@ -139,7 +139,7 @@ convertToCompatibleStencilTable<Far::LimitStencilTable, Far::LimitStencilTable, 
     Far::LimitStencilTable const *table, void *  /*context*/) {
     // no need for conversion
     // XXX: We don't want to even copy.
-    if (not table) return NULL;
+    if (! table) return NULL;
     return new Far::LimitStencilTable(*table);
 }
 
@@ -149,7 +149,7 @@ convertToCompatibleStencilTable<Far::StencilTable, Far::StencilTable, ID3D11Devi
     Far::StencilTable const *table, ID3D11DeviceContext *  /*context*/) {
     // no need for conversion
     // XXX: We don't want to even copy.
-    if (not table) return NULL;
+    if (! table) return NULL;
     return new Far::StencilTable(*table);
 }
 

--- a/tutorials/far/tutorial_3/far_tutorial_3.cpp
+++ b/tutorials/far/tutorial_3/far_tutorial_3.cpp
@@ -345,7 +345,7 @@ int main(int, char **) {
             Far::ConstIndexArray fuvs   = refLastLevel.GetFaceFVarValues(face, channelUV);
 
             // all refined Catmark faces should be quads
-            assert(fverts.size()==4 and fuvs.size()==4);
+            assert(fverts.size()==4 && fuvs.size()==4);
 
             printf("f ");
             for (int vert=0; vert<fverts.size(); ++vert) {

--- a/tutorials/far/tutorial_8/far_tutorial_8.cpp
+++ b/tutorials/far/tutorial_8/far_tutorial_8.cpp
@@ -513,7 +513,7 @@ int main(int argc, char ** argv) {
             Far::ConstIndexArray fuvs   = refLastLevel.GetFaceFVarValues(face, channelUV);
 
             // all refined Catmark faces should be quads
-            assert(fverts.size()==4 and fuvs.size()==4);
+            assert(fverts.size()==4 && fuvs.size()==4);
 
             printf("f ");
             for (int vert=0; vert<fverts.size(); ++vert) {

--- a/tutorials/hbr/tutorial_1/hbr_tutorial_1.cpp
+++ b/tutorials/hbr/tutorial_1/hbr_tutorial_1.cpp
@@ -145,7 +145,7 @@ int main(int, char **) {
             Hhalfedge const * opposite = destination->GetEdge(origin);
 
             // Make sure that the vertices exist in the mesh
-            if (origin==NULL or destination==NULL) {
+            if (origin==NULL || destination==NULL) {
                 printf(" An edge was specified that connected a nonexistent vertex\n");
                 valid=false;
                 break;
@@ -159,7 +159,7 @@ int main(int, char **) {
             }
 
             // Check that no more than 2 faces are adjacent to the edge
-            if (opposite and opposite->GetOpposite() ) {
+            if (opposite && opposite->GetOpposite() ) {
                 printf(" A non-manifold edge incident to more than 2 faces was found\n");
                 valid=false;
                 break;

--- a/tutorials/hbr/tutorial_2/hbr_tutorial_2.cpp
+++ b/tutorials/hbr/tutorial_2/hbr_tutorial_2.cpp
@@ -215,7 +215,7 @@ createMesh() {
             Hhalfedge const * opposite = destination->GetEdge(origin);
 
             // Make sure that the vertices exist in the mesh
-            if (origin==NULL or destination==NULL) {
+            if (origin==NULL || destination==NULL) {
                 printf(" An edge was specified that connected a nonexistent vertex\n");
                 valid=false;
                 break;
@@ -229,7 +229,7 @@ createMesh() {
             }
 
             // Check that no more than 2 faces are adjacent to the edge
-            if (opposite and opposite->GetOpposite() ) {
+            if (opposite && opposite->GetOpposite() ) {
                 printf(" A non-manifold edge incident to more than 2 faces was found\n");
                 valid=false;
                 break;


### PR DESCRIPTION
Renaming `and`, `or`, and `not` et. al for the DirectX project. Ref 779.