### PR TITLE
Added Derivative Options to LimitStencilFactory

### DIFF
--- a/opensubdiv/far/stencilBuilder.h
+++ b/opensubdiv/far/stencilBuilder.h
@@ -84,7 +84,7 @@ public:
 
         // Add with first derivative.
         void AddWithWeight(Stencil const& src,
-                                     float weight, float du, float dv);
+            float weight, float du, float dv);
 
         // Add with first and second derivatives.
         void AddWithWeight(Stencil const& src,

--- a/opensubdiv/far/stencilTable.cpp
+++ b/opensubdiv/far/stencilTable.cpp
@@ -96,24 +96,24 @@ namespace {
             std::memcpy(&(*_weights)[curOffset],
                         &(*weights)[off], sz*sizeof(float));
 
-            if (_duWeights) {
+            if (_duWeights && !_duWeights->empty()) {
                 std::memcpy(&(*_duWeights)[curOffset],
                             &(*duWeights)[off], sz*sizeof(float));
             }
-            if (_dvWeights) {
+            if (_dvWeights && !_dvWeights->empty()) {
                 std::memcpy(&(*_dvWeights)[curOffset],
                         &(*dvWeights)[off], sz*sizeof(float));
             }
 
-            if (_duuWeights) {
+            if (_duuWeights && !_duuWeights->empty()) {
                 std::memcpy(&(*_duuWeights)[curOffset],
                         &(*duuWeights)[off], sz*sizeof(float));
             }
-            if (_duvWeights) {
+            if (_duvWeights && !_duvWeights->empty()) {
                 std::memcpy(&(*_duvWeights)[curOffset],
                         &(*duvWeights)[off], sz*sizeof(float));
             }
-            if (_dvvWeights) {
+            if (_dvvWeights && !_dvvWeights->empty()) {
                 std::memcpy(&(*_dvvWeights)[curOffset],
                         &(*dvvWeights)[off], sz*sizeof(float));
             }
@@ -127,16 +127,16 @@ namespace {
         _sizes->resize(stencilCount);
         _sources->resize(weightCount);
 
-        if (_duWeights)
+        if (_duWeights && !_duWeights->empty())
             _duWeights->resize(weightCount);
-        if (_dvWeights)
+        if (_dvWeights && !_dvWeights->empty())
             _dvWeights->resize(weightCount);
 
-        if (_duuWeights)
+        if (_duuWeights && !_duuWeights->empty())
             _duuWeights->resize(weightCount);
-        if (_duvWeights)
+        if (_duvWeights && !_duvWeights->empty())
             _duvWeights->resize(weightCount);
-        if (_dvvWeights)
+        if (_dvvWeights && !_dvvWeights->empty())
             _dvvWeights->resize(weightCount);
     }
 };

--- a/opensubdiv/far/stencilTableFactory.h
+++ b/opensubdiv/far/stencilTableFactory.h
@@ -158,6 +158,15 @@ public:
 
     typedef std::vector<LocationArray> LocationArrayVec;
 
+    struct Options {
+
+        Options() : generate1stDerivatives(true),
+                    generate2ndDerivatives(false) { }
+
+        unsigned int generate1stDerivatives      : 1, ///< Generate weights for 1st derivatives
+                     generate2ndDerivatives      : 1; ///< Generate weights for 2nd derivatives
+    };
+
     /// \brief Instantiates LimitStencilTable from a TopologyRefiner that has
     ///        been refined either uniformly or adaptively.
     ///
@@ -174,10 +183,14 @@ public:
     ///                         TopologyRefiner (optional: prevents redundant
     ///                         instantiation of the table if available)
     ///
+    /// @param options          Options controlling the creation of the table
+    ///
     static LimitStencilTable const * Create(TopologyRefiner const & refiner,
         LocationArrayVec const & locationArrays,
             StencilTable const * cvStencils=0,
-                PatchTable const * patchTable=0);
+              PatchTable const * patchTable=0,
+                         Options options=Options());
+
 };
 
 


### PR DESCRIPTION
This change updates the Far::LimitStencilFactory to
to support options to generate 1st and 2nd derivative
limit stencil weights.

For backward compatibility, the option to generate 1st
derivatives defaults to true.  While for efficiency,
the option to generate 2nd derivatives defaults to false.

Also, updated the Far::LimitStencil class to expose
computed 1st and 2nd derivative limit stencil weights.