### PR TITLE
Updated Osd mesh util classes for FVar refinement

### DIFF
--- a/opensubdiv/far/patchBasis.cpp
+++ b/opensubdiv/far/patchBasis.cpp
@@ -52,11 +52,11 @@ public:
     static void GetWeights(float v, float w, float point[]);
 
     // patch weights
-    static void GetPatchWeights(PatchParamBase const & param,
+    static void GetPatchWeights(PatchParam const & param,
         float s, float t, float point[], float deriv1[], float deriv2[], float deriv11[], float deriv12[], float deriv22[]);
 
     // adjust patch weights for boundary (and corner) edges
-    static void AdjustBoundaryWeights(PatchParamBase const & param,
+    static void AdjustBoundaryWeights(PatchParam const & param,
         float sWeights[4], float tWeights[4]);
 };
 
@@ -180,7 +180,7 @@ inline void Spline<BASIS_BOX_SPLINE>::GetWeights(
 }
 
 template <>
-inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParamBase const & param,
+inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParam const & param,
     float s, float t, float point[4], float derivS[4], float derivT[4], float derivSS[4], float derivST[4], float derivTT[4]) {
 
     param.Normalize(s,t);
@@ -225,7 +225,7 @@ inline void Spline<BASIS_BILINEAR>::GetPatchWeights(PatchParamBase const & param
 }
 
 template <SplineBasis BASIS>
-void Spline<BASIS>::AdjustBoundaryWeights(PatchParamBase const & param,
+void Spline<BASIS>::AdjustBoundaryWeights(PatchParam const & param,
     float sWeights[4], float tWeights[4]) {
 
     int boundary = param.GetBoundary();
@@ -253,7 +253,7 @@ void Spline<BASIS>::AdjustBoundaryWeights(PatchParamBase const & param,
 }
 
 template <SplineBasis BASIS>
-void Spline<BASIS>::GetPatchWeights(PatchParamBase const & param,
+void Spline<BASIS>::GetPatchWeights(PatchParam const & param,
     float s, float t, float point[16], float derivS[16], float derivT[16], float derivSS[16], float derivST[16], float derivTT[16]) {
 
     float sWeights[4], tWeights[4], dsWeights[4], dtWeights[4], dssWeights[4], dttWeights[4];
@@ -310,22 +310,22 @@ void Spline<BASIS>::GetPatchWeights(PatchParamBase const & param,
     }
 }
 
-void GetBilinearWeights(PatchParamBase const & param,
+void GetBilinearWeights(PatchParam const & param,
     float s, float t, float point[4], float deriv1[4], float deriv2[4], float deriv11[4], float deriv12[4], float deriv22[4]) {
     Spline<BASIS_BILINEAR>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
-void GetBezierWeights(PatchParamBase const param,
+void GetBezierWeights(PatchParam const param,
     float s, float t, float point[16], float deriv1[16], float deriv2[16], float deriv11[16], float deriv12[16], float deriv22[16]) {
     Spline<BASIS_BEZIER>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
-void GetBSplineWeights(PatchParamBase const & param,
+void GetBSplineWeights(PatchParam const & param,
     float s, float t, float point[16], float deriv1[16], float deriv2[16], float deriv11[16], float deriv12[16], float deriv22[16]) {
     Spline<BASIS_BSPLINE>::GetPatchWeights(param, s, t, point, deriv1, deriv2, deriv11, deriv12, deriv22);
 }
 
-void GetGregoryWeights(PatchParamBase const & param,
+void GetGregoryWeights(PatchParam const & param,
     float s, float t, float point[20], float deriv1[20], float deriv2[20], float deriv11[20], float deriv12[20], float deriv22[20]) {
     //
     //  P3         e3-      e2+         P2

--- a/opensubdiv/far/patchBasis.h
+++ b/opensubdiv/far/patchBasis.h
@@ -45,16 +45,16 @@ namespace internal {
 // So this interface will be changing in future.
 //
 
-void GetBilinearWeights(PatchParamBase const & patchParam,
+void GetBilinearWeights(PatchParam const & patchParam,
     float s, float t, float wP[4], float wDs[4], float wDt[4], float wDss[4] = 0, float wDst[4] = 0, float wDtt[4] = 0);
 
-void GetBezierWeights(PatchParamBase const & patchParam,
+void GetBezierWeights(PatchParam const & patchParam,
     float s, float t, float wP[16], float wDs[16], float wDt[16], float wDss[16] = 0, float wDst[16] = 0, float wDtt[16] = 0);
 
-void GetBSplineWeights(PatchParamBase const & patchParam,
+void GetBSplineWeights(PatchParam const & patchParam,
     float s, float t, float wP[16], float wDs[16], float wDt[16], float wDss[16] = 0, float wDst[16] = 0, float wDtt[16] = 0);
 
-void GetGregoryWeights(PatchParamBase const & patchParam,
+void GetGregoryWeights(PatchParam const & patchParam,
     float s, float t, float wP[20], float wDs[20], float wDt[20], float wDss[20] = 0, float wDst[20] = 0, float wDtt[20] = 0);
 
 

--- a/opensubdiv/far/patchDescriptor.h
+++ b/opensubdiv/far/patchDescriptor.h
@@ -47,12 +47,6 @@ namespace Far {
 /// * Adaptively subdivided meshes contain bicubic patches of types REGULAR,
 ///   GREGORY, GREGORY_BOUNDARY, GREGORY_BASIS.
 ///
-/// Bitfield layout :
-///
-///  Field       | Bits | Content
-///  ------------|:----:|------------------------------------------------------
-///  _type       | 4    | patch type
-///
 class PatchDescriptor {
 
 public:
@@ -107,6 +101,7 @@ public:
     /// type described
     static inline short GetNumControlVertices( Type t );
 
+    /// \brief Deprecated @see PatchDescriptor#GetNumControlVertices
     static inline short GetNumFVarControlVertices( Type t );
 
     /// \brief Returns the number of control vertices expected for a patch of the
@@ -115,8 +110,7 @@ public:
         return GetNumControlVertices( this->GetType() );
     }
 
-    /// \brief Returns the number of control vertices expected for a patch of the
-    /// type described
+    /// \brief Deprecated @see PatchDescriptor#GetNumControlVertices
     short GetNumFVarControlVertices() const {
         return GetNumFVarControlVertices( this->GetType() );
     }
@@ -145,7 +139,7 @@ public:
     void print() const;
 
 private:
-    unsigned int  _type:4;
+    unsigned int _type;
 };
 
 typedef Vtr::ConstArray<PatchDescriptor> ConstPatchDescriptorArray;
@@ -169,17 +163,7 @@ PatchDescriptor::GetNumControlVertices( Type type ) {
 // Returns the number of face-varying control vertices expected for a patch of this type
 inline short
 PatchDescriptor::GetNumFVarControlVertices( Type type ) {
-    switch (type) {
-        case REGULAR           : return GetRegularPatchSize();
-        case QUADS             : return 4;
-        case TRIANGLES         : return 3;
-        case LINES             : return 2;
-        case POINTS            : return 1;
-        case GREGORY_BASIS     : assert(0); return GetGregoryBasisPatchSize();
-        case GREGORY           :
-        case GREGORY_BOUNDARY  : assert(0); // unsupported types
-        default : return -1;
-    }
+    return PatchDescriptor::GetNumControlVertices(type);
 }
 
 // Allows ordering of patches by type

--- a/opensubdiv/far/patchParam.h
+++ b/opensubdiv/far/patchParam.h
@@ -34,8 +34,6 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Far {
 
-namespace internal {
-
 /// \brief Patch parameterization
 ///
 /// Topological refinement splits coarse mesh faces into refined faces.
@@ -82,19 +80,20 @@ namespace internal {
 ///
 /// Bitfield layout :
 ///
-///  Field1     | Bits | Content
-///  -----------|:----:|------------------------------------------------------
-///  level      | 4    | the subdivision level of the patch
-///  nonquad    | 1    | whether the patch is refined from a non-quad face
-///  unused     | 3    | unused
-///  boundary   | 4    | boundary edge mask encoding
-///  v          | 10   | log2 value of u parameter at first patch corner
-///  u          | 10   | log2 value of v parameter at first patch corner
-///
 ///  Field0     | Bits | Content
 ///  -----------|:----:|------------------------------------------------------
 ///  faceId     | 28   | the faceId of the patch
 ///  transition | 4    | transition edge mask encoding
+///
+///  Field1     | Bits | Content
+///  -----------|:----:|------------------------------------------------------
+///  level      | 4    | the subdivision level of the patch
+///  nonquad    | 1    | whether patch is refined from a non-quad face
+///  regular    | 1    | whether patch is regular
+///  unused     | 2    | unused
+///  boundary   | 4    | boundary edge mask encoding
+///  v          | 10   | log2 value of u parameter at first patch corner
+///  u          | 10   | log2 value of v parameter at first patch corner
 ///
 /// Note : the bitfield is not expanded in the struct due to differences in how
 ///        GPU & CPU compilers pack bit-fields and endian-ness.
@@ -150,155 +149,7 @@ namespace internal {
  \endverbatim
 */
 
-template <class IMPL>
-struct PatchParamInterface {
-public:
-    /// \brief Returns the log2 value of the u parameter at
-    /// the first corner of the patch
-    unsigned short GetU() const { return baseData<unsigned short>(10,22); }
-
-    /// \brief Returns the log2 value of the v parameter at
-    /// the first corner of the patch
-    unsigned short GetV() const { return baseData<unsigned short>(10,12); }
-
-    /// \brief Returns the boundary edge encoding for the patch.
-    unsigned short GetBoundary() const { return baseData<unsigned short>(4,8); }
-
-    /// \brief True if the parent coarse face is a non-quad
-    bool NonQuadRoot() const { return (baseData<unsigned int>(1,4) != 0); }
-
-    /// \brief Returns the level of subdivision of the patch
-    unsigned short GetDepth() const { return baseData<unsigned short>(4,0); }
-
-    /// \brief Returns the fraction of the coarse face parametric space
-    /// covered by this refined face.
-    float GetParamFraction() const;
-
-    /// \brief Maps the (u,v) parameterization from coarse to refined
-    /// The (u,v) pair is mapped from the coarse face parameterization to
-    /// the refined face parameterization
-    ///
-    void MapCoarseToRefined( float & u, float & v ) const;
-
-    /// \brief Maps the (u,v) parameterization from refined to coarse
-    /// The (u,v) pair is mapped from the refined face parameterization to
-    /// the coarse face parameterization
-    ///
-    void MapRefinedToCoarse( float & u, float & v ) const;
-
-    /// \brief Deprecated @see PatchParam#MapCoarseToRefined
-    void Normalize( float & u, float & v ) const {
-        return MapCoarseToRefined(u, v);
-    }
-
-protected:
-    unsigned int packBaseData(short u, short v,
-                              unsigned short depth, bool nonquad,
-                              unsigned short boundary) {
-        return pack(u,       10, 22) |
-               pack(v,       10, 12) |
-               pack(boundary, 4,  8) |
-               pack(nonquad,  1,  4) |
-               pack(depth,    4,  0);
-    }
-
-    template <class RETURN_TYPE>
-    RETURN_TYPE baseData(int width, int offset) const {
-        unsigned int value = static_cast<IMPL const *>(this)->baseValue();
-        return (RETURN_TYPE)unpack(value, width, offset);
-    }
-
-    unsigned int pack(unsigned int value, int width, int offset) const {
-        return (unsigned int)((value & ((1<<width)-1)) << offset);
-    }
-
-    unsigned int unpack(unsigned int value, int width, int offset) const {
-        return (unsigned short)((value >> offset) & ((1<<width)-1));
-    }
-};
-
-template<class IMPL>
-inline float
-PatchParamInterface<IMPL>::GetParamFraction( ) const {
-
-    if (NonQuadRoot()) {
-        return 1.0f / float( 1 << (GetDepth()-1) );
-    } else {
-        return 1.0f / float( 1 << GetDepth() );
-    }
-}
-
-template<class IMPL>
-inline void
-PatchParamInterface<IMPL>::MapCoarseToRefined( float & u, float & v ) const {
-
-    float frac = GetParamFraction();
-
-    float pu = (float)GetU()*frac;
-    float pv = (float)GetV()*frac;
-
-    u = (u - pu) / frac,
-    v = (v - pv) / frac;
-}
-
-template<class IMPL>
-inline void
-PatchParamInterface<IMPL>::MapRefinedToCoarse( float & u, float & v ) const {
-
-    float frac = GetParamFraction();
-
-    float pu = (float)GetU()*frac;
-    float pv = (float)GetV()*frac;
-
-    u = u * frac + pu,
-    v = v * frac + pv;
-}
-
-} // end namespace internal
-
-/// \brief Local patch parameterization
-///
-struct PatchParamBase : public Far::internal::PatchParamInterface<PatchParamBase> {
-public:
-    /// \brief Sets the values of the bit fields
-    ///
-    /// @param u value of the u parameter for the first corner of the face
-    /// @param v value of the v parameter for the first corner of the face
-    ///
-    /// @param depth subdivision level of the patch
-    /// @param nonquad true if the root face is not a quad
-    ///
-    /// @param boundary 4-bits identifying boundary edges
-    ///
-    void Set(short u, short v,
-             unsigned short depth, bool nonquad,
-             unsigned short boundary, bool isRegular = true) {
-        field1 = packBaseData(u, v, depth, nonquad, boundary);
-        field1 |= pack(isRegular,1,5);
-    }
-
-    /// \brief Resets everything to 0
-    void Clear() { field1 = 0; }
-
-    /// \brief Returns whether the patch is regular
-    bool IsRegular() const { return (unpack(field1,1,5) != 0); }
-
-    unsigned int field1:32;
-
-protected:
-    friend struct Far::internal::PatchParamInterface<PatchParamBase>;
-    unsigned int baseValue() const { return field1; }
-};
-
-typedef std::vector<PatchParamBase> PatchParamBaseTable;
-
-typedef Vtr::Array<PatchParamBase> PatchParamBaseArray;
-typedef Vtr::ConstArray<PatchParamBase> ConstPatchParamBaseArray;
-
-/// \brief Local patch parameterization for vertex patches
-///
-struct PatchParam : public Far::internal::PatchParamInterface<PatchParam> {
-public:
+struct PatchParam {
     /// \brief Sets the values of the bit fields
     ///
     /// @param faceid face index
@@ -312,12 +163,12 @@ public:
     /// @param boundary 4-bits identifying boundary edges
     /// @param transition 4-bits identifying transition edges
     ///
+    /// @param regular whether the patch is regular
+    ///
     void Set(Index faceid, short u, short v,
              unsigned short depth, bool nonquad,
-             unsigned short boundary, unsigned short transition) {
-        field0 = pack(faceid, 28, 0) | pack(transition, 4, 28);
-        field1 = packBaseData(u, v, depth, nonquad, boundary);
-    }
+             unsigned short boundary, unsigned short transition,
+             bool regular = false);
 
     /// \brief Resets everything to 0
     void Clear() { field0 = field1 = 0; }
@@ -325,29 +176,124 @@ public:
     /// \brief Retuns the faceid
     Index GetFaceId() const { return Index(unpack(field0,28,0)); }
 
-    /// \brief Returns the transition edge encoding for the patch.
-    unsigned short GetTransition() const {
-        return (unsigned short)unpack(field0,4,28);
-    }
+    /// \brief Returns the log2 value of the u parameter at
+    /// the first corner of the patch
+    unsigned short GetU() const { return (unsigned short)unpack(field1,10,22); }
 
-    PatchParamBase GetPatchParamBase() const {
-        PatchParamBase result;
-        result.field1 = field1;
-        return result;
-    }
+    /// \brief Returns the log2 value of the v parameter at
+    /// the first corner of the patch
+    unsigned short GetV() const { return (unsigned short)unpack(field1,10,12); }
+
+    /// \brief Returns the transition edge encoding for the patch.
+    unsigned short GetTransition() const { return (unsigned short)unpack(field0,4,28); }
+
+    /// \brief Returns the boundary edge encoding for the patch.
+    unsigned short GetBoundary() const { return (unsigned short)unpack(field1,4,8); }
+
+    /// \brief True if the parent coarse face is a non-quad
+    bool NonQuadRoot() const { return (unpack(field1,1,4) != 0); }
+
+    /// \brief Returns the level of subdivision of the patch
+    unsigned short GetDepth() const { return (unsigned short)unpack(field1,4,0); }
+
+    /// \brief Returns the fraction of the coarse face parametric space
+    /// covered by this refined face.
+    float GetParamFraction() const;
+
+    /// \brief Maps the (u,v) parameterization from coarse to refined
+    /// The (u,v) pair is mapped from the base face parameterization to
+    /// the refined face parameterization
+    ///
+    void MapBaseToRefined( float & u, float & v ) const;
+
+    /// \brief Maps the (u,v) parameterization from refined to coarse
+    /// The (u,v) pair is mapped from the refined face parameterization to
+    /// the base face parameterization
+    ///
+    void MapRefinedToBase( float & u, float & v ) const;
+
+    /// \brief The (u,v) pair is normalized to this sub-parametric space.
+    ///
+    /// @param u  u parameter
+    /// @param v  v parameter
+    ///
+    /// @see PatchParam#MapBaseToRefined
+    void Normalize( float & u, float & v ) const;
+
+    /// \brief Returns whether the patch is regular
+    bool IsRegular() const { return (unpack(field1,1,5) != 0); }
 
     unsigned int field0:32;
     unsigned int field1:32;
 
-protected:
-    friend struct Far::internal::PatchParamInterface<PatchParam>;
-    unsigned int baseValue() const { return field1; }
+private:
+    unsigned int pack(unsigned int value, int width, int offset) const {
+        return (unsigned int)((value & ((1<<width)-1)) << offset);
+    }
+
+    unsigned int unpack(unsigned int value, int width, int offset) const {
+        return (unsigned short)((value >> offset) & ((1<<width)-1));
+    }
 };
 
 typedef std::vector<PatchParam> PatchParamTable;
 
 typedef Vtr::Array<PatchParam> PatchParamArray;
 typedef Vtr::ConstArray<PatchParam> ConstPatchParamArray;
+
+inline void
+PatchParam::Set(Index faceid, short u, short v,
+                unsigned short depth, bool nonquad,
+                unsigned short boundary, unsigned short transition,
+                bool regular) {
+    field0 = pack(faceid,    28,  0) |
+             pack(transition, 4, 28);
+
+    field1 = pack(u,         10, 22) |
+             pack(v,         10, 12) |
+             pack(boundary,   4,  8) |
+             pack(regular,    1,  5) |
+             pack(nonquad,    1,  4) |
+             pack(depth,      4,  0);
+}
+
+inline float
+PatchParam::GetParamFraction( ) const {
+    if (NonQuadRoot()) {
+        return 1.0f / float( 1 << (GetDepth()-1) );
+    } else {
+        return 1.0f / float( 1 << GetDepth() );
+    }
+}
+
+inline void
+PatchParam::MapBaseToRefined( float & u, float & v ) const {
+
+    float frac = GetParamFraction();
+
+    float pu = (float)GetU()*frac;
+    float pv = (float)GetV()*frac;
+
+    u = (u - pu) / frac,
+    v = (v - pv) / frac;
+}
+
+inline void
+PatchParam::MapRefinedToBase( float & u, float & v ) const {
+
+    float frac = GetParamFraction();
+
+    float pu = (float)GetU()*frac;
+    float pv = (float)GetV()*frac;
+
+    u = u * frac + pu,
+    v = v * frac + pv;
+}
+
+inline void
+PatchParam::Normalize( float & u, float & v ) const {
+    return MapBaseToRefined(u, v);
+}
 
 } // end namespace Far
 

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -155,7 +155,7 @@ struct PatchTable::FVarPatchChannel {
     PatchDescriptor desc;
 
     std::vector<Index> patchValues;
-    std::vector<PatchParamBase> patchParam;
+    std::vector<PatchParam> patchParam;
 };
 
 void
@@ -503,35 +503,35 @@ PatchTable::GetPatchArrayFVarValues(int array, int channel) const {
     int count = pa.numPatches * ncvs;
     return ConstIndexArray(&c.patchValues[start], count);
 }
-PatchParamBase
+PatchParam
 PatchTable::getPatchFVarPatchParam(int patch, int channel) const {
 
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
     return c.patchParam[patch];
 }
-PatchParamBase
+PatchParam
 PatchTable::GetPatchFVarPatchParam(PatchHandle const & handle, int channel) const {
     return getPatchFVarPatchParam(handle.patchIndex, channel);
 }
-PatchParamBase
+PatchParam
 PatchTable::GetPatchFVarPatchParam(int arrayIndex, int patchIndex, int channel) const {
     return getPatchFVarPatchParam(getPatchIndex(arrayIndex, patchIndex), channel);
 }
-ConstPatchParamBaseArray
+ConstPatchParamArray
 PatchTable::GetPatchArrayFVarPatchParam(int array, int channel) const {
     PatchArray const & pa = getPatchArray(array);
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
-    return ConstPatchParamBaseArray(&c.patchParam[pa.patchIndex], pa.numPatches);
+    return ConstPatchParamArray(&c.patchParam[pa.patchIndex], pa.numPatches);
 }
-ConstPatchParamBaseArray
+ConstPatchParamArray
 PatchTable::GetFVarPatchParam(int channel) const {
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
-    return ConstPatchParamBaseArray(&c.patchParam[0], (int)c.patchParam.size());
+    return ConstPatchParamArray(&c.patchParam[0], (int)c.patchParam.size());
 }
-PatchParamBaseArray
+PatchParamArray
 PatchTable::getFVarPatchParam(int channel) {
     FVarPatchChannel & c = getFVarPatchChannel(channel);
-    return PatchParamBaseArray(&c.patchParam[0], (int)c.patchParam.size());
+    return PatchParamArray(&c.patchParam[0], (int)c.patchParam.size());
 }
 
 void
@@ -555,8 +555,7 @@ PatchTable::EvaluateBasis(
     float wDss[], float wDst[], float wDtt[]) const {
 
     PatchDescriptor::Type patchType = GetPatchArrayDescriptor(handle.arrayIndex).GetType();
-    PatchParamBase const & param =
-        _paramTable[handle.patchIndex].GetPatchParamBase();
+    PatchParam const & param = _paramTable[handle.patchIndex];
 
     if (patchType == PatchDescriptor::REGULAR) {
         internal::GetBSplineWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
@@ -578,8 +577,7 @@ PatchTable::EvaluateBasisVarying(
     float wP[], float wDs[], float wDt[],
     float wDss[], float wDst[], float wDtt[]) const {
 
-    PatchParamBase const & param =
-        _paramTable[handle.patchIndex].GetPatchParamBase();
+    PatchParam const & param = _paramTable[handle.patchIndex];
 
     internal::GetBilinearWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
 }
@@ -594,7 +592,7 @@ PatchTable::EvaluateBasisFaceVarying(
     float wDss[], float wDst[], float wDtt[],
     int channel) const {
 
-    PatchParamBase param = GetPatchFVarPatchParam(handle.arrayIndex, handle.patchIndex, channel);
+    PatchParam param = GetPatchFVarPatchParam(handle.arrayIndex, handle.patchIndex, channel);
     PatchDescriptor::Type patchType = param.IsRegular()
             ? PatchDescriptor::REGULAR
             : GetFVarChannelPatchDescriptor(channel).GetType();

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -36,7 +36,8 @@ namespace Far {
 PatchTable::PatchTable(int maxvalence) :
     _maxValence(maxvalence),
     _localPointStencils(NULL),
-    _localPointVaryingStencils(NULL) {
+    _localPointVaryingStencils(NULL),
+    _varyingDesc(Far::PatchDescriptor::QUADS) {
 }
 
 // Copy constructor
@@ -49,8 +50,9 @@ PatchTable::PatchTable(PatchTable const & src) :
     _paramTable(src._paramTable),
     _quadOffsetsTable(src._quadOffsetsTable),
     _vertexValenceTable(src._vertexValenceTable),
-    _localPointStencils(NULL),
-    _localPointVaryingStencils(NULL),
+    _localPointStencils(src._localPointStencils),
+    _localPointVaryingStencils(src._localPointVaryingStencils),
+    _varyingDesc(src._varyingDesc),
     _fvarChannels(src._fvarChannels),
     _sharpnessIndices(src._sharpnessIndices),
     _sharpnessValues(src._sharpnessValues) {
@@ -384,14 +386,24 @@ PatchTable::IsFeatureAdaptive() const {
     return false;
 }
 
+PatchDescriptor
+PatchTable::GetVaryingPatchDescriptor() const {
+    return _varyingDesc;
+}
 ConstIndexArray
 PatchTable::GetPatchVaryingVertices(PatchHandle const & handle) const {
+    if (_varyingVerts.empty()) {
+        return ConstIndexArray();
+    }
     int numVaryingCVs = _varyingDesc.GetNumControlVertices();
     Index start = handle.patchIndex * numVaryingCVs;
     return ConstIndexArray(&_varyingVerts[start], numVaryingCVs);
 }
 ConstIndexArray
 PatchTable::GetPatchVaryingVertices(int array, int patch) const {
+    if (_varyingVerts.empty()) {
+        return ConstIndexArray();
+    }
     PatchArray const & pa = getPatchArray(array);
     int numVaryingCVs = _varyingDesc.GetNumControlVertices();
     Index start = (pa.patchIndex + patch) * numVaryingCVs;
@@ -399,6 +411,9 @@ PatchTable::GetPatchVaryingVertices(int array, int patch) const {
 }
 ConstIndexArray
 PatchTable::GetPatchArrayVaryingVertices(int array) const {
+    if (_varyingVerts.empty()) {
+        return ConstIndexArray();
+    }
     PatchArray const & pa = getPatchArray(array);
     int numVaryingCVs = _varyingDesc.GetNumControlVertices();
     Index start = pa.patchIndex * numVaryingCVs;
@@ -407,6 +422,9 @@ PatchTable::GetPatchArrayVaryingVertices(int array) const {
 }
 ConstIndexArray
 PatchTable::GetVaryingVertices() const {
+    if (_varyingVerts.empty()) {
+        return ConstIndexArray();
+    }
     return ConstIndexArray(&_varyingVerts[0], (int)_varyingVerts.size());
 }
 IndexArray

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -312,16 +312,16 @@ public:
     ConstIndexArray GetFVarValues(int channel = 0) const;
 
     /// \brief Returns the value indices for a given patch in \p channel
-    PatchParamBase GetPatchFVarPatchParam(PatchHandle const & handle, int channel = 0) const;
+    PatchParam GetPatchFVarPatchParam(PatchHandle const & handle, int channel = 0) const;
 
     /// \brief Returns the face-varying params for a given patch \p channel
-    PatchParamBase GetPatchFVarPatchParam(int array, int patch, int channel = 0) const;
+    PatchParam GetPatchFVarPatchParam(int array, int patch, int channel = 0) const;
 
     /// \brief Returns the face-varying for a given patch in \p array in \p channel
-    ConstPatchParamBaseArray GetPatchArrayFVarPatchParam(int array, int channel = 0) const;
+    ConstPatchParamArray GetPatchArrayFVarPatchParam(int array, int channel = 0) const;
 
     /// \brief Returns an array of face-varying patch param for \p channel
-    ConstPatchParamBaseArray GetFVarPatchParam(int channel = 0) const;
+    ConstPatchParamArray GetFVarPatchParam(int channel = 0) const;
     //@}
 
 
@@ -510,8 +510,8 @@ private:
     IndexArray getFVarValues(int channel);
     ConstIndexArray getPatchFVarValues(int patch, int channel) const;
 
-    PatchParamBaseArray getFVarPatchParam(int channel);
-    PatchParamBase getPatchFVarPatchParam(int patch, int channel) const;
+    PatchParamArray getFVarPatchParam(int channel);
+    PatchParam getPatchFVarPatchParam(int patch, int channel) const;
 
 private:
 

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -268,6 +268,9 @@ public:
     /// \brief Accessors for varying data
     ///
 
+    /// \brief Returns the varying patch descriptor
+    PatchDescriptor GetVaryingPatchDescriptor() const;
+
     /// \brief Returns the varying vertex indices for a given patch
     ConstIndexArray GetPatchVaryingVertices(PatchHandle const & handle) const;
 

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -821,8 +821,8 @@ PatchTableFactory::allocateFVarChannels(
 PatchParam
 PatchTableFactory::computePatchParam(
     BuilderContext const & context,
-    int depth, Index faceIndex, int boundaryMask, 
-    int transitionMask) {
+    int depth, Index faceIndex,
+    int boundaryMask, int transitionMask) {
 
     TopologyRefiner const & refiner = context.refiner;
 
@@ -873,7 +873,7 @@ PatchTableFactory::computePatchParam(
 
     PatchParam param;
     param.Set(ptexIndex, (short)u, (short)v, (unsigned short) depth, nonquad,
-               (unsigned short) boundaryMask, (unsigned short) transitionMask);
+              (unsigned short) boundaryMask, (unsigned short) transitionMask);
     return param;
 }
 
@@ -1169,7 +1169,7 @@ PatchTableFactory::populateAdaptivePatches(
         Far::PatchParam *pptr;
         Far::Index *sptr;
         Vtr::internal::StackBuffer<Far::Index*,1> fptr;
-        Vtr::internal::StackBuffer<Far::PatchParamBase*,1> fpptr;
+        Vtr::internal::StackBuffer<Far::PatchParam*,1> fpptr;
 
     private:
         // Non-copyable
@@ -1450,7 +1450,7 @@ PatchTableFactory::populateAdaptivePatches(
 
                 PatchDescriptor desc = table->GetFVarChannelPatchDescriptor(fvc);
 
-                PatchParamBase fvarPatchParam = patchParam.GetPatchParamBase();
+                PatchParam fvarPatchParam = patchParam;
 
                 // Deal with the linear cases trivially first
                 if (desc.GetType() == PatchDescriptor::QUADS) {
@@ -1507,10 +1507,12 @@ PatchTableFactory::populateAdaptivePatches(
                 arrayBuilder->fptr[fvc] += desc.GetNumControlVertices();
 
                 fvarPatchParam.Set(
+                    patchParam.GetFaceId(),
                     patchParam.GetU(), patchParam.GetV(),
                     patchParam.GetDepth(),
                     patchParam.NonQuadRoot(),
                     (fvarIsRegular ? fvarBoundaryMask : 0),
+                    patchParam.GetTransition(),
                     fvarIsRegular);
                 *arrayBuilder->fpptr[fvc]++ = fvarPatchParam;
             }

--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -52,6 +52,10 @@ set(PUBLIC_HEADER_FILES
     types.h
 )
 
+list(APPEND KERNEL_FILES
+    patchBasisCommon.h
+)
+
 set(DOXY_HEADER_FILES ${PUBLIC_HEADER_FILES})
 
 #-------------------------------------------------------------------------------

--- a/opensubdiv/osd/clEvaluator.cpp
+++ b/opensubdiv/osd/clEvaluator.cpp
@@ -41,6 +41,9 @@ namespace Osd {
 static const char *clSource =
 #include "clKernel.gen.h"
 ;
+static const char *patchBasisSource =
+#include "patchBasisCommon.gen.h"
+;
 
 // ----------------------------------------------------------------------------
 
@@ -140,11 +143,12 @@ CLEvaluator::Compile(BufferDescriptor const &srcDesc,
     std::ostringstream defines;
     defines << "#define LENGTH "     << srcDesc.length << "\n"
             << "#define SRC_STRIDE " << srcDesc.stride << "\n"
-            << "#define DST_STRIDE " << dstDesc.stride << "\n";
+            << "#define DST_STRIDE " << dstDesc.stride << "\n"
+            << "#define OSD_PATCH_BASIS_OPENCL\n";
     std::string defineStr = defines.str();
 
-    const char *sources[] = { defineStr.c_str(), clSource };
-    _program = clCreateProgramWithSource(_clContext, 2, sources, 0, &errNum);
+    const char *sources[] = { defineStr.c_str(), patchBasisSource, clSource };
+    _program = clCreateProgramWithSource(_clContext, 3, sources, 0, &errNum);
     if (errNum != CL_SUCCESS) {
         Far::Error(Far::FAR_RUNTIME_ERROR,
                    "clCreateProgramWithSource (%d)", errNum);

--- a/opensubdiv/osd/clPatchTable.cpp
+++ b/opensubdiv/osd/clPatchTable.cpp
@@ -42,6 +42,17 @@ CLPatchTable::~CLPatchTable() {
     if (_patchArrays) clReleaseMemObject(_patchArrays);
     if (_indexBuffer) clReleaseMemObject(_indexBuffer);
     if (_patchParamBuffer) clReleaseMemObject(_patchParamBuffer);
+    if (_varyingPatchArrays) clReleaseMemObject(_varyingPatchArrays);
+    if (_varyingIndexBuffer) clReleaseMemObject(_varyingIndexBuffer);
+    for (int fvc=0; fvc<(int)_fvarPatchArrays.size(); ++fvc) {
+        if (_fvarPatchArrays[fvc]) clReleaseMemObject(_fvarPatchArrays[fvc]);
+    }
+    for (int fvc=0; fvc<(int)_fvarIndexBuffers.size(); ++fvc) {
+        if (_fvarIndexBuffers[fvc]) clReleaseMemObject(_fvarIndexBuffers[fvc]);
+    }
+    for (int fvc=0; fvc<(int)_fvarParamBuffers.size(); ++fvc) {
+        if (_fvarParamBuffers[fvc]) clReleaseMemObject(_fvarParamBuffers[fvc]);
+    }
 }
 
 CLPatchTable *
@@ -91,6 +102,63 @@ CLPatchTable::allocate(Far::PatchTable const *farPatchTable, cl_context clContex
         Far::Error(Far::FAR_RUNTIME_ERROR, "clCreateBuffer: %d", err);
         return false;
     }
+
+    _varyingPatchArrays = clCreateBuffer(clContext,
+                                  CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,
+                                  numPatchArrays * sizeof(Osd::PatchArray),
+                                  (void*)patchTable.GetVaryingPatchArrayBuffer(),
+                                  &err);
+    if (err != CL_SUCCESS) {
+        Far::Error(Far::FAR_RUNTIME_ERROR, "clCreateBuffer: %d", err);
+        return false;
+    }
+
+    _varyingIndexBuffer = clCreateBuffer(clContext,
+                                  CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,
+                                  patchTable.GetVaryingPatchIndexSize() * sizeof(int),
+                                  (void*)patchTable.GetVaryingPatchIndexBuffer(),
+                                  &err);
+    if (err != CL_SUCCESS) {
+        Far::Error(Far::FAR_RUNTIME_ERROR, "clCreateBuffer: %d", err);
+        return false;
+    }
+
+    size_t numFVarChannels = patchTable.GetNumFVarChannels();
+    _fvarPatchArrays.resize(numFVarChannels, 0);
+    _fvarIndexBuffers.resize(numFVarChannels, 0);
+    _fvarParamBuffers.resize(numFVarChannels, 0);
+    for (int fvc=0; fvc<(int)numFVarChannels; ++fvc) {
+        _fvarPatchArrays[fvc] = clCreateBuffer(clContext,
+                                  CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,
+                                  numPatchArrays * sizeof(Osd::PatchArray),
+                                  (void*)patchTable.GetFVarPatchArrayBuffer(fvc),
+                                  &err);
+        if (err != CL_SUCCESS) {
+            Far::Error(Far::FAR_RUNTIME_ERROR, "clCreateBuffer: %d", err);
+            return false;
+        }
+
+        _fvarIndexBuffers[fvc] = clCreateBuffer(clContext,
+                                  CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,
+                                  patchTable.GetFVarPatchIndexSize(fvc) * sizeof(int),
+                                  (void*)patchTable.GetFVarPatchIndexBuffer(fvc),
+                                  &err);
+        if (err != CL_SUCCESS) {
+            Far::Error(Far::FAR_RUNTIME_ERROR, "clCreateBuffer: %d", err);
+            return false;
+        }
+
+        _fvarParamBuffers[fvc] = clCreateBuffer(clContext,
+                                   CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,
+                                   patchTable.GetFVarPatchParamSize(fvc) * sizeof(Osd::PatchParam),
+                                   (void*)patchTable.GetFVarPatchParamBuffer(fvc),
+                                   &err);
+        if (err != CL_SUCCESS) {
+            Far::Error(Far::FAR_RUNTIME_ERROR, "clCreateBuffer: %d", err);
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/opensubdiv/osd/clPatchTable.h
+++ b/opensubdiv/osd/clPatchTable.h
@@ -31,6 +31,8 @@
 #include "../osd/nonCopyable.h"
 #include "../osd/types.h"
 
+#include <vector>
+
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
@@ -71,6 +73,21 @@ public:
     /// Returns the CL memory of the array of Osd::PatchParam buffer
     cl_mem GetPatchParamBuffer() const { return _patchParamBuffer; }
 
+    /// Returns the CL memory of the array of Osd::PatchArray buffer
+    cl_mem GetVaryingPatchArrayBuffer() const { return _varyingPatchArrays; }
+
+    /// Returns the CL memory of the varying control vertices
+    cl_mem GetVaryingPatchIndexBuffer() const { return _varyingIndexBuffer; }
+
+    /// Returns the CL memory of the array of Osd::PatchArray buffer
+    cl_mem GetFVarPatchArrayBuffer(int fvarChannel = 0) const { return _fvarPatchArrays[fvarChannel]; }
+
+    /// Returns the CL memory of the face-varying control vertices
+    cl_mem GetFVarPatchIndexBuffer(int fvarChannel = 0) const { return _fvarIndexBuffers[fvarChannel]; }
+
+    /// Returns the CL memory of the array of Osd::PatchParam buffer
+    cl_mem GetFVarPatchParamBuffer(int fvarChannel = 0) const { return _fvarParamBuffers[fvarChannel]; }
+
 protected:
     CLPatchTable();
 
@@ -79,6 +96,14 @@ protected:
     cl_mem _patchArrays;
     cl_mem _indexBuffer;
     cl_mem _patchParamBuffer;
+
+    cl_mem _varyingPatchArrays;
+    cl_mem _varyingIndexBuffer;
+
+    std::vector<cl_mem> _fvarPatchArrays;
+    std::vector<cl_mem> _fvarIndexBuffers;
+    std::vector<cl_mem> _fvarParamBuffers;
+
 };
 
 }  // end namespace Osd

--- a/opensubdiv/osd/cpuEvaluator.cpp
+++ b/opensubdiv/osd/cpuEvaluator.cpp
@@ -141,12 +141,11 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         PatchCoord const &coord = patchCoords[i];
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
-        int patchType = array.GetPatchType();
-        // XXX: patchIndex is absolute. not sure it's consistent.
-        //      (should be offsetted by array.primitiveIdBase?)
-        //    patchParamBuffer[array.primitiveIdBase + coord.handle.patchIndex]
         Far::PatchParam const & param =
             patchParamBuffer[coord.handle.patchIndex];
+        int patchType = param.IsRegular()
+            ? Far::PatchDescriptor::REGULAR
+            : array.GetPatchType();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -165,8 +164,12 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
             assert(0);
             return false;
         }
-        const int *cvs =
-            &patchIndexBuffer[array.indexBase + coord.handle.vertIndex];
+
+        int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
+        int indexBase = array.GetIndexBase() + indexStride *
+                (coord.handle.patchIndex - array.GetPrimitiveIdBase());
+
+        const int *cvs = &patchIndexBuffer[indexBase];
 
         dstT.Clear();
         for (int j = 0; j < numControlVertices; ++j) {
@@ -217,9 +220,11 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         PatchCoord const &coord = patchCoords[i];
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
-        int patchType = array.GetPatchType();
         Far::PatchParam const & param =
             patchParamBuffer[coord.handle.patchIndex];
+        int patchType = param.IsRegular()
+            ? Far::PatchDescriptor::REGULAR
+            : array.GetPatchType();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -237,8 +242,12 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         } else {
             assert(0);
         }
-        const int *cvs =
-            &patchIndexBuffer[array.indexBase + coord.handle.vertIndex];
+
+        int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
+        int indexBase = array.GetIndexBase() + indexStride *
+                (coord.handle.patchIndex - array.GetPrimitiveIdBase());
+
+        const int *cvs = &patchIndexBuffer[indexBase];
 
         dstT.Clear();
         duT.Clear();

--- a/opensubdiv/osd/cpuEvaluator.cpp
+++ b/opensubdiv/osd/cpuEvaluator.cpp
@@ -145,8 +145,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         // XXX: patchIndex is absolute. not sure it's consistent.
         //      (should be offsetted by array.primitiveIdBase?)
         //    patchParamBuffer[array.primitiveIdBase + coord.handle.patchIndex]
-        Far::PatchParamBase const & param =
-            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -218,8 +218,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
         int patchType = array.GetPatchType();
-        Far::PatchParamBase const & param =
-            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {

--- a/opensubdiv/osd/cpuEvaluator.h
+++ b/opensubdiv/osd/cpuEvaluator.h
@@ -28,7 +28,6 @@
 #include "../version.h"
 
 #include <cstddef>
-#include <vector>
 #include "../osd/bufferDescriptor.h"
 #include "../osd/types.h"
 
@@ -457,6 +456,111 @@ public:
         PatchArray const *patchArrays,
         const int *patchIndexBuffer,
         PatchParam const *patchParamBuffer);
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CpuEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        CpuEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
 
     /// ----------------------------------------------------------------------
     ///

--- a/opensubdiv/osd/cpuPatchTable.h
+++ b/opensubdiv/osd/cpuPatchTable.h
@@ -32,6 +32,8 @@
 #include "../osd/nonCopyable.h"
 #include "../osd/types.h"
 
+#include <vector>
+
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
@@ -85,10 +87,52 @@ public:
         return _patchParamBuffer.size();
     }
 
+    const PatchArray *GetVaryingPatchArrayBuffer() const {
+        if (_varyingPatchArrays.empty()) {
+            return NULL;
+        }
+        return &_varyingPatchArrays[0];
+    }
+    const int *GetVaryingPatchIndexBuffer() const {
+        if (_varyingIndexBuffer.empty()) {
+            return NULL;
+        }
+        return &_varyingIndexBuffer[0];
+    }
+    size_t GetVaryingPatchIndexSize() const {
+        return _varyingIndexBuffer.size();
+    }
+
+    int GetNumFVarChannels() const {
+        return (int)_fvarPatchArrays.size();
+    }
+    const PatchArray *GetFVarPatchArrayBuffer(int fvarChannel = 0) const {
+        return &_fvarPatchArrays[fvarChannel][0];
+    }
+    const int *GetFVarPatchIndexBuffer(int fvarChannel = 0) const {
+        return &_fvarIndexBuffers[fvarChannel][0];
+    }
+    size_t GetFVarPatchIndexSize(int fvarChannel = 0) const {
+        return _fvarIndexBuffers[fvarChannel].size();
+    }
+    const PatchParam *GetFVarPatchParamBuffer(int fvarChannel= 0) const {
+        return &_fvarParamBuffers[fvarChannel][0];
+    }
+    size_t GetFVarPatchParamSize(int fvarChannel = 0) const {
+        return _fvarParamBuffers[fvarChannel].size();
+    }
+
 protected:
     PatchArrayVector _patchArrays;
     std::vector<int> _indexBuffer;
     PatchParamVector _patchParamBuffer;
+
+    PatchArrayVector _varyingPatchArrays;
+    std::vector<int> _varyingIndexBuffer;
+
+    std::vector< PatchArrayVector > _fvarPatchArrays;
+    std::vector< std::vector<int> > _fvarIndexBuffers;
+    std::vector< PatchParamVector > _fvarParamBuffers;
 };
 
 }  // end namespace Osd

--- a/opensubdiv/osd/cudaEvaluator.cpp
+++ b/opensubdiv/osd/cudaEvaluator.cpp
@@ -61,6 +61,7 @@ extern "C" {
         const void *patchArrays,
         const int *patchIndices,
         const void *patchParams);
+
 }
 
 namespace OpenSubdiv {

--- a/opensubdiv/osd/cudaEvaluator.h
+++ b/opensubdiv/osd/cudaEvaluator.h
@@ -494,6 +494,111 @@ public:
         const int *patchIndices,
         const PatchParam *patchParams);
 
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///                         must have BindCudaBuffer() method returning an
+    ///                         array of PatchCoord struct in cuda memory.
+    ///
+    /// @param patchTable       CudaPatchTable or equivalent
+    ///
+    /// @param instance         not used in the cuda evaluator
+    ///
+    /// @param deviceContext    not used in the cuda evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CudaEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        (void)instance;   // unused
+        (void)deviceContext;   // unused
+
+        return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
+                           dstBuffer->BindCudaBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord *)patchCoords->BindCudaBuffer(),
+                           (const PatchArray *)patchTable->GetVaryingPatchArrayBuffer(),
+                           (const int *)patchTable->GetVaryingPatchIndexBuffer(),
+                           (const PatchParam *)patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///                         must have BindCudaBuffer() method returning an
+    ///                         array of PatchCoord struct in cuda memory.
+    ///
+    /// @param patchTable       CudaPatchTable or equivalent
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the cuda evaluator
+    ///
+    /// @param deviceContext    not used in the cuda evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        CudaEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        (void)instance;   // unused
+        (void)deviceContext;   // unused
+
+        return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
+                           dstBuffer->BindCudaBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord *)patchCoords->BindCudaBuffer(),
+                           (const PatchArray *)patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           (const int *)patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           (const PatchParam *)patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
     /// ----------------------------------------------------------------------
     ///
     ///   Other methods

--- a/opensubdiv/osd/cudaPatchTable.cpp
+++ b/opensubdiv/osd/cudaPatchTable.cpp
@@ -35,13 +35,25 @@ namespace OPENSUBDIV_VERSION {
 namespace Osd {
 
 CudaPatchTable::CudaPatchTable() :
-    _patchArrays(NULL), _indexBuffer(NULL), _patchParamBuffer(NULL) {
+    _patchArrays(NULL), _indexBuffer(NULL), _patchParamBuffer(NULL),
+    _varyingPatchArrays(NULL), _varyingIndexBuffer(NULL) {
 }
 
 CudaPatchTable::~CudaPatchTable() {
     if (_patchArrays) cudaFree(_patchArrays);
     if (_indexBuffer) cudaFree(_indexBuffer);
     if (_patchParamBuffer) cudaFree(_patchParamBuffer);
+    if (_varyingPatchArrays) cudaFree(_varyingPatchArrays);
+    if (_varyingIndexBuffer) cudaFree(_varyingIndexBuffer);
+    for (int fvc=0; fvc<(int)_fvarPatchArrays.size(); ++fvc) {
+        if (_fvarPatchArrays[fvc]) cudaFree(_fvarPatchArrays[fvc]);
+    }
+    for (int fvc=0; fvc<(int)_fvarIndexBuffers.size(); ++fvc) {
+        if (_fvarIndexBuffers[fvc]) cudaFree(_fvarIndexBuffers[fvc]);
+    }
+    for (int fvc=0; fvc<(int)_fvarParamBuffers.size(); ++fvc) {
+        if (_fvarParamBuffers[fvc]) cudaFree(_fvarParamBuffers[fvc]);
+    }
 }
 
 CudaPatchTable *
@@ -71,6 +83,48 @@ CudaPatchTable::allocate(Far::PatchTable const *farPatchTable) {
     err = cudaMalloc(&_patchParamBuffer, patchParamSize * sizeof(Osd::PatchParam));
     if (err != cudaSuccess) return false;
 
+    err = cudaMalloc(&_varyingPatchArrays, numPatchArrays * sizeof(Osd::PatchArray));
+    if (err != cudaSuccess) return false;
+
+    size_t varyingIndexSize = patchTable.GetVaryingPatchIndexSize();
+    err = cudaMalloc(&_varyingIndexBuffer, varyingIndexSize * sizeof(int));
+    if (err != cudaSuccess) return false;
+
+    size_t numFVarChannels = patchTable.GetNumFVarChannels();
+    _fvarPatchArrays.resize(numFVarChannels, 0);
+    _fvarIndexBuffers.resize(numFVarChannels, 0);
+    _fvarParamBuffers.resize(numFVarChannels, 0);
+    for (int fvc=0; fvc<(int)numFVarChannels; ++fvc) {
+        err = cudaMalloc(&_fvarPatchArrays[fvc], numPatchArrays * sizeof(Osd::PatchArray));
+        if (err != cudaSuccess) return false;
+
+        err = cudaMemcpy(_fvarPatchArrays[fvc],
+                         patchTable.GetFVarPatchArrayBuffer(fvc),
+                         numPatchArrays * sizeof(Osd::PatchArray),
+                         cudaMemcpyHostToDevice);
+        if (err != cudaSuccess) return false;
+
+        size_t fvarIndexSize = patchTable.GetFVarPatchIndexSize(fvc);
+        err = cudaMalloc(&_fvarIndexBuffers[fvc], fvarIndexSize * sizeof(int));
+        if (err != cudaSuccess) return false;
+
+        err = cudaMemcpy(_fvarIndexBuffers[fvc],
+                         patchTable.GetFVarPatchIndexBuffer(fvc),
+                         indexSize * sizeof(int),
+                         cudaMemcpyHostToDevice);
+        if (err != cudaSuccess) return false;
+
+        size_t fvarParamSize = patchTable.GetFVarPatchParamSize(fvc);
+        err = cudaMalloc(&_fvarParamBuffers[fvc], fvarParamSize * sizeof(Osd::PatchParam));
+        if (err != cudaSuccess) return false;
+
+        err = cudaMemcpy(_fvarParamBuffers[fvc],
+                         patchTable.GetFVarPatchParamBuffer(fvc),
+                         patchParamSize * sizeof(PatchParam),
+                         cudaMemcpyHostToDevice);
+        if (err != cudaSuccess) return false;
+    }
+
     // copy patch array
     err = cudaMemcpy(_patchArrays,
                      patchTable.GetPatchArrayBuffer(),
@@ -89,6 +143,18 @@ CudaPatchTable::allocate(Far::PatchTable const *farPatchTable) {
     err = cudaMemcpy(_patchParamBuffer,
                      patchTable.GetPatchParamBuffer(),
                      patchParamSize * sizeof(Osd::PatchParam),
+                     cudaMemcpyHostToDevice);
+    if (err != cudaSuccess) return false;
+
+    // copy varying patch arrays and index buffer
+    err = cudaMemcpy(_varyingPatchArrays,
+                     patchTable.GetVaryingPatchArrayBuffer(),
+                     numPatchArrays * sizeof(Osd::PatchArray),
+                     cudaMemcpyHostToDevice);
+    if (err != cudaSuccess) return false;
+    err = cudaMemcpy(_varyingIndexBuffer,
+                     patchTable.GetVaryingPatchIndexBuffer(),
+                     varyingIndexSize * sizeof(int),
                      cudaMemcpyHostToDevice);
     if (err != cudaSuccess) return false;
 

--- a/opensubdiv/osd/cudaPatchTable.h
+++ b/opensubdiv/osd/cudaPatchTable.h
@@ -30,6 +30,8 @@
 #include "../osd/nonCopyable.h"
 #include "../osd/types.h"
 
+#include <vector>
+
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
@@ -63,6 +65,30 @@ public:
     /// Returns the cuda memory of the array of Osd::PatchParam buffer
     void *GetPatchParamBuffer() const { return _patchParamBuffer; }
 
+    /// Returns the cuda memory of the array of Osd::PatchArray buffer
+    void *GetVaryingPatchArrayBuffer() const {
+        return _varyingPatchArrays;
+    }
+    /// Returns the cuda memory of the array of varying control vertices
+    void *GetVaryingPatchIndexBuffer() const {
+        return _varyingIndexBuffer;
+    }
+
+    /// Returns the cuda memory of the array of Osd::PatchArray buffer
+    void *GetFVarPatchArrayBuffer(int fvarChannel) const {
+        return _fvarPatchArrays[fvarChannel];
+    }
+
+    /// Returns the cuda memory of the array of face-varying control vertices
+    void *GetFVarPatchIndexBuffer(int fvarChannel = 0) const {
+        return _fvarIndexBuffers[fvarChannel];
+    }
+
+    /// Returns the cuda memory of the array of face-varying param
+    void *GetFVarPatchParamBuffer(int fvarChannel = 0) const {
+        return _fvarParamBuffers[fvarChannel];
+    }
+
 protected:
     CudaPatchTable();
 
@@ -71,6 +97,13 @@ protected:
     void *_patchArrays;
     void *_indexBuffer;
     void *_patchParamBuffer;
+
+    void *_varyingPatchArrays;
+    void *_varyingIndexBuffer;
+
+    std::vector<void *> _fvarPatchArrays;
+    std::vector<void *> _fvarIndexBuffers;
+    std::vector<void *> _fvarParamBuffers;
 };
 
 }  // end namespace Osd

--- a/opensubdiv/osd/glComputeEvaluator.cpp
+++ b/opensubdiv/osd/glComputeEvaluator.cpp
@@ -23,6 +23,7 @@
 //
 
 #include "../osd/glComputeEvaluator.h"
+#include "../osd/glslPatchShaderSource.h"
 
 #include <cassert>
 #include <sstream>
@@ -127,18 +128,25 @@ compileKernel(BufferDescriptor const &srcDesc,
 
     GLuint shader = glCreateShader(GL_COMPUTE_SHADER);
 
+    std::string patchBasisShaderSource =
+        GLSLPatchShaderSource::GetPatchBasisShaderSource();
+    const char *patchBasisShaderSourceDefine = "#define OSD_PATCH_BASIS_GLSL\n";
+
     std::ostringstream defines;
     defines << "#define LENGTH "     << srcDesc.length << "\n"
             << "#define SRC_STRIDE " << srcDesc.stride << "\n"
             << "#define DST_STRIDE " << dstDesc.stride << "\n"
             << "#define WORK_GROUP_SIZE " << workGroupSize << "\n"
-            << kernelDefine << "\n";
+            << kernelDefine << "\n"
+            << patchBasisShaderSourceDefine << "\n";
     std::string defineStr = defines.str();
 
-    const char *shaderSources[3] = {"#version 430\n", 0, 0};
+    const char *shaderSources[4] = {"#version 430\n", 0, 0, 0};
+
     shaderSources[1] = defineStr.c_str();
-    shaderSources[2] = shaderSource;
-    glShaderSource(shader, 3, shaderSources, NULL);
+    shaderSources[2] = patchBasisShaderSource.c_str();
+    shaderSources[3] = shaderSource;
+    glShaderSource(shader, 4, shaderSources, NULL);
     glCompileShader(shader);
     glAttachShader(program, shader);
 

--- a/opensubdiv/osd/glPatchTable.cpp
+++ b/opensubdiv/osd/glPatchTable.cpp
@@ -43,6 +43,14 @@ GLPatchTable::~GLPatchTable() {
     if (_patchParamBuffer) glDeleteBuffers(1, &_patchParamBuffer);
     if (_patchIndexTexture) glDeleteTextures(1, &_patchIndexTexture);
     if (_patchParamTexture) glDeleteTextures(1, &_patchParamTexture);
+    if (_varyingIndexBuffer) glDeleteBuffers(1, &_varyingIndexBuffer);
+    if (_varyingIndexTexture) glDeleteTextures(1, &_varyingIndexTexture);
+    for (int fvc=0; fvc<(int)_fvarIndexBuffers.size(); ++fvc) {
+        if (_fvarIndexBuffers[fvc]) glDeleteBuffers(1, &_fvarIndexBuffers[fvc]);
+    }
+    for (int fvc=0; fvc<(int)_fvarIndexTextures.size(); ++fvc) {
+        if (_fvarIndexTextures[fvc]) glDeleteTextures(1, &_fvarIndexTextures[fvc]);
+    }
 }
 
 GLPatchTable *
@@ -93,6 +101,60 @@ GLPatchTable::allocate(Far::PatchTable const *farPatchTable) {
 
     glBindTexture(GL_TEXTURE_BUFFER, _patchParamTexture);
     glTexBuffer(GL_TEXTURE_BUFFER, GL_RGB32I, _patchParamBuffer);
+
+    // varying
+    _varyingPatchArrays.assign(
+        patchTable.GetVaryingPatchArrayBuffer(),
+        patchTable.GetVaryingPatchArrayBuffer() + numPatchArrays);
+
+    glGenBuffers(1, &_varyingIndexBuffer);
+    glBindBuffer(GL_ARRAY_BUFFER, _varyingIndexBuffer);
+    glBufferData(GL_ARRAY_BUFFER,
+                 patchTable.GetVaryingPatchIndexSize() * sizeof(GLint),
+                 patchTable.GetVaryingPatchIndexBuffer(),
+                 GL_STATIC_DRAW);
+
+    glGenTextures(1, &_varyingIndexTexture);
+    glBindTexture(GL_TEXTURE_BUFFER, _varyingIndexTexture);
+    glTexBuffer(GL_TEXTURE_BUFFER, GL_R32I, _varyingIndexBuffer);
+
+    // face-varying
+    int numFVarChannels = patchTable.GetNumFVarChannels();
+    _fvarPatchArrays.resize(numFVarChannels);
+    _fvarIndexBuffers.resize(numFVarChannels);
+    _fvarIndexTextures.resize(numFVarChannels);
+    _fvarParamBuffers.resize(numFVarChannels);
+    _fvarParamTextures.resize(numFVarChannels);
+    for (int fvc=0; fvc<numFVarChannels; ++fvc) {
+        _fvarPatchArrays[fvc].assign(
+            patchTable.GetFVarPatchArrayBuffer(fvc),
+            patchTable.GetFVarPatchArrayBuffer(fvc) + numPatchArrays);
+
+        glGenBuffers(1, &_fvarIndexBuffers[fvc]);
+        glBindBuffer(GL_ARRAY_BUFFER, _fvarIndexBuffers[fvc]);
+        glBufferData(GL_ARRAY_BUFFER,
+                     patchTable.GetFVarPatchIndexSize(fvc) * sizeof(GLint),
+                     patchTable.GetFVarPatchIndexBuffer(fvc),
+                 GL_STATIC_DRAW);
+
+        glGenTextures(1, &_fvarIndexTextures[fvc]);
+        glBindTexture(GL_TEXTURE_BUFFER, _fvarIndexTextures[fvc]);
+        glTexBuffer(GL_TEXTURE_BUFFER, GL_R32I, _fvarIndexBuffers[fvc]);
+
+        glGenBuffers(1, &_fvarParamBuffers[fvc]);
+        glBindBuffer(GL_ARRAY_BUFFER, _fvarParamBuffers[fvc]);
+        glBufferData(GL_ARRAY_BUFFER,
+                     patchTable.GetFVarPatchParamSize(fvc) * sizeof(PatchParam),
+                     patchTable.GetFVarPatchParamBuffer(fvc),
+                 GL_STATIC_DRAW);
+
+        glGenTextures(1, &_fvarParamTextures[fvc]);
+        glBindTexture(GL_TEXTURE_BUFFER, _fvarParamTextures[fvc]);
+        glTexBuffer(GL_TEXTURE_BUFFER, GL_RGB32I, _fvarParamBuffers[fvc]);
+        glBindTexture(GL_TEXTURE_BUFFER, 0);
+    }
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindTexture(GL_TEXTURE_BUFFER, 0);
 
     return true;

--- a/opensubdiv/osd/glPatchTable.h
+++ b/opensubdiv/osd/glPatchTable.h
@@ -31,6 +31,8 @@
 #include "../osd/opengl.h"
 #include "../osd/types.h"
 
+#include <vector>
+
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
@@ -73,6 +75,38 @@ public:
         return _patchParamTexture;
     }
 
+    PatchArrayVector const &GetVaryingPatchArrays() const {
+        return _varyingPatchArrays;
+    }
+
+    /// Returns the GL index buffer containing the varying control vertices
+    GLuint GetVaryingPatchIndexBuffer() const {
+        return _varyingIndexBuffer;
+    }
+
+    /// Returns the GL texture buffer containing the varying control vertices
+    GLuint GetVaryingPatchIndexTextureBuffer() const {
+        return _varyingIndexTexture;
+    }
+
+    PatchArrayVector const &GetFVarPatchArrays(int fvarChannel = 0) const {
+        return _fvarPatchArrays[fvarChannel];
+    }
+
+    /// Returns the GL texture buffer containing the face-varying control vertices
+    GLuint GetFVarPatchIndexBuffer(int fvarChannel = 0) const {
+        return _fvarIndexBuffers[fvarChannel];
+    }
+    GLuint GetFVarPatchIndexTextureBuffer(int fvarChannel = 0) const {
+        return _fvarIndexTextures[fvarChannel];
+    }
+    GLuint GetFVarPatchParamBuffer(int fvarChannel = 0) const {
+        return _fvarParamBuffers[fvarChannel];
+    }
+    GLuint GetFVarPatchParamTextureBuffer(int fvarChannel = 0) const {
+        return _fvarParamTextures[fvarChannel];
+    }
+
 protected:
     GLPatchTable();
 
@@ -86,6 +120,17 @@ protected:
 
     GLuint _patchIndexTexture;
     GLuint _patchParamTexture;
+
+    PatchArrayVector _varyingPatchArrays;
+    GLuint _varyingIndexBuffer;
+    GLuint _varyingIndexTexture;
+
+    std::vector<PatchArrayVector> _fvarPatchArrays;
+    std::vector<GLuint> _fvarIndexBuffers;
+    std::vector<GLuint> _fvarIndexTextures;
+
+    std::vector<GLuint> _fvarParamBuffers;
+    std::vector<GLuint> _fvarParamTextures;
 };
 
 

--- a/opensubdiv/osd/glXFBEvaluator.cpp
+++ b/opensubdiv/osd/glXFBEvaluator.cpp
@@ -23,6 +23,7 @@
 //
 
 #include "../osd/glXFBEvaluator.h"
+#include "../osd/glslPatchShaderSource.h"
 
 #include <sstream>
 #include <string>
@@ -154,18 +155,25 @@ compileKernel(BufferDescriptor const &srcDesc,
 
     GLuint vertexShader = glCreateShader(GL_VERTEX_SHADER);
 
+    std::string patchBasisShaderSource =
+        GLSLPatchShaderSource::GetPatchBasisShaderSource();
+    const char *patchBasisShaderSourceDefine = "#define OSD_PATCH_BASIS_GLSL\n";
+
     std::ostringstream defines;
     defines << "#define LENGTH " << srcDesc.length << "\n"
             << "#define SRC_STRIDE " << srcDesc.stride << "\n"
             << "#define VERTEX_SHADER\n"
-            << kernelDefine << "\n";
+            << kernelDefine << "\n"
+            << patchBasisShaderSourceDefine << "\n";
     std::string defineStr = defines.str();
 
-    const char *shaderSources[3] = {"#version 410\n", NULL, NULL};
+
+    const char *shaderSources[4] = {"#version 410\n", NULL, NULL, NULL};
 
     shaderSources[1] = defineStr.c_str();
-    shaderSources[2] = shaderSource;
-    glShaderSource(vertexShader, 3, shaderSources, NULL);
+    shaderSources[2] = patchBasisShaderSource.c_str();
+    shaderSources[3] = shaderSource;
+    glShaderSource(vertexShader, 4, shaderSources, NULL);
     glCompileShader(vertexShader);
     glAttachShader(program, vertexShader);
 

--- a/opensubdiv/osd/glXFBEvaluator.h
+++ b/opensubdiv/osd/glXFBEvaluator.h
@@ -380,7 +380,7 @@ public:
     ///   Limit evaluations with PatchTable
     ///
     /// ----------------------------------------------------------------------
-    ///
+
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
     ///        in the same way.
@@ -530,13 +530,13 @@ public:
     ///        in the same way.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindCudaBuffer() method returning a
+    ///                       must have BindVBO() method returning a
     ///                       const float pointer for read
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindCudaBuffer() method returning a
+    ///                       must have BindVBO() method returning a
     ///                       float pointer for write
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
@@ -544,7 +544,7 @@ public:
     /// @param numPatchCoords number of patchCoords.
     ///
     /// @param patchCoords    array of locations to be evaluated.
-    ///                       must have BindCudaBuffer() method returning an
+    ///                       must have BindVBO() method returning an
     ///                       array of PatchCoord struct in cuda memory.
     ///
     /// @param patchTable     GLPatchTable or equivalent
@@ -574,25 +574,25 @@ public:
     ///        called in the same way.
     ///
     /// @param srcBuffer        Input primvar buffer.
-    ///                         must have BindCudaBuffer() method returning a
+    ///                         must have BindVBO() method returning a
     ///                         const float pointer for read
     ///
     /// @param srcDesc          vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer        Output primvar buffer
-    ///                         must have BindCudaBuffer() method returning a
+    ///                         must have BindVBO() method returning a
     ///                         float pointer for write
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
     /// @param duBuffer         Output s-derivatives buffer
-    ///                         must have BindCudaBuffer() method returning a
+    ///                         must have BindVBO() method returning a
     ///                         float pointer for write
     ///
     /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
     /// @param dvBuffer         Output t-derivatives buffer
-    ///                         must have BindCudaBuffer() method returning a
+    ///                         must have BindVBO() method returning a
     ///                         float pointer for write
     ///
     /// @param dvDesc           vertex buffer descriptor for the dvBuffer
@@ -634,6 +634,238 @@ public:
                      const PatchArrayVector &patchArrays,
                      GLuint patchIndexBuffer,
                      GLuint patchParamsBuffer) const;
+
+    ///
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        GLXFBEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              BufferDescriptor(),
+                              BufferDescriptor());
+            if (instance) {
+                bool r = instance->EvalPatchesVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a
+    ///                       const float pointer for read
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in cuda memory.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           0, BufferDescriptor(),
+                           0, BufferDescriptor(),
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetVaryingPatchArrays(),
+                           patchTable->GetVaryingPatchIndexTextureBuffer(),
+                           patchTable->GetPatchParamTextureBuffer());
+    }
+
+    ///
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        GLXFBEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesFaceVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable, fvarChannel);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              BufferDescriptor(),
+                              BufferDescriptor());
+            if (instance) {
+                bool r = instance->EvalPatchesFaceVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable, fvarChannel);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a
+    ///                       const float pointer for read
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in cuda memory.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel = 0) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           0, BufferDescriptor(),
+                           0, BufferDescriptor(),
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetFVarPatchArrays(fvarChannel),
+                           patchTable->GetFVarPatchIndexTextureBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamTextureBuffer(fvarChannel));
+    }
 
     /// ----------------------------------------------------------------------
     ///

--- a/opensubdiv/osd/glslPatchShaderSource.cpp
+++ b/opensubdiv/osd/glslPatchShaderSource.cpp
@@ -34,6 +34,9 @@ namespace Osd {
 static const char *commonShaderSource =
 #include "glslPatchCommon.gen.h"
 ;
+static const char *patchBasisShaderSource =
+#include "patchBasisCommon.gen.h"
+;
 static const char *bsplineShaderSource =
 #include "glslPatchBSpline.gen.h"
 ;
@@ -48,6 +51,12 @@ static const char *gregoryBasisShaderSource =
 std::string
 GLSLPatchShaderSource::GetCommonShaderSource() {
     return std::string(commonShaderSource);
+}
+
+/*static*/
+std::string
+GLSLPatchShaderSource::GetPatchBasisShaderSource() {
+    return std::string(patchBasisShaderSource);
 }
 
 /*static*/

--- a/opensubdiv/osd/glslPatchShaderSource.h
+++ b/opensubdiv/osd/glslPatchShaderSource.h
@@ -38,6 +38,8 @@ class GLSLPatchShaderSource {
 public:
     static std::string GetCommonShaderSource();
 
+    static std::string GetPatchBasisShaderSource();
+
     static std::string GetVertexShaderSource(
         Far::PatchDescriptor::Type type);
 

--- a/opensubdiv/osd/glslXFBKernel.glsl
+++ b/opensubdiv/osd/glslXFBKernel.glsl
@@ -153,25 +153,6 @@ uniform ivec4 patchArray[2];
 uniform isamplerBuffer patchParamBuffer;
 uniform isamplerBuffer patchIndexBuffer;
 
-void getBSplineWeights(float t, inout vec4 point, inout vec4 deriv) {
-    // The four uniform cubic B-Spline basis functions evaluated at t:
-    float one6th = 1.0f / 6.0f;
-
-    float t2 = t * t;
-    float t3 = t * t2;
-
-    point.x = one6th * (1.0f - 3.0f*(t -      t2) -      t3);
-    point.y = one6th * (4.0f           - 6.0f*t2  + 3.0f*t3);
-    point.z = one6th * (1.0f + 3.0f*(t +      t2  -      t3));
-    point.w = one6th * (                                 t3);
-
-    // Derivatives of the above four basis functions at t:
-    deriv.x = -0.5f*t2 +      t - 0.5f;
-    deriv.y =  1.5f*t2 - 2.0f*t;
-    deriv.z = -1.5f*t2 +      t + 0.5f;
-    deriv.w =  0.5f*t2;
-}
-
 uint getDepth(uint patchBits) {
     return (patchBits & 0xfU);
 }
@@ -200,29 +181,14 @@ vec2 normalizePatchCoord(uint patchBits, vec2 uv) {
     return vec2((uv.x - pu) / frac, (uv.y - pv) / frac);
 }
 
-void adjustBoundaryWeights(uint bits, inout vec4 sWeights, inout vec4 tWeights) {
-    uint boundary = ((bits >> 8) & 0xfU);
+bool isRegular(uint patchBits) {
+    return (((patchBits >> 5) & 0x1u) != 0);
+}
 
-    if ((boundary & 1U) != 0) {
-        tWeights[2] -= tWeights[0];
-        tWeights[1] += 2*tWeights[0];
-        tWeights[0] = 0;
-    }
-    if ((boundary & 2U) != 0) {
-        sWeights[1] -= sWeights[3];
-        sWeights[2] += 2*sWeights[3];
-        sWeights[3] = 0;
-    }
-    if ((boundary & 4U) != 0) {
-        tWeights[1] -= tWeights[3];
-        tWeights[2] += 2*tWeights[3];
-        tWeights[3] = 0;
-    }
-    if ((boundary & 8U) != 0) {
-        sWeights[2] -= sWeights[0];
-        sWeights[1] += 2*sWeights[0];
-        sWeights[0] = 0;
-    }
+int getNumControlVertices(int patchType) {
+    return (patchType == 3) ? 4 :
+           (patchType == 6) ? 16 :
+           (patchType == 9) ? 20 : 0;
 }
 
 void main() {
@@ -233,32 +199,39 @@ void main() {
 
     vec2 coord = patchCoords;
     ivec4 array = patchArray[handle.x];
-    int patchType = array.x;
-    int numControlVertices = 16;
 
     uint patchBits = texelFetch(patchParamBuffer, patchIndex).y;
+    int patchType = isRegular(patchBits) ? 6 : array.x;
 
     // normalize
     coord = normalizePatchCoord(patchBits, coord);
     float dScale = float(1 << getDepth(patchBits));
+    int boundary = int((patchBits >> 8) & 0xfU);
 
-    // if regular
-    float wP[20], wDs[20], wDt[20];
-    {
-        vec4 sWeights, tWeights, dsWeights, dtWeights;
-        getBSplineWeights(coord.s, sWeights, dsWeights);
-        getBSplineWeights(coord.t, tWeights, dtWeights);
+    float wP[20], wDs[20], wDt[20], wDss[20], wDst[20], wDtt[20];
 
-        adjustBoundaryWeights(patchBits, sWeights, tWeights);
-        adjustBoundaryWeights(patchBits, dsWeights, dtWeights);
-
-        for (int k = 0; k < 4; ++k) {
-            for (int l = 0; l < 4; ++l) {
-                wP[4*k+l]  = sWeights[l]  * tWeights[k];
-                wDs[4*k+l] = dsWeights[l] * tWeights[k]  * dScale;
-                wDt[4*k+l] = sWeights[l]  * dtWeights[k] * dScale;
-            }
+    int numControlVertices = 0;
+    if (patchType == 3) {
+        float wP4[4], wDs4[4], wDt4[4], wDss4[4], wDst4[4], wDtt4[4];
+        OsdGetBilinearPatchWeights(coord.s, coord.t, dScale, wP4, wDs4, wDt4, wDss4, wDst4, wDtt4);
+        numControlVertices = 4;
+        for (int i=0; i<numControlVertices; ++i) {
+            wP[i] = wP4[i];
+            wDs[i] = wDs4[i];
+            wDt[i] = wDt4[i];
         }
+    } else if (patchType == 6) {
+        float wP16[16], wDs16[16], wDt16[16], wDss16[16], wDst16[16], wDtt16[16];
+        OsdGetBSplinePatchWeights(coord.s, coord.t, dScale, boundary, wP16, wDs16, wDt16, wDss16, wDst16, wDtt16);
+        numControlVertices = 16;
+        for (int i=0; i<numControlVertices; ++i) {
+            wP[i] = wP16[i];
+            wDs[i] = wDs16[i];
+            wDt[i] = wDt16[i];
+        }
+    } else if (patchType == 9) {
+        OsdGetGregoryPatchWeights(coord.s, coord.t, dScale, wP, wDs, wDt, wDss, wDst, wDtt);
+        numControlVertices = 20;
     }
 
     Vertex dst, du, dv;
@@ -266,7 +239,9 @@ void main() {
     clear(du);
     clear(dv);
 
-    int indexBase = array.z + handle.z;
+    int indexStride = getNumControlVertices(array.x);
+    int indexBase = array.z + indexStride * (patchIndex - array.w);
+
     for (int cv = 0; cv < numControlVertices; ++cv) {
         int index = texelFetch(patchIndexBuffer, indexBase + cv).x;
         addWithWeight(dst, readVertex(index), wP[cv]);

--- a/opensubdiv/osd/hlslPatchShaderSource.cpp
+++ b/opensubdiv/osd/hlslPatchShaderSource.cpp
@@ -36,6 +36,9 @@ namespace Osd {
 static const char *commonShaderSource =
 #include "hlslPatchCommon.gen.h"
 ;
+static const char *patchBasisShaderSource =
+#include "patchBasisCommon.gen.h"
+;
 static const char *bsplineShaderSource =
 #include "hlslPatchBSpline.gen.h"
 ;
@@ -50,6 +53,12 @@ static const char *gregoryBasisShaderSource =
 std::string
 HLSLPatchShaderSource::GetCommonShaderSource() {
     return std::string(commonShaderSource);
+}
+
+/*static*/
+std::string
+HLSLPatchShaderSource::GetPatchBasisShaderSource() {
+    return std::string(patchBasisShaderSource);
 }
 
 /*static*/

--- a/opensubdiv/osd/hlslPatchShaderSource.h
+++ b/opensubdiv/osd/hlslPatchShaderSource.h
@@ -38,6 +38,8 @@ class HLSLPatchShaderSource {
 public:
     static std::string GetCommonShaderSource();
 
+    static std::string GetPatchBasisShaderSource();
+
     static std::string GetVertexShaderSource(Far::PatchDescriptor::Type type);
 
     static std::string GetHullShaderSource(Far::PatchDescriptor::Type type);

--- a/opensubdiv/osd/ompEvaluator.cpp
+++ b/opensubdiv/osd/ompEvaluator.cpp
@@ -138,12 +138,11 @@ OmpEvaluator::EvalPatches(
         PatchCoord const &coord = patchCoords[i];
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
-        int patchType = array.GetPatchType();
-        // XXX: patchIndex is absolute. not sure it's consistent.
-        //      (should be offsetted by array.primitiveIdBase?)
-        //    patchParamBuffer[array.primitiveIdBase + coord.handle.patchIndex]
         Far::PatchParam const & param =
             patchParamBuffer[coord.handle.patchIndex];
+        int patchType = param.IsRegular()
+            ? Far::PatchDescriptor::REGULAR
+            : array.GetPatchType();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -161,8 +160,12 @@ OmpEvaluator::EvalPatches(
         } else {
             continue;
         }
-        const int *cvs =
-            &patchIndexBuffer[array.indexBase + coord.handle.vertIndex];
+
+        int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
+        int indexBase = array.GetIndexBase() + indexStride *
+                (coord.handle.patchIndex - array.GetPrimitiveIdBase());
+
+        const int *cvs = &patchIndexBuffer[indexBase];
 
         dstT.Clear();
         for (int j = 0; j < numControlVertices; ++j) {
@@ -202,9 +205,11 @@ OmpEvaluator::EvalPatches(
         PatchCoord const &coord = patchCoords[i];
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
-        int patchType = array.GetPatchType();
         Far::PatchParam const & param =
             patchParamBuffer[coord.handle.patchIndex];
+        int patchType = param.IsRegular()
+            ? Far::PatchDescriptor::REGULAR
+            : array.GetPatchType();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -222,8 +227,12 @@ OmpEvaluator::EvalPatches(
         } else {
             continue;
         }
-        const int *cvs =
-            &patchIndexBuffer[array.indexBase + coord.handle.vertIndex];
+
+        int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
+        int indexBase = array.GetIndexBase() + indexStride *
+                (coord.handle.patchIndex - array.GetPrimitiveIdBase());
+
+        const int *cvs = &patchIndexBuffer[indexBase];
 
         dstT.Clear();
         duT.Clear();
@@ -239,6 +248,7 @@ OmpEvaluator::EvalPatches(
     }
     return true;
 }
+
 
 /* static */
 void

--- a/opensubdiv/osd/ompEvaluator.cpp
+++ b/opensubdiv/osd/ompEvaluator.cpp
@@ -142,8 +142,8 @@ OmpEvaluator::EvalPatches(
         // XXX: patchIndex is absolute. not sure it's consistent.
         //      (should be offsetted by array.primitiveIdBase?)
         //    patchParamBuffer[array.primitiveIdBase + coord.handle.patchIndex]
-        Far::PatchParamBase const & param =
-            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -203,8 +203,8 @@ OmpEvaluator::EvalPatches(
         PatchArray const &array = patchArrays[coord.handle.arrayIndex];
 
         int patchType = array.GetPatchType();
-        Far::PatchParamBase const & param =
-            patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {

--- a/opensubdiv/osd/ompEvaluator.h
+++ b/opensubdiv/osd/ompEvaluator.h
@@ -28,8 +28,8 @@
 #include "../version.h"
 
 #include <cstddef>
-#include "../osd/types.h"
 #include "../osd/bufferDescriptor.h"
+#include "../osd/types.h"
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
@@ -456,6 +456,111 @@ public:
         PatchArray const *patchArrays,
         const int *patchIndexBuffer,
         PatchParam const *patchParamBuffer);
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the omp evaluator
+    ///
+    /// @param deviceContext    not used in the omp evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        OmpEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the omp evaluator
+    ///
+    /// @param deviceContext    not used in the omp evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        OmpEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
 
     /// ----------------------------------------------------------------------
     ///

--- a/opensubdiv/osd/patchBasisCommon.h
+++ b/opensubdiv/osd/patchBasisCommon.h
@@ -1,0 +1,540 @@
+//
+//   Copyright 2016 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_H
+#define OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_H
+
+#if defined(OSD_PATCH_BASIS_GLSL)
+
+    #define OSD_FUNCTION_STORAGE_CLASS
+    #define OSD_DATA_STORAGE_CLASS
+    #define OSD_OPTIONAL(a) true
+    #define OSD_OPTIONAL_INIT(a,b) b
+    #define OSD_OUT out
+    #define OSD_INOUT inout
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            elementType[](a0,a1,a2,a3,a4,a5,a6,a7)
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            elementType[](a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11)
+
+#elif defined(OSD_PATCH_BASIS_HLSL)
+
+    #define OSD_FUNCTION_STORAGE_CLASS
+    #define OSD_DATA_STORAGE_CLASS
+    #define OSD_OPTIONAL(a) true
+    #define OSD_OPTIONAL_INIT(a,b) b
+    #define OSD_OUT out
+    #define OSD_INOUT inout
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            {a0,a1,a2,a3,a4,a5,a6,a7}
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
+
+#elif defined(OSD_PATCH_BASIS_CUDA)
+
+    #define OSD_FUNCTION_STORAGE_CLASS __device__
+    #define OSD_DATA_STORAGE_CLASS static
+    #define OSD_OPTIONAL(a) true
+    #define OSD_OPTIONAL_INIT(a,b) b
+    #define OSD_OUT
+    #define OSD_INOUT
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            {a0,a1,a2,a3,a4,a5,a6,a7}
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
+
+#elif defined(OSD_PATCH_BASIS_OPENCL)
+
+    #define OSD_FUNCTION_STORAGE_CLASS static
+    #define OSD_DATA_STORAGE_CLASS
+    #define OSD_OPTIONAL(a) true
+    #define OSD_OPTIONAL_INIT(a,b) b
+    #define OSD_OUT
+    #define OSD_INOUT
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            {a0,a1,a2,a3,a4,a5,a6,a7}
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
+
+#else
+
+    #define OSD_FUNCTION_STORAGE_CLASS static inline
+    #define OSD_DATA_STORAGE_CLASS static
+    #define OSD_OPTIONAL(a) (a)
+    #define OSD_OPTIONAL_INIT(a,b) (a ? b : 0)
+    #define OSD_OUT
+    #define OSD_INOUT
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            {a0,a1,a2,a3,a4,a5,a6,a7}
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
+
+#endif
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetBezierWeights(
+    float t, OSD_OUT float wP[4], OSD_OUT float wDP[4], OSD_OUT float wDP2[4]) {
+
+    // The four uniform cubic Bezier basis functions (in terms of t and its
+    // complement tC) evaluated at t:
+    float t2 = t*t;
+    float tC = 1.0f - t;
+    float tC2 = tC * tC;
+
+    wP[0] = tC2 * tC;
+    wP[1] = tC2 * t * 3.0f;
+    wP[2] = t2 * tC * 3.0f;
+    wP[3] = t2 * t;
+
+    // Derivatives of the above four basis functions at t:
+    if (OSD_OPTIONAL(wDP)) {
+       wDP[0] = -3.0f * tC2;
+       wDP[1] =  9.0f * t2 - 12.0f * t + 3.0f;
+       wDP[2] = -9.0f * t2 +  6.0f * t;
+       wDP[3] =  3.0f * t2;
+    }
+
+    // Second derivatives of the basis functions at t:
+    if (OSD_OPTIONAL(wDP2)) {
+        wDP2[0] =   6.0f * tC;
+        wDP2[1] =  18.0f * t - 12.0f;
+        wDP2[2] = -18.0f * t +  6.0f;
+        wDP2[3] =   6.0f * t;
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetBSplineWeights(
+    float t, OSD_OUT float wP[4], OSD_OUT float wDP[4], OSD_OUT float wDP2[4]) {
+
+    // The four uniform cubic B-Spline basis functions evaluated at t:
+    const float one6th = 1.0f / 6.0f;
+
+    float t2 = t * t;
+    float t3 = t * t2;
+
+    wP[0] = one6th * (1.0f - 3.0f*(t -      t2) -      t3);
+    wP[1] = one6th * (4.0f           - 6.0f*t2  + 3.0f*t3);
+    wP[2] = one6th * (1.0f + 3.0f*(t +      t2  -      t3));
+    wP[3] = one6th * (                                 t3);
+
+    // Derivatives of the above four basis functions at t:
+    if (OSD_OPTIONAL(wDP)) {
+        wDP[0] = -0.5f*t2 +      t - 0.5f;
+        wDP[1] =  1.5f*t2 - 2.0f*t;
+        wDP[2] = -1.5f*t2 +      t + 0.5f;
+        wDP[3] =  0.5f*t2;
+    }
+
+    // Second derivatives of the basis functions at t:
+    if (OSD_OPTIONAL(wDP2)) {
+        wDP2[0] = -       t + 1.0f;
+        wDP2[1] =  3.0f * t - 2.0f;
+        wDP2[2] = -3.0f * t + 1.0f;
+        wDP2[3] =         t;
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetBoxSplineWeights(float v, float w, OSD_OUT float wP[12]) {
+
+    float u = 1.0f - v - w;
+
+    //
+    //  The 12 basis functions of the quartic box spline (unscaled by their common
+    //  factor of 1/12 until later, and formatted to make it easy to spot any
+    //  typing errors):
+    //
+    //      15 terms for the 3 points above the triangle corners
+    //       9 terms for the 3 points on faces opposite the triangle edges
+    //       2 terms for the 6 points on faces opposite the triangle corners
+    //
+    //  Powers of each variable for notational convenience:
+    float u2 = u*u;
+    float u3 = u*u2;
+    float u4 = u*u3;
+    float v2 = v*v;
+    float v3 = v*v2;
+    float v4 = v*v3;
+    float w2 = w*w;
+    float w3 = w*w2;
+    float w4 = w*w3;
+
+    //  And now the basis functions:
+    wP[ 0] = u4 + 2.0f*u3*v;
+    wP[ 1] = u4 + 2.0f*u3*w;
+    wP[ 8] = w4 + 2.0f*w3*u;
+    wP[11] = w4 + 2.0f*w3*v;
+    wP[ 9] = v4 + 2.0f*v3*w;
+    wP[ 5] = v4 + 2.0f*v3*u;
+
+    wP[ 2] = u4 + 2.0f*u3*w + 6.0f*u3*v + 6.0f*u2*v*w + 12.0f*u2*v2 +
+                v4 + 2.0f*v3*w + 6.0f*v3*u + 6.0f*v2*u*w;
+    wP[ 4] = w4 + 2.0f*w3*v + 6.0f*w3*u + 6.0f*w2*u*v + 12.0f*w2*u2 +
+                u4 + 2.0f*u3*v + 6.0f*u3*w + 6.0f*u2*v*w;
+    wP[10] = v4 + 2.0f*v3*u + 6.0f*v3*w + 6.0f*v2*w*u + 12.0f*v2*w2 +
+                w4 + 2.0f*w3*u + 6.0f*w3*v + 6.0f*w3*u*v;
+
+    wP[ 3] = v4 + 6*v3*w + 8*v3*u + 36*v2*w*u + 24*v2*u2 + 24*v*u3 +
+                w4 + 6*w3*v + 8*w3*u + 36*w2*v*u + 24*w2*u2 + 24*w*u3 + 6*u4 + 60*u2*v*w + 12*v2*w2;
+    wP[ 6] = w4 + 6*w3*u + 8*w3*v + 36*w2*u*v + 24*w2*v2 + 24*w*v3 +
+                u4 + 6*u3*w + 8*u3*v + 36*u2*v*w + 24*u2*v2 + 24*u*v3 + 6*v4 + 60*v2*w*u + 12*w2*u2;
+    wP[ 7] = u4 + 6*u3*v + 8*u3*w + 36*u2*v*w + 24*u2*w2 + 24*u*w3 +
+                v4 + 6*v3*u + 8*v3*w + 36*v2*u*w + 24*v2*w2 + 24*v*w3 + 6*w4 + 60*w2*u*v + 12*u2*v2;
+
+    for (int i = 0; i < 12; ++i) {
+        wP[i] *= 1.0f / 12.0f;
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetBilinearPatchWeights(
+        float s, float t, float dScale,
+        OSD_OUT float wP[4], OSD_OUT float wDs[4], OSD_OUT float wDt[4],
+        OSD_OUT float wDss[4], OSD_OUT float wDst[4], OSD_OUT float wDtt[4]) {
+
+    float sC = 1.0f - s,
+          tC = 1.0f - t;
+
+    if (OSD_OPTIONAL(wP)) {
+        wP[0] = sC * tC;
+        wP[1] =  s * tC;
+        wP[2] =  s * t;
+        wP[3] = sC * t;
+    }
+
+    if (OSD_OPTIONAL(derivS && derivT)) {
+
+        wDs[0] = -tC * dScale;
+        wDs[1] =  tC * dScale;
+        wDs[2] =   t * dScale;
+        wDs[3] =  -t * dScale;
+
+        wDt[0] = -sC * dScale;
+        wDt[1] =  -s * dScale;
+        wDt[2] =   s * dScale;
+        wDt[3] =  sC * dScale;
+
+        if (OSD_OPTIONAL(derivSS && derivST && derivTT)) {
+            float d2Scale = dScale * dScale;
+
+            for(int i=0;i<4;i++) {
+                wDss[i] = 0;
+                wDtt[i] = 0;
+            }
+
+            wDst[0] =  d2Scale;
+            wDst[1] = -d2Scale;
+            wDst[2] = -d2Scale;
+            wDst[3] =  d2Scale;
+        }
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void OsdAdjustBoundaryWeights(
+        int boundary,
+        OSD_INOUT float sWeights[4], OSD_INOUT float tWeights[4]) {
+
+    if ((boundary & 1) != 0) {
+        tWeights[2] -= tWeights[0];
+        tWeights[1] += 2*tWeights[0];
+        tWeights[0] = 0;
+    }
+    if ((boundary & 2) != 0) {
+        sWeights[1] -= sWeights[3];
+        sWeights[2] += 2*sWeights[3];
+        sWeights[3] = 0;
+    }
+    if ((boundary & 4) != 0) {
+        tWeights[1] -= tWeights[3];
+        tWeights[2] += 2*tWeights[3];
+        tWeights[3] = 0;
+    }
+    if ((boundary & 8) != 0) {
+        sWeights[2] -= sWeights[0];
+        sWeights[1] += 2*sWeights[0];
+        sWeights[0] = 0;
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void OsdComputeTensorProductPatchWeights(float dScale, int boundary,
+    float sWeights[4], float tWeights[4],
+    float dsWeights[4], float dtWeights[4],
+    float dssWeights[4], float dttWeights[4],
+    OSD_OUT float wP[16], OSD_OUT float wDs[16], OSD_OUT float wDt[16],
+    OSD_OUT float wDss[16], OSD_OUT float wDst[16], OSD_OUT float wDtt[16]) {
+
+    if (OSD_OPTIONAL(wP)) {
+        // Compute the tensor product weight of the (s,t) basis function
+        // corresponding to each control vertex:
+
+        OsdAdjustBoundaryWeights(boundary, sWeights, tWeights);
+
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                wP[4*i+j] = sWeights[j] * tWeights[i];
+            }
+        }
+    }
+
+    if (OSD_OPTIONAL(derivS && derivT)) {
+        // Compute the tensor product weight of the differentiated (s,t) basis
+        // function corresponding to each control vertex (scaled accordingly):
+
+        OsdAdjustBoundaryWeights(boundary, dsWeights, dtWeights);
+
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                wDs[4*i+j] = dsWeights[j] * tWeights[i] * dScale;
+                wDt[4*i+j] = sWeights[j] * dtWeights[i] * dScale;
+            }
+        }
+
+        if (OSD_OPTIONAL(derivSS && derivST && derivTT)) {
+            // Compute the tensor product weight of appropriate differentiated
+            // (s,t) basis functions for each control vertex (scaled accordingly):
+            float d2Scale = dScale * dScale;
+
+            OsdAdjustBoundaryWeights(boundary, dssWeights, dttWeights);
+
+            for (int i = 0; i < 4; ++i) {
+                for (int j = 0; j < 4; ++j) {
+                    wDss[4*i+j] = dssWeights[j] * tWeights[i] * d2Scale;
+                    wDst[4*i+j] = dsWeights[j] * dtWeights[i] * d2Scale;
+                    wDtt[4*i+j] = sWeights[j] * dttWeights[i] * d2Scale;
+                }
+            }
+        }
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void OsdGetBezierPatchWeights(
+    float s, float t, float dScale,
+    OSD_OUT float wP[16], OSD_OUT float wDS[16], OSD_OUT float wDT[16],
+    OSD_OUT float wDSS[16], OSD_OUT float wDST[16], OSD_OUT float wDTT[16]) {
+
+    float sWeights[4], tWeights[4], dsWeights[4], dtWeights[4], dssWeights[4], dttWeights[4];
+
+    OsdGetBezierWeights(s, OSD_OPTIONAL_INIT(wP, sWeights), OSD_OPTIONAL_INIT(wDS, dsWeights), OSD_OPTIONAL_INIT(wDSS, dssWeights));
+    OsdGetBezierWeights(t, OSD_OPTIONAL_INIT(wP, tWeights), OSD_OPTIONAL_INIT(wDT, dtWeights), OSD_OPTIONAL_INIT(wDTT, dttWeights));
+
+    OsdComputeTensorProductPatchWeights(dScale, /*boundary=*/0, sWeights, tWeights, dsWeights, dtWeights, dssWeights, dttWeights, wP, wDS, wDT, wDSS, wDST, wDTT);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void OsdGetBSplinePatchWeights(
+    float s, float t, float dScale, int boundary,
+    OSD_OUT float wP[16], OSD_OUT float wDs[16], OSD_OUT float wDt[16],
+    OSD_OUT float wDss[16], OSD_OUT float wDst[16], OSD_OUT float wDtt[16]) {
+
+    float sWeights[4], tWeights[4], dsWeights[4], dtWeights[4], dssWeights[4], dttWeights[4];
+
+    OsdGetBSplineWeights(s, sWeights, OSD_OPTIONAL_INIT(wDS, dsWeights), OSD_OPTIONAL_INIT(wDSS, dssWeights));
+    OsdGetBSplineWeights(t, tWeights, OSD_OPTIONAL_INIT(wDT, dtWeights), OSD_OPTIONAL_INIT(wDTT, dttWeights));
+
+    OsdComputeTensorProductPatchWeights(dScale, boundary, sWeights, tWeights, dsWeights, dtWeights, dssWeights, dttWeights, wP, wDs, wDt, wDss, wDst, wDtt);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void OsdGetGregoryPatchWeights(
+    float s, float t, float dScale,
+    OSD_OUT float wP[20], OSD_OUT float wDs[20], OSD_OUT float wDt[20],
+    OSD_OUT float wDss[20], OSD_OUT float wDst[20], OSD_OUT float wDtt[20]) {
+
+    //
+    //  P3         e3-      e2+         P2
+    //     15------17-------11--------10
+    //     |        |        |        |
+    //     |        |        |        |
+    //     |        | f3-    | f2+    |
+    //     |       19       13        |
+    // e3+ 16-----18           14-----12 e2-
+    //     |     f3+          f2-     |
+    //     |                          |
+    //     |                          |
+    //     |      f0-         f1+     |
+    // e0- 2------4            8------6 e1+
+    //     |        3        9        |
+    //     |        | f0+    | f1-    |
+    //     |        |        |        |
+    //     |        |        |        |
+    //     O--------1--------7--------5
+    //  P0         e0+      e1-         P1
+    //
+
+    //  Indices of boundary and interior points and their corresponding Bezier points
+    //  (this can be reduced with more direct indexing and unrolling of loops):
+    //
+    OSD_DATA_STORAGE_CLASS const int boundaryGregory[12] = OSD_ARRAY_12(int, 0, 1, 7, 5, 2, 6, 16, 12, 15, 17, 11, 10 );
+    OSD_DATA_STORAGE_CLASS const int boundaryBezSCol[12] = OSD_ARRAY_12(int, 0, 1, 2, 3, 0, 3,  0,  3,  0,  1,  2,  3 );
+    OSD_DATA_STORAGE_CLASS const int boundaryBezTRow[12] = OSD_ARRAY_12(int, 0, 0, 0, 0, 1, 1,  2,  2,  3,  3,  3,  3 );
+
+    OSD_DATA_STORAGE_CLASS const int interiorGregory[8] = OSD_ARRAY_8(int, 3, 4,  8, 9,  13, 14,  18, 19 );
+    OSD_DATA_STORAGE_CLASS const int interiorBezSCol[8] = OSD_ARRAY_8(int, 1, 1,  2, 2,   2,  2,   1,  1 );
+    OSD_DATA_STORAGE_CLASS const int interiorBezTRow[8] = OSD_ARRAY_8(int, 1, 1,  1, 1,   2,  2,   2,  2 );
+
+    //
+    //  Bezier basis functions are denoted with B while the rational multipliers for the
+    //  interior points will be denoted G -- so we have B(s), B(t) and G(s,t):
+    //
+    //  Directional Bezier basis functions B at s and t:
+    float Bs[4], Bds[4], Bdss[4];
+    float Bt[4], Bdt[4], Bdtt[4];
+
+    OsdGetBezierWeights(s, Bs, OSD_OPTIONAL_INIT(wDs, Bds), OSD_OPTIONAL_INIT(wDss, Bdss));
+    OsdGetBezierWeights(t, Bt, OSD_OPTIONAL_INIT(wDt, Bdt), OSD_OPTIONAL_INIT(wDtt, Bdtt));
+
+    //  Rational multipliers G at s and t:
+    float sC = 1.0f - s;
+    float tC = 1.0f - t;
+
+    //  Use <= here to avoid compiler warnings -- the sums should always be non-negative:
+    float df0 = s  + t;   df0 = (df0 <= 0.0f) ? 1.0f : (1.0f / df0);
+    float df1 = sC + t;   df1 = (df1 <= 0.0f) ? 1.0f : (1.0f / df1);
+    float df2 = sC + tC;  df2 = (df2 <= 0.0f) ? 1.0f : (1.0f / df2);
+    float df3 = s  + tC;  df3 = (df3 <= 0.0f) ? 1.0f : (1.0f / df3);
+
+    float G[8] = OSD_ARRAY_8(float, s*df0, t*df0,  t*df1, sC*df1,  sC*df2, tC*df2,  tC*df3, s*df3 );
+
+    //  Combined weights for boundary and interior points:
+    for (int i = 0; i < 12; ++i) {
+        wP[boundaryGregory[i]] = Bs[boundaryBezSCol[i]] * Bt[boundaryBezTRow[i]];
+    }
+    for (int i = 0; i < 8; ++i) {
+        wP[interiorGregory[i]] = Bs[interiorBezSCol[i]] * Bt[interiorBezTRow[i]] * G[i];
+    }
+
+    //
+    //  For derivatives, the basis functions for the interior points are rational and ideally
+    //  require appropriate differentiation, i.e. product rule for the combination of B and G
+    //  and the quotient rule for the rational G itself.  As initially proposed by Loop et al
+    //  though, the approximation using the 16 Bezier points arising from the G(s,t) has
+    //  proved adequate (and is what the GPU shaders use) so we continue to use that here.
+    //
+    //  An implementation of the true derivatives is provided for future reference -- it is
+    //  unclear if the approximations will hold up under surface analysis involving higher
+    //  order differentiation.
+    //
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        bool find_second_partials = OSD_OPTIONAL(wDs && wDst && wDtt);
+        //  Remember to include derivative scaling in all assignments below:
+        float d2Scale = dScale * dScale;
+
+        //  Combined weights for boundary points -- simple (scaled) tensor products:
+        for (int i = 0; i < 12; ++i) {
+            int iDst = boundaryGregory[i];
+            int tRow = boundaryBezTRow[i];
+            int sCol = boundaryBezSCol[i];
+
+            wDs[iDst] = Bds[sCol] * Bt[tRow] * dScale;
+            wDt[iDst] = Bdt[tRow] * Bs[sCol] * dScale;
+
+            if (find_second_partials) {
+                wDss[iDst] = Bdss[sCol] * Bt[tRow] * d2Scale;
+                wDst[iDst] = Bds[sCol] * Bdt[tRow] * d2Scale;
+                wDtt[iDst] = Bs[sCol] * Bdtt[tRow] * d2Scale;
+            }
+        }
+
+//#define _USE_BEZIER_PSEUDO_DERIVATIVES
+        // dclyde's note: skipping half of the product rule like this does seem to change the result a lot in my tests.
+        // This is not a runtime bottleneck for cloth sims anyway so I'm just using the accurate version.
+#ifdef _USE_BEZIER_PSEUDO_DERIVATIVES
+        //  Approximation to the true Gregory derivatives by differentiating the Bezier patch
+        //  unique to the given (s,t), i.e. having F = (g^+ * f^+) + (g^- * f^-) as its four
+        //  interior points:
+        //
+        //  Combined weights for interior points -- (scaled) tensor products with G+ or G-:
+        for (int i = 0; i < 8; ++i) {
+            int iDst = interiorGregory[i];
+            int tRow = interiorBezTRow[i];
+            int sCol = interiorBezSCol[i];
+
+            wDs[iDst] = Bds[sCol] * Bt[tRow] * G[i] * dScale;
+            wDt[iDst] = Bdt[tRow] * Bs[sCol] * G[i] * dScale;
+
+            if (find_second_partials) {
+                wDss[iDst] = Bdss[sCol] * Bt[tRow] * G[i] * d2Scale;
+                wDst[iDst] = Bds[sCol] * Bdt[tRow] * G[i] * d2Scale;
+                wDtt[iDst] = Bs[sCol] * Bdtt[tRow] * G[i] * d2Scale;
+            }
+        }
+#else
+        //  True Gregory derivatives using appropriate differentiation of composite functions:
+        //
+        //  Note that for G(s,t) = N(s,t) / D(s,t), all N' and D' are trivial constants (which
+        //  simplifies things for higher order derivatives).  And while each pair of functions
+        //  G (i.e. the G+ and G- corresponding to points f+ and f-) must sum to 1 to ensure
+        //  Bezier equivalence (when f+ = f-), the pairs of G' must similarly sum to 0.  So we
+        //  can potentially compute only one of the pair and negate the result for the other
+        //  (and with 4 or 8 computations involving these constants, this is all very SIMD
+        //  friendly...) but for now we treat all 8 independently for simplicity.
+        //
+        //float N[8] = OSD_ARRAY_8(float,    s,     t,      t,     sC,      sC,     tC,      tC,     s );
+        float D[8] = OSD_ARRAY_8(float,  df0,   df0,    df1,    df1,     df2,    df2,     df3,   df3 );
+
+        OSD_DATA_STORAGE_CLASS const float Nds[8] = OSD_ARRAY_8(float, 1.0f, 0.0f,  0.0f, -1.0f, -1.0f,  0.0f,  0.0f,  1.0f );
+        OSD_DATA_STORAGE_CLASS const float Ndt[8] = OSD_ARRAY_8(float, 0.0f, 1.0f,  1.0f,  0.0f,  0.0f, -1.0f, -1.0f,  0.0f );
+
+        OSD_DATA_STORAGE_CLASS const float Dds[8] = OSD_ARRAY_8(float, 1.0f, 1.0f, -1.0f, -1.0f, -1.0f, -1.0f,  1.0f,  1.0f );
+        OSD_DATA_STORAGE_CLASS const float Ddt[8] = OSD_ARRAY_8(float, 1.0f, 1.0f,  1.0f,  1.0f, -1.0f, -1.0f, -1.0f, -1.0f );
+
+        //  Combined weights for interior points -- (scaled) combinations of B, B', G and G':
+        for (int i = 0; i < 8; ++i) {
+            int iDst = interiorGregory[i];
+            int tRow = interiorBezTRow[i];
+            int sCol = interiorBezSCol[i];
+
+            //  Quotient rule for G' (re-expressed in terms of G to simplify (and D = 1/D)):
+            float Gds = (Nds[i] - Dds[i] * G[i]) * D[i];
+            float Gdt = (Ndt[i] - Ddt[i] * G[i]) * D[i];
+
+            //  Product rule combining B and B' with G and G' (and scaled):
+            wDs[iDst] = (Bds[sCol] * G[i] + Bs[sCol] * Gds) * Bt[tRow] * dScale;
+            wDt[iDst] = (Bdt[tRow] * G[i] + Bt[tRow] * Gdt) * Bs[sCol] * dScale;
+
+            if (find_second_partials) {
+                float Dsqr_inv = D[i]*D[i];
+
+                float Gdss = 2.0f * Dds[i] * Dsqr_inv * (G[i] * Dds[i] - Nds[i]);
+                float Gdst = Dsqr_inv * (2.0f * G[i] * Dds[i] * Ddt[i] - Nds[i] * Ddt[i] - Ndt[i] * Dds[i]);
+                float Gdtt = 2.0f * Ddt[i] * Dsqr_inv * (G[i] * Ddt[i] - Ndt[i]);
+
+                wDss[iDst] = (Bdss[sCol] * G[i] + 2.0f * Bds[sCol] * Gds + Bs[sCol] * Gdss) * Bt[tRow] * d2Scale;
+                wDst[iDst] = (Bt[tRow] * (Bs[sCol] * Gdst + Bds[sCol] * Gdt) + Bdt[tRow] * (Bds[sCol] * G[i] + Bs[sCol] * Gds)) * d2Scale;
+                wDtt[iDst] = (Bdtt[tRow] * G[i] + 2.0f * Bdt[tRow] * Gdt + Bt[tRow] * Gdtt) * Bs[sCol] * d2Scale;
+            }
+        }
+#endif
+    }
+}
+
+#endif /* OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_H */

--- a/opensubdiv/osd/tbbEvaluator.h
+++ b/opensubdiv/osd/tbbEvaluator.h
@@ -454,6 +454,111 @@ public:
         const int *patchIndexBuffer,
         const PatchParam *patchParamBuffer);
 
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       Far::PatchTable
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        TbbEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(),
+                           srcDesc,
+                           dstBuffer->BindCpuBuffer(),
+                           dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       Far::PatchTable
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        TbbEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(),
+                           srcDesc,
+                           dstBuffer->BindCpuBuffer(),
+                           dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
     /// ----------------------------------------------------------------------
     ///
     ///   Other methods

--- a/opensubdiv/osd/tbbKernel.cpp
+++ b/opensubdiv/osd/tbbKernel.cpp
@@ -316,9 +316,11 @@ public:
             PatchCoord const &coord = _patchCoords[i];
             PatchArray const &array = _patchArrayBuffer[coord.handle.arrayIndex];
 
-            int patchType = array.GetPatchType();
             Far::PatchParam const & param =
                 _patchParamBuffer[coord.handle.patchIndex];
+            int patchType = param.IsRegular()
+                ? Far::PatchDescriptor::REGULAR
+                : array.GetPatchType();
 
             int numControlVertices = 0;
             if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -337,8 +339,11 @@ public:
                 assert(0);
             }
 
-            const int *cvs =
-                &_patchIndexBuffer[array.indexBase + coord.handle.vertIndex];
+            int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
+            int indexBase = array.GetIndexBase() + indexStride *
+                    (coord.handle.patchIndex - array.GetPrimitiveIdBase());
+
+            const int *cvs = &_patchIndexBuffer[indexBase];
 
             dstT.Clear();
             for (int j = 0; j < numControlVertices; ++j) {
@@ -370,9 +375,11 @@ public:
             PatchCoord const &coord = _patchCoords[i];
             PatchArray const &array = _patchArrayBuffer[coord.handle.arrayIndex];
 
-            int patchType = array.GetPatchType();
             Far::PatchParam const & param =
                 _patchParamBuffer[coord.handle.patchIndex];
+            int patchType = param.IsRegular()
+                ? Far::PatchDescriptor::REGULAR
+                : array.GetPatchType();
 
             int numControlVertices = 0;
             if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -391,8 +398,11 @@ public:
                 assert(0);
             }
 
-            const int *cvs =
-                &_patchIndexBuffer[array.indexBase + coord.handle.vertIndex];
+            int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
+            int indexBase = array.GetIndexBase() + indexStride *
+                    (coord.handle.patchIndex - array.GetPrimitiveIdBase());
+
+            const int *cvs = &_patchIndexBuffer[indexBase];
 
             dstT.Clear();
             dstDuT.Clear();
@@ -432,6 +442,7 @@ TbbEvalPatches(float const *src, BufferDescriptor const &srcDesc,
     tbb::parallel_for(range, kernel);
 
 }
+
 
 }  // end namespace Osd
 

--- a/opensubdiv/osd/tbbKernel.cpp
+++ b/opensubdiv/osd/tbbKernel.cpp
@@ -317,8 +317,8 @@ public:
             PatchArray const &array = _patchArrayBuffer[coord.handle.arrayIndex];
 
             int patchType = array.GetPatchType();
-            Far::PatchParamBase const & param =
-                _patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+            Far::PatchParam const & param =
+                _patchParamBuffer[coord.handle.patchIndex];
 
             int numControlVertices = 0;
             if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -371,8 +371,8 @@ public:
             PatchArray const &array = _patchArrayBuffer[coord.handle.arrayIndex];
 
             int patchType = array.GetPatchType();
-            Far::PatchParamBase const & param =
-                _patchParamBuffer[coord.handle.patchIndex].GetPatchParamBase();
+            Far::PatchParam const & param =
+                _patchParamBuffer[coord.handle.patchIndex];
 
             int numControlVertices = 0;
             if (patchType == Far::PatchDescriptor::REGULAR) {

--- a/opensubdiv/osd/tbbKernel.h
+++ b/opensubdiv/osd/tbbKernel.h
@@ -26,6 +26,8 @@
 #define OPENSUBDIV3_OSD_TBB_KERNEL_H
 
 #include "../version.h"
+#include "../far/patchDescriptor.h"
+#include "../far/patchParam.h"
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {


### PR DESCRIPTION
This adds some support to the Osd::*Mesh classes for
refining and populating face-varying patches.