### PR TITLE
Fixed cmake GLFW X11 link dependencies

### DIFF
--- a/cmake/FindGLFW.cmake
+++ b/cmake/FindGLFW.cmake
@@ -158,7 +158,11 @@ else ()
             message(FATAL_ERROR "Xinerama library not found - required for GLFW")
         endif()
 
-        list(APPEND GLFW_x11_LIBRARY "${X11_Xrandr_LIB}" "${X11_Xxf86vm_LIB}" "${X11_Xcursor_LIB}" "${X11_Xinerama_LIB}" "${CMAKE_THREAD_LIBS_INIT}" -lrt -lXi)
+        if(NOT X11_Xi_FOUND)
+            message(FATAL_ERROR "Xi library not found - required for GLFW")
+        endif()
+
+        list(APPEND GLFW_x11_LIBRARY "${X11_Xrandr_LIB}" "${X11_Xxf86vm_LIB}" "${X11_Xcursor_LIB}" "${X11_Xinerama_LIB}" "${X11_Xi_LIB}" "${X11_LIBRARIES}" "${CMAKE_THREAD_LIBS_INIT}" -lrt -ldl)
 
         find_library( GLFW_glfw_LIBRARY
             NAMES 


### PR DESCRIPTION
There is more we can clean up here, but this
fixes link issues while building on X11 platforms
when using cmake 3.x