### PR TITLE
Fixed naming inconsistencies in Far::PatchTable

### DIFF
--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -213,7 +213,7 @@ struct FVarData
 
         glDeleteBuffers(1, &buffer);
 
-        Far::ConstPatchParamArray fvarParam = patchTable->GetFVarPatchParam();
+        Far::ConstPatchParamArray fvarParam = patchTable->GetFVarPatchParams();
 
         glGenBuffers(1, &buffer);
         glBindBuffer(GL_ARRAY_BUFFER, buffer);

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -538,18 +538,18 @@ PatchTable::GetPatchFVarPatchParam(int arrayIndex, int patchIndex, int channel) 
     return getPatchFVarPatchParam(getPatchIndex(arrayIndex, patchIndex), channel);
 }
 ConstPatchParamArray
-PatchTable::GetPatchArrayFVarPatchParam(int array, int channel) const {
+PatchTable::GetPatchArrayFVarPatchParams(int array, int channel) const {
     PatchArray const & pa = getPatchArray(array);
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
     return ConstPatchParamArray(&c.patchParam[pa.patchIndex], pa.numPatches);
 }
 ConstPatchParamArray
-PatchTable::GetFVarPatchParam(int channel) const {
+PatchTable::GetFVarPatchParams(int channel) const {
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
     return ConstPatchParamArray(&c.patchParam[0], (int)c.patchParam.size());
 }
 PatchParamArray
-PatchTable::getFVarPatchParam(int channel) {
+PatchTable::getFVarPatchParams(int channel) {
     FVarPatchChannel & c = getFVarPatchChannel(channel);
     return PatchParamArray(&c.patchParam[0], (int)c.patchParam.size());
 }

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -208,6 +208,8 @@ public:
     /// @param dst       Destination buffer for the computed local point
     ///                  face-varying values
     ///
+    /// @param channel   face-varying channel
+    ///
     ///
     template <class T> void
     ComputeLocalPointValuesFaceVarying(T const *src, T *dst, int channel = 0) const;
@@ -321,10 +323,10 @@ public:
     PatchParam GetPatchFVarPatchParam(int array, int patch, int channel = 0) const;
 
     /// \brief Returns the face-varying for a given patch in \p array in \p channel
-    ConstPatchParamArray GetPatchArrayFVarPatchParam(int array, int channel = 0) const;
+    ConstPatchParamArray GetPatchArrayFVarPatchParams(int array, int channel = 0) const;
 
     /// \brief Returns an array of face-varying patch param for \p channel
-    ConstPatchParamArray GetFVarPatchParam(int channel = 0) const;
+    ConstPatchParamArray GetFVarPatchParams(int channel = 0) const;
     //@}
 
 
@@ -513,7 +515,7 @@ private:
     IndexArray getFVarValues(int channel);
     ConstIndexArray getPatchFVarValues(int patch, int channel) const;
 
-    PatchParamArray getFVarPatchParam(int channel);
+    PatchParamArray getFVarPatchParams(int channel);
     PatchParam getPatchFVarPatchParam(int patch, int channel) const;
 
 private:

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1262,7 +1262,7 @@ PatchTableFactory::populateAdaptivePatches(
                 int   ofs  = pidx * desc.GetNumControlVertices();
 
                 arrayBuilder.fptr[fvc] = &table->getFVarValues(fvc)[ofs];
-                arrayBuilder.fpptr[fvc] = &table->getFVarPatchParam(fvc)[pidx];
+                arrayBuilder.fpptr[fvc] = &table->getFVarPatchParams(fvc)[pidx];
             }
         }
     }

--- a/opensubdiv/osd/cpuPatchTable.cpp
+++ b/opensubdiv/osd/cpuPatchTable.cpp
@@ -96,7 +96,7 @@ CpuPatchTable::CpuPatchTable(const Far::PatchTable *farPatchTable) {
 
             // face-varying param
             Far::ConstPatchParamArray
-                fvarParam = farPatchTable->GetPatchArrayFVarPatchParam(j, fvc);
+                fvarParam = farPatchTable->GetPatchArrayFVarPatchParams(j, fvc);
             for (int k = 0; k < numPatches; ++k) {
                 PatchParam param;
                 //param.patchParam = patchParamTable[patchIndex];


### PR DESCRIPTION
The methods which return arrays of FVarPatchParam have
been made plural, e.g. GetFVarPatchParams(), for consistency
with the other methods in PatchTable.

Also fixed a missing doxygen tag.