### PR TITLE
Enabled point sharing for face-varying Gregory patches

### DIFF
--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
@@ -155,7 +155,13 @@ EndCapGregoryBasisPatchFactory::GetPatchPoints(
         ConstIndexArray fedges = level->getFaceEdges(faceIndex);
         assert(fedges.size()==4);
 
+        Vtr::internal::Level::ETag etags[4];
+        level->getFaceETags(faceIndex, etags, fvarChannel);
+
         for (int i=0; i<4; ++i) {
+            // Ignore boundary edges (or those with a face-varying discontinuity)
+            if (etags[i]._boundary) continue;
+
             Index edge = fedges[i];
             Index adjFaceIndex = 0;
 

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1257,9 +1257,7 @@ PatchTableFactory::populateAdaptivePatches(
                     refiner,
                     localPointFVarStencils[fvc],
                     NULL,
-                    // XXX - disabled until FVar bug fixed:
-                    //context.options.shareEndCapPatchPoints);
-                    false);
+                    context.options.shareEndCapPatchPoints);
                 break;
             case Options::ENDCAP_BSPLINE_BASIS:
                 localPointFVarStencils[fvc] = new StencilTable(0);


### PR DESCRIPTION
Sharing of points for adjacent face-varying Gregory patches had been disabled as edges that were discontinuous in face-varying space were not being detected in the Gregory patch factory.  The Gregory patch factory now detects such edges and the sharing option has been re-enabled in the PatchTableFactory.