### PR TITLE
Support creation of Face-varying stencil tables

### DIFF
--- a/examples/glEvalLimit/init_shapes.h
+++ b/examples/glEvalLimit/init_shapes.h
@@ -47,6 +47,7 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner4",     catmark_cube_corner4,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases2",    catmark_cube_creases2,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
@@ -55,6 +56,8 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_chaikin0",         catmark_chaikin0,         kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_chaikin1",         catmark_chaikin1,         kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_chaikin2",         catmark_chaikin2,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_single_crease",    catmark_single_crease,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_inf_crease0",      catmark_inf_crease0,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fan",              catmark_fan,              kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_flap",             catmark_flap,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_flap2",            catmark_flap2,            kCatmark ) );

--- a/opensubdiv/far/stencilTableFactory.h
+++ b/opensubdiv/far/stencilTableFactory.h
@@ -50,8 +50,9 @@ class StencilTableFactory {
 public:
 
     enum Mode {
-        INTERPOLATE_VERTEX=0,
-        INTERPOLATE_VARYING
+        INTERPOLATE_VERTEX=0,           ///< vertex primvar stencils
+        INTERPOLATE_VARYING,            ///< varying primvar stencils
+        INTERPOLATE_FACE_VARYING        ///< face-varying primvar stencils
     };
 
     struct Options {
@@ -61,7 +62,8 @@ public:
                     generateControlVerts(false),
                     generateIntermediateLevels(true),
                     factorizeIntermediateLevels(true),
-                    maxLevel(10) { }
+                    maxLevel(10),
+                    fvarChannel(0) { }
 
         unsigned int interpolationMode           : 2, ///< interpolation mode
                      generateOffsets             : 1, ///< populate optional "_offsets" field
@@ -71,6 +73,8 @@ public:
                                                       ///  vertices or from the stencils of the
                                                       ///  previous level
                      maxLevel                    : 4; ///< generate stencils up to 'maxLevel'
+        unsigned int fvarChannel;                     ///< face-varying channel to use
+                                                      ///  when generating face-varying stencils
     };
 
     /// \brief Instantiates StencilTable from TopologyRefiner that have been
@@ -123,10 +127,42 @@ public:
         StencilTable const *localPointStencilTable,
         bool factorize = true);
 
+    /// \brief Utility function for stencil splicing for local point
+    /// face-varying stencils.
+    ///
+    /// @param refiner              The TopologyRefiner containing the topology
+    ///
+    /// @param baseStencilTable     Input StencilTable for refined vertices
+    ///
+    /// @param localPointStencilTable
+    ///                             StencilTable for the change of basis patch points.
+    ///
+    /// @param channel              face-varying channel
+    ///
+    /// @param factorize            If factorize sets to true, endcap stencils will be
+    ///                             factorized with supporting vertices from baseStencil
+    ///                             table so that the endcap points can be computed
+    ///                             directly from control vertices.
+    ///
+    static StencilTable const * AppendLocalPointStencilTableFaceVarying(
+        TopologyRefiner const &refiner,
+        StencilTable const *baseStencilTable,
+        StencilTable const *localPointStencilTable,
+        int channel = 0,
+        bool factorize = true);
+
 private:
 
     // Generate stencils for the coarse control-vertices (single weight = 1.0f)
     static void generateControlVertStencils(int numControlVerts, Stencil & dst);
+
+    // Internal method to splice local point stencils
+    static StencilTable const * appendLocalPointStencilTable(
+        TopologyRefiner const &refiner,
+        StencilTable const * baseStencilTable,
+        StencilTable const * localPointStencilTable,
+        int channel,
+        bool factorize);
 };
 
 /// \brief A specialized factory for LimitStencilTable


### PR DESCRIPTION
Extended Far::StencilTableFactory to support the creation
of stencil tables for face-varying channels. We already
use stencil tables to compute local point face-varying values.
These changes allow a stencil table to be created which
refines face-varying primvar data for all refined points.