### PR TITLE
Added new options for adaptive refinement

### DIFF
--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -287,11 +287,6 @@ namespace internal {
 
         int_type selectNonManifold  : 1;
         int_type selectFVarFeatures : 1;
-
-    private:
-        //  Temporary options pending addition to public interface of Refiner::AdaptiveOptions:
-        static int const options_reduceInfSharpPatches = false;
-        static int const options_considerFVarChannels  = false;
     };
 
     void
@@ -322,25 +317,25 @@ namespace internal {
         selectSemiSharpNonSingle = true;
 
         //  Inf-sharp features -- boundary extra-ordinary vertices are irreg creases:
-        selectInfSharpRegularCrease   = !(options_reduceInfSharpPatches || useSingleCreasePatch);
-        selectInfSharpRegularCorner   = !options_reduceInfSharpPatches;
+        selectInfSharpRegularCrease   = !(options.useInfSharpPatch || useSingleCreasePatch);
+        selectInfSharpRegularCorner   = !options.useInfSharpPatch;
         selectInfSharpIrregularDart   = true;
         selectInfSharpIrregularCrease = true;
         selectInfSharpIrregularCorner = true;
 
         selectNonManifold  = true;
-        selectFVarFeatures = options_considerFVarChannels;
+        selectFVarFeatures = options.considerFVarChannels;
     }
 
     void
-    FeatureMask::ReduceFeatures(Options const & /* options */) {
+    FeatureMask::ReduceFeatures(Options const & options) {
 
         //  Disable typical xordinary vertices:
         selectXOrdinaryInterior = false;
         selectXOrdinaryBoundary = false;
 
         //  If minimizing inf-sharp patches, disable all but sharp/corner irregularities
-        if (options_reduceInfSharpPatches) {
+        if (options.useInfSharpPatch) {
             selectInfSharpRegularCrease    = false;
             selectInfSharpRegularCorner    = false;
             selectInfSharpIrregularDart    = false;
@@ -379,8 +374,7 @@ TopologyRefiner::RefineAdaptive(AdaptiveOptions options) {
     //  of levels isolating different sets of features, initialize the two feature sets
     //  up front and use the appropriate one for each level:
     //
-    //int shallowLevel = std::min<int>(options_secondaryLevel, options.isolationLevel);
-    int shallowLevel = options.isolationLevel;
+    int shallowLevel = std::min<int>(options.secondaryLevel, options.isolationLevel);
     int deeperLevel  = options.isolationLevel;
 
     int potentialMaxLevel = deeperLevel;

--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -135,14 +135,23 @@ public:
 
         AdaptiveOptions(int level) :
             isolationLevel(level),
+            secondaryLevel(15),
             useSingleCreasePatch(false),
+            useInfSharpPatch(false),
+            considerFVarChannels(false),
             orderVerticesFromFacesFirst(false) { }
 
-        unsigned int isolationLevel:4,              ///< Number of iterations applied to isolate
+        unsigned int isolationLevel:4;              ///< Number of iterations applied to isolate
                                                     ///< extraordinary vertices and creases
-                     useSingleCreasePatch:1,        ///< Use 'single-crease' patch and stop
+        unsigned int secondaryLevel:4;              ///< Shallower level to stop isolation of
+                                                    ///< smooth irregular features
+        unsigned int useSingleCreasePatch:1;        ///< Use 'single-crease' patch and stop
                                                     ///< isolation where applicable
-                     orderVerticesFromFacesFirst:1; ///< Order child vertices from faces first
+        unsigned int useInfSharpPatch:1;            ///< Use infinitely sharp patches and stop
+                                                    ///< isolation where applicable
+        unsigned int considerFVarChannels:1;        ///< Inspect face-varying channels and
+                                                    ///< isolate when irregular features present
+        unsigned int orderVerticesFromFacesFirst:1; ///< Order child vertices from faces first
                                                     ///< instead of child vertices of vertices
     };
 


### PR DESCRIPTION
This change exposes controls for adaptive refinement for face-varying patches and inf-sharp patches that have been internalized to this point.  It also includes the secondary isolation level to reduce excessive refinement of smooth vs semi-sharp features.