### PR TITLE
Bug fixes and improvements for face-varying and inf-sharp patches:

### DIFF
--- a/opensubdiv/far/primvarRefiner.h
+++ b/opensubdiv/far/primvarRefiner.h
@@ -713,7 +713,7 @@ PrimvarRefiner::interpFVarFromEdges(int level, T const & src, U & dst, int chann
 
     Mask eMask(eVertWeights, 0, eFaceWeights);
 
-    bool isLinearFVar = parentFVar.isLinear();
+    bool isLinearFVar = parentFVar.isLinear() || (_refiner._subdivType == Sdc::SCHEME_BILINEAR);
     if (isLinearFVar) {
         eMask.SetNumVertexWeights(2);
         eMask.SetNumEdgeWeights(0);
@@ -848,7 +848,7 @@ PrimvarRefiner::interpFVarFromVerts(int level, T const & src, U & dst, int chann
     Vtr::internal::FVarLevel const &      parentFVar = parentLevel.getFVarLevel(channel);
     Vtr::internal::FVarLevel const &      childFVar  = childLevel.getFVarLevel(channel);
 
-    bool isLinearFVar = parentFVar.isLinear();
+    bool isLinearFVar = parentFVar.isLinear() || (_refiner._subdivType == Sdc::SCHEME_BILINEAR);
 
     Vtr::internal::StackBuffer<float,32> weightBuffer(2*parentLevel.getMaxValence());
 
@@ -964,7 +964,7 @@ PrimvarRefiner::interpFVarFromVerts(int level, T const & src, U & dst, int chann
                 Vtr::Index cVertValue = cVertValues[cSibling];
 
                 dst[cVertValue].Clear();
-                if (cValueTags[cSibling].isCorner()) {
+                if (isLinearFVar || cValueTags[cSibling].isCorner()) {
                     dst[cVertValue].AddWithWeight(src[pVertValue], 1.0f);
                 } else {
                     //

--- a/opensubdiv/far/topologyLevel.h
+++ b/opensubdiv/far/topologyLevel.h
@@ -119,6 +119,23 @@ public:
     //@}
 
     //@{
+    /// @name Methods to inspect other topological properties of individual components:
+    ///
+
+    /// \brief Return if the edge is non-manifold
+    bool IsEdgeNonManifold(Index e) const   { return _level->isEdgeNonManifold(e); }
+
+    /// \brief Return if the vertex is non-manifold
+    bool IsVertexNonManifold(Index v) const { return _level->isVertexNonManifold(v); }
+
+    /// \brief Return if the edge is a boundary
+    bool IsEdgeBoundary(Index e) const   { return _level->getEdgeTag(e)._boundary; }
+
+    /// \brief Return if the vertex is a boundary
+    bool IsVertexBoundary(Index v) const { return _level->getVertexTag(v)._boundary; }
+    //@}
+
+    //@{
     /// @name Methods to inspect feature tags for individual components:
     ///
     /// While only a subset of components may have been tagged with features such
@@ -157,16 +174,46 @@ public:
     /// the way in which vertices associated with the face are accessed -- an
     /// array of fixed size containing the indices for each corner is provided
     /// for inspection, iteration, etc.
+    ///
+    /// When the face-varying topology around a vertex "matches", it has the
+    /// same limit properties and so results in the same limit surface when
+    /// collections of adjacent vertices match.  Like other references to
+    /// "topology", this includes consideration of sharpness.  So it may be
+    /// that face-varying values are assigned around a vertex on a boundary in
+    /// a way that appears to match, but the face-varying interpolation option
+    /// requires sharpening of that vertex in face-varying space -- the
+    /// difference in the topology of the resulting limit surfaces leading to
+    /// the query returning false for the match.  The edge case is simpler in
+    /// that it only considers continuity across the edge, not the entire
+    /// neighborhood around each end vertex.
 
     /// \brief Return the number of face-varying channels (should be same for all levels)
-    int GetNumFVarChannels() const              { return _level->getNumFVarChannels(); }
+    int GetNumFVarChannels() const { return _level->getNumFVarChannels(); }
 
     /// \brief Return the total number of face-varying values in a particular channel
     /// (the upper bound of a face-varying value index)
     int GetNumFVarValues(int channel = 0) const { return _level->getNumFVarValues(channel); }
 
     /// \brief Access the face-varying values associated with a particular face
-    ConstIndexArray GetFaceFVarValues(Index f, int channel = 0) const { return _level->getFaceFVarValues(f, channel); }
+    ConstIndexArray GetFaceFVarValues(Index f, int channel = 0) const {
+        return _level->getFaceFVarValues(f, channel);
+    }
+
+    /// \brief Return if face-varying topology around a vertex matches
+    bool DoesVertexFVarTopologyMatch(Index v, int channel = 0) const {
+        return _level->doesVertexFVarTopologyMatch(v, channel);
+    }
+
+    /// \brief Return if face-varying topology across the edge only matches
+    bool DoesEdgeFVarTopologyMatch(Index e, int channel = 0) const {
+        return _level->doesEdgeFVarTopologyMatch(e, channel);
+    }
+
+    /// \brief Return if face-varying topology around a face matches
+    bool DoesFaceFVarTopologyMatch(Index f, int channel = 0) const {
+        return _level->doesFaceFVarTopologyMatch(f, channel);
+    }
+
     //@}
 
     //@{

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -635,6 +635,11 @@ namespace {
             return true;
         }
 
+        //  Any remaining locally extra-ordinary face-varying boundaries warrant selection:
+        if (compVTag._xordinary && featureMask.selectXOrdinaryInterior) {
+            return true;
+        }
+
         //  If no smooth corners, too many boundaries/sharp-features and need to isolate:
         if (!(compVTag._rule & Sdc::Crease::RULE_SMOOTH)) {
             return true;

--- a/opensubdiv/vtr/fvarLevel.cpp
+++ b/opensubdiv/vtr/fvarLevel.cpp
@@ -386,6 +386,15 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
         }
 
         //
+        //  Some non-manifold cases can have multiple fvar-values but without any discts
+        //  edges that would previously have identified mismatch (e.g. two faces meeting
+        //  at a common vertex), so deal with that case now that we've counted values:
+        //
+        if (!vIsManifold && !vertexMismatch[vIndex]) {
+            vertexMismatch[vIndex] = (uniqueValueCount > 1);
+        }
+
+        //
         //  Update the value count and offset for this vertex and cumulative totals:
         //
         _vertSiblingCounts[vIndex]  = (LocalIndex) uniqueValueCount;
@@ -965,7 +974,6 @@ FVarLevel::gatherValueSpans(Index vIndex, ValueSpan * vValueSpans) const {
                 }
             } else if (_level.getEdgeTag(vEdges[i])._infSharp) {
                 ++ vValueSpans[0]._infSharpEdgeCount;
-                break;
             } else if (_level.getEdgeTag(vEdges[i])._semiSharp) {
                 ++ vValueSpans[0]._semiSharpEdgeCount;
             }

--- a/opensubdiv/vtr/fvarRefinement.cpp
+++ b/opensubdiv/vtr/fvarRefinement.cpp
@@ -433,6 +433,7 @@ FVarRefinement::propagateValueTags() {
     //
     cVert    = _refinement.getFirstChildVertexFromVertices();
     cVertEnd = cVert + _refinement.getNumChildVerticesFromVertices();
+
     for ( ; cVert < cVertEnd; ++cVert) {
         Index pVert = _refinement.getChildVertexParentIndex(cVert);
         assert(_refinement.isChildVertexComplete(cVert));
@@ -531,16 +532,6 @@ FVarRefinement::reclassifySemisharpValues() {
 
     internal::StackBuffer<Index,16> cVertEdgeBuffer(_childLevel.getMaxValence());
 
-    FVarLevel::ValueTag valTagCrease;
-    valTagCrease.clear();
-    valTagCrease._mismatch = true;
-    valTagCrease._crease   = true;
-
-    FVarLevel::ValueTag valTagSemiSharp;
-    valTagSemiSharp.clear();
-    valTagSemiSharp._mismatch = true;
-    valTagSemiSharp._semiSharp = true;
-
     Index cVert    = _refinement.getFirstChildVertexFromVertices();
     Index cVertEnd = cVert + _refinement.getNumChildVerticesFromVertices();
 
@@ -567,9 +558,9 @@ FVarRefinement::reclassifySemisharpValues() {
         if (!cVertTags._semiSharp && !cVertTags._semiSharpEdges) {
             for (int j = 0; j < cValueTags.size(); ++j) {
                 if (cValueTags[j]._semiSharp) {
-                    FVarLevel::ValueTag cValueTagOld = cValueTags[j];
-                    cValueTags[j] = valTagCrease;
-                    cValueTags[j]._xordinary = cValueTagOld._xordinary;
+                    cValueTags[j]._semiSharp = false;
+                    cValueTags[j]._depSharp = false;
+                    cValueTags[j]._crease = true;
                 }
             }
             continue;
@@ -612,9 +603,9 @@ FVarRefinement::reclassifySemisharpValues() {
                     }
                 }
                 if (!isStillSemiSharp) {
-                    FVarLevel::ValueTag cValueTagOld = cValueTags[j];
-                    cValueTags[j] = valTagCrease;
-                    cValueTags[j]._xordinary = cValueTagOld._xordinary;
+                    cValueTags[j]._semiSharp = false;
+                    cValueTags[j]._depSharp = false;
+                    cValueTags[j]._crease = true;
                 }
             }
         }

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -554,7 +554,7 @@ bool
 Level::doesVertexFVarTopologyMatch(Index vIndex, int fvarChannel) const {
 
     return getFVarLevel(fvarChannel).valueTopologyMatches(
-            getFVarLevel(fvarChannel).getVertexValue(vIndex));
+             getFVarLevel(fvarChannel).getVertexValueOffset(vIndex));
 }
 bool
 Level::doesEdgeFVarTopologyMatch(Index eIndex, int fvarChannel) const {


### PR DESCRIPTION
This set of changes includes a number of bug fixes and minor improvements to the feature tagging, adaptive refinement and construction of face-varying and inf-sharp patches.

Historically patches at smooth corners have been represented with sharp regular patches at the deepest level of refinement -- unnoticeable at a deep levels, but a poor approximation at shallow levels (and is under review for change in a later release).  While this approximation persists, for the sake of consistency, it is now being considered and applied in the context of face-varying and inf-sharp patches.

Several bugs occurring in uncommon cases were identified and fixed in the assignment and interpretation of the inf-sharp tags in face-varying channels.  A long existing bug in face-varying interpolation with the Bilinear scheme was also fixed.
