### PR TITLE
Updated Far::EndCap*PatchFactory for fvar patches

### DIFF
--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.h
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.h
@@ -45,8 +45,6 @@ class TopologyRefiner;
 class EndCapBSplineBasisPatchFactory {
 
 public:
-    // XXXX need to add support for face-varying channel stencils
-
     /// \brief This factory accumulates vertex for bspline basis end cap
     ///
     /// @param refiner                TopologyRefiner from which to generate patches
@@ -76,26 +74,28 @@ public:
     ///
     /// @param levelVertOffset  relative offset of patch vertex indices
     ///
+    /// @param fvarChannel      face-varying channel index
+    ///
     ConstIndexArray GetPatchPoints(
         Vtr::internal::Level const * level, Index faceIndex,
         Vtr::internal::Level::VSpan const cornerSpans[],
-        int levelVertOffset);
+        int levelVertOffset, int fvarChannel = -1);
 
 private:
     ConstIndexArray getPatchPointsFromGregoryBasis(
         Vtr::internal::Level const * level, Index thisFace,
         Vtr::internal::Level::VSpan const cornerSpans[],
         ConstIndexArray facePoints,
-        int levelVertOffset);
+        int levelVertOffset, int fvarChannel);
 
     ConstIndexArray getPatchPoints(
         Vtr::internal::Level const *level, Index thisFace,
         Index extraOrdinaryIndex, ConstIndexArray facePoints,
-        int levelVertOffset);
+        int levelVertOffset, int fvarChannel);
 
     void computeLimitStencils(
         Vtr::internal::Level const *level,
-        ConstIndexArray facePoints, int vid,
+        ConstIndexArray facePoints, int vid, int fvarChannel,
         GregoryBasis::Point *P, GregoryBasis::Point *Ep, GregoryBasis::Point *Em);
 
     StencilTable * _vertexStencils;

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.h
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.h
@@ -46,29 +46,9 @@ class EndCapGregoryBasisPatchFactory {
 
 public:
 
-    //
-    // Single patch GregoryBasis basis factory
-    //
-
-    /// \brief Instantiates a GregoryBasis from a TopologyRefiner that has been
-    ///        refined adaptively for a given face.
-    ///
-    /// @param refiner     The TopologyRefiner containing the topology
-    ///
-    /// @param faceIndex   The index of the face (level is assumed to be MaxLevel)
-    ///
-    /// @param fvarChannel Index of face-varying channel topology (default -1)
-    ///
-    static GregoryBasis const * Create(TopologyRefiner const & refiner,
-        Index faceIndex, int fvarChannel=-1);
-
-public:
-
     ///
     /// Multi-patch Gregory stencils factory
     ///
-
-    // XXXX need to add support for face-varying channel stencils
 
     /// \brief This factory accumulates vertex for Gregory basis patch
     ///
@@ -101,10 +81,12 @@ public:
     /// @param cornerSpans      information about topology for each corner of patch
     /// @param levelVertOffset  relative offset of patch vertex indices
     ///
+    /// @param fvarChannel      face-varying channel index
+    ///
     ConstIndexArray GetPatchPoints(
         Vtr::internal::Level const * level, Index faceIndex,
         Vtr::internal::Level::VSpan const cornerSpans[],
-        int levelVertOffset);
+        int levelVertOffset, int fvarChannel = -1);
 
 private:
 
@@ -112,7 +94,8 @@ private:
     /// accumates it
     bool addPatchBasis(Vtr::internal::Level const & level, Index faceIndex,
                        Vtr::internal::Level::VSpan const cornerSpans[],
-                       bool newVerticesMask[4][5], int levelVertOffset);
+                       bool newVerticesMask[4][5],
+                       int levelVertOffset, int fvarChannel);
 
     StencilTable *_vertexStencils;
     StencilTable *_varyingStencils;

--- a/opensubdiv/far/endCapLegacyGregoryPatchFactory.h
+++ b/opensubdiv/far/endCapLegacyGregoryPatchFactory.h
@@ -58,14 +58,17 @@ public:
     ///
     /// @param levelVertOffset  relative offset of patch vertex indices
     ///
+    /// @param fvarChannel      face-varying channel index
+    ///
     ConstIndexArray GetPatchPoints(
         Vtr::internal::Level const * level, Index faceIndex,
         Vtr::internal::Level::VSpan const cornerSpans[],
-        int levelVertOffset);
+        int levelVertOffset, int fvarChannel = -1);
 
     void Finalize(int maxValence, 
                   PatchTable::QuadOffsetsTable *quadOffsetsTable,
-                  PatchTable::VertexValenceTable *vertexValenceTable);
+                  PatchTable::VertexValenceTable *vertexValenceTable,
+                  int fvarChannel = -1);
 
 
 private:

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -347,6 +347,9 @@ gatherEndCapPatchPoints(
     int levelVertOffset = (fvarChannel < 0)
                         ? levelVertOffsets[patch.levelIndex]
                         : levelFVarValueOffsets[fvarChannel][patch.levelIndex];
+    int refinerChannel = (fvarChannel < 0)
+                       ? fvarChannel
+                       : fvarChannelIndices[fvarChannel];
 
     // identify relevant spans around the corner vertices for the irregular patches
     // (this is just a stub for now -- leaving the span "size" to zero, as constructed,
@@ -354,7 +357,7 @@ gatherEndCapPatchPoints(
     Vtr::internal::Level::VSpan cornerSpans[4];
 
     ConstIndexArray cvs = endCapFactory->GetPatchPoints(
-        level, patch.faceIndex, cornerSpans, levelVertOffset);
+        level, patch.faceIndex, cornerSpans, levelVertOffset, refinerChannel);
 
     for (int i = 0; i < cvs.size(); ++i) iptrs[i] = cvs[i];
     return cvs.size();


### PR DESCRIPTION
Added support for gathering face-varying patch points to
the Far::EndCap*PatchFactory classes. Also, changed these classes
to compute varying stencils optionally, since separate varying
stencils are not needed for face-varying patches.

Also, removed a no longer used stateless factory method from
the EndCapGregoryBasisPatchFactory.