### PR TITLE
Improvements to Far::PatchTableFactory for face-varying patches

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -780,10 +780,10 @@ PatchTableFactory::computePatchParam(
         Refinement const& refinement  = refiner.getRefinement(i-1);
         Level const&      parentLevel = refiner.getLevel(i-1);
 
-        Index parentFaceIndex    = refinement.getChildFaceParentFace(faceIndex);
-        int   childIndexInParent = refinement.getChildFaceInParentFace(faceIndex);
+        Index parentFaceIndex = refinement.getChildFaceParentFace(faceIndex);
 
         if (parentLevel.getFaceVertices(parentFaceIndex).size() == 4) {
+            childIndexInParent = refinement.getChildFaceInParentFace(faceIndex);
             switch ( childIndexInParent ) {
                 case 0 :                     break;
                 case 1 : { u+=ofs;         } break;

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -40,39 +40,9 @@ class TopologyRefiner;
 
 class PatchTableFactory {
 public:
-    //  PatchFaceTag
-    //  A simple struct containing all information gathered about a face that is relevant
-    //  to constructing a patch for it (some of these enums should probably be defined more
-    //  as part of PatchTable)
-    //
-    //  Like the HbrFace<T>::AdaptiveFlags, this struct aggregates all of the face tags
-    //  supporting feature adaptive refinement.  For now it is not used elsewhere and can
-    //  remain local to this implementation, but we may want to move it into a header of
-    //  its own if it has greater use later.
-    //
-    //  Note that several properties being assigned here attempt to do so given a 4-bit
-    //  mask of properties at the edges or vertices of the quad.  Still not sure exactly
-    //  what will be done this way, but the goal is to create lookup tables (of size 16
-    //  for the 4 bits) to quickly determine was is needed, rather than iteration and
-    //  branching on the edges or vertices.
-    //
-    struct PatchFaceTag {
-    public:
-        unsigned int   _isRegular       : 1;
-        unsigned int   _isLinear        : 1;
-        unsigned int   _transitionMask  : 4;
-        unsigned int   _boundaryMask    : 4;
-        unsigned int   _boundaryIndex   : 2;
-        unsigned int   _boundaryCount   : 3;
-        unsigned int   _hasBoundaryEdge : 3;
-        unsigned int   _isSingleCrease  : 1;
 
-        void clear();
-        void assignBoundaryPropertiesFromEdgeMask(int boundaryEdgeMask);
-        void assignBoundaryPropertiesFromVertexMask(int boundaryVertexMask);
-    };
-    typedef std::vector<PatchFaceTag> PatchTagVector;
-
+    /// \brief Public options for the PatchTable factory
+    ///
     struct Options {
 
         enum EndCapType {
@@ -163,6 +133,33 @@ private:
     static PatchParam computePatchParam(BuilderContext const & context,
                                         int level, int face,
                                         int boundaryMask, int transitionMask);
+
+public:
+    //  PatchFaceTag
+    //  This simple struct was previously used within the factory to take inventory of
+    //  various kinds of patches to fully allocate buffers prior to populating them.  It
+    //  was not intended to be exposed as part of the public interface.
+    //
+    //  It is no longer used internally and is being kept here to respect preservation
+    //  of the public interface, but it will be deprecated at the earliest opportunity.
+    //
+    struct PatchFaceTag {
+    public:
+        unsigned int   _hasPatch        : 1;
+        unsigned int   _isRegular       : 1;
+        unsigned int   _transitionMask  : 4;
+        unsigned int   _boundaryMask    : 4;
+        unsigned int   _boundaryIndex   : 2;
+        unsigned int   _boundaryCount   : 3;
+        unsigned int   _hasBoundaryEdge : 3;
+        unsigned int   _isSingleCrease  : 1;
+
+        void clear();
+        void assignBoundaryPropertiesFromEdgeMask(int boundaryEdgeMask);
+        void assignBoundaryPropertiesFromVertexMask(int boundaryVertexMask);
+        void assignTransitionPropertiesFromEdgeMask(int boundaryVertexMask);
+    };
+    typedef std::vector<PatchFaceTag> PatchTagVector;
 };
 
 } // end namespace Far

--- a/opensubdiv/vtr/fvarLevel.cpp
+++ b/opensubdiv/vtr/fvarLevel.cpp
@@ -96,7 +96,7 @@ FVarLevel::resizeVertexValues(int vertexValueCount) {
     valueTagMatch.clear();
     _vertValueTags.resize(vertexValueCount, valueTagMatch);
 
-    if (hasSmoothBoundaries()) {
+    if (hasCreaseEnds()) {
         _vertValueCreaseEnds.resize(vertexValueCount);
     }
 }
@@ -383,30 +383,13 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
 
     //
     //  Now that we know the total number of additional sibling values (M values in addition
-    //  to the N vertex values) allocate space to accomodate all N + M vertex values.  The
-    //  vertex value tags will be initialized to match, and we proceed to sparsely mark the
-    //  vertices that mismatch, so initialize a few local ValueTag constants for that purpose
-    //  (assigning entire Tag structs is much more efficient than setting individual bits)
+    //  to the N vertex values) allocate space to accomodate all N + M vertex values.
+    //
+    //  Then make the second pass through the vertices to identify the values associated with
+    //  each and to inspect and tag local face-varying topology for those that don't match:
     //
     resizeVertexValues(totalValueCount);
 
-    ValueTag valueTagMismatch;
-    valueTagMismatch.clear();
-    valueTagMismatch._mismatch = true;
-
-    ValueTag valueTagCrease = valueTagMismatch;
-    valueTagCrease._crease = true;
-
-    ValueTag valueTagSemiSharp = valueTagMismatch;
-    valueTagSemiSharp._semiSharp = true;
-
-    ValueTag valueTagDepSharp = valueTagSemiSharp;
-    valueTagDepSharp._depSharp = true;
-
-    //
-    //  Now the second pass through the vertices to identify the values associated with the
-    //  vertex and to inspect and tag local face-varying topology for those that don't match:
-    //
     for (int vIndex = 0; vIndex < _level.getNumVertices(); ++vIndex) {
         ConstIndexArray       vFaces  = _level.getVertexFaces(vIndex);
         ConstLocalIndexArray  vInFace = _level.getVertexFaceLocalIndices(vIndex);
@@ -466,10 +449,6 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
         bool allCornersAreSharp = _hasLinearBoundaries || vTag._infSharp || vTag._nonManifold ||
                                   (_hasDependentSharpness && (vValues.size() > 2)) ||
                                   (sharpenDarts && (vValues.size() == 1) && !vTag._boundary);
-        if (allCornersAreSharp) {
-            std::fill(vValueTags.begin(), vValueTags.end(), valueTagMismatch);
-            continue;
-        }
 
         //
         //  Values may be a mix of sharp corners and smooth boundaries -- start by
@@ -493,26 +472,20 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
         //  infinitely sharp where possible (rather than semi-sharp) to avoid
         //  re-assessing this dependency as sharpness is reduced during refinement.
         //
-        allCornersAreSharp = false;
-
         bool hasDependentValuesToSharpen = false;
-        if (_hasDependentSharpness && (vValues.size() == 2)) {
-            //  Detect interior inf-sharp (or discts) edge:
-            allCornersAreSharp = vValueSpans[0]._disjoint || vValueSpans[1]._disjoint;
+        if (!allCornersAreSharp) {
+            if (_hasDependentSharpness && (vValues.size() == 2)) {
+                //  Detect interior inf-sharp (or discts) edge:
+                allCornersAreSharp = vValueSpans[0]._disjoint || vValueSpans[1]._disjoint;
 
-            //  Detect a sharp corner, making both sharp:
-            if (sharpenBothIfOneCorner) {
-                allCornersAreSharp |= (vValueSpans[0]._size == 1) || (vValueSpans[1]._size == 1);
+                //  Detect a sharp corner, making both sharp:
+                if (sharpenBothIfOneCorner) {
+                    allCornersAreSharp |= (vValueSpans[0]._size == 1) || (vValueSpans[1]._size == 1);
+                }
+
+                //  If only one semi-sharp, need to mark the other as dependent on it:
+                hasDependentValuesToSharpen = vValueSpans[0]._semiSharp != vValueSpans[1]._semiSharp;
             }
-
-            //  If only one semi-sharp, need to mark the other as dependent on it:
-            hasDependentValuesToSharpen = vValueSpans[0]._semiSharp != vValueSpans[1]._semiSharp;
-        }
-
-        //  XXXX (barfowl) -- see note above about this "pre-emptive" sharpening...
-        if (allCornersAreSharp) {
-            std::fill(vValueTags.begin(), vValueTags.end(), valueTagMismatch);
-            continue;
         }
 
         //
@@ -523,27 +496,46 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
         CreaseEndPairArray vValueCreaseEnds = getVertexValueCreaseEnds(vIndex);
 
         for (int i = 0; i < vValues.size(); ++i) {
+            ValueTag & valueTag = vValueTags[i];
+
+            valueTag.clear();
+            valueTag._mismatch = true;
+
             ValueSpan const & vSpan = vValueSpans[i];
+            if (vSpan._disjoint) {
+                valueTag._nonManifold = true;
+                continue;
+            }
+            assert(vSpan._size != 0);
 
-            if (vSpan._disjoint || ((vSpan._size == 1) && fvarCornersAreSharp)) {
-                vValueTags[i] = valueTagMismatch;
+            bool isInfSharp = allCornersAreSharp || vSpan._infSharp ||
+                              ((vSpan._size == 1) && fvarCornersAreSharp);
+            if (vSpan._size == 1) {
+                valueTag._xordinary = !isInfSharp;
             } else {
-                if ((vSpan._semiSharp > 0) || vTag._semiSharp) {
-                    vValueTags[i] = valueTagSemiSharp;
+                valueTag._xordinary = (vSpan._size != regularBoundaryValence);
+            }
+
+            if (!isInfSharp) {
+                if (vSpan._semiSharp || vTag._semiSharp) {
+                    valueTag._semiSharp = true;
                 } else if (hasDependentValuesToSharpen) {
-                    vValueTags[i] = valueTagDepSharp;
+                    valueTag._semiSharp = true;
+                    valueTag._depSharp = true;
                 } else {
-                    vValueTags[i] = valueTagCrease;
-                }
-                if (vSpan._size != regularBoundaryValence) {
-                    vValueTags[i]._xordinary = true;
+                    valueTag._crease = true;
                 }
 
-                vValueCreaseEnds[i]._startFace = vSpan._start;
-                if ((i == 0) && (vSpan._start != 0)) {
-                    vValueCreaseEnds[i]._endFace = (LocalIndex) (vSpan._start + vSpan._size - 1 - vFaces.size());
-                } else {
-                    vValueCreaseEnds[i]._endFace = (LocalIndex) (vSpan._start + vSpan._size - 1);
+                if (hasCreaseEnds()) {
+                    CreaseEndPair & valueCrease = vValueCreaseEnds[i];
+
+                    valueCrease._startFace = vSpan._start;
+                    if ((i == 0) && (vSpan._start != 0)) {
+                        valueCrease._endFace = (LocalIndex) (vSpan._start + vSpan._size - 1 - vFaces.size());
+                    } else {
+                        valueCrease._endFace = (LocalIndex) (vSpan._start + vSpan._size - 1);
+                    }
+                    valueTag._creaseEnds = true;
                 }
             }
         }
@@ -925,25 +917,35 @@ FVarLevel::gatherValueSpans(Index vIndex, ValueSpan * vValueSpans) const {
 
     bool vHasSingleValue = (getNumVertexValues(vIndex) == 1);
     bool vIsBoundary = vEdges.size() > vFaces.size();
+    bool vIsNonManifold = _level.getVertexTag(vIndex)._nonManifold;
 
-    if (vHasSingleValue) {
+    if (vIsNonManifold) {
+        ConstIndexArray vValues = getVertexValues(vIndex);
+        for (int i = 0; i < vValues.size(); ++i) {
+            vValueSpans[i]._size = 0;
+            vValueSpans[i]._disjoint = 1;
+        }
+    } else if (vHasSingleValue) {
         //  Mark an interior dart disjoint if more than one discts edge:
+        vValueSpans[0]._size  = 0;
+        vValueSpans[0]._start = 0;
         for (int i = 0; i < vEdges.size(); ++i) {
             if (_edgeTags[vEdges[i]]._mismatch) {
-                if (vValueSpans[0]._size) {
-                    vValueSpans[0]._disjoint = true;
+                if (vValueSpans[0]._size > 0) {
+                    vValueSpans[0]._disjoint = 1;
                     break;
                 } else {
                     vValueSpans[0]._size  = (LocalIndex) vFaces.size();
                     vValueSpans[0]._start = (LocalIndex) i;
                 }
             } else if (_level.getEdgeTag(vEdges[i])._infSharp) {
-                vValueSpans[0]._disjoint = true;
+                ++ vValueSpans[0]._infSharp;
                 break;
             } else if (_level.getEdgeTag(vEdges[i])._semiSharp) {
                 ++ vValueSpans[0]._semiSharp;
             }
         }
+        vValueSpans[0]._size = (LocalIndex) vFaces.size();
     } else {
         //  Walk around the vertex and accumulate span info for each value -- be
         //  careful about the span for the first value "wrapping" around:
@@ -951,9 +953,9 @@ FVarLevel::gatherValueSpans(Index vIndex, ValueSpan * vValueSpans) const {
         vValueSpans[0]._start = 0;
         if (!vIsBoundary && (vFaceSiblings[vFaces.size() - 1] == 0)) {
             if (_edgeTags[vEdges[0]]._mismatch) {
-                vValueSpans[0]._disjoint = true;
+                ++ vValueSpans[0]._disjoint;
             } else if (_level.getEdgeTag(vEdges[0])._infSharp) {
-                vValueSpans[0]._disjoint = true;
+                ++ vValueSpans[0]._infSharp;
             } else if (_level.getEdgeTag(vEdges[0])._semiSharp) {
                 ++ vValueSpans[0]._semiSharp;
             }
@@ -963,7 +965,7 @@ FVarLevel::gatherValueSpans(Index vIndex, ValueSpan * vValueSpans) const {
                 if (_edgeTags[vEdges[i]]._mismatch) {
                     ++ vValueSpans[vFaceSiblings[i]]._disjoint;
                 } else if (_level.getEdgeTag(vEdges[i])._infSharp) {
-                    vValueSpans[vFaceSiblings[i]]._disjoint = true;
+                    ++ vValueSpans[vFaceSiblings[i]]._infSharp;
                 } else if (_level.getEdgeTag(vEdges[i])._semiSharp) {
                     ++ vValueSpans[vFaceSiblings[i]]._semiSharp;
                 }
@@ -985,8 +987,31 @@ FVarLevel::gatherValueSpans(Index vIndex, ValueSpan * vValueSpans) const {
 }
 
 //
-//  Miscellaneous utilities:
+//  Methods to retrieve and combine value and vertex tags:
 //
+void
+FVarLevel::getFaceValueTags(Index faceIndex, ValueTag valueTags[]) const {
+
+    ConstIndexArray faceValues = getFaceValues(faceIndex);
+    ConstIndexArray faceVerts  = _level.getFaceVertices(faceIndex);
+
+    for (int i = 0; i < faceValues.size(); ++i) {
+        Index srcValueIndex = findVertexValueIndex(faceVerts[i], faceValues[i]);
+        assert(_vertValueIndices[srcValueIndex] == faceValues[i]);
+
+        valueTags[i] = _vertValueTags[srcValueIndex];
+    }
+}
+
+FVarLevel::ValueTag
+FVarLevel::getFaceCompositeValueTag(Index faceIndex) const {
+
+    ConstIndexArray faceValues = getFaceValues(faceIndex);
+    ConstIndexArray faceVerts  = _level.getFaceVertices(faceIndex);
+
+    return getFaceCompositeValueTag(faceValues, faceVerts);
+}
+
 FVarLevel::ValueTag
 FVarLevel::getFaceCompositeValueTag(ConstIndexArray & faceValues,
                                     ConstIndexArray & faceVerts) const {
@@ -1036,18 +1061,8 @@ FVarLevel::getFaceCompositeValueAndVTag(ConstIndexArray & faceValues,
         assert(_vertValueIndices[srcValueIndex] == faceValues[i]);
 
         ValueTag const & srcValueTag = _vertValueTags[srcValueIndex];
-        if (srcValueTag._mismatch) {
-            if (srcValueTag.isCorner()) {
-                srcVTag._rule = (VertTagSize) Sdc::Crease::RULE_CORNER;
-                srcVTag._infSharp = true;
-            } else {
-                srcVTag._rule = (VertTagSize) Sdc::Crease::RULE_CREASE;
-                srcVTag._infSharp = false;
-            }
-            srcVTag._boundary = true;
-            srcVTag._xordinary = srcValueTag._xordinary;
-            srcVTag._nonManifold = false;
-        }
+        srcVTag = srcValueTag.combineWithLevelVTag(srcVTag);
+
         compInt |= srcInt;
     }
     return compVTag;

--- a/opensubdiv/vtr/fvarLevel.cpp
+++ b/opensubdiv/vtr/fvarLevel.cpp
@@ -493,8 +493,6 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
         //  it accordingly.  If not semi-sharp, be sure to consider those values sharpened by
         //  the topology of other values.
         //
-        CreaseEndPairArray vValueCreaseEnds = getVertexValueCreaseEnds(vIndex);
-
         for (int i = 0; i < vValues.size(); ++i) {
             ValueTag & valueTag = vValueTags[i];
 
@@ -527,7 +525,7 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
                 }
 
                 if (hasCreaseEnds()) {
-                    CreaseEndPair & valueCrease = vValueCreaseEnds[i];
+                    CreaseEndPair & valueCrease = getVertexValueCreaseEnds(vIndex)[i];
 
                     valueCrease._startFace = vSpan._start;
                     if ((i == 0) && (vSpan._start != 0)) {

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -124,6 +124,8 @@ public:
         //VTagSize _constSharp   : 1;  // variable when _semiSharp
         //VTagSize _hasEdits     : 1;  // variable
         //VTagSize _editsApplied : 1;  // variable
+
+        static VTag BitwiseOr(VTag const vTags[], int size = 4);
     };
     struct ETag {
         ETag() { }
@@ -137,6 +139,8 @@ public:
         ETagSize _boundary     : 1;  // fixed
         ETagSize _infSharp     : 1;  // fixed
         ETagSize _semiSharp    : 1;  // variable
+
+        static ETag BitwiseOr(ETag const eTags[], int size = 4);
     };
     struct FTag {
         FTag() { }
@@ -150,10 +154,6 @@ public:
         //  On deck -- coming soon...
         //FTagSize _hasEdits : 1;  // variable
     };
-
-    VTag getFaceCompositeVTag(ConstIndexArray & faceVerts) const;
-
-    ETag getFaceCompositeETag(ConstIndexArray & faceEdges) const;
 
     //  Additional simple struct to identify a "span" around a vertex, i.e. a
     //  subset of the faces around a vertex delimited by some property (e.g. a
@@ -295,6 +295,26 @@ public:
     //  High-level topology queries -- these may be moved elsewhere:
 
     bool isSingleCreasePatch(Index face, float* sharpnessOut=NULL, int* rotationOut=NULL) const;
+
+    //
+    //  When inspecting topology, the component tags -- particularly VTag and ETag -- are most
+    //  often inspected in groups for the face to which they belong.  They are designed to be
+    //  bitwise OR'd (the result then referred to as a "composite" tag) to make quick decisions
+    //  about the face as a whole to avoid tedious topological inspection.
+    //
+    //  The same logic can be applied to topology in a FVar channel when tags specific to that
+    //  channel are used.  Note that the VTags apply to the FVar values assigned to the corners
+    //  of the face and not the vertex as a whole.
+    //
+    bool doesVertexFVarTopologyMatch(Index vIndex, int fvarChannel) const;
+    bool doesFaceFVarTopologyMatch(  Index fIndex, int fvarChannel) const;
+    bool doesEdgeFVarTopologyMatch(  Index eIndex, int fvarChannel) const;
+
+    void getFaceVTags(Index fIndex, VTag vTags[], int fvarChannel = -1) const;
+    void getFaceETags(Index fIndex, ETag eTags[], int fvarChannel = -1) const;
+
+    VTag getFaceCompositeVTag(Index fIndex, int fvarChannel = -1) const;
+    VTag getFaceCompositeVTag(ConstIndexArray & fVerts) const;
 
     //
     //  When gathering "patch points" we may want the indices of the vertices or the corresponding


### PR DESCRIPTION
These changes reorganize some of the work in Far::PatchTableFactory to simplify the recognition and construction of patches for face-varying channels.  Patches are now more clearly separated into regular and irregular patches, with the recognition and inspection of regular patches streamlined.  The construction of face-varying patches now reuses information gathered from the vertex patch when the face-varying topology matches.  This will help synchronize the vertex and face-varying patches when other topological decisions are made, e.g. when we enable infinitely sharp patches.