### PR TITLE
WIN32 Glew and DLL fixes to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,10 +530,11 @@ else()
 endif()
 
 if (WIN32)
-    add_definitions(
-        # Link against the static version of GLEW.
-        -DGLEW_STATIC
-    )
+    if ("${GLEW_LIBRARY}" MATCHES "glew32s(d|)")
+        add_definitions(
+	    -DGLEW_STATIC
+	)
+    endif()
 
     if (DXSDK_FOUND AND NOT NO_DX)
         add_definitions(
@@ -550,15 +551,6 @@ if (WIN32)
             "environment variable."
         )
     endif()
-    
-    # Link examples & regressions statically against Osd for
-    # Windows until all the kinks can be worked out.
-    if( OSD_GPU )
-        set( OSD_LINK_TARGET osd_static_cpu osd_static_gpu )
-    else()
-        set( OSD_LINK_TARGET osd_static_cpu )
-    endif()
-    
 endif()
 
 

--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -175,7 +175,7 @@ if (NOT NO_LIB)
 
 
     # Build dynamic libs  ----------------------------------
-    if (NOT WIN32 AND NOT IOS)
+    if (NOT IOS)
 
         # generate dynamic-link targets
 
@@ -208,7 +208,17 @@ if (NOT NO_LIB)
             ${PLATFORM_CPU_LIBRARIES}
         )
 
-        install( TARGETS osd_dynamic_cpu LIBRARY DESTINATION "${CMAKE_LIBDIR_BASE}" )
+        if (WIN32)
+            install( TARGETS osd_dynamic_cpu
+                ARCHIVE DESTINATION "${CMAKE_LIBDIR_BASE}"
+                RUNTIME DESTINATION "${CMAKE_BINDIR_BASE}"
+                )
+        else()
+            install( TARGETS osd_dynamic_cpu
+                LIBRARY DESTINATION "${CMAKE_LIBDIR_BASE}"
+                )
+        endif()
+
 
         #---------------------------------------------------
         if( OSD_GPU )
@@ -239,7 +249,16 @@ if (NOT NO_LIB)
                 ${PLATFORM_CPU_LIBRARIES} ${PLATFORM_GPU_LIBRARIES}
             )
 
-            install( TARGETS osd_dynamic_gpu LIBRARY DESTINATION "${CMAKE_LIBDIR_BASE}" )
+            if (WIN32)
+                install( TARGETS osd_dynamic_gpu
+                    ARCHIVE DESTINATION "${CMAKE_LIBDIR_BASE}"
+                    RUNTIME DESTINATION "${CMAKE_BINDIR_BASE}"
+                    )
+            else()
+                install( TARGETS osd_dynamic_gpu
+                    LIBRARY DESTINATION "${CMAKE_LIBDIR_BASE}"
+                    )
+            endif()
         endif()
 
     endif()

--- a/opensubdiv/osd/glComputeEvaluator.cpp
+++ b/opensubdiv/osd/glComputeEvaluator.cpp
@@ -22,6 +22,8 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
+#include "../osd/opengl.h"
+
 #include "../osd/glComputeEvaluator.h"
 #include "../osd/glslPatchShaderSource.h"
 

--- a/opensubdiv/osd/glComputeEvaluator.h
+++ b/opensubdiv/osd/glComputeEvaluator.h
@@ -27,7 +27,6 @@
 
 #include "../version.h"
 
-#include "../osd/opengl.h"
 #include "../osd/types.h"
 #include "../osd/bufferDescriptor.h"
 


### PR DESCRIPTION
Previously, dynamic targets were disabled on Windows due to configuration
errors in the CMake install targets. In addition, glew was forced to
static linkage on windows, even when dynamic Glew libraries were linked
which would result in linker errors.

In this change, static glew libraries are detected by looking for the "s"
suffix convention on the library (though, maybe this should be handled in
the FindGlew module).

In addition, there is now a fork in the opensubdiv osd_dynamic_{cpu|gpu}
install targets to account for the Windows DLL CMake quirks.
