### PR TITLE
Introducing Vtr::Level::VSpan to standardize representation of partial rings around vertices

### DIFF
--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
@@ -77,6 +77,7 @@ EndCapBSplineBasisPatchFactory::EndCapBSplineBasisPatchFactory(
 ConstIndexArray
 EndCapBSplineBasisPatchFactory::GetPatchPoints(
     Vtr::internal::Level const * level, Index thisFace,
+    Vtr::internal::Level::VSpan const cornerSpans[],
     PatchTableFactory::PatchFaceTag const *levelPatchTags,
     int levelVertOffset) {
 
@@ -85,7 +86,7 @@ EndCapBSplineBasisPatchFactory::GetPatchPoints(
     // if it's boundary, fallback to use GregoryBasis
     if (patchTag._boundaryCount > 0) {
         return getPatchPointsFromGregoryBasis(
-            level, thisFace, facePoints, levelVertOffset);
+            level, thisFace, cornerSpans, facePoints, levelVertOffset);
     }
 
     // there's a short-cut when the face contains only 1 extraordinary vertex.
@@ -99,7 +100,7 @@ EndCapBSplineBasisPatchFactory::GetPatchPoints(
                 // more than one extraoridinary vertices.
                 // fallback to use GregoryBasis
                 return getPatchPointsFromGregoryBasis(
-                    level, thisFace, facePoints, levelVertOffset);
+                    level, thisFace, cornerSpans, facePoints, levelVertOffset);
             }
             irregular = i;
         }
