### PR TITLE
Minor updates to tags for face-varying and inf-sharp topology

### DIFF
--- a/opensubdiv/far/topologyRefinerFactory.cpp
+++ b/opensubdiv/far/topologyRefinerFactory.cpp
@@ -273,11 +273,12 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
         //
         vTag._infSharpEdges   = (infSharpEdgeCount > 0);
         vTag._infSharpCrease  = false;
-        vTag._infSharpCorners = false;
         vTag._infIrregular    = vTag._infSharp || vTag._infSharpEdges;
 
         if (vTag._infSharpEdges) {
-            Sdc::Crease::Rule infRule = creasing.DetermineVertexVertexRule(vSharpness, infSharpEdgeCount);
+            //  Ignore semi-sharp vertex sharpness when computing the inf-sharp Rule:
+            Sdc::Crease::Rule infRule = creasing.DetermineVertexVertexRule(
+                        (vTag._infSharp ? vSharpness : 0.0f), infSharpEdgeCount);
 
             if (infRule == Sdc::Crease::RULE_CREASE) {
                 vTag._infSharpCrease = true;
@@ -305,8 +306,6 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
                     }
                 }
             } else if (infRule == Sdc::Crease::RULE_CORNER) {
-                vTag._infSharpCorners = true;
-
                 //  A regular set of inf-corners occurs when all edges are sharp and not
                 //  a smooth corner:
                 //

--- a/opensubdiv/vtr/fvarLevel.h
+++ b/opensubdiv/vtr/fvarLevel.h
@@ -103,7 +103,7 @@ public:
     //  Tag per Value:
     //      - informs both refinement and interpolation
     //          - every value spawns a child value in refinement
-    //      - given ordering of values (1-per-vertex first) serves as a vertex tag
+    //      - includes a subset of Level::VTag to be later combined with a VTag
     //
     struct ValueTag {
         ValueTag() { }
@@ -116,7 +116,10 @@ public:
         bool isSemiSharp() const   { return _semiSharp; }
         bool isInfSharp() const    { return !_semiSharp && !_crease; }
         bool isDepSharp() const    { return _depSharp; }
-        bool hasCreaseEnds() const { return _creaseEnds; }
+        bool hasCreaseEnds() const { return _crease || _semiSharp; }
+
+        bool hasInfSharpEdges() const   { return _infSharpEdges; }
+        bool hasInfIrregularity() const { return _infIrregular; }
 
         typedef unsigned char ValueTagSize;
 
@@ -125,9 +128,11 @@ public:
         ValueTagSize _xordinary   : 1;  // local FVar topology is extra-ordinary
         ValueTagSize _nonManifold : 1;  // local FVar topology is non-manifold
         ValueTagSize _crease      : 1;  // value is a crease, otherwise a corner
-        ValueTagSize _creaseEnds  : 1;  // set when a crease-end-pair is assigned
         ValueTagSize _semiSharp   : 1;  // value is a corner decaying to crease
         ValueTagSize _depSharp    : 1;  // value is a corner by dependency on another
+
+        ValueTagSize _infSharpEdges : 1;  // value is a corner by inf-sharp features
+        ValueTagSize _infIrregular  : 1;  // value span includes inf-sharp irregularity
 
         Level::VTag combineWithLevelVTag(Level::VTag) const;
     };
@@ -209,15 +214,6 @@ public:
     void getFaceValueTags(Index faceIndex, ValueTag valueTags[]) const;
 
     ValueTag getFaceCompositeValueTag(Index faceIndex) const;
-    ValueTag getFaceCompositeValueTag(ConstIndexArray & faceValues,
-                                      ConstIndexArray & faceVerts) const;
-
-    Level::VTag getFaceCompositeValueAndVTag(ConstIndexArray & faceValues,
-                                             ConstIndexArray & faceVerts,
-                                             Level::VTag *     fvarVTags) const;
-
-    Level::ETag getFaceCompositeCombinedEdgeTag(ConstIndexArray & faceEdges,
-                                                Level::ETag *     fvarETags) const;
 
     //  Higher-level topological queries, i.e. values in a neighborhood:
     void getEdgeFaceValues(Index eIndex, int fIncToEdge, Index valuesPerVert[2]) const;
@@ -401,10 +397,15 @@ FVarLevel::ValueTag::combineWithLevelVTag(Level::VTag levelTag) const
         if (this->isCorner()) {
             levelTag._rule = (Level::VTag::VTagSize) Sdc::Crease::RULE_CORNER;
             levelTag._infSharp = true;
+            levelTag._infSharpCrease = false;
         } else {
             levelTag._rule = (Level::VTag::VTagSize) Sdc::Crease::RULE_CREASE;
             levelTag._infSharp = false;
+            levelTag._infSharpCrease = true;
         }
+        levelTag._infSharpEdges = true;
+        levelTag._infIrregular = this->_infIrregular;
+
         levelTag._boundary = true;
         levelTag._xordinary = this->_xordinary;
         levelTag._nonManifold = this->_nonManifold;

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -539,7 +539,6 @@ Level::print(const Refinement* pRefinement) const {
         printf(", infSharp = %d",       (int)vTag._infSharp);
         printf(", infSharpEdges = %d",  (int)vTag._infSharpEdges);
         printf(", infSharpCrease = %d", (int)vTag._infSharpCrease);
-        printf(", infSharpCorners = %d",(int)vTag._infSharpCorners);
         printf(", infIrregular = %d",   (int)vTag._infIrregular);
         printf(", semiSharp = %d",      (int)vTag._semiSharp);
         printf(", semiSharpEdges = %d", (int)vTag._semiSharpEdges);

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -114,16 +114,10 @@ public:
         VTagSize _rule            : 4;  // variable when _semiSharp
         VTagSize _incomplete      : 1;  // variable for sparse refinement
 
-        //  Inf-sharp tags -- in development, some may not persist...
+        //  Tags indicating incident infinitely-sharp (permanent) features
         VTagSize _infSharpEdges   : 1;  // fixed
         VTagSize _infSharpCrease  : 1;  // fixed
-        VTagSize _infSharpCorners : 1;  // fixed
         VTagSize _infIrregular    : 1;  // fixed
-
-        //  On deck -- coming soon...
-        //VTagSize _constSharp   : 1;  // variable when _semiSharp
-        //VTagSize _hasEdits     : 1;  // variable
-        //VTagSize _editsApplied : 1;  // variable
 
         static VTag BitwiseOr(VTag const vTags[], int size = 4);
     };


### PR DESCRIPTION
This change set includes some cleanup and minor extensions to the tags that are used to accelerate topology inspection.  Some obsolete/redundant tags were removed along with some awkward methods formerly used for their inspection.  Recent additions now provide a more consistent interface for gathering the tags for both vertex and face-varying topology.