### PR TITLE
WIN32 Glew fixes to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,10 +530,12 @@ else()
 endif()
 
 if (WIN32)
-    add_definitions(
-        # Link against the static version of GLEW.
-        -DGLEW_STATIC
-    )
+    if ("${GLEW_LIBRARY}" MATCHES "glew32s(d|)")
+        # Link against the static version of GLEW
+        add_definitions(
+            -DGLEW_STATIC
+        )
+    endif()
 
     if (DXSDK_FOUND AND NOT NO_DX)
         add_definitions(


### PR DESCRIPTION
Previously, glew was forced to static linkage on windows, even when
dynamic Glew libraries were linked which would result in linker errors.

In this change, static glew libraries are detected by looking for the "s"
suffix convention on the library (though, maybe this should be handled in
the FindGlew module).

Change cherry-picked by davidgyu from jcowles branch