@@ -113,6 +114,7 @@ EndCapBSplineBasisPatchFactory::GetPatchPoints(
 ConstIndexArray
 EndCapBSplineBasisPatchFactory::getPatchPointsFromGregoryBasis(
     Vtr::internal::Level const * level, Index thisFace,
+    Vtr::internal::Level::VSpan const cornerSpans[],
     ConstIndexArray facePoints, int levelVertOffset) {
 
     // XXX: For now, always create new 16 indices for each patch.
@@ -124,7 +126,7 @@ EndCapBSplineBasisPatchFactory::getPatchPointsFromGregoryBasis(
         _patchPoints.push_back(_numVertices + offset);
         ++_numVertices;
     }
-    GregoryBasis::ProtoBasis basis(*level, thisFace, levelVertOffset, -1);
+    GregoryBasis::ProtoBasis basis(*level, thisFace, cornerSpans, levelVertOffset, -1);
     // XXX: temporary hack. we should traverse topology and find existing
     //      vertices if available
     //

--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.h
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.h
@@ -80,12 +80,14 @@ public:
     ///
     ConstIndexArray GetPatchPoints(
         Vtr::internal::Level const * level, Index faceIndex,
+        Vtr::internal::Level::VSpan const cornerSpans[],
         PatchTableFactory::PatchFaceTag const * levelPatchTags,
         int levelVertOffset);
 
 private:
     ConstIndexArray getPatchPointsFromGregoryBasis(
         Vtr::internal::Level const * level, Index thisFace,
+        Vtr::internal::Level::VSpan const cornerSpans[],
         ConstIndexArray facePoints,
         int levelVertOffset);
 

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
@@ -77,7 +77,8 @@ EndCapGregoryBasisPatchFactory::Create(TopologyRefiner const & refiner,
     // Gregory patches are end-caps: they only exist on max-level
     Vtr::internal::Level const & level = refiner.getLevel(refiner.GetMaxLevel());
 
-    GregoryBasis::ProtoBasis basis(level, faceIndex, 0, fvarChannel);
+    // Is this method used/supported?  If so, needs corner spans (and vert offset?)...
+    GregoryBasis::ProtoBasis basis(level, faceIndex, 0, 0, fvarChannel);
     GregoryBasis * result = new GregoryBasis;
     basis.Copy(result);
 
@@ -86,16 +87,14 @@ EndCapGregoryBasisPatchFactory::Create(TopologyRefiner const & refiner,
 }
 
 bool
-EndCapGregoryBasisPatchFactory::addPatchBasis(Index faceIndex,
+EndCapGregoryBasisPatchFactory::addPatchBasis(Vtr::internal::Level const & level, Index faceIndex,
+                                              Vtr::internal::Level::VSpan const cornerSpans[],
                                               bool verticesMask[4][5],
                                               int levelVertOffset) {
 
-    // Gregory patches only exist on the hight
-    Vtr::internal::Level const & level = _refiner->getLevel(_refiner->GetMaxLevel());
-
     // Gather the CVs that influence the Gregory patch and their relative
     // weights in a basis
-    GregoryBasis::ProtoBasis basis(level, faceIndex, levelVertOffset, -1);
+    GregoryBasis::ProtoBasis basis(level, faceIndex, cornerSpans, levelVertOffset, -1);
 
     for (int i = 0; i < 4; ++i) {
         if (verticesMask[i][0]) {
@@ -131,8 +130,10 @@ EndCapGregoryBasisPatchFactory::addPatchBasis(Index faceIndex,
 ConstIndexArray
 EndCapGregoryBasisPatchFactory::GetPatchPoints(
     Vtr::internal::Level const * level, Index faceIndex,
+    Vtr::internal::Level::VSpan const cornerSpans[],
     PatchTableFactory::PatchFaceTag const * levelPatchTags,
     int levelVertOffset) {
+
     // allocate indices (awkward)
     // assert(Vtr::INDEX_INVALID==0xFFFFFFFF);
     for (int i = 0; i < 20; ++i) {
@@ -227,7 +228,7 @@ EndCapGregoryBasisPatchFactory::GetPatchPoints(
     _faceIndices.push_back(faceIndex);
 
     // add basis
-    addPatchBasis(faceIndex, newVerticesMask, levelVertOffset);
+    addPatchBasis(*level, faceIndex, cornerSpans, newVerticesMask, levelVertOffset);
 
     ++_numGregoryBasisPatches;
 

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.h
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.h
@@ -98,6 +98,8 @@ public:
     /// @param level            vtr refinement level
     ///
     /// @param faceIndex        vtr faceIndex at the level
+    //
+    /// @param cornerSpans      information about topology for each corner of patch
     ///
     /// @param levelPatchTags   Array of patchTags for all faces in the level
     ///
@@ -105,6 +107,7 @@ public:
     ///
     ConstIndexArray GetPatchPoints(
         Vtr::internal::Level const * level, Index faceIndex,
+        Vtr::internal::Level::VSpan const cornerSpans[],
         PatchTableFactory::PatchFaceTag const * levelPatchTags,
         int levelVertOffset);
 
@@ -112,8 +115,9 @@ private:
 
     /// Creates a basis for the vertices specified in mask on the face and
     /// accumates it
-    bool addPatchBasis(Index faceIndex, bool newVerticesMask[4][5],
-                       int levelVertOffset);
+    bool addPatchBasis(Vtr::internal::Level const & level, Index faceIndex,
+                       Vtr::internal::Level::VSpan const cornerSpans[],
+                       bool newVerticesMask[4][5], int levelVertOffset);
 
     StencilTable *_vertexStencils;
     StencilTable *_varyingStencils;

--- a/opensubdiv/far/gregoryBasis.h
+++ b/opensubdiv/far/gregoryBasis.h
@@ -189,6 +189,7 @@ public:
 
         ProtoBasis(Vtr::internal::Level const & level,
                    Vtr::Index faceIndex,
+                   Vtr::internal::Level::VSpan const cornerSpans[],
                    int levelVertOffset,
                    int fvarChannel);
 

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1223,13 +1223,18 @@ PatchTableFactory::populateAdaptivePatches(
                 // emit end patch. end patch should be in the max level (until we implement DFAS)
                 assert(i==refiner.GetMaxLevel());
 
+                // identify relevant spans around the corner vertices for the irregular patches
+                // (this is just a stub for now -- leaving the span "size" to zero, as constructed,
+                // indicates to use the full neighborhood)...
+                Vtr::internal::Level::VSpan cornerSpans[4];
+
                 // switch endcap patchtype by option
                 switch(context.options.GetEndCapType()) {
                 case Options::ENDCAP_GREGORY_BASIS:
                 {
                     // note: this call will be moved into vtr::level.
                     ConstIndexArray cvs = endCapGregoryBasis->GetPatchPoints(
-                        level, faceIndex, levelPatchTags, levelVertOffset);
+                        level, faceIndex, cornerSpans, levelPatchTags, levelVertOffset);
 
                     for (int j = 0; j < cvs.size(); ++j) iptrs.GP[j] = cvs[j];
                     iptrs.GP += cvs.size();
@@ -1244,7 +1249,7 @@ PatchTableFactory::populateAdaptivePatches(
                 case Options::ENDCAP_BSPLINE_BASIS:
                 {
                     ConstIndexArray cvs = endCapBSpline->GetPatchPoints(
-                        level, faceIndex, levelPatchTags, levelVertOffset);
+                        level, faceIndex, cornerSpans, levelPatchTags, levelVertOffset);
 
                     for (int j = 0; j < cvs.size(); ++j) iptrs.R[j] = cvs[j];
                     iptrs.R += cvs.size();

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -650,6 +650,44 @@ Level::gatherQuadRegularRingAroundVertex(
     return ringIndex;
 }
 
+int
+Level::gatherQuadRegularPartialRingAroundVertex(
+    Index vIndex, VSpan const & span, int ringPoints[], int fvarChannel) const {
+
+    Level const& level = *this;
+
+    assert(! level.isVertexNonManifold(vIndex));
+
+    ConstIndexArray      vFaces   = level.getVertexFaces(vIndex);
+    ConstLocalIndexArray vInFaces = level.getVertexFaceLocalIndices(vIndex);
+
+    int nFaces      = span._numFaces;
+    int leadingEdge = span._leadingVertEdge;
+
+    int ringIndex = 0;
+    for (int i = 0; i < nFaces; ++i) {
+        //
+        //  For every incident quad, we want the two vertices clockwise in each face, i.e.
+        //  the vertex at the end of the leading edge and the vertex opposite this one:
+        //
+        int fIncident = (leadingEdge + i) % vFaces.size();
+
+        ConstIndexArray fPoints = (fvarChannel < 0)
+                                ? level.getFaceVertices(vFaces[fIncident])
+                                : level.getFaceFVarValues(vFaces[fIncident], fvarChannel);
+
+        int vInThisFace = vInFaces[fIncident];
+
+        ringPoints[ringIndex++] = fPoints[fastMod4(vInThisFace + 1)];
+        ringPoints[ringIndex++] = fPoints[fastMod4(vInThisFace + 2)];
+
+        if (i == nFaces - 1) {
+            ringPoints[ringIndex++] = fPoints[fastMod4(vInThisFace + 3)];
+        }
+    }
+    return ringIndex;
+}
+
 //
 //  Gathering the 4 vertices of a quad:
 //      

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -149,6 +149,28 @@ public:
 
     ETag getFaceCompositeETag(ConstIndexArray & faceEdges) const;
 
+    //  Additional simple struct to identify a "span" around a vertex, i.e. a
+    //  subset of the faces around a vertex delimited by some property (e.g. a
+    //  face-varying discontinuity, an inf-sharp edge, etc.)
+    //
+    //  The span requires an "origin", i.e. a leading edge or face and a "size"
+    //  to fully define its extent.  Use of the size is preferred over leading
+    //  and trailing edges/faces so that valence is available since for a non-
+    //  manifold vertex that cannot be determined from the two extremeties.
+    //  There is also a subtle but marginal advantage in using a leading edge
+    //  rather than face, but it may be worth using the leading face with the
+    //  face count for consistency (both properties defined in terms of faces).
+    //
+    //  Currently setting the size to 0 is an indication to use the full
+    //  neighborhood rather than a subset -- may want to revisit that choice...
+    //
+    struct VSpan {
+        VSpan() : _numFaces(0), _leadingVertEdge(0) { }
+
+        LocalIndex _numFaces;
+        LocalIndex _leadingVertEdge;
+    };
+
 public:
     Level();
     ~Level();
@@ -284,7 +306,10 @@ public:
     int gatherQuadRegularCornerPatchPoints(  Index fIndex, Index patchPoints[], int cornerVertInFace,
                                                                                 int fvarChannel = -1) const;
 
-    int gatherQuadRegularRingAroundVertex(Index vIndex, Index ringPoints[], int fvarChannel = -1) const;
+    int gatherQuadRegularRingAroundVertex(Index vIndex, Index ringPoints[],
+                                          int fvarChannel = -1) const;
+    int gatherQuadRegularPartialRingAroundVertex(Index vIndex, VSpan const & span, Index ringPoints[],
+                                                 int fvarChannel = -1) const;
 
     //  WIP -- for future use, need to extend for face-varying...
     int gatherTriRegularInteriorPatchPoints(      Index fIndex, Index patchVerts[], int rotation = 0) const;


### PR DESCRIPTION
With ongoing work to identify patches around discontinuities such as face-varying boundaries or infinitely sharp creases, its useful to have a consistent representation of a sub-ring around a vertex.  The VSpan in Vtr::Level provides that along with a gathering method in Vtr::Level.  It is a simple and compact pair of local indices that identify the origin and extent of a set of faces around a vertex.

This is still work in progress but after offline discussions we wanted to make it available for development that's currently ongoing.  Aside from the definition and gathering method in Vtr, this set of changes includes extensions of signatures to several Far patch construction methods to accept a set of VSpan[4] for the four corners of a patch.

Aside from the plumbing to move the VSpan corners through the patch code, the most significant changes here are to the Gregory patch construction in far/gregoryBasis.cpp.  While extending it to recognize possible partial rings at each corner, a few other issues were identified and addressed.  The most significant was the bookkeeping logic that existed to keep track of the start/end of the gathered ring when a corner vertex was a boundary.  This appears to have been necessary previously with Hbr, but with the Vtr rings always beginning and ending at the boundaries when present, this is no longer the case and the code can be greatly simplified.  These changes have been tested externally.  A bug related to smooth corners was also identified and corrected as part of the testing.