### PR TITLE
Improved internal span types for support non-manifold cases

### DIFF
--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
@@ -101,7 +101,7 @@ EndCapBSplineBasisPatchFactory::GetPatchPoints(
     for (int corner = 0; (corner < 4) && !useGregoryPatch; ++corner) {
         Vtr::internal::Level::VTag vtag = level->getVertexTag(facePoints[corner]);
 
-        if (vtag._boundary || (cornerSpans[corner]._numFaces > 0)) {
+        if (vtag._boundary || cornerSpans[corner].isAssigned()) {
             useGregoryPatch = true;
         }
         if (vtag._xordinary) {

--- a/opensubdiv/far/gregoryBasis.cpp
+++ b/opensubdiv/far/gregoryBasis.cpp
@@ -123,7 +123,7 @@ GregoryBasis::ProtoBasis::ProtoBasis(
 
         //  Gather the (partial) one-ring around the corner vertex:
         int ringSize = 0;
-        if (cornerSpans[corner]._numFaces == 0) {
+        if (!cornerSpans[corner].isAssigned()) {
             ringSize = level.gatherQuadRegularRingAroundVertex( faceVerts[corner],
                     manifoldRings[corner], fvarChannel);
         } else {

--- a/opensubdiv/vtr/fvarLevel.h
+++ b/opensubdiv/vtr/fvarLevel.h
@@ -231,14 +231,7 @@ public:
     void initializeFaceValuesFromFaceVertices();
     void initializeFaceValuesFromVertexFaceSiblings();
 
-    //  Information about the "span" for a value:
-    struct ValueSpan {
-        LocalIndex _size;
-        LocalIndex _start;
-        LocalIndex _disjoint;
-        LocalIndex _semiSharp;
-        LocalIndex _infSharp;
-    };
+    struct ValueSpan;
     void gatherValueSpans(Index vIndex, ValueSpan * vValueSpans) const;
 
     //  Debugging methods:

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -747,8 +747,8 @@ Level::gatherQuadRegularPartialRingAroundVertex(
     ConstIndexArray      vFaces   = level.getVertexFaces(vIndex);
     ConstLocalIndexArray vInFaces = level.getVertexFaceLocalIndices(vIndex);
 
-    int nFaces      = span._numFaces;
-    int leadingEdge = span._leadingVertEdge;
+    int nFaces    = span._numFaces;
+    int startFace = span._startFace;
 
     int ringIndex = 0;
     for (int i = 0; i < nFaces; ++i) {
@@ -756,7 +756,7 @@ Level::gatherQuadRegularPartialRingAroundVertex(
         //  For every incident quad, we want the two vertices clockwise in each face, i.e.
         //  the vertex at the end of the leading edge and the vertex opposite this one:
         //
-        int fIncident = (leadingEdge + i) % vFaces.size();
+        int fIncident = (startFace + i) % vFaces.size();
 
         ConstIndexArray fPoints = (fvarChannel < 0)
                                 ? level.getFaceVertices(vFaces[fIncident])
@@ -767,7 +767,7 @@ Level::gatherQuadRegularPartialRingAroundVertex(
         ringPoints[ringIndex++] = fPoints[fastMod4(vInThisFace + 1)];
         ringPoints[ringIndex++] = fPoints[fastMod4(vInThisFace + 2)];
 
-        if (i == nFaces - 1) {
+        if ((i == nFaces - 1) && !span._periodic) {
             ringPoints[ringIndex++] = fPoints[fastMod4(vInThisFace + 3)];
         }
     }

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -153,22 +153,28 @@ public:
     //  subset of the faces around a vertex delimited by some property (e.g. a
     //  face-varying discontinuity, an inf-sharp edge, etc.)
     //
-    //  The span requires an "origin", i.e. a leading edge or face and a "size"
-    //  to fully define its extent.  Use of the size is preferred over leading
-    //  and trailing edges/faces so that valence is available since for a non-
-    //  manifold vertex that cannot be determined from the two extremeties.
-    //  There is also a subtle but marginal advantage in using a leading edge
-    //  rather than face, but it may be worth using the leading face with the
-    //  face count for consistency (both properties defined in terms of faces).
+    //  The span requires an "origin" and a "size" to fully define its extent.
+    //  Use of the size is required over a leading/trailing pair as the valence
+    //  around a non-manifold vertex cannot be trivially determined from two
+    //  extremeties.  Similarly a start face is chosen over an edge as starting
+    //  with a manifold edge is ambiguous.  Additional tags also support
+    //  non-manifold cases, e.g. periodic spans at the apex of a double cone.
     //
-    //  Currently setting the size to 0 is an indication to use the full
-    //  neighborhood rather than a subset -- may want to revisit that choice...
+    //  Currently setting the size to 0 or leaving the span "unassigned" is an
+    //  indication to use the full neighborhood rather than a subset -- prefer
+    //  use of the const method here to direct inspection of the member.
     //
     struct VSpan {
-        VSpan() : _numFaces(0), _leadingVertEdge(0) { }
+        VSpan() { std::memset(this, 0, sizeof(VSpan)); }
+
+        void clear()            { std::memset(this, 0, sizeof(VSpan)); }
+        bool isAssigned() const { return _numFaces > 0; }
 
         LocalIndex _numFaces;
-        LocalIndex _leadingVertEdge;
+        LocalIndex _startFace;
+
+        unsigned short _periodic : 1;
+        unsigned short _sharp    : 1;
     };
 
 public:


### PR DESCRIPTION
 These are minor changes to better support non-manifold cases in future, but are being pushed now to update usage and verify correctness in more common cases.

The "leading edge" member of Vtr::Level::VSpan turns out to be ambiguous when the vertex is non-manifold as the face that follows may not be clearly defined if that edge is non-manifold -- changing the start of the span to identify a face will be unambiguous.  A "partial ring" may also be periodic in non-manifold cases (e.g. the apex of a double cone, which has two separate periodic spans) so additional members were added.  Some simple convenience members were add now that this struct is getting more complex.

Also renamed members of the face-varying span (Vtr::FVarLevel::ValueSpan) to better reflect usage, and moved its definition local to the source file containing its sole usage to prevent unintended use.