### PR TITLE
PatchTableFactory changes for smooth FVar patches

### DIFF
--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
@@ -96,7 +96,7 @@ EndCapBSplineBasisPatchFactory::GetPatchPoints(
     Vtr::ConstIndexArray facePoints = level->getFaceVertices(thisFace);
 
     int irregCornerIndex = -1;
-    bool useGregoryPatch = false;
+    bool useGregoryPatch = (fvarChannel >= 0);
 
     for (int corner = 0; (corner < 4) && !useGregoryPatch; ++corner) {
         Vtr::internal::Level::VTag vtag = level->getVertexTag(facePoints[corner]);

--- a/opensubdiv/far/patchBasis.cpp
+++ b/opensubdiv/far/patchBasis.cpp
@@ -52,11 +52,11 @@ public:
     static void GetWeights(float v, float w, float point[]);
 
     // patch weights
-    static void GetPatchWeights(PatchParam const & param,
+    static void GetPatchWeights(PatchParamBase const & param,
         float s, float t, float point[], float deriv1[], float deriv2[], float deriv11[], float deriv12[], float deriv22[]);
 
     // adjust patch weights for boundary (and corner) edges
-    static void AdjustBoundaryWeights(PatchParam const & param,
+    static void AdjustBoundaryWeights(PatchParamBase const & param,
         float sWeights[4], float tWeights[4]);
 };
 
@@ -180,7 +180,7 @@ inline void Spline<BASIS_BOX_SPLINE>::GetWeights(
 }
 
 template <>
-inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParam const & param,
+inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParamBase const & param,
     float s, float t, float point[4], float derivS[4], float derivT[4], float derivSS[4], float derivST[4], float derivTT[4]) {
 
     param.Normalize(s,t);
@@ -225,7 +225,7 @@ inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParam const & param,
 }
 
 template <SplineBasis BASIS>
-void Spline<BASIS>::AdjustBoundaryWeights(PatchParam const & param,
+void Spline<BASIS>::AdjustBoundaryWeights(PatchParamBase const & param,
     float sWeights[4], float tWeights[4]) {
 
     int boundary = param.GetBoundary();
@@ -253,7 +253,7 @@ void Spline<BASIS>::AdjustBoundaryWeights(PatchParam const & param,
 }
 
 template <SplineBasis BASIS>
-void Spline<BASIS>::GetPatchWeights(PatchParam const & param,
+void Spline<BASIS>::GetPatchWeights(PatchParamBase const & param,
     float s, float t, float point[16], float derivS[16], float derivT[16], float derivSS[16], float derivST[16], float derivTT[16]) {
 
     float sWeights[4], tWeights[4], dsWeights[4], dtWeights[4], dssWeights[4], dttWeights[4];
@@ -310,22 +310,22 @@ void Spline<BASIS>::GetPatchWeights(PatchParam const & param,
     }
 }
 
-void GetBilinearWeights(PatchParam const & param,
+void GetBilinearWeights(PatchParamBase const & param,
     float s, float t, float point[4], float deriv1[4], float deriv2[4], float deriv11[4], float deriv12[4], float deriv22[4]) {
     Spline<BASIS_BILINEAR>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
-void GetBezierWeights(PatchParam const param,
+void GetBezierWeights(PatchParamBase const param,
     float s, float t, float point[16], float deriv1[16], float deriv2[16], float deriv11[16], float deriv12[16], float deriv22[16]) {
     Spline<BASIS_BEZIER>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
-void GetBSplineWeights(PatchParam const & param,
+void GetBSplineWeights(PatchParamBase const & param,
     float s, float t, float point[16], float deriv1[16], float deriv2[16], float deriv11[16], float deriv12[16], float deriv22[16]) {
     Spline<BASIS_BSPLINE>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
-void GetGregoryWeights(PatchParam const & param,
+void GetGregoryWeights(PatchParamBase const & param,
     float s, float t, float point[20], float deriv1[20], float deriv2[20], float deriv11[20], float deriv12[20], float deriv22[20]) {
     //
     //  P3         e3-      e2+         P2

--- a/opensubdiv/far/patchBasis.h
+++ b/opensubdiv/far/patchBasis.h
@@ -45,16 +45,16 @@ namespace internal {
 // So this interface will be changing in future.
 //
 
-void GetBilinearWeights(PatchParam const & patchParam,
+void GetBilinearWeights(PatchParamBase const & patchParam,
     float s, float t, float wP[4], float wDs[4], float wDt[4], float wDss[4] = 0, float wDst[4] = 0, float wDtt[4] = 0);
 
-void GetBezierWeights(PatchParam const & patchParam,
+void GetBezierWeights(PatchParamBase const & patchParam,
     float s, float t, float wP[16], float wDs[16], float wDt[16], float wDss[16] = 0, float wDst[16] = 0, float wDtt[16] = 0);
 
-void GetBSplineWeights(PatchParam const & patchParam,
+void GetBSplineWeights(PatchParamBase const & patchParam,
     float s, float t, float wP[16], float wDs[16], float wDt[16], float wDss[16] = 0, float wDst[16] = 0, float wDtt[16] = 0);
 
-void GetGregoryWeights(PatchParam const & patchParam,
+void GetGregoryWeights(PatchParamBase const & patchParam,
     float s, float t, float wP[20], float wDs[20], float wDt[20], float wDss[20] = 0, float wDst[20] = 0, float wDtt[20] = 0);
 
 

--- a/opensubdiv/far/patchParam.h
+++ b/opensubdiv/far/patchParam.h
@@ -135,7 +135,7 @@ PatchParam::Set( Index faceid, short u, short v,
              ((v & 0x3ff) << 12) |
              ((boundary & 0xf) << 8) |
              ((nonquad ? 1:0) << 4) |
-             (nonquad ? depth+1 : depth);
+             (depth);
 }
 
 inline float

--- a/opensubdiv/far/patchParam.h
+++ b/opensubdiv/far/patchParam.h
@@ -34,34 +34,267 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Far {
 
-/// \brief Local patch parameterization descriptor
+namespace internal {
+
+/// \brief Patch parameterization
 ///
-/// Coarse mesh faces are split into sets of patches in both uniform and feature
-/// adaptive modes. In order to maintain local patch parameterization, it is
-/// necessary to retain some information, such as level of subdivision, face-
-/// winding status... This parameterization is directly applicable to ptex textures,
-/// but has to be remapped to a specific layout for uv textures.
+/// Topological refinement splits coarse mesh faces into refined faces.
+///
+/// This patch parameterzation describes the relationship between one
+/// of these refined faces and its corresponding coarse face. It is used
+/// both for refined faces that are represented as full limit surface
+/// parametric patches as well as for refined faces represented as simple
+/// triangles or quads. This parameterization is needed to interpolate
+/// primvar data across a refined face.
+///
+/// The U,V and refinement level parameters describe the scale and offset
+/// needed to map a location on the patch between levels of refinement.
+/// The encoding of these values exploits the quad-tree organization of
+/// the faces produced by subdivision. We encode the U,V origin of the
+/// patch using two 10-bit integer values and the refinement level as
+/// a 4-bit integer. This is sufficient to represent up through 10 levels
+/// of refinement.
+///
+/// Special consideration must be given to the refined faces resulting from
+/// irregular coarse faces. We adopt a convention similar to Ptex texture
+/// mapping and define the parameterization for these faces in terms of the
+/// regular faces resulting from the first topological splitting of the
+/// irregular coarse face.
+///
+/// When computing the basis functions needed to evaluate the limit surface
+/// parametric patch representing a refined face, we also need to know which
+/// edges of the patch are interpolated boundaries. These edges are encoded
+/// as a boundary bitmask identifying the boundary edges of the patch in
+/// sequential order starting from the first vertex of the refined face.
+///
+/// A sparse topological refinement (like feature adaptive refinement) can
+/// produce refined faces that are adjacent to faces at the next level of
+/// subdivision. We identify these transitional edges with a transition
+/// bitmask using the same encoding as the boundary bitmask.
+///
+/// For triangular subdivision schemes we specify the parameterization using
+/// a similar method. Alternate triangles at a given level of refinement
+/// are parameterized from their opposite corners and encoded as occupying
+/// the opposite diagonal of the quad-tree hierarchy. The third barycentric
+/// coordinate is dependent on and can be derived from the other two
+/// coordinates. This encoding also takes inspiration from the Ptex
+/// texture mapping specification.
 ///
 /// Bitfield layout :
+///
+///  Field1     | Bits | Content
+///  -----------|:----:|------------------------------------------------------
+///  level      | 4    | the subdivision level of the patch
+///  nonquad    | 1    | whether the patch is refined from a non-quad face
+///  unused     | 3    | unused
+///  boundary   | 4    | boundary edge mask encoding
+///  v          | 10   | log2 value of u parameter at first patch corner
+///  u          | 10   | log2 value of v parameter at first patch corner
 ///
 ///  Field0     | Bits | Content
 ///  -----------|:----:|------------------------------------------------------
 ///  faceId     | 28   | the faceId of the patch
 ///  transition | 4    | transition edge mask encoding
 ///
-///  Field1     | Bits | Content
-///  -----------|:----:|------------------------------------------------------
-///  level      | 4    | the subdivision level of the patch
-///  nonquad    | 1    | whether the patch is the child of a non-quad face
-///  unused     | 3    | unused
-///  boundary   | 4    | boundary edge mask encoding
-///  v          | 10   | log2 value of u parameter at first patch corner
-///  u          | 10   | log2 value of v parameter at first patch corner
-///
 /// Note : the bitfield is not expanded in the struct due to differences in how
 ///        GPU & CPU compilers pack bit-fields and endian-ness.
 ///
-struct PatchParam {
+/*!
+ \verbatim
+ Quad Patch Parameterization
+
+ (0,1)                           (1,1)
+   +-------+-------+---------------+
+   |       |       |               |
+   |   L2  |   L2  |               |
+   |0,3    |1,3    |               |
+   +-------+-------+       L1      |
+   |       |       |               |
+   |   L2  |   L2  |               |
+   |0,2    |1,2    |1,1            |
+   +-------+-------+---------------+
+   |               |               |
+   |               |               |
+   |               |               |
+   |       L1      |       L1      |
+   |               |               |
+   |               |               |
+   |0,0            |1,0            |
+   +---------------+---------------+
+ (0,0)                           (1,0)
+ \endverbatim
+*/
+/*!
+ \verbatim
+ Triangle Patch Parameterization
+
+ (0,1)                           (1,1)  (0,1,0)
+   +-------+-------+---------------+       +
+   | \     | \     | \             |       | \
+   |L2 \   |L2 \   |   \           |       |   \
+   |0,3  \ |1,3  \ |     \         |       | L2  \
+   +-------+-------+       \       |       +-------+
+   | \     | \     |   L1    \     |       | \  L2 | \
+   |L2 \   |L2 \   |           \   |       |   \   |   \
+   |0,2  \ |1,2  \ |1,1          \ |       | L2  \ | L2  \
+   +-------+-------+---------------+       +-------+-------+
+   | \             | \             |       | \             | \
+   |   \           |   \           |       |   \           |   \
+   |     \         |     \         |       |     \    L1   |     \
+   |       \       |       \       |       |       \       |       \
+   |   L1    \     |   L1    \     |       |   L1    \     |   L1    \
+   |           \   |           \   |       |           \   |           \
+   |0,0          \ |1,0          \ |       |             \ |             \
+   +---------------+---------------+       +---------------+---------------+
+ (0,0)                           (1,0)  (0,0,1)                         (1,0,0)
+ \endverbatim
+*/
+
+template <class IMPL>
+struct PatchParamInterface {
+public:
+    /// \brief Returns the log2 value of the u parameter at
+    /// the first corner of the patch
+    unsigned short GetU() const { return baseData<unsigned short>(10,22); }
+
+    /// \brief Returns the log2 value of the v parameter at
+    /// the first corner of the patch
+    unsigned short GetV() const { return baseData<unsigned short>(10,12); }
+
+    /// \brief Returns the boundary edge encoding for the patch.
+    unsigned short GetBoundary() const { return baseData<unsigned short>(4,8); }
+
+    /// \brief True if the parent coarse face is a non-quad
+    bool NonQuadRoot() const { return (baseData<unsigned int>(1,4) != 0); }
+
+    /// \brief Returns the level of subdivision of the patch
+    unsigned short GetDepth() const { return baseData<unsigned short>(4,0); }
+
+    /// \brief Returns the fraction of the coarse face parametric space
+    /// covered by this refined face.
+    float GetParamFraction() const;
+
+    /// \brief Maps the (u,v) parameterization from coarse to refined
+    /// The (u,v) pair is mapped from the coarse face parameterization to
+    /// the refined face parameterization
+    ///
+    void MapCoarseToRefined( float & u, float & v ) const;
+
+    /// \brief Maps the (u,v) parameterization from refined to coarse
+    /// The (u,v) pair is mapped from the refined face parameterization to
+    /// the coarse face parameterization
+    ///
+    void MapRefinedToCoarse( float & u, float & v ) const;
+
+    /// \brief Deprecated @see PatchParam#MapCoarseToRefined
+    void Normalize( float & u, float & v ) const {
+        return MapCoarseToRefined(u, v);
+    }
+
+protected:
+    unsigned int packBaseData(short u, short v,
+                              unsigned short depth, bool nonquad,
+                              unsigned short boundary) {
+        return pack(u,       10, 22) |
+               pack(v,       10, 12) |
+               pack(boundary, 4,  8) |
+               pack(nonquad,  1,  4) |
+               pack(depth,    4,  0);
+    }
+
+    template <class RETURN_TYPE>
+    RETURN_TYPE baseData(int width, int offset) const {
+        unsigned int value = static_cast<IMPL const *>(this)->baseValue();
+        return (RETURN_TYPE)unpack(value, width, offset);
+    }
+
+    unsigned int pack(unsigned int value, int width, int offset) const {
+        return (unsigned int)((value & ((1<<width)-1)) << offset);
+    }
+
+    unsigned int unpack(unsigned int value, int width, int offset) const {
+        return (unsigned short)((value >> offset) & ((1<<width)-1));
+    }
+};
+
+template<class IMPL>
+inline float
+PatchParamInterface<IMPL>::GetParamFraction( ) const {
+
+    if (NonQuadRoot()) {
+        return 1.0f / float( 1 << (GetDepth()-1) );
+    } else {
+        return 1.0f / float( 1 << GetDepth() );
+    }
+}
+
+template<class IMPL>
+inline void
+PatchParamInterface<IMPL>::MapCoarseToRefined( float & u, float & v ) const {
+
+    float frac = GetParamFraction();
+
+    float pu = (float)GetU()*frac;
+    float pv = (float)GetV()*frac;
+
+    u = (u - pu) / frac,
+    v = (v - pv) / frac;
+}
+
+template<class IMPL>
+inline void
+PatchParamInterface<IMPL>::MapRefinedToCoarse( float & u, float & v ) const {
+
+    float frac = GetParamFraction();
+
+    float pu = (float)GetU()*frac;
+    float pv = (float)GetV()*frac;
+
+    u = u * frac + pu,
+    v = v * frac + pv;
+}
+
+} // end namespace internal
+
+/// \brief Local patch parameterization
+///
+struct PatchParamBase : public Far::internal::PatchParamInterface<PatchParamBase> {
+public:
+    /// \brief Sets the values of the bit fields
+    ///
+    /// @param u value of the u parameter for the first corner of the face
+    /// @param v value of the v parameter for the first corner of the face
+    ///
+    /// @param depth subdivision level of the patch
+    /// @param nonquad true if the root face is not a quad
+    ///
+    /// @param boundary 4-bits identifying boundary edges
+    ///
+    void Set(short u, short v,
+             unsigned short depth, bool nonquad,
+             unsigned short boundary) {
+        field1 = packBaseData(u, v, depth, nonquad, boundary);
+    }
+
+    /// \brief Resets everything to 0
+    void Clear() { field1 = 0; }
+
+    unsigned int field1:32;
+
+protected:
+    friend struct Far::internal::PatchParamInterface<PatchParamBase>;
+    unsigned int baseValue() const { return field1; }
+};
+
+typedef std::vector<PatchParamBase> PatchParamBaseTable;
+
+typedef Vtr::Array<PatchParamBase> PatchParamBaseArray;
+typedef Vtr::ConstArray<PatchParamBase> ConstPatchParamBaseArray;
+
+/// \brief Local patch parameterization for vertex patches
+///
+struct PatchParam : public Far::internal::PatchParamInterface<PatchParam> {
+public:
     /// \brief Sets the values of the bit fields
     ///
     /// @param faceid face index
@@ -71,95 +304,46 @@ struct PatchParam {
     ///
     /// @param depth subdivision level of the patch
     /// @param nonquad true if the root face is not a quad
-    //
+    ///
     /// @param boundary 4-bits identifying boundary edges
     /// @param transition 4-bits identifying transition edges
     ///
-    void Set( Index faceid, short u, short v,
-              unsigned short depth, bool nonquad ,
-              unsigned short boundary, unsigned short transition );
+    void Set(Index faceid, short u, short v,
+             unsigned short depth, bool nonquad,
+             unsigned short boundary, unsigned short transition) {
+        field0 = pack(faceid, 28, 0) | pack(transition, 4, 28);
+        field1 = packBaseData(u, v, depth, nonquad, boundary);
+    }
 
     /// \brief Resets everything to 0
     void Clear() { field0 = field1 = 0; }
 
     /// \brief Retuns the faceid
-    Index GetFaceId() const { return Index(field0 & 0xfffffff); }
-
-    /// \brief Returns the log2 value of the u parameter at the top left corner of
-    /// the patch
-    unsigned short GetU() const { return (unsigned short)((field1 >> 22) & 0x3ff); }
-
-    /// \brief Returns the log2 value of the v parameter at the top left corner of
-    /// the patch
-    unsigned short GetV() const { return (unsigned short)((field1 >> 12) & 0x3ff); }
+    Index GetFaceId() const { return Index(unpack(field0,28,0)); }
 
     /// \brief Returns the transition edge encoding for the patch.
-    unsigned short GetTransition() const { return (unsigned short)((field0 >> 28) & 0xf); }
+    unsigned short GetTransition() const {
+        return (unsigned short)unpack(field0,4,28);
+    }
 
-    /// \brief Returns the boundary edge encoding for the patch.
-    unsigned short GetBoundary() const { return (unsigned short)((field1 >> 8) & 0xf); }
-
-    /// \brief True if the parent coarse face is a non-quad
-    bool NonQuadRoot() const { return (field1 >> 4) & 0x1; }
-
-    /// \brief Returns the fraction of normalized parametric space covered by the
-    /// sub-patch.
-    float GetParamFraction() const;
-
-    /// \brief Returns the level of subdivision of the patch
-    unsigned short GetDepth() const { return  (unsigned short)(field1 & 0xf); }
-
-    /// The (u,v) pair is normalized to this sub-parametric space.
-    ///
-    /// @param u  u parameter
-    /// @param v  v parameter
-    ///
-    void Normalize( float & u, float & v ) const;
+    PatchParamBase GetPatchParamBase() const {
+        PatchParamBase result;
+        result.field1 = field1;
+        return result;
+    }
 
     unsigned int field0:32;
     unsigned int field1:32;
+
+protected:
+    friend struct Far::internal::PatchParamInterface<PatchParam>;
+    unsigned int baseValue() const { return field1; }
 };
 
 typedef std::vector<PatchParam> PatchParamTable;
 
 typedef Vtr::Array<PatchParam> PatchParamArray;
 typedef Vtr::ConstArray<PatchParam> ConstPatchParamArray;
-
-inline void
-PatchParam::Set( Index faceid, short u, short v,
-                 unsigned short depth, bool nonquad,
-                 unsigned short boundary, unsigned short transition ) {
-    field0 = (((unsigned int)faceid) & 0xfffffff) |
-             ((transition & 0xf) << 28);
-    field1 = ((u & 0x3ff) << 22) |
-             ((v & 0x3ff) << 12) |
-             ((boundary & 0xf) << 8) |
-             ((nonquad ? 1:0) << 4) |
-             (depth);
-}
-
-inline float
-PatchParam::GetParamFraction( ) const {
-    if (NonQuadRoot()) {
-        return 1.0f / float( 1 << (GetDepth()-1) );
-    } else {
-        return 1.0f / float( 1 << GetDepth() );
-    }
-}
-
-inline void
-PatchParam::Normalize( float & u, float & v ) const {
-
-    float frac = GetParamFraction();
-
-    // top left corner
-    float pu = (float)GetU()*frac;
-    float pv = (float)GetV()*frac;
-
-    // normalize u,v coordinates
-    u = (u - pu) / frac,
-    v = (v - pv) / frac;
-}
 
 } // end namespace Far
 

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -414,6 +414,45 @@ PatchTable::getPatchArrayVaryingVertices(int arrayIndex) {
     Index start = pa.patchIndex * numVaryingCVs;
     return IndexArray(&_varyingVerts[start], pa.numPatches * numVaryingCVs);
 }
+void
+PatchTable::populateVaryingVertices() {
+    // In order to support evaluation of varying data we need to access
+    // the varying values indexed by the zero ring vertices of the vertex
+    // patch. This indexing is redundant for triangles and quads and
+    // could be made redunant for other patch types if we reorganized
+    // the vertex patch indices so that the zero ring indices always occured
+    // first. This will also need to be updated when we add support for
+    // triangle patches.
+    int numVaryingCVs = _varyingDesc.GetNumControlVertices();
+    for (int arrayIndex=0; arrayIndex<(int)_patchArrays.size(); ++arrayIndex) {
+        PatchArray const & pa = getPatchArray(arrayIndex);
+        PatchDescriptor::Type patchType = pa.desc.GetType();
+        for (int patch=0; patch<pa.numPatches; ++patch) {
+            ConstIndexArray vertexCVs = GetPatchVertices(arrayIndex, patch);
+            int start = (pa.patchIndex + patch) * numVaryingCVs;
+            if (patchType == PatchDescriptor::REGULAR) {
+                _varyingVerts[start+0] = vertexCVs[5];
+                _varyingVerts[start+1] = vertexCVs[6];
+                _varyingVerts[start+2] = vertexCVs[10];
+                _varyingVerts[start+3] = vertexCVs[9];
+            } else if (patchType == PatchDescriptor::GREGORY_BASIS) {
+                _varyingVerts[start+0] = vertexCVs[0];
+                _varyingVerts[start+1] = vertexCVs[5];
+                _varyingVerts[start+2] = vertexCVs[10];
+                _varyingVerts[start+3] = vertexCVs[15];
+            } else if (patchType == PatchDescriptor::QUADS) {
+                _varyingVerts[start+0] = vertexCVs[0];
+                _varyingVerts[start+1] = vertexCVs[1];
+                _varyingVerts[start+2] = vertexCVs[2];
+                _varyingVerts[start+3] = vertexCVs[3];
+            } else if (patchType == PatchDescriptor::TRIANGLES) {
+                _varyingVerts[start+0] = vertexCVs[0];
+                _varyingVerts[start+1] = vertexCVs[1];
+                _varyingVerts[start+2] = vertexCVs[2];
+            }
+        }
+    }
+}
 
 int
 PatchTable::GetNumFVarChannels() const {

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -523,7 +523,8 @@ PatchTable::EvaluateBasis(
     float wDss[], float wDst[], float wDtt[]) const {
 
     PatchDescriptor::Type patchType = GetPatchArrayDescriptor(handle.arrayIndex).GetType();
-    PatchParam const & param = _paramTable[handle.patchIndex];
+    PatchParamBase const & param =
+        _paramTable[handle.patchIndex].GetPatchParamBase();
 
     if (patchType == PatchDescriptor::REGULAR) {
         internal::GetBSplineWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
@@ -545,7 +546,8 @@ PatchTable::EvaluateBasisVarying(
     float wP[], float wDs[], float wDt[],
     float wDss[], float wDst[], float wDtt[]) const {
 
-    PatchParam const & param = _paramTable[handle.patchIndex];
+    PatchParamBase const & param =
+        _paramTable[handle.patchIndex].GetPatchParamBase();
 
     internal::GetBilinearWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
 }
@@ -561,7 +563,8 @@ PatchTable::EvaluateBasisFaceVarying(
     int channel) const {
 
     PatchDescriptor::Type patchType = GetFVarChannelPatchDescriptor(channel).GetType();
-    PatchParam param = _paramTable[handle.patchIndex];
+    PatchParamBase const & param =
+        _paramTable[handle.patchIndex].GetPatchParamBase();
     // XXXdyu need fvar boundary parameterization
 
     if (patchType == PatchDescriptor::REGULAR) {

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -476,6 +476,7 @@ private:
 
     void allocateVaryingVertices(
         PatchDescriptor desc, int numPatches);
+    void populateVaryingVertices();
 
     //
     // Face-varying patch channels

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -308,9 +308,20 @@ public:
     /// \brief Returns the value indices for the patches in \p array in \p channel
     ConstIndexArray GetPatchArrayFVarValues(int array, int channel = 0) const;
 
-
     /// \brief Returns an array of value indices for the patches in \p channel
     ConstIndexArray GetFVarValues(int channel = 0) const;
+
+    /// \brief Returns the value indices for a given patch in \p channel
+    PatchParamBase GetPatchFVarPatchParam(PatchHandle const & handle, int channel = 0) const;
+
+    /// \brief Returns the face-varying params for a given patch \p channel
+    PatchParamBase GetPatchFVarPatchParam(int array, int patch, int channel = 0) const;
+
+    /// \brief Returns the face-varying for a given patch in \p array in \p channel
+    ConstPatchParamBaseArray GetPatchArrayFVarPatchParam(int array, int channel = 0) const;
+
+    /// \brief Returns an array of face-varying patch param for \p channel
+    ConstPatchParamBaseArray GetFVarPatchParam(int channel = 0) const;
     //@}
 
 
@@ -498,6 +509,9 @@ private:
 
     IndexArray getFVarValues(int channel);
     ConstIndexArray getPatchFVarValues(int patch, int channel) const;
+
+    PatchParamBaseArray getFVarPatchParam(int channel);
+    PatchParamBase getPatchFVarPatchParam(int patch, int channel) const;
 
 private:
 

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -702,7 +702,6 @@ PatchTableFactory::computePatchParam(
 
     if (nonquad) {
         ptexIndex+=childIndexInParent;
-        --depth;
     }
 
     PatchParam param;

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -156,7 +156,8 @@ private:
     static void populateAdaptivePatches(BuilderContext & context,
                                         PatchTable * table);
 
-    static void allocateVertexTables(PatchTable * table, bool hasSharpness);
+    static void allocateVertexTables(BuilderContext const & context,
+                                     PatchTable * table);
 
     static void allocateFVarChannels(BuilderContext const & context,
                                      PatchTable * table);

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -59,6 +59,7 @@ public:
     struct PatchFaceTag {
     public:
         unsigned int   _isRegular       : 1;
+        unsigned int   _isLinear        : 1;
         unsigned int   _transitionMask  : 4;
         unsigned int   _boundaryMask    : 4;
         unsigned int   _boundaryIndex   : 2;
@@ -90,6 +91,7 @@ public:
              endCapType(ENDCAP_GREGORY_BASIS),
              shareEndCapPatchPoints(true),
              generateFVarTables(false),
+             generateFVarLegacyLinearPatches(true),
              numFVarChannels(-1),
              fvarChannelIndices(0)
         { }
@@ -111,7 +113,8 @@ public:
                                                   ///< currently only work with GregoryBasis.
 
                      // face-varying
-                     generateFVarTables   : 1;///< Generate face-varying patch tables
+                     generateFVarTables              : 1, ///< Generate face-varying patch tables
+                     generateFVarLegacyLinearPatches : 1; ///< Generate all linear face-varying patches (legacy)
         int          numFVarChannels;          ///< Number of channel indices and interpolation modes passed
         int const *  fvarChannelIndices;       ///< List containing the indices of the channels selected for the factory
     };
@@ -145,11 +148,6 @@ private:
     //
     //  High-level methods for identifying and populating patches associated with faces:
     //
-
-    static bool computePatchTag(BuilderContext & context,
-                                Index const levelIndex,
-                                Index const faceIndex,
-                                PatchTableFactory::PatchFaceTag &patchTag);
 
     static void identifyAdaptivePatches(BuilderContext & context);
 

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -291,7 +291,7 @@ TopologyRefiner::RefineAdaptive(AdaptiveOptions options) {
         //  Ignore face-varying channels if none present are non-linear:
         adaptiveFeatureMask.fvarFeatures = false;
         for (int channel = 0; channel < _levels[0]->getNumFVarChannels(); ++channel) {
-            adaptiveFeatureMask.fvarFeatures |= _levels[0]->getFVarLevel(channel).isLinear();
+            adaptiveFeatureMask.fvarFeatures |= !_levels[0]->getFVarLevel(channel).isLinear();
         }
     }
 

--- a/opensubdiv/osd/cpuEvaluator.cpp
+++ b/opensubdiv/osd/cpuEvaluator.cpp
@@ -145,8 +145,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         // XXX: patchIndex is absolute. not sure it's consistent.
         //      (should be offsetted by array.primitiveIdBase?)
         //    patchParamBuffer[array.primitiveIdBase + coord.handle.patchIndex]
-        Far::PatchParam const & param =
-            patchParamBuffer[coord.handle.patchIndex];
+        Far::PatchParamBase const & param =
+            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -218,8 +218,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
         int patchType = array.GetPatchType();
-        Far::PatchParam const & param =
-            patchParamBuffer[coord.handle.patchIndex];
+        Far::PatchParamBase const & param =
+            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {

--- a/opensubdiv/osd/ompEvaluator.cpp
+++ b/opensubdiv/osd/ompEvaluator.cpp
@@ -142,8 +142,8 @@ OmpEvaluator::EvalPatches(
         // XXX: patchIndex is absolute. not sure it's consistent.
         //      (should be offsetted by array.primitiveIdBase?)
         //    patchParamBuffer[array.primitiveIdBase + coord.handle.patchIndex]
-        Far::PatchParam const & param =
-            patchParamBuffer[coord.handle.patchIndex];
+        Far::PatchParamBase const & param =
+            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -203,8 +203,8 @@ OmpEvaluator::EvalPatches(
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
         int patchType = array.GetPatchType();
-        Far::PatchParam const & param =
-            patchParamBuffer[coord.handle.patchIndex];
+        Far::PatchParamBase const & param =
+            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {

--- a/opensubdiv/osd/tbbKernel.cpp
+++ b/opensubdiv/osd/tbbKernel.cpp
@@ -317,8 +317,8 @@ public:
             PatchArray const &array = _patchArrayBuffer[coord.handle.arrayIndex];
 
             int patchType = array.GetPatchType();
-            Far::PatchParam const & param =
-                _patchParamBuffer[coord.handle.patchIndex];
+            Far::PatchParamBase const & param =
+                _patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
 
             int numControlVertices = 0;
             if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -371,8 +371,8 @@ public:
             PatchArray const &array = _patchArrayBuffer[coord.handle.arrayIndex];
 
             int patchType = array.GetPatchType();
-            Far::PatchParam const & param =
-                _patchParamBuffer[coord.handle.patchIndex];
+            Far::PatchParamBase const & param =
+                _patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
 
             int numControlVertices = 0;
             if (patchType == Far::PatchDescriptor::REGULAR) {


### PR DESCRIPTION
These changes add basic support for building patch
tables with smooth face-varying patches. There is more
work to do to improve topological inspection and
tagging in order to take full advantage of improvements
for handling the change of basis for irregular patches.