### PR TITLE
Reverted recent Far::PatchParam refactoring

### DIFF
--- a/opensubdiv/far/patchBasis.cpp
+++ b/opensubdiv/far/patchBasis.cpp
@@ -52,11 +52,11 @@ public:
     static void GetWeights(float v, float w, float point[]);
 
     // patch weights
-    static void GetPatchWeights(PatchParamBase const & param,
+    static void GetPatchWeights(PatchParam const & param,
         float s, float t, float point[], float deriv1[], float deriv2[], float deriv11[], float deriv12[], float deriv22[]);
 
     // adjust patch weights for boundary (and corner) edges
-    static void AdjustBoundaryWeights(PatchParamBase const & param,
+    static void AdjustBoundaryWeights(PatchParam const & param,
         float sWeights[4], float tWeights[4]);
 };
 
@@ -180,7 +180,7 @@ inline void Spline<BASIS_BOX_SPLINE>::GetWeights(
 }
 
 template <>
-inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParamBase const & param,
+inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParam const & param,
     float s, float t, float point[4], float derivS[4], float derivT[4], float derivSS[4], float derivST[4], float derivTT[4]) {
 
     param.Normalize(s,t);
@@ -225,7 +225,7 @@ inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParamBase const & param
 }
 
 template <SplineBasis BASIS>
-void Spline<BASIS>::AdjustBoundaryWeights(PatchParamBase const & param,
+void Spline<BASIS>::AdjustBoundaryWeights(PatchParam const & param,
     float sWeights[4], float tWeights[4]) {
 
     int boundary = param.GetBoundary();
@@ -253,7 +253,7 @@ void Spline<BASIS>::AdjustBoundaryWeights(PatchParamBase const & param,
 }
 
 template <SplineBasis BASIS>
-void Spline<BASIS>::GetPatchWeights(PatchParamBase const & param,
+void Spline<BASIS>::GetPatchWeights(PatchParam const & param,
     float s, float t, float point[16], float derivS[16], float derivT[16], float derivSS[16], float derivST[16], float derivTT[16]) {
 
     float sWeights[4], tWeights[4], dsWeights[4], dtWeights[4], dssWeights[4], dttWeights[4];
@@ -310,22 +310,22 @@ void Spline<BASIS>::GetPatchWeights(PatchParamBase const & param,
     }
 }
 
-void GetBilinearWeights(PatchParamBase const & param,
+void GetBilinearWeights(PatchParam const & param,
     float s, float t, float point[4], float deriv1[4], float deriv2[4], float deriv11[4], float deriv12[4], float deriv22[4]) {
     Spline<BASIS_BILINEAR>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
-void GetBezierWeights(PatchParamBase const param,
+void GetBezierWeights(PatchParam const param,
     float s, float t, float point[16], float deriv1[16], float deriv2[16], float deriv11[16], float deriv12[16], float deriv22[16]) {
     Spline<BASIS_BEZIER>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
-void GetBSplineWeights(PatchParamBase const & param,
+void GetBSplineWeights(PatchParam const & param,
     float s, float t, float point[16], float deriv1[16], float deriv2[16], float deriv11[16], float deriv12[16], float deriv22[16]) {
     Spline<BASIS_BSPLINE>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
-void GetGregoryWeights(PatchParamBase const & param,
+void GetGregoryWeights(PatchParam const & param,
     float s, float t, float point[20], float deriv1[20], float deriv2[20], float deriv11[20], float deriv12[20], float deriv22[20]) {
     //
     //  P3         e3-      e2+         P2

--- a/opensubdiv/far/patchBasis.h
+++ b/opensubdiv/far/patchBasis.h
@@ -45,16 +45,16 @@ namespace internal {
 // So this interface will be changing in future.
 //
 
-void GetBilinearWeights(PatchParamBase const & patchParam,
+void GetBilinearWeights(PatchParam const & patchParam,
     float s, float t, float wP[4], float wDs[4], float wDt[4], float wDss[4] = 0, float wDst[4] = 0, float wDtt[4] = 0);
 
-void GetBezierWeights(PatchParamBase const & patchParam,
+void GetBezierWeights(PatchParam const & patchParam,
     float s, float t, float wP[16], float wDs[16], float wDt[16], float wDss[16] = 0, float wDst[16] = 0, float wDtt[16] = 0);
 
-void GetBSplineWeights(PatchParamBase const & patchParam,
+void GetBSplineWeights(PatchParam const & patchParam,
     float s, float t, float wP[16], float wDs[16], float wDt[16], float wDss[16] = 0, float wDst[16] = 0, float wDtt[16] = 0);
 
-void GetGregoryWeights(PatchParamBase const & patchParam,
+void GetGregoryWeights(PatchParam const & patchParam,
     float s, float t, float wP[20], float wDs[20], float wDt[20], float wDss[20] = 0, float wDst[20] = 0, float wDtt[20] = 0);
 
 

--- a/opensubdiv/far/patchParam.h
+++ b/opensubdiv/far/patchParam.h
@@ -34,8 +34,6 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Far {
 
-namespace internal {
-
 /// \brief Patch parameterization
 ///
 /// Topological refinement splits coarse mesh faces into refined faces.
@@ -82,19 +80,20 @@ namespace internal {
 ///
 /// Bitfield layout :
 ///
-///  Field1     | Bits | Content
-///  -----------|:----:|------------------------------------------------------
-///  level      | 4    | the subdivision level of the patch
-///  nonquad    | 1    | whether the patch is refined from a non-quad face
-///  unused     | 3    | unused
-///  boundary   | 4    | boundary edge mask encoding
-///  v          | 10   | log2 value of u parameter at first patch corner
-///  u          | 10   | log2 value of v parameter at first patch corner
-///
 ///  Field0     | Bits | Content
 ///  -----------|:----:|------------------------------------------------------
 ///  faceId     | 28   | the faceId of the patch
 ///  transition | 4    | transition edge mask encoding
+///
+///  Field1     | Bits | Content
+///  -----------|:----:|------------------------------------------------------
+///  level      | 4    | the subdivision level of the patch
+///  nonquad    | 1    | whether patch is refined from a non-quad face
+///  regular    | 1    | whether patch is regular
+///  unused     | 2    | unused
+///  boundary   | 4    | boundary edge mask encoding
+///  v          | 10   | log2 value of u parameter at first patch corner
+///  u          | 10   | log2 value of v parameter at first patch corner
 ///
 /// Note : the bitfield is not expanded in the struct due to differences in how
 ///        GPU & CPU compilers pack bit-fields and endian-ness.
@@ -150,155 +149,7 @@ namespace internal {
  \endverbatim
 */
 
-template <class IMPL>
-struct PatchParamInterface {
-public:
-    /// \brief Returns the log2 value of the u parameter at
-    /// the first corner of the patch
-    unsigned short GetU() const { return baseData<unsigned short>(10,22); }
-
-    /// \brief Returns the log2 value of the v parameter at
-    /// the first corner of the patch
-    unsigned short GetV() const { return baseData<unsigned short>(10,12); }
-
-    /// \brief Returns the boundary edge encoding for the patch.
-    unsigned short GetBoundary() const { return baseData<unsigned short>(4,8); }
-
-    /// \brief True if the parent coarse face is a non-quad
-    bool NonQuadRoot() const { return (baseData<unsigned int>(1,4) != 0); }
-
-    /// \brief Returns the level of subdivision of the patch
-    unsigned short GetDepth() const { return baseData<unsigned short>(4,0); }
-
-    /// \brief Returns the fraction of the coarse face parametric space
-    /// covered by this refined face.
-    float GetParamFraction() const;
-
-    /// \brief Maps the (u,v) parameterization from coarse to refined
-    /// The (u,v) pair is mapped from the coarse face parameterization to
-    /// the refined face parameterization
-    ///
-    void MapCoarseToRefined( float & u, float & v ) const;
-
-    /// \brief Maps the (u,v) parameterization from refined to coarse
-    /// The (u,v) pair is mapped from the refined face parameterization to
-    /// the coarse face parameterization
-    ///
-    void MapRefinedToCoarse( float & u, float & v ) const;
-
-    /// \brief Deprecated @see PatchParam#MapCoarseToRefined
-    void Normalize( float & u, float & v ) const {
-        return MapCoarseToRefined(u, v);
-    }
-
-protected:
-    unsigned int packBaseData(short u, short v,
-                              unsigned short depth, bool nonquad,
-                              unsigned short boundary) {
-        return pack(u,       10, 22) |
-               pack(v,       10, 12) |
-               pack(boundary, 4,  8) |
-               pack(nonquad,  1,  4) |
-               pack(depth,    4,  0);
-    }
-
-    template <class RETURN_TYPE>
-    RETURN_TYPE baseData(int width, int offset) const {
-        unsigned int value = static_cast<IMPL const *>(this)->baseValue();
-        return (RETURN_TYPE)unpack(value, width, offset);
-    }
-
-    unsigned int pack(unsigned int value, int width, int offset) const {
-        return (unsigned int)((value & ((1<<width)-1)) << offset);
-    }
-
-    unsigned int unpack(unsigned int value, int width, int offset) const {
-        return (unsigned short)((value >> offset) & ((1<<width)-1));
-    }
-};
-
-template<class IMPL>
-inline float
-PatchParamInterface<IMPL>::GetParamFraction( ) const {
-
-    if (NonQuadRoot()) {
-        return 1.0f / float( 1 << (GetDepth()-1) );
-    } else {
-        return 1.0f / float( 1 << GetDepth() );
-    }
-}
-
-template<class IMPL>
-inline void
-PatchParamInterface<IMPL>::MapCoarseToRefined( float & u, float & v ) const {
-
-    float frac = GetParamFraction();
-
-    float pu = (float)GetU()*frac;
-    float pv = (float)GetV()*frac;
-
-    u = (u - pu) / frac,
-    v = (v - pv) / frac;
-}
-
-template<class IMPL>
-inline void
-PatchParamInterface<IMPL>::MapRefinedToCoarse( float & u, float & v ) const {
-
-    float frac = GetParamFraction();
-
-    float pu = (float)GetU()*frac;
-    float pv = (float)GetV()*frac;
-
-    u = u * frac + pu,
-    v = v * frac + pv;
-}
-
-} // end namespace internal
-
-/// \brief Local patch parameterization
-///
-struct PatchParamBase : public Far::internal::PatchParamInterface<PatchParamBase> {
-public:
-    /// \brief Sets the values of the bit fields
-    ///
-    /// @param u value of the u parameter for the first corner of the face
-    /// @param v value of the v parameter for the first corner of the face
-    ///
-    /// @param depth subdivision level of the patch
-    /// @param nonquad true if the root face is not a quad
-    ///
-    /// @param boundary 4-bits identifying boundary edges
-    ///
-    void Set(short u, short v,
-             unsigned short depth, bool nonquad,
-             unsigned short boundary, bool isRegular = true) {
-        field1 = packBaseData(u, v, depth, nonquad, boundary);
-        field1 |= pack(isRegular,1,5);
-    }
-
-    /// \brief Resets everything to 0
-    void Clear() { field1 = 0; }
-
-    /// \brief Returns whether the patch is regular
-    bool IsRegular() const { return (unpack(field1,1,5) != 0); }
-
-    unsigned int field1:32;
-
-protected:
-    friend struct Far::internal::PatchParamInterface<PatchParamBase>;
-    unsigned int baseValue() const { return field1; }
-};
-
-typedef std::vector<PatchParamBase> PatchParamBaseTable;
-
-typedef Vtr::Array<PatchParamBase> PatchParamBaseArray;
-typedef Vtr::ConstArray<PatchParamBase> ConstPatchParamBaseArray;
-
-/// \brief Local patch parameterization for vertex patches
-///
-struct PatchParam : public Far::internal::PatchParamInterface<PatchParam> {
-public:
+struct PatchParam {
     /// \brief Sets the values of the bit fields
     ///
     /// @param faceid face index
@@ -312,12 +163,12 @@ public:
     /// @param boundary 4-bits identifying boundary edges
     /// @param transition 4-bits identifying transition edges
     ///
+    /// @param regular whether the patch is regular
+    ///
     void Set(Index faceid, short u, short v,
              unsigned short depth, bool nonquad,
-             unsigned short boundary, unsigned short transition) {
-        field0 = pack(faceid, 28, 0) | pack(transition, 4, 28);
-        field1 = packBaseData(u, v, depth, nonquad, boundary);
-    }
+             unsigned short boundary, unsigned short transition,
+             bool regular = false);
 
     /// \brief Resets everything to 0
     void Clear() { field0 = field1 = 0; }
@@ -325,29 +176,124 @@ public:
     /// \brief Retuns the faceid
     Index GetFaceId() const { return Index(unpack(field0,28,0)); }
 
-    /// \brief Returns the transition edge encoding for the patch.
-    unsigned short GetTransition() const {
-        return (unsigned short)unpack(field0,4,28);
-    }
+    /// \brief Returns the log2 value of the u parameter at
+    /// the first corner of the patch
+    unsigned short GetU() const { return (unsigned short)unpack(field1,10,22); }
 
-    PatchParamBase GetPatchParamBase() const {
-        PatchParamBase result;
-        result.field1 = field1;
-        return result;
-    }
+    /// \brief Returns the log2 value of the v parameter at
+    /// the first corner of the patch
+    unsigned short GetV() const { return (unsigned short)unpack(field1,10,12); }
+
+    /// \brief Returns the transition edge encoding for the patch.
+    unsigned short GetTransition() const { return (unsigned short)unpack(field0,4,28); }
+
+    /// \brief Returns the boundary edge encoding for the patch.
+    unsigned short GetBoundary() const { return (unsigned short)unpack(field1,4,8); }
+
+    /// \brief True if the parent coarse face is a non-quad
+    bool NonQuadRoot() const { return (unpack(field1,1,4) != 0); }
+
+    /// \brief Returns the level of subdivision of the patch
+    unsigned short GetDepth() const { return (unsigned short)unpack(field1,4,0); }
+
+    /// \brief Returns the fraction of the coarse face parametric space
+    /// covered by this refined face.
+    float GetParamFraction() const;
+
+    /// \brief Maps the (u,v) parameterization from coarse to refined
+    /// The (u,v) pair is mapped from the base face parameterization to
+    /// the refined face parameterization
+    ///
+    void MapBaseToRefined( float & u, float & v ) const;
+
+    /// \brief Maps the (u,v) parameterization from refined to coarse
+    /// The (u,v) pair is mapped from the refined face parameterization to
+    /// the base face parameterization
+    ///
+    void MapRefinedToBase( float & u, float & v ) const;
+
+    /// \brief The (u,v) pair is normalized to this sub-parametric space.
+    ///
+    /// @param u  u parameter
+    /// @param v  v parameter
+    ///
+    /// @see PatchParam#MapBaseToRefined
+    void Normalize( float & u, float & v ) const;
+
+    /// \brief Returns whether the patch is regular
+    bool IsRegular() const { return (unpack(field1,1,5) != 0); }
 
     unsigned int field0:32;
     unsigned int field1:32;
 
-protected:
-    friend struct Far::internal::PatchParamInterface<PatchParam>;
-    unsigned int baseValue() const { return field1; }
+private:
+    unsigned int pack(unsigned int value, int width, int offset) const {
+        return (unsigned int)((value & ((1<<width)-1)) << offset);
+    }
+
+    unsigned int unpack(unsigned int value, int width, int offset) const {
+        return (unsigned short)((value >> offset) & ((1<<width)-1));
+    }
 };
 
 typedef std::vector<PatchParam> PatchParamTable;
 
 typedef Vtr::Array<PatchParam> PatchParamArray;
 typedef Vtr::ConstArray<PatchParam> ConstPatchParamArray;
+
+inline void
+PatchParam::Set(Index faceid, short u, short v,
+                unsigned short depth, bool nonquad,
+                unsigned short boundary, unsigned short transition,
+                bool regular) {
+    field0 = pack(faceid,    28,  0) |
+             pack(transition, 4, 28);
+
+    field1 = pack(u,         10, 22) |
+             pack(v,         10, 12) |
+             pack(boundary,   4,  8) |
+             pack(regular,    1,  5) |
+             pack(nonquad,    1,  4) |
+             pack(depth,      4,  0);
+}
+
+inline float
+PatchParam::GetParamFraction( ) const {
+    if (NonQuadRoot()) {
+        return 1.0f / float( 1 << (GetDepth()-1) );
+    } else {
+        return 1.0f / float( 1 << GetDepth() );
+    }
+}
+
+inline void
+PatchParam::MapBaseToRefined( float & u, float & v ) const {
+
+    float frac = GetParamFraction();
+
+    float pu = (float)GetU()*frac;
+    float pv = (float)GetV()*frac;
+
+    u = (u - pu) / frac,
+    v = (v - pv) / frac;
+}
+
+inline void
+PatchParam::MapRefinedToBase( float & u, float & v ) const {
+
+    float frac = GetParamFraction();
+
+    float pu = (float)GetU()*frac;
+    float pv = (float)GetV()*frac;
+
+    u = u * frac + pu,
+    v = v * frac + pv;
+}
+
+inline void
+PatchParam::Normalize( float & u, float & v ) const {
+    return MapBaseToRefined(u, v);
+}
 
 } // end namespace Far
 

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -155,7 +155,7 @@ struct PatchTable::FVarPatchChannel {
     PatchDescriptor desc;
 
     std::vector<Index> patchValues;
-    std::vector<PatchParamBase> patchParam;
+    std::vector<PatchParam> patchParam;
 };
 
 void
@@ -503,35 +503,35 @@ PatchTable::GetPatchArrayFVarValues(int array, int channel) const {
     int count = pa.numPatches * ncvs;
     return ConstIndexArray(&c.patchValues[start], count);
 }
-PatchParamBase
+PatchParam
 PatchTable::getPatchFVarPatchParam(int patch, int channel) const {
 
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
     return c.patchParam[patch];
 }
-PatchParamBase
+PatchParam
 PatchTable::GetPatchFVarPatchParam(PatchHandle const & handle, int channel) const {
     return getPatchFVarPatchParam(handle.patchIndex, channel);
 }
-PatchParamBase
+PatchParam
 PatchTable::GetPatchFVarPatchParam(int arrayIndex, int patchIndex, int channel) const {
     return getPatchFVarPatchParam(getPatchIndex(arrayIndex, patchIndex), channel);
 }
-ConstPatchParamBaseArray
+ConstPatchParamArray
 PatchTable::GetPatchArrayFVarPatchParam(int array, int channel) const {
     PatchArray const & pa = getPatchArray(array);
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
-    return ConstPatchParamBaseArray(&c.patchParam[pa.patchIndex], pa.numPatches);
+    return ConstPatchParamArray(&c.patchParam[pa.patchIndex], pa.numPatches);
 }
-ConstPatchParamBaseArray
+ConstPatchParamArray
 PatchTable::GetFVarPatchParam(int channel) const {
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
-    return ConstPatchParamBaseArray(&c.patchParam[0], (int)c.patchParam.size());
+    return ConstPatchParamArray(&c.patchParam[0], (int)c.patchParam.size());
 }
-PatchParamBaseArray
+PatchParamArray
 PatchTable::getFVarPatchParam(int channel) {
     FVarPatchChannel & c = getFVarPatchChannel(channel);
-    return PatchParamBaseArray(&c.patchParam[0], (int)c.patchParam.size());
+    return PatchParamArray(&c.patchParam[0], (int)c.patchParam.size());
 }
 
 void
@@ -555,8 +555,7 @@ PatchTable::EvaluateBasis(
     float wDss[], float wDst[], float wDtt[]) const {
 
     PatchDescriptor::Type patchType = GetPatchArrayDescriptor(handle.arrayIndex).GetType();
-    PatchParamBase const & param =
-        _paramTable[handle.patchIndex].GetPatchParamBase();
+    PatchParam const & param = _paramTable[handle.patchIndex];
 
     if (patchType == PatchDescriptor::REGULAR) {
         internal::GetBSplineWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
@@ -578,8 +577,7 @@ PatchTable::EvaluateBasisVarying(
     float wP[], float wDs[], float wDt[],
     float wDss[], float wDst[], float wDtt[]) const {
 
-    PatchParamBase const & param =
-        _paramTable[handle.patchIndex].GetPatchParamBase();
+    PatchParam const & param = _paramTable[handle.patchIndex];
 
     internal::GetBilinearWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
 }
@@ -594,7 +592,7 @@ PatchTable::EvaluateBasisFaceVarying(
     float wDss[], float wDst[], float wDtt[],
     int channel) const {
 
-    PatchParamBase param = GetPatchFVarPatchParam(handle.arrayIndex, handle.patchIndex, channel);
+    PatchParam param = GetPatchFVarPatchParam(handle.arrayIndex, handle.patchIndex, channel);
     PatchDescriptor::Type patchType = param.IsRegular()
             ? PatchDescriptor::REGULAR
             : GetFVarChannelPatchDescriptor(channel).GetType();

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -312,16 +312,16 @@ public:
     ConstIndexArray GetFVarValues(int channel = 0) const;
 
     /// \brief Returns the value indices for a given patch in \p channel
-    PatchParamBase GetPatchFVarPatchParam(PatchHandle const & handle, int channel = 0) const;
+    PatchParam GetPatchFVarPatchParam(PatchHandle const & handle, int channel = 0) const;
 
     /// \brief Returns the face-varying params for a given patch \p channel
-    PatchParamBase GetPatchFVarPatchParam(int array, int patch, int channel = 0) const;
+    PatchParam GetPatchFVarPatchParam(int array, int patch, int channel = 0) const;
 
     /// \brief Returns the face-varying for a given patch in \p array in \p channel
-    ConstPatchParamBaseArray GetPatchArrayFVarPatchParam(int array, int channel = 0) const;
+    ConstPatchParamArray GetPatchArrayFVarPatchParam(int array, int channel = 0) const;
 
     /// \brief Returns an array of face-varying patch param for \p channel
-    ConstPatchParamBaseArray GetFVarPatchParam(int channel = 0) const;
+    ConstPatchParamArray GetFVarPatchParam(int channel = 0) const;
     //@}
 
 
@@ -510,8 +510,8 @@ private:
     IndexArray getFVarValues(int channel);
     ConstIndexArray getPatchFVarValues(int patch, int channel) const;
 
-    PatchParamBaseArray getFVarPatchParam(int channel);
-    PatchParamBase getPatchFVarPatchParam(int patch, int channel) const;
+    PatchParamArray getFVarPatchParam(int channel);
+    PatchParam getPatchFVarPatchParam(int patch, int channel) const;
 
 private:
 

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -821,8 +821,8 @@ PatchTableFactory::allocateFVarChannels(
 PatchParam
 PatchTableFactory::computePatchParam(
     BuilderContext const & context,
-    int depth, Index faceIndex, int boundaryMask, 
-    int transitionMask) {
+    int depth, Index faceIndex,
+    int boundaryMask, int transitionMask) {
 
     TopologyRefiner const & refiner = context.refiner;
 
@@ -873,7 +873,7 @@ PatchTableFactory::computePatchParam(
 
     PatchParam param;
     param.Set(ptexIndex, (short)u, (short)v, (unsigned short) depth, nonquad,
-               (unsigned short) boundaryMask, (unsigned short) transitionMask);
+              (unsigned short) boundaryMask, (unsigned short) transitionMask);
     return param;
 }
 
@@ -1169,7 +1169,7 @@ PatchTableFactory::populateAdaptivePatches(
         Far::PatchParam *pptr;
         Far::Index *sptr;
         Vtr::internal::StackBuffer<Far::Index*,1> fptr;
-        Vtr::internal::StackBuffer<Far::PatchParamBase*,1> fpptr;
+        Vtr::internal::StackBuffer<Far::PatchParam*,1> fpptr;
 
     private:
         // Non-copyable
@@ -1450,7 +1450,7 @@ PatchTableFactory::populateAdaptivePatches(
 
                 PatchDescriptor desc = table->GetFVarChannelPatchDescriptor(fvc);
 
-                PatchParamBase fvarPatchParam = patchParam.GetPatchParamBase();
+                PatchParam fvarPatchParam = patchParam;
 
                 // Deal with the linear cases trivially first
                 if (desc.GetType() == PatchDescriptor::QUADS) {
@@ -1507,10 +1507,12 @@ PatchTableFactory::populateAdaptivePatches(
                 arrayBuilder->fptr[fvc] += desc.GetNumControlVertices();
 
                 fvarPatchParam.Set(
+                    patchParam.GetFaceId(),
                     patchParam.GetU(), patchParam.GetV(),
                     patchParam.GetDepth(),
                     patchParam.NonQuadRoot(),
                     (fvarIsRegular ? fvarBoundaryMask : 0),
+                    patchParam.GetTransition(),
                     fvarIsRegular);
                 *arrayBuilder->fpptr[fvc]++ = fvarPatchParam;
             }

--- a/opensubdiv/osd/cpuEvaluator.cpp
+++ b/opensubdiv/osd/cpuEvaluator.cpp
@@ -145,8 +145,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         // XXX: patchIndex is absolute. not sure it's consistent.
         //      (should be offsetted by array.primitiveIdBase?)
         //    patchParamBuffer[array.primitiveIdBase + coord.handle.patchIndex]
-        Far::PatchParamBase const & param =
-            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -218,8 +218,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
         int patchType = array.GetPatchType();
-        Far::PatchParamBase const & param =
-            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {

--- a/opensubdiv/osd/ompEvaluator.cpp
+++ b/opensubdiv/osd/ompEvaluator.cpp
@@ -142,8 +142,8 @@ OmpEvaluator::EvalPatches(
         // XXX: patchIndex is absolute. not sure it's consistent.
         //      (should be offsetted by array.primitiveIdBase?)
         //    patchParamBuffer[array.primitiveIdBase + coord.handle.patchIndex]
-        Far::PatchParamBase const & param =
-            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -203,8 +203,8 @@ OmpEvaluator::EvalPatches(
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
         int patchType = array.GetPatchType();
-        Far::PatchParamBase const & param =
-            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {

--- a/opensubdiv/osd/tbbKernel.cpp
+++ b/opensubdiv/osd/tbbKernel.cpp
@@ -317,8 +317,8 @@ public:
             PatchArray const &array = _patchArrayBuffer[coord.handle.arrayIndex];
 
             int patchType = array.GetPatchType();
-            Far::PatchParamBase const & param =
-                _patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+            Far::PatchParam const & param =
+                _patchParamBuffer[coord.handle.patchIndex];
 
             int numControlVertices = 0;
             if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -371,8 +371,8 @@ public:
             PatchArray const &array = _patchArrayBuffer[coord.handle.arrayIndex];
 
             int patchType = array.GetPatchType();
-            Far::PatchParamBase const & param =
-                _patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+            Far::PatchParam const & param =
+                _patchParamBuffer[coord.handle.patchIndex];
 
             int numControlVertices = 0;
             if (patchType == Far::PatchDescriptor::REGULAR) {


### PR DESCRIPTION
This reverts most of the recent changes to the
organization of Far::PatchParam. In particular,
the core parameterization is no longer exposed
as a speparate PatchParamBase class.

We'll revisit this again in a later release, but
stick with a more straight forward implementation
for now.