### PR TITLE
Improved PatchTableFactory for mixed FVar patches

### DIFF
--- a/opensubdiv/far/patchParam.h
+++ b/opensubdiv/far/patchParam.h
@@ -272,12 +272,16 @@ public:
     ///
     void Set(short u, short v,
              unsigned short depth, bool nonquad,
-             unsigned short boundary) {
+             unsigned short boundary, bool isRegular = true) {
         field1 = packBaseData(u, v, depth, nonquad, boundary);
+        field1 |= pack(isRegular,1,5);
     }
 
     /// \brief Resets everything to 0
     void Clear() { field1 = 0; }
+
+    /// \brief Returns whether the patch is regular
+    bool IsRegular() const { return (unpack(field1,1,5) != 0); }
 
     unsigned int field1:32;
 

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -594,8 +594,10 @@ PatchTable::EvaluateBasisFaceVarying(
     float wDss[], float wDst[], float wDtt[],
     int channel) const {
 
-    PatchDescriptor::Type patchType = GetFVarChannelPatchDescriptor(channel).GetType();
     PatchParamBase param = GetPatchFVarPatchParam(handle.arrayIndex, handle.patchIndex, channel);
+    PatchDescriptor::Type patchType = param.IsRegular()
+            ? PatchDescriptor::REGULAR
+            : GetFVarChannelPatchDescriptor(channel).GetType();
 
     if (patchType == PatchDescriptor::REGULAR) {
         internal::GetBSplineWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);


### PR DESCRIPTION
The patches generated for a face-varying channel can be a
mix of regular patches and patches in an alternate basis
for faces that are irregular in face-varying space.

This mix of patches is packed into a single fvar value array
in the patch table using a consistent stride with the individual
patch type determined by the fvar patch param encoding.

- Added Far::PatchParamBase::IsRegular() to designate which
patches are regular.

- Updated Far::PatchTableFactory to gather mixed basis
patches when using the Gregory basis approximation for
irregular patches.

- Fixed Far::PatchTable::EvaluateBasisFaceVarying() to
use the fvar patch param encoding to determine the type
of face-varying patches.