### PR TITLE
No longer use CMAKE_SOURCE_DIR and CMAKE_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,12 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 #-------------------------------------------------------------------------------
 # Obtain OpenSubdiv API version from version.h file
-if(EXISTS "${CMAKE_SOURCE_DIR}/opensubdiv/version.h")
-    file(STRINGS "${CMAKE_SOURCE_DIR}/opensubdiv/version.h"
+if(EXISTS "${OpenSubdiv_SOURCE_DIR}/opensubdiv/version.h")
+    file(STRINGS "${OpenSubdiv_SOURCE_DIR}/opensubdiv/version.h"
         OpenSubdiv_VERSION REGEX "^#define OPENSUBDIV_VERSION .*$")
     string(REPLACE "#define OPENSUBDIV_VERSION " "" OpenSubdiv_VERSION ${OpenSubdiv_VERSION})
 else()
-    message(FATAL_ERROR, "Cannot locate opensubdiv/version.h in CMAKE_SOURCE_DIR")
+    message(FATAL_ERROR, "Cannot locate opensubdiv/version.h in ${OpenSubdiv_SOURCE_DIR}")
 endif()
 
 # Evaluate 'soname' from OSD version
@@ -571,14 +571,14 @@ add_custom_target( public_headers )
 
 macro(_add_doxy_headers headers)
     if (NOT NO_DOC AND DOXYGEN_FOUND)
-        file(RELATIVE_PATH path "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" )
+        file(RELATIVE_PATH path "${OpenSubdiv_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" )
 
         string(REPLACE  "/" "_" targetpath ${path})
 
         foreach (header ${headers})
 
             set(infile "${CMAKE_CURRENT_SOURCE_DIR}/${header}")
-            set(outfile "${CMAKE_BINARY_DIR}/public_headers/${path}/${header}")
+            set(outfile "${OpenSubdiv_BINARY_DIR}/public_headers/${path}/${header}")
             set(targetname "${targetpath}_${header}")
 
             add_custom_command(

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -31,7 +31,7 @@ if (DOXYGEN_FOUND)
     add_custom_target(doc_doxy
             ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/OpenSubdiv.doxy"
         WORKING_DIRECTORY
-            "${CMAKE_BINARY_DIR}/public_headers/"
+            "${OpenSubdiv_BINARY_DIR}/public_headers/"
         DEPENDS
             public_headers
         COMMENT
@@ -184,7 +184,7 @@ if (DOCUTILS_FOUND AND PYTHONINTERP_FOUND)
         get_filename_component(BASENAME ${tutorial} NAME_WE)
 
         string(REGEX REPLACE "(/)" "_" TARGET_NAME ${tutorial})
-        set(infile "${CMAKE_SOURCE_DIR}/tutorials/${tutorial}")
+        set(infile "${OpenSubdiv_SOURCE_DIR}/tutorials/${tutorial}")
         set(rstfile "${CMAKE_CURRENT_BINARY_DIR}/${BASENAME}.rst")
         set(htmlfile "${CMAKE_CURRENT_BINARY_DIR}/${BASENAME}.html")
 

--- a/examples/mayaPolySmooth/CMakeLists.txt
+++ b/examples/mayaPolySmooth/CMakeLists.txt
@@ -111,14 +111,14 @@ add_custom_target(maya_polySmoothNode_melScripts
         COMMAND
             ${CMAKE_COMMAND} -E copy
             "${CMAKE_CURRENT_SOURCE_DIR}/mayaPolySmooth.mel"
-            "${CMAKE_BINARY_DIR}/${CMAKE_LIBDIR_BASE}/mayaPolySmooth.mel"
+            "${OpenSubdiv_BINARY_DIR}/${CMAKE_LIBDIR_BASE}/mayaPolySmooth.mel"
         DEPENDS
             "${CMAKE_CURRENT_SOURCE_DIR}/mayaPolySmooth.mel"
 )
 
 install(
     FILES
-        "${CMAKE_BINARY_DIR}/${CMAKE_LIBDIR_BASE}/mayaPolySmooth.mel"
+        "${OpenSubdiv_BINARY_DIR}/${CMAKE_LIBDIR_BASE}/mayaPolySmooth.mel"
     DESTINATION
         "${CMAKE_PLUGINDIR_BASE}"
 )


### PR DESCRIPTION
As mentioned in issue #814, avoiding the use of CMAKE_SOURCE_DIR makes it easier to integrate OpenSubdiv as a submodule in other projects.

Fixes #814.