### PR TITLE
Exposed control for Gregory derivative weight eval

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,8 @@ option(NO_DX "Disable DirectX support")
 option(NO_TESTS "Disable all tests")
 option(NO_GLTESTS "Disable GL tests")
 
+option(OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES "Enable true derivative evaluation for Gregory basis patches" OFF)
+
 set(OSD_GPU FALSE)
 
 # Check for dependencies
@@ -514,6 +516,10 @@ else()
             "${PROJECT_SOURCE_DIR}/cmake or set it through the PTEX_LOCATION "
             "cmake command line argument or environment variable.")
     endif()
+endif()
+
+if( OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES )
+    add_definitions(-DOPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES)
 endif()
 
 # Link examples & regressions dynamically against Osd

--- a/opensubdiv/far/patchBasis.cpp
+++ b/opensubdiv/far/patchBasis.cpp
@@ -425,10 +425,9 @@ void GetGregoryWeights(PatchParam const & param,
             }
         }
 
-//#define _USE_BEZIER_PSEUDO_DERIVATIVES
         // dclyde's note: skipping half of the product rule like this does seem to change the result a lot in my tests.
         // This is not a runtime bottleneck for cloth sims anyway so I'm just using the accurate version.
-#ifdef _USE_BEZIER_PSEUDO_DERIVATIVES
+#ifndef OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES
         //  Approximation to the true Gregory derivatives by differentiating the Bezier patch
         //  unique to the given (s,t), i.e. having F = (g^+ * f^+) + (g^- * f^-) as its four
         //  interior points:

--- a/opensubdiv/osd/glslPatchShaderSource.cpp
+++ b/opensubdiv/osd/glslPatchShaderSource.cpp
@@ -56,7 +56,12 @@ GLSLPatchShaderSource::GetCommonShaderSource() {
 /*static*/
 std::string
 GLSLPatchShaderSource::GetPatchBasisShaderSource() {
-    return std::string(patchBasisShaderSource);
+    std::stringstream ss;
+#if defined(OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES)
+    ss << "#define OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES\n";
+#endif
+    ss << std::string(patchBasisShaderSource);
+    return ss.str();
 }
 
 /*static*/

--- a/opensubdiv/osd/hlslPatchShaderSource.cpp
+++ b/opensubdiv/osd/hlslPatchShaderSource.cpp
@@ -58,7 +58,12 @@ HLSLPatchShaderSource::GetCommonShaderSource() {
 /*static*/
 std::string
 HLSLPatchShaderSource::GetPatchBasisShaderSource() {
-    return std::string(patchBasisShaderSource);
+    std::stringstream ss;
+#if defined(OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES)
+    ss << "#define OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES\n";
+#endif
+    ss << std::string(patchBasisShaderSource);
+    return ss.str();
 }
 
 /*static*/

--- a/opensubdiv/osd/patchBasisCommon.h
+++ b/opensubdiv/osd/patchBasisCommon.h
@@ -464,10 +464,9 @@ void OsdGetGregoryPatchWeights(
             }
         }
 
-//#define _USE_BEZIER_PSEUDO_DERIVATIVES
         // dclyde's note: skipping half of the product rule like this does seem to change the result a lot in my tests.
         // This is not a runtime bottleneck for cloth sims anyway so I'm just using the accurate version.
-#ifdef _USE_BEZIER_PSEUDO_DERIVATIVES
+#ifndef OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES
         //  Approximation to the true Gregory derivatives by differentiating the Bezier patch
         //  unique to the given (s,t), i.e. having F = (g^+ * f^+) + (g^- * f^-) as its four
         //  interior points:


### PR DESCRIPTION
The symbol OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES
determines the method used to compute derivative weights
for Gregory basis patches.

Setting this symbol during CMake configuration (and
hence during C++ and shader compilation) will enable
the use of true derivative weights.

The default behavior is to use a simpler approximation
for consistency with earlier releases.