### PR TITLE
Added new vertex tags to identify infinitely sharp features

### DIFF
--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -531,13 +531,17 @@ Level::print(const Refinement* pRefinement) const {
     for (int i = 0; printVertTags && i < (int)_vertTags.size(); ++i) {
         VTag const& vTag = _vertTags[i];
         printf("        vert %4d:", i);
-        printf("  rule = %s",      ruleString((Sdc::Crease::Rule)vTag._rule));
-        printf(", boundary = %d",  (int)vTag._boundary);
-        printf(", corner = %d",    (int)vTag._corner);
-        printf(", xordinary = %d", (int)vTag._xordinary);
-        printf(", nonManifold = %d", (int)vTag._nonManifold);
-        printf(", infSharp = %d",  (int)vTag._infSharp);
-        printf(", semiSharp = %d", (int)vTag._semiSharp);
+        printf("  rule = %s",           ruleString((Sdc::Crease::Rule)vTag._rule));
+        printf(", boundary = %d",       (int)vTag._boundary);
+        printf(", corner = %d",         (int)vTag._corner);
+        printf(", xordinary = %d",      (int)vTag._xordinary);
+        printf(", nonManifold = %d",    (int)vTag._nonManifold);
+        printf(", infSharp = %d",       (int)vTag._infSharp);
+        printf(", infSharpEdges = %d",  (int)vTag._infSharpEdges);
+        printf(", infSharpCrease = %d", (int)vTag._infSharpCrease);
+        printf(", infSharpCorners = %d",(int)vTag._infSharpCorners);
+        printf(", infIrregular = %d",   (int)vTag._infIrregular);
+        printf(", semiSharp = %d",      (int)vTag._semiSharp);
         printf(", semiSharpEdges = %d", (int)vTag._semiSharpEdges);
         printf("\n");
     }

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -114,6 +114,12 @@ public:
         VTagSize _rule            : 4;  // variable when _semiSharp
         VTagSize _incomplete      : 1;  // variable for sparse refinement
 
+        //  Inf-sharp tags -- in development, some may not persist...
+        VTagSize _infSharpEdges   : 1;  // fixed
+        VTagSize _infSharpCrease  : 1;  // fixed
+        VTagSize _infSharpCorners : 1;  // fixed
+        VTagSize _infIrregular    : 1;  // fixed
+
         //  On deck -- coming soon...
         //VTagSize _constSharp   : 1;  // variable when _semiSharp
         //VTagSize _hasEdits     : 1;  // variable

--- a/opensubdiv/vtr/refinement.cpp
+++ b/opensubdiv/vtr/refinement.cpp
@@ -753,6 +753,9 @@ Refinement::populateVertexTagsFromParentEdges() {
         vTag._nonManifold    = pEdgeTag._nonManifold;
         vTag._boundary       = pEdgeTag._boundary;
         vTag._semiSharpEdges = pEdgeTag._semiSharp;
+        vTag._infSharpEdges  = pEdgeTag._infSharp;
+        vTag._infSharpCrease = pEdgeTag._infSharp;
+        vTag._infIrregular   = pEdgeTag._infSharp && pEdgeTag._nonManifold;
 
         vTag._rule = (Level::VTag::VTagSize)((pEdgeTag._semiSharp || pEdgeTag._infSharp)
                        ? Sdc::Crease::RULE_CREASE : Sdc::Crease::RULE_SMOOTH);


### PR DESCRIPTION
As a basis for upcoming work to improve patches around infinitely sharp features, this change includes the definition and propagation of new vertex tags that identify the presence and nature of infinitely sharp features at a vertex.  As with other VTags, this greatly simplifies the logic required in adaptive refinement and patch construction.  The new tags are not yet used to affect adaptive refinement or patches -- they are only defined, initialized and propagated through the refinement hierarchy, making them available for these processes in future.