### PR TITLE
Fixed recent regression in Far::PatchParam

### DIFF
--- a/opensubdiv/far/patchParam.h
+++ b/opensubdiv/far/patchParam.h
@@ -227,7 +227,7 @@ private:
     }
 
     unsigned int unpack(unsigned int value, int width, int offset) const {
-        return (unsigned short)((value >> offset) & ((1<<width)-1));
+        return (unsigned int)((value >> offset) & ((1<<width)-1));
     }
 };
 


### PR DESCRIPTION
Fixed an incorrect type cast in Far::PatchParam
which could result in truncated FaceId values.