### PR TITLE
Fixed CUDA build with newer SDKs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,22 @@ if(CUDA_FOUND)
         -DOPENSUBDIV_HAS_CUDA
     )
     set(OSD_GPU TRUE)
+
+    if (UNIX)
+        list( APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC )
+        if (NOT DEFINED OSD_CUDA_NVCC_FLAGS)
+            if (CUDA_VERSION_MAJOR LESS 6)
+                set( OSD_CUDA_NVCC_FLAGS --gpu-architecture compute_11 )
+            else()
+                set( OSD_CUDA_NVCC_FLAGS --gpu-architecture compute_20 )
+            endif()
+        endif()
+    endif()
+
+    if (DEFINED OSD_CUDA_NVCC_FLAGS)
+        list( APPEND CUDA_NVCC_FLAGS ${OSD_CUDA_NVCC_FLAGS})
+    endif()
+
 else()
     if (NOT NO_CUDA)
         message(WARNING

--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -105,9 +105,6 @@ if (NOT NO_LIB)
 
     if( CUDA_FOUND )
         include_directories( "${CUDA_INCLUDE_DIRS}" )
-        if (UNIX)
-            list( APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC --gpu-architecture compute_11 )
-        endif()
     endif()
 
 

--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -294,10 +294,6 @@ if( CUDA_FOUND )
             cudaD3D11VertexBuffer.h
         )
     endif()
-
-    if (UNIX)
-        list( APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC --gpu-architecture compute_11 )
-    endif()
 endif()
 
 list(APPEND DOXY_HEADER_FILES ${CUDA_PUBLIC_HEADERS})


### PR DESCRIPTION
Recent CUDA SDKs no longer support the "compute_11"
gpu architecture. We now fallback to "compute_20"
instead for newer SDK versions. Additionally, this
behavior can be overriden using the new CMake list
variable OSD_CUDA_NVCC_FLAGS so that it is easier
for clients to target newer architectures and specify
additional arguments.

Fixes #751 