### PR TITLE
Populate varying vertices in Far::PatchTable

### DIFF
--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -414,6 +414,45 @@ PatchTable::getPatchArrayVaryingVertices(int arrayIndex) {
     Index start = pa.patchIndex * numVaryingCVs;
     return IndexArray(&_varyingVerts[start], pa.numPatches * numVaryingCVs);
 }
+void
+PatchTable::populateVaryingVertices() {
+    // In order to support evaluation of varying data we need to access
+    // the varying values indexed by the zero ring vertices of the vertex
+    // patch. This indexing is redundant for triangles and quads and
+    // could be made redunant for other patch types if we reorganized
+    // the vertex patch indices so that the zero ring indices always occured
+    // first. This will also need to be updated when we add support for
+    // triangle patches.
+    int numVaryingCVs = _varyingDesc.GetNumControlVertices();
+    for (int arrayIndex=0; arrayIndex<(int)_patchArrays.size(); ++arrayIndex) {
+        PatchArray const & pa = getPatchArray(arrayIndex);
+        PatchDescriptor::Type patchType = pa.desc.GetType();
+        for (int patch=0; patch<pa.numPatches; ++patch) {
+            ConstIndexArray vertexCVs = GetPatchVertices(arrayIndex, patch);
+            int start = (pa.patchIndex + patch) * numVaryingCVs;
+            if (patchType == PatchDescriptor::REGULAR) {
+                _varyingVerts[start+0] = vertexCVs[5];
+                _varyingVerts[start+1] = vertexCVs[6];
+                _varyingVerts[start+2] = vertexCVs[10];
+                _varyingVerts[start+3] = vertexCVs[9];
+            } else if (patchType == PatchDescriptor::GREGORY_BASIS) {
+                _varyingVerts[start+0] = vertexCVs[0];
+                _varyingVerts[start+1] = vertexCVs[5];
+                _varyingVerts[start+2] = vertexCVs[10];
+                _varyingVerts[start+3] = vertexCVs[15];
+            } else if (patchType == PatchDescriptor::QUADS) {
+                _varyingVerts[start+0] = vertexCVs[0];
+                _varyingVerts[start+1] = vertexCVs[1];
+                _varyingVerts[start+2] = vertexCVs[2];
+                _varyingVerts[start+3] = vertexCVs[3];
+            } else if (patchType == PatchDescriptor::TRIANGLES) {
+                _varyingVerts[start+0] = vertexCVs[0];
+                _varyingVerts[start+1] = vertexCVs[1];
+                _varyingVerts[start+2] = vertexCVs[2];
+            }
+        }
+    }
+}
 
 int
 PatchTable::GetNumFVarChannels() const {

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -476,6 +476,7 @@ private:
 
     void allocateVaryingVertices(
         PatchDescriptor desc, int numPatches);
+    void populateVaryingVertices();
 
     //
     // Face-varying patch channels

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -156,7 +156,8 @@ private:
     static void populateAdaptivePatches(BuilderContext & context,
                                         PatchTable * table);
 
-    static void allocateVertexTables(PatchTable * table, bool hasSharpness);
+    static void allocateVertexTables(BuilderContext const & context,
+                                     PatchTable * table);
 
     static void allocateFVarChannels(BuilderContext const & context,
                                      PatchTable * table);


### PR DESCRIPTION
In order to support a consistent API for refinement and
evaluation of varying primvar data, Far::PatchTable needs
to provide indices for varying data. This adds support to
Far::PatchTableFactory for generating these indices.