### PR TITLE
Exposed public patch table option to enable use of inf-sharp patches

### DIFF
--- a/opensubdiv/far/gregoryBasis.cpp
+++ b/opensubdiv/far/gregoryBasis.cpp
@@ -237,7 +237,19 @@ GregoryBasis::ProtoBasis::ProtoBasis(
         //  results as the Ep and Em can be computed more directly from the limit
         //  masks for the tangent vectors.
         //
-        if (! cornerBoundary[corner]) {
+        if (cornerSpans[corner]._sharp) {
+            P[corner].Clear(stencilCapacity);
+            P[corner].AddWithWeight(vCorner, 1.0f);
+
+            // Approximating these for now, pending future investigation...
+            e0[corner].Clear(stencilCapacity);
+            e0[corner].AddWithWeight(facePoints[corner],       2.0f / 3.0f);
+            e0[corner].AddWithWeight(facePoints[(corner+1)%4], 1.0f / 3.0f);
+
+            e1[corner].Clear(stencilCapacity);
+            e1[corner].AddWithWeight(facePoints[corner],       2.0f / 3.0f);
+            e1[corner].AddWithWeight(facePoints[(corner+3)%4], 1.0f / 3.0f);
+        } else if (! cornerBoundary[corner]) {
             float theta    = cornerFaceAngle[corner];
             float posScale = 1.0f / float(cornerValence);
             float tanScale = computeCoefficient(cornerValence);
@@ -331,7 +343,10 @@ GregoryBasis::ProtoBasis::ProtoBasis(
         float faceAngleNext = faceAngle * float(iEdgeNext);
         float faceAnglePrev = faceAngle * float(iEdgePrev);
 
-        if (! cornerBoundary[corner]) {
+        if (cornerSpans[corner]._sharp) {
+            Ep[corner] = e0[corner];
+            Em[corner] = e1[corner];
+        } else if (! cornerBoundary[corner]) {
             Ep[corner] = P[corner];
             Ep[corner].AddWithWeight(e0[corner], cosf(faceAngleNext));
             Ep[corner].AddWithWeight(e1[corner], sinf(faceAngleNext));

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -562,12 +562,14 @@ PatchTableFactory::BuilderContext::IsPatchRegular(
     //
     bool isRegular = ! fCompVTag._xordinary || fCompVTag._nonManifold;
 
+
+
     //  Reconsider when using inf-sharp patches in presence of inf-sharp features:
-    if (options.useInfSharpPatch && fCompVTag._infSharpEdges) {
-        if (fCompVTag._nonManifold) {
+    if (options.useInfSharpPatch && (fCompVTag._infSharp || fCompVTag._infSharpEdges)) {
+        if (fCompVTag._nonManifold || !fCompVTag._infIrregular) {
             isRegular = true;
-        } else if (!fCompVTag._infIrregular) {
-            isRegular = true;
+        } else if (!fCompVTag._infSharpEdges) {
+            isRegular = false;
         } else {
             //
             //   This is unfortunately a relatively complex case to determine... if a corner

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -57,6 +57,7 @@ public:
              generateAllLevels(false),
              triangulateQuads(false),
              useSingleCreasePatch(false),
+             useInfSharpPatch(false),
              maxIsolationLevel(maxIsolation),
              endCapType(ENDCAP_GREGORY_BASIS),
              shareEndCapPatchPoints(true),
@@ -75,6 +76,7 @@ public:
         unsigned int generateAllLevels    : 1, ///< Include levels from 'firstLevel' to 'maxLevel' (Uniform mode only)
                      triangulateQuads     : 1, ///< Triangulate 'QUADS' primitives (Uniform mode only)
                      useSingleCreasePatch : 1, ///< Use single crease patch
+                     useInfSharpPatch     : 1, ///< Use infinitely-sharp patch
                      maxIsolationLevel    : 4, ///< Cap adaptive feature isolation to the given level (max. 10)
 
                      // end-capping


### PR DESCRIPTION
This change adds the new "useInfSharpPatch" option to Far::PatchTableFactory::Options that was previously being enabled internally.  It also includes tagging of a few additional cases as sharp and changes to the Gregory patch conversion to reflect the sharpness.