### PR TITLE
Addressed notes from shader API review

### DIFF
--- a/examples/glFVarViewer/shader.glsl
+++ b/examples/glFVarViewer/shader.glsl
@@ -177,18 +177,19 @@ interpolateFaceVarying(vec2 uv, int fvarOffset)
     float wP[16], wDs[16], wDt[16], wDss[16], wDst[16], wDtt[16];
     int patchCVs = 16;
     int patchStride = patchCVs;
-    int boundaryMask = (int(texelFetch(OsdFVarParamBuffer, patchIndex).y) >> 8) & 0xf;
+    ivec3 fvarPatchParam = texelFetch(OsdFVarParamBuffer, patchIndex).xyz;
+    int boundaryMask = OsdGetPatchBoundaryMask(fvarPatchParam);
     OsdGetBSplinePatchWeights(uv.s, uv.t, 1.0f, boundaryMask, wP, wDs, wDt, wDss, wDst, wDtt);
 
 #elif defined(SHADING_FACEVARYING_SMOOTH_GREGORY_BASIS)
     float wP[20], wDs[20], wDt[20], wDss[20], wDst[20], wDtt[20];
     int patchCVs = 20;
     int patchStride = patchCVs;
-    bool isRegular = ((int(texelFetch(OsdFVarParamBuffer, patchIndex).y) >> 5) & 0x1) != 0;
-    if (isRegular) {
+    ivec3 fvarPatchParam = texelFetch(OsdFVarParamBuffer, patchIndex).xyz;
+    if (OsdGetPatchIsRegular(fvarPatchParam)) {
         float wP16[16], wDs16[16], wDt16[16], wDss16[16], wDst16[16], wDtt16[16];
         patchCVs = 16;
-        int boundaryMask = (int(texelFetch(OsdFVarParamBuffer, patchIndex).y) >> 8) & 0xf;
+        int boundaryMask = OsdGetPatchBoundaryMask(fvarPatchParam);
         OsdGetBSplinePatchWeights(uv.s, uv.t, 1.0f, boundaryMask, wP16, wDs16, wDt16, wDss16, wDst16, wDtt16);
         for (int i=0; i<patchCVs; ++i) {
             wP[i] = wP16[i];

--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -187,6 +187,11 @@ ivec2 OsdGetPatchFaceUV(ivec3 patchParam)
     return ivec2(u,v);
 }
 
+bool OsdGetPatchIsRegular(ivec3 patchParam)
+{
+    return ((patchParam.y >> 5) & 0x1) != 0;
+}
+
 float OsdGetPatchSharpness(ivec3 patchParam)
 {
     return intBitsToFloat(patchParam.z);

--- a/opensubdiv/osd/hlslPatchCommon.hlsl
+++ b/opensubdiv/osd/hlslPatchCommon.hlsl
@@ -162,6 +162,11 @@ int2 OsdGetPatchFaceUV(int3 patchParam)
     return int2(u,v);
 }
 
+bool OsdGetPatchIsRegular(int3 patchParam)
+{
+    return ((patchParam.y >> 5) & 0x1) != 0;
+}
+
 float OsdGetPatchSharpness(int3 patchParam)
 {
     return asfloat(patchParam.z);


### PR DESCRIPTION
This fixes the glFVarViewer to access the IsRegular bit
from PatchParam using an API wrapper rather than
directly extracting the bit. This is more consistent
with other shader API for PatchParam.