### PR TITLE
Restore sharp approximation to smooth corners of irregular patches

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -742,6 +742,15 @@ PatchTableFactory::BuilderContext::GetIrregularPatchCornerSpans(
         if (options.useInfSharpPatch) {
             cornerSpans[i]._sharp = vTags[i]._infIrregular && (vTags[i]._rule == Sdc::Crease::RULE_CORNER);
         }
+
+        //  Legacy option -- reinterpret an irregular smooth corner as sharp if specified:
+        if (!cornerSpans[i]._sharp && options_approxSmoothCornerWithSharp) {
+            if (vTags[i]._xordinary && vTags[i]._boundary && !vTags[i]._nonManifold) {
+                    int nFaces = cornerSpans[i].isAssigned() ? cornerSpans[i]._numFaces
+                               : level.getVertexFaces(fVerts[i]).size();
+                    cornerSpans[i]._sharp = (nFaces == 1);
+            }
+        }
     }
 }
 
@@ -1393,7 +1402,7 @@ PatchTableFactory::populateAdaptivePatches(
 
             // Leaving the corner span "size" to zero, as constructed, indicates to use the full
             // neighborhood -- we only need to identify a subset when using inf-sharp patches
-            if (context.options.useInfSharpPatch) {
+            if (context.options.useInfSharpPatch || context.options_approxSmoothCornerWithSharp) {
                 context.GetIrregularPatchCornerSpans(
                                     patch.levelIndex, patch.faceIndex, irregCornerSpans);
             }


### PR DESCRIPTION
Historically smooth corners have been represented with sharp patches -- isolated regular patches would use a sharp regular patch and un-isolated Gregory patches would create a sharp corner even when making it smooth was trivial.  The latter was changed recently so that corners of Gregory patches were appropriately smooth for interior inf-sharp patches.  While the smooth corners now on boundaries are a much better approximation to the limit surface, the old behavior is being restored for consistency.