### PR TITLE
Add internal support for separate levels of refinement for different features

### DIFF
--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.h
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.h
@@ -126,8 +126,10 @@ private:
     bool _shareBoundaryVertices;
     int _numGregoryBasisVertices;
     int _numGregoryBasisPatches;
-    std::vector<Index> _faceIndices;
     std::vector<Index> _patchPoints;
+
+    //  Only used when sharing vertices:
+    std::vector<unsigned int> _levelAndFaceIndices;
 };
 
 } // end namespace Far

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1220,9 +1220,6 @@ PatchTableFactory::populateAdaptivePatches(
                 fofss.R += gatherFVarData(context,
                                           i, faceIndex, levelFaceOffset, /*rotation*/0, levelFVarVertOffsets, fofss.R, fptrs.R);
             } else {
-                // emit end patch. end patch should be in the max level (until we implement DFAS)
-                assert(i==refiner.GetMaxLevel());
-
                 // identify relevant spans around the corner vertices for the irregular patches
                 // (this is just a stub for now -- leaving the span "size" to zero, as constructed,
                 // indicates to use the full neighborhood)...

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -465,8 +465,8 @@ TopologyRefiner::selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& 
         } else if (compFaceVTag._xordinary) {
             if (considerXOrdinaryFaces) {
                 selectFace = true;
-            } else {
-                selectFace = (compFaceVTag._rule & Sdc::Crease::RULE_CORNER);
+            } else if (compFaceVTag._rule & Sdc::Crease::RULE_CORNER) {
+                selectFace = true;
             }
         } else if (! (compFaceVTag._rule & Sdc::Crease::RULE_CORNER)) {
             //  We are now left with boundary faces -- if no Corner vertex, we have a mix of both

--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -199,7 +199,9 @@ private:
     TopologyRefiner(TopologyRefiner const &) : _uniformOptions(0), _adaptiveOptions(0) { }
     TopologyRefiner & operator=(TopologyRefiner const &) { return *this; }
 
-    void selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& selector);
+    class FeatureMask;
+    void selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& selector, FeatureMask const & mask);
+    //void selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& selector, bool xordFeatures);
 
     void initializeInventory();
     void updateInventory(Vtr::internal::Level const & newLevel);


### PR DESCRIPTION
This change includes internal support allowing different levels of adaptive refinement for extra-ordinary vertices vs other sharp features -- preventing the over-representation of smooth patches around all extra-ordinary vertices when a high level of refinement is required for a particular crease.

The feature is not publicly exposed here yet (we need to work out some public interface details) but removes internal assumptions when constructing patches that irregular patches can only exist at the last level of refinement.  Any further changes in this area should now be constrained to the refinement stage rather than patch construction.  Changes to adaptive refinement here are minor but due to change more extensively soon to better support infinitely sharp creases.
