### PR TITLE
Fixed bug in Far::PatchTableFactory to correct sharpness assignment:

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1240,7 +1240,7 @@ PatchTableFactory::populateAdaptivePatches(
                     iptrs.GP += cvs.size();
                     pptrs.GP = computePatchParam(
                         refiner, ptexIndices, i, faceIndex, /*boundary*/0, /*transition*/0, pptrs.GP);
-                    if (sptrs.R) *sptrs.R++ = assignSharpnessIndex(0, table->_sharpnessValues);
+                    if (sptrs.GP) *sptrs.GP++ = assignSharpnessIndex(0, table->_sharpnessValues);
                     fofss.GP += gatherFVarData(context,
                                                i, faceIndex, levelFaceOffset,
                                                0, levelFVarVertOffsets, fofss.GP, fptrs.GP);
@@ -1271,7 +1271,7 @@ PatchTableFactory::populateAdaptivePatches(
                         iptrs.G += cvs.size();
                         pptrs.G = computePatchParam(
                             refiner, ptexIndices, i, faceIndex, /*boundary*/0, /*transition*/0, pptrs.G);
-                        if (sptrs.R) *sptrs.R++ = assignSharpnessIndex(0, table->_sharpnessValues);
+                        if (sptrs.G) *sptrs.G++ = assignSharpnessIndex(0, table->_sharpnessValues);
                         fofss.G += gatherFVarData(context,
                                                   i, faceIndex, levelFaceOffset,
                                                   0, levelFVarVertOffsets, fofss.G, fptrs.G);
@@ -1280,7 +1280,7 @@ PatchTableFactory::populateAdaptivePatches(
                         iptrs.GB += cvs.size();
                         pptrs.GB = computePatchParam(
                             refiner, ptexIndices, i, faceIndex, /*boundary*/0, /*transition*/0, pptrs.GB);
-                        if (sptrs.R) *sptrs.R++ = assignSharpnessIndex(0, table->_sharpnessValues);
+                        if (sptrs.GB) *sptrs.GB++ = assignSharpnessIndex(0, table->_sharpnessValues);
                         fofss.GB += gatherFVarData(context,
                                                    i, faceIndex, levelFaceOffset,
                                                    0, levelFVarVertOffsets, fofss.GB, fptrs.GB);


### PR DESCRIPTION
The bug appears to be the result of a cut/paste oversight -- when populating the irregular patch types, the sharpness index vector that was used was that of the regular patches rather than the specific patch type.

This doesn't appear as a problem now because the corruption of the regular vector only occurs in the last level when Gregory patches are generated, and single crease patches are not generated in the last level.  Once Gregory patches are generated before the last level, the corruption of single crease patches becomes evident.