### PR TITLE
Fixed overly aggressive adaptive refinement of face-varying channels

### DIFF
--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -666,6 +666,25 @@ Level::getFaceCompositeVTag(Index fIndex, int fvarChannel) const {
     }
 }
 
+Level::VTag
+Level::getVertexCompositeFVarVTag(Index vIndex, int fvarChannel) const {
+
+    FVarLevel const & fvarLevel = getFVarLevel(fvarChannel);
+
+    FVarLevel::ConstValueTagArray fvTags = fvarLevel.getVertexValueTags(vIndex);
+
+    VTag vTag = getVertexTag(vIndex);
+    if (fvTags[0].isMismatch()) {
+        VTag compVTag = fvTags[0].combineWithLevelVTag(vTag);
+        for (int i = 1; i < fvTags.size(); ++i) {
+            combineTags<VTag, VTag::VTagSize>(compVTag, fvTags[i].combineWithLevelVTag(vTag));
+        }
+        return compVTag;
+    } else {
+        return vTag;
+    }
+}
+
 //
 //  High-level topology gathering functions -- used mainly in patch construction.  These
 //  may eventually be moved elsewhere, possibly to classes specialized for quad- and tri-

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -304,7 +304,8 @@ public:
     //
     //  The same logic can be applied to topology in a FVar channel when tags specific to that
     //  channel are used.  Note that the VTags apply to the FVar values assigned to the corners
-    //  of the face and not the vertex as a whole.
+    //  of the face and not the vertex as a whole.  The "composite" face-varying VTag for a
+    //  vertex is the union of VTags of all distinct FVar values for that vertex.
     //
     bool doesVertexFVarTopologyMatch(Index vIndex, int fvarChannel) const;
     bool doesFaceFVarTopologyMatch(  Index fIndex, int fvarChannel) const;
@@ -315,6 +316,8 @@ public:
 
     VTag getFaceCompositeVTag(Index fIndex, int fvarChannel = -1) const;
     VTag getFaceCompositeVTag(ConstIndexArray & fVerts) const;
+
+    VTag getVertexCompositeFVarVTag(Index vIndex, int fvarChannel) const;
 
     //
     //  When gathering "patch points" we may want the indices of the vertices or the corresponding


### PR DESCRIPTION
Adaptive refinement of face-varying data has been a bit too aggressive -- not isolating faces that are regular in face-varying space, even though an adjoining face in a completely disjoint face-varying region may have irregular features.  In order to ensure faces/patches differ by at most one level of refinement, adaptive refinement now considers all face-varying features around the corner vertices of a face, regardless of how disjoint they are.