### PR TITLE
Updated LimitStencilTableFactory for InfSharpPatch

### DIFF
--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -401,6 +401,8 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
         PatchTableFactory::Options options;
         options.SetEndCapType(
             Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS);
+        options.useInfSharpPatch = !uniform &&
+            refiner.GetAdaptiveOptions().useInfSharpPatch;
 
         patchtable = PatchTableFactory::Create(refiner, options);
 


### PR DESCRIPTION
Far::LimitStencilTableFactory computes limit stencils using
patches from a Far::PatchTable, creating one temporarily if
necessary. This change propagates the useInfSharpPatch option
from adaptively refined topologies.