### PR TITLE
Updated Osd Evaluator methods for derivative eval

### DIFF
--- a/opensubdiv/osd/clEvaluator.cpp
+++ b/opensubdiv/osd/clEvaluator.cpp
@@ -49,6 +49,10 @@ static const char *patchBasisSource =
 
 template <class T> cl_mem
 createCLBuffer(std::vector<T> const & src, cl_context clContext) {
+    if (src.empty()) {
+        return NULL;
+    }
+
     cl_int errNum = 0;
     cl_mem devicePtr = clCreateBuffer(clContext,
                                       CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,
@@ -76,9 +80,11 @@ CLStencilTable::CLStencilTable(Far::StencilTable const *stencilTable,
                                   clContext);
         _weights = createCLBuffer(stencilTable->GetWeights(), clContext);
         _duWeights = _dvWeights = NULL;
+        _duuWeights = _duvWeights = _dvvWeights = NULL;
     } else {
         _sizes = _offsets = _indices = _weights = NULL;
         _duWeights = _dvWeights = NULL;
+        _duuWeights = _duvWeights = _dvvWeights = NULL;
     }
 }
 
@@ -96,9 +102,16 @@ CLStencilTable::CLStencilTable(Far::LimitStencilTable const *limitStencilTable,
             limitStencilTable->GetDuWeights(), clContext);
         _dvWeights = createCLBuffer(
             limitStencilTable->GetDvWeights(), clContext);
+        _duuWeights = createCLBuffer(
+            limitStencilTable->GetDuuWeights(), clContext);
+        _duvWeights = createCLBuffer(
+            limitStencilTable->GetDuvWeights(), clContext);
+        _dvvWeights = createCLBuffer(
+            limitStencilTable->GetDvvWeights(), clContext);
     } else {
         _sizes = _offsets = _indices = _weights = NULL;
         _duWeights = _dvWeights = NULL;
+        _duuWeights = _duvWeights = _dvvWeights = NULL;
     }
 }
 
@@ -109,6 +122,9 @@ CLStencilTable::~CLStencilTable() {
     if (_weights) clReleaseMemObject(_weights);
     if (_duWeights) clReleaseMemObject(_duWeights);
     if (_dvWeights) clReleaseMemObject(_dvWeights);
+    if (_duuWeights) clReleaseMemObject(_duuWeights);
+    if (_duvWeights) clReleaseMemObject(_duvWeights);
+    if (_dvvWeights) clReleaseMemObject(_dvvWeights);
 }
 
 // ---------------------------------------------------------------------------
@@ -130,7 +146,10 @@ bool
 CLEvaluator::Compile(BufferDescriptor const &srcDesc,
                      BufferDescriptor const &dstDesc,
                      BufferDescriptor const & /*duDesc*/,
-                     BufferDescriptor const & /*dvDesc*/) {
+                     BufferDescriptor const & /*dvDesc*/,
+                     BufferDescriptor const & /*duuDesc*/,
+                     BufferDescriptor const & /*duvDesc*/,
+                     BufferDescriptor const & /*dvvDesc*/) {
     if (srcDesc.length > dstDesc.length) {
         Far::Error(Far::FAR_RUNTIME_ERROR,
                    "srcDesc length must be less than or equal to "
@@ -263,6 +282,7 @@ CLEvaluator::EvalStencils(cl_mem src, BufferDescriptor const &srcDesc,
 
     size_t globalWorkSize = (size_t)(end - start);
 
+    BufferDescriptor empty;
     clSetKernelArg(_stencilDerivKernel,  0, sizeof(cl_mem), &src);
     clSetKernelArg(_stencilDerivKernel,  1, sizeof(int), &srcDesc.offset);
     clSetKernelArg(_stencilDerivKernel,  2, sizeof(cl_mem), &dst);
@@ -273,14 +293,26 @@ CLEvaluator::EvalStencils(cl_mem src, BufferDescriptor const &srcDesc,
     clSetKernelArg(_stencilDerivKernel,  7, sizeof(cl_mem), &dv);
     clSetKernelArg(_stencilDerivKernel,  8, sizeof(int), &dvDesc.offset);
     clSetKernelArg(_stencilDerivKernel,  9, sizeof(int), &dvDesc.stride);
-    clSetKernelArg(_stencilDerivKernel, 10, sizeof(cl_mem), &sizes);
-    clSetKernelArg(_stencilDerivKernel, 11, sizeof(cl_mem), &offsets);
-    clSetKernelArg(_stencilDerivKernel, 12, sizeof(cl_mem), &indices);
-    clSetKernelArg(_stencilDerivKernel, 13, sizeof(cl_mem), &weights);
-    clSetKernelArg(_stencilDerivKernel, 14, sizeof(cl_mem), &duWeights);
-    clSetKernelArg(_stencilDerivKernel, 15, sizeof(cl_mem), &dvWeights);
-    clSetKernelArg(_stencilDerivKernel, 16, sizeof(int), &start);
-    clSetKernelArg(_stencilDerivKernel, 17, sizeof(int), &end);
+    clSetKernelArg(_stencilDerivKernel, 10, sizeof(cl_mem), NULL);
+    clSetKernelArg(_stencilDerivKernel, 11, sizeof(int), &empty.offset);
+    clSetKernelArg(_stencilDerivKernel, 12, sizeof(int), &empty.stride);
+    clSetKernelArg(_stencilDerivKernel, 13, sizeof(cl_mem), NULL);
+    clSetKernelArg(_stencilDerivKernel, 14, sizeof(int), &empty.offset);
+    clSetKernelArg(_stencilDerivKernel, 15, sizeof(int), &empty.stride);
+    clSetKernelArg(_stencilDerivKernel, 16, sizeof(cl_mem), NULL);
+    clSetKernelArg(_stencilDerivKernel, 17, sizeof(int), &empty.offset);
+    clSetKernelArg(_stencilDerivKernel, 18, sizeof(int), &empty.stride);
+    clSetKernelArg(_stencilDerivKernel, 19, sizeof(cl_mem), &sizes);
+    clSetKernelArg(_stencilDerivKernel, 20, sizeof(cl_mem), &offsets);
+    clSetKernelArg(_stencilDerivKernel, 21, sizeof(cl_mem), &indices);
+    clSetKernelArg(_stencilDerivKernel, 22, sizeof(cl_mem), &weights);
+    clSetKernelArg(_stencilDerivKernel, 23, sizeof(cl_mem), &duWeights);
+    clSetKernelArg(_stencilDerivKernel, 24, sizeof(cl_mem), &dvWeights);
+    clSetKernelArg(_stencilDerivKernel, 25, sizeof(cl_mem), NULL);
+    clSetKernelArg(_stencilDerivKernel, 26, sizeof(cl_mem), NULL);
+    clSetKernelArg(_stencilDerivKernel, 27, sizeof(cl_mem), NULL);
+    clSetKernelArg(_stencilDerivKernel, 28, sizeof(int), &start);
+    clSetKernelArg(_stencilDerivKernel, 29, sizeof(int), &end);
 
     cl_int errNum = clEnqueueNDRangeKernel(
         _clCommandQueue, _stencilDerivKernel, 1, NULL,
@@ -292,9 +324,80 @@ CLEvaluator::EvalStencils(cl_mem src, BufferDescriptor const &srcDesc,
         return false;
     }
 
-    if (endEvent == NULL)
-    {
-    clFinish(_clCommandQueue);
+    if (endEvent == NULL) {
+        clFinish(_clCommandQueue);
+    }
+    return true;
+}
+
+bool
+CLEvaluator::EvalStencils(cl_mem src, BufferDescriptor const &srcDesc,
+                          cl_mem dst, BufferDescriptor const &dstDesc,
+                          cl_mem du,  BufferDescriptor const &duDesc,
+                          cl_mem dv,  BufferDescriptor const &dvDesc,
+                          cl_mem duu, BufferDescriptor const &duuDesc,
+                          cl_mem duv, BufferDescriptor const &duvDesc,
+                          cl_mem dvv, BufferDescriptor const &dvvDesc,
+                          cl_mem sizes,
+                          cl_mem offsets,
+                          cl_mem indices,
+                          cl_mem weights,
+                          cl_mem duWeights,
+                          cl_mem dvWeights,
+                          cl_mem duuWeights,
+                          cl_mem duvWeights,
+                          cl_mem dvvWeights,
+                          int start, int end,
+                          unsigned int numStartEvents,
+                          const cl_event* startEvents,
+                          cl_event* endEvent) const {
+    if (end <= start) return true;
+
+    size_t globalWorkSize = (size_t)(end - start);
+
+    clSetKernelArg(_stencilDerivKernel,  0, sizeof(cl_mem), &src);
+    clSetKernelArg(_stencilDerivKernel,  1, sizeof(int), &srcDesc.offset);
+    clSetKernelArg(_stencilDerivKernel,  2, sizeof(cl_mem), &dst);
+    clSetKernelArg(_stencilDerivKernel,  3, sizeof(int), &dstDesc.offset);
+    clSetKernelArg(_stencilDerivKernel,  4, sizeof(cl_mem), &du);
+    clSetKernelArg(_stencilDerivKernel,  5, sizeof(int), &duDesc.offset);
+    clSetKernelArg(_stencilDerivKernel,  6, sizeof(int), &duDesc.stride);
+    clSetKernelArg(_stencilDerivKernel,  7, sizeof(cl_mem), &dv);
+    clSetKernelArg(_stencilDerivKernel,  8, sizeof(int), &dvDesc.offset);
+    clSetKernelArg(_stencilDerivKernel,  9, sizeof(int), &dvDesc.stride);
+    clSetKernelArg(_stencilDerivKernel, 10, sizeof(cl_mem), &duu);
+    clSetKernelArg(_stencilDerivKernel, 11, sizeof(int), &duuDesc.offset);
+    clSetKernelArg(_stencilDerivKernel, 12, sizeof(int), &duuDesc.stride);
+    clSetKernelArg(_stencilDerivKernel, 13, sizeof(cl_mem), &duv);
+    clSetKernelArg(_stencilDerivKernel, 14, sizeof(int), &duvDesc.offset);
+    clSetKernelArg(_stencilDerivKernel, 15, sizeof(int), &duvDesc.stride);
+    clSetKernelArg(_stencilDerivKernel, 16, sizeof(cl_mem), &dvv);
+    clSetKernelArg(_stencilDerivKernel, 17, sizeof(int), &dvvDesc.offset);
+    clSetKernelArg(_stencilDerivKernel, 18, sizeof(int), &dvvDesc.stride);
+    clSetKernelArg(_stencilDerivKernel, 19, sizeof(cl_mem), &sizes);
+    clSetKernelArg(_stencilDerivKernel, 20, sizeof(cl_mem), &offsets);
+    clSetKernelArg(_stencilDerivKernel, 21, sizeof(cl_mem), &indices);
+    clSetKernelArg(_stencilDerivKernel, 22, sizeof(cl_mem), &weights);
+    clSetKernelArg(_stencilDerivKernel, 23, sizeof(cl_mem), &duWeights);
+    clSetKernelArg(_stencilDerivKernel, 24, sizeof(cl_mem), &dvWeights);
+    clSetKernelArg(_stencilDerivKernel, 25, sizeof(cl_mem), &duuWeights);
+    clSetKernelArg(_stencilDerivKernel, 26, sizeof(cl_mem), &duvWeights);
+    clSetKernelArg(_stencilDerivKernel, 27, sizeof(cl_mem), &dvvWeights);
+    clSetKernelArg(_stencilDerivKernel, 28, sizeof(int), &start);
+    clSetKernelArg(_stencilDerivKernel, 29, sizeof(int), &end);
+
+    cl_int errNum = clEnqueueNDRangeKernel(
+        _clCommandQueue, _stencilDerivKernel, 1, NULL,
+        &globalWorkSize, NULL, numStartEvents, startEvents, endEvent);
+
+    if (errNum != CL_SUCCESS) {
+        Far::Error(Far::FAR_RUNTIME_ERROR,
+                   "ApplyStencilKernel (%d) ", errNum);
+        return false;
+    }
+
+    if (endEvent == NULL) {
+        clFinish(_clCommandQueue);
     }
     return true;
 }
@@ -304,6 +407,66 @@ CLEvaluator::EvalPatches(cl_mem src, BufferDescriptor const &srcDesc,
                          cl_mem dst, BufferDescriptor const &dstDesc,
                          cl_mem du,  BufferDescriptor const &duDesc,
                          cl_mem dv,  BufferDescriptor const &dvDesc,
+                         int numPatchCoords,
+                         cl_mem patchCoordsBuffer,
+                         cl_mem patchArrayBuffer,
+                         cl_mem patchIndexBuffer,
+                         cl_mem patchParamBuffer,
+                         unsigned int numStartEvents,
+                         const cl_event* startEvents,
+                         cl_event* endEvent) const {
+
+    size_t globalWorkSize = (size_t)(numPatchCoords);
+
+    BufferDescriptor empty;
+    clSetKernelArg(_patchKernel,  0, sizeof(cl_mem), &src);
+    clSetKernelArg(_patchKernel,  1, sizeof(int),    &srcDesc.offset);
+    clSetKernelArg(_patchKernel,  2, sizeof(cl_mem), &dst);
+    clSetKernelArg(_patchKernel,  3, sizeof(int),    &dstDesc.offset);
+    clSetKernelArg(_patchKernel,  4, sizeof(cl_mem), &du);
+    clSetKernelArg(_patchKernel,  5, sizeof(int),    &duDesc.offset);
+    clSetKernelArg(_patchKernel,  6, sizeof(int),    &duDesc.stride);
+    clSetKernelArg(_patchKernel,  7, sizeof(cl_mem), &dv);
+    clSetKernelArg(_patchKernel,  8, sizeof(int),    &dvDesc.offset);
+    clSetKernelArg(_patchKernel,  9, sizeof(int),    &dvDesc.stride);
+    clSetKernelArg(_patchKernel, 10, sizeof(cl_mem), NULL);
+    clSetKernelArg(_patchKernel, 11, sizeof(int),    &empty.offset);
+    clSetKernelArg(_patchKernel, 12, sizeof(int),    &empty.stride);
+    clSetKernelArg(_patchKernel, 13, sizeof(cl_mem), NULL);
+    clSetKernelArg(_patchKernel, 14, sizeof(int),    &empty.offset);
+    clSetKernelArg(_patchKernel, 15, sizeof(int),    &empty.stride);
+    clSetKernelArg(_patchKernel, 16, sizeof(cl_mem), NULL);
+    clSetKernelArg(_patchKernel, 17, sizeof(int),    &empty.offset);
+    clSetKernelArg(_patchKernel, 18, sizeof(int),    &empty.stride);
+    clSetKernelArg(_patchKernel, 19, sizeof(cl_mem), &patchCoordsBuffer);
+    clSetKernelArg(_patchKernel, 20, sizeof(cl_mem), &patchArrayBuffer);
+    clSetKernelArg(_patchKernel, 21, sizeof(cl_mem), &patchIndexBuffer);
+    clSetKernelArg(_patchKernel, 22, sizeof(cl_mem), &patchParamBuffer);
+
+    cl_int errNum = clEnqueueNDRangeKernel(
+        _clCommandQueue, _patchKernel, 1, NULL,
+        &globalWorkSize, NULL, numStartEvents, startEvents, endEvent);
+
+    if (errNum != CL_SUCCESS) {
+        Far::Error(Far::FAR_RUNTIME_ERROR,
+                   "ApplyPatchKernel (%d) ", errNum);
+        return false;
+    }
+
+    if (endEvent == NULL) {
+        clFinish(_clCommandQueue);
+    }
+    return true;
+}
+
+bool
+CLEvaluator::EvalPatches(cl_mem src, BufferDescriptor const &srcDesc,
+                         cl_mem dst, BufferDescriptor const &dstDesc,
+                         cl_mem du,  BufferDescriptor const &duDesc,
+                         cl_mem dv,  BufferDescriptor const &dvDesc,
+                         cl_mem duu, BufferDescriptor const &duuDesc,
+                         cl_mem duv, BufferDescriptor const &duvDesc,
+                         cl_mem dvv, BufferDescriptor const &dvvDesc,
                          int numPatchCoords,
                          cl_mem patchCoordsBuffer,
                          cl_mem patchArrayBuffer,
@@ -325,10 +488,19 @@ CLEvaluator::EvalPatches(cl_mem src, BufferDescriptor const &srcDesc,
     clSetKernelArg(_patchKernel,  7, sizeof(cl_mem), &dv);
     clSetKernelArg(_patchKernel,  8, sizeof(int),    &dvDesc.offset);
     clSetKernelArg(_patchKernel,  9, sizeof(int),    &dvDesc.stride);
-    clSetKernelArg(_patchKernel, 10, sizeof(cl_mem), &patchCoordsBuffer);
-    clSetKernelArg(_patchKernel, 11, sizeof(cl_mem), &patchArrayBuffer);
-    clSetKernelArg(_patchKernel, 12, sizeof(cl_mem), &patchIndexBuffer);
-    clSetKernelArg(_patchKernel, 13, sizeof(cl_mem), &patchParamBuffer);
+    clSetKernelArg(_patchKernel, 10, sizeof(cl_mem), &duu);
+    clSetKernelArg(_patchKernel, 11, sizeof(int),    &duuDesc.offset);
+    clSetKernelArg(_patchKernel, 12, sizeof(int),    &duuDesc.stride);
+    clSetKernelArg(_patchKernel, 13, sizeof(cl_mem), &duv);
+    clSetKernelArg(_patchKernel, 14, sizeof(int),    &duvDesc.offset);
+    clSetKernelArg(_patchKernel, 15, sizeof(int),    &duvDesc.stride);
+    clSetKernelArg(_patchKernel, 16, sizeof(cl_mem), &dvv);
+    clSetKernelArg(_patchKernel, 17, sizeof(int),    &dvvDesc.offset);
+    clSetKernelArg(_patchKernel, 18, sizeof(int),    &dvvDesc.stride);
+    clSetKernelArg(_patchKernel, 19, sizeof(cl_mem), &patchCoordsBuffer);
+    clSetKernelArg(_patchKernel, 20, sizeof(cl_mem), &patchArrayBuffer);
+    clSetKernelArg(_patchKernel, 21, sizeof(cl_mem), &patchIndexBuffer);
+    clSetKernelArg(_patchKernel, 22, sizeof(cl_mem), &patchParamBuffer);
 
     cl_int errNum = clEnqueueNDRangeKernel(
         _clCommandQueue, _patchKernel, 1, NULL,
@@ -340,13 +512,11 @@ CLEvaluator::EvalPatches(cl_mem src, BufferDescriptor const &srcDesc,
         return false;
     }
 
-    if (endEvent == NULL)
-    {
-    clFinish(_clCommandQueue);
+    if (endEvent == NULL) {
+        clFinish(_clCommandQueue);
     }
     return true;
 }
-
 
 
 /* static */

--- a/opensubdiv/osd/clEvaluator.h
+++ b/opensubdiv/osd/clEvaluator.h
@@ -77,6 +77,9 @@ public:
     cl_mem GetWeightsBuffer()    const { return _weights; }
     cl_mem GetDuWeightsBuffer()  const { return _duWeights; }
     cl_mem GetDvWeightsBuffer()  const { return _dvWeights; }
+    cl_mem GetDuuWeightsBuffer() const { return _duuWeights; }
+    cl_mem GetDuvWeightsBuffer() const { return _duvWeights; }
+    cl_mem GetDvvWeightsBuffer() const { return _dvvWeights; }
     int GetNumStencils()         const { return _numStencils; }
 
 private:
@@ -86,6 +89,9 @@ private:
     cl_mem _weights;
     cl_mem _duWeights;
     cl_mem _dvWeights;
+    cl_mem _duuWeights;
+    cl_mem _duvWeights;
+    cl_mem _dvvWeights;
     int _numStencils;
 };
 
@@ -115,6 +121,39 @@ public:
                                 cl_command_queue clCommandQueue) {
         CLEvaluator *instance = new CLEvaluator(clContext, clCommandQueue);
         if (instance->Compile(srcDesc, dstDesc, duDesc, dvDesc))
+            return instance;
+        delete instance;
+        return NULL;
+    }
+
+    /// Generic creator template.
+    template <typename DEVICE_CONTEXT>
+    static CLEvaluator *Create(BufferDescriptor const &srcDesc,
+                               BufferDescriptor const &dstDesc,
+                               BufferDescriptor const &duDesc,
+                               BufferDescriptor const &dvDesc,
+                               BufferDescriptor const &duuDesc,
+                               BufferDescriptor const &duvDesc,
+                               BufferDescriptor const &dvvDesc,
+                               DEVICE_CONTEXT deviceContext) {
+        return Create(srcDesc, dstDesc, duDesc, dvDesc,
+                      duuDesc, duvDesc, dvvDesc,
+                      deviceContext->GetContext(),
+                      deviceContext->GetCommandQueue());
+    }
+
+    static CLEvaluator * Create(BufferDescriptor const &srcDesc,
+                                BufferDescriptor const &dstDesc,
+                                BufferDescriptor const &duDesc,
+                                BufferDescriptor const &dvDesc,
+                                BufferDescriptor const &duuDesc,
+                                BufferDescriptor const &duvDesc,
+                                BufferDescriptor const &dvvDesc,
+                                cl_context clContext,
+                                cl_command_queue clCommandQueue) {
+        CLEvaluator *instance = new CLEvaluator(clContext, clCommandQueue);
+        if (instance->Compile(srcDesc, dstDesc, duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc))
             return instance;
         delete instance;
         return NULL;
@@ -304,6 +343,129 @@ public:
         }
     }
 
+    /// \brief Generic static stencil function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        transparently from OsdMesh template interface.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for read
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for results to be written
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for du results to be written
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for dv results to be written
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for du results to be written
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for du results to be written
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for dv results to be written
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param stencilTable   stencil table to be applied. The table must have
+    ///                       SSBO interfaces.
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  client providing context class which supports
+    ///                         cL_context GetContext()
+    ///                         cl_command_queue GetCommandQueue()
+    ///                       methods.
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename STENCIL_TABLE, typename DEVICE_CONTEXT>
+    static bool EvalStencils(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        STENCIL_TABLE const *stencilTable,
+        CLEvaluator const *instance,
+        DEVICE_CONTEXT deviceContext,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) {
+
+        if (instance) {
+            return instance->EvalStencils(srcBuffer, srcDesc,
+                                          dstBuffer, dstDesc,
+                                          duBuffer,  duDesc,
+                                          dvBuffer,  dvDesc,
+                                          duuBuffer, duuDesc,
+                                          duvBuffer, duvDesc,
+                                          dvvBuffer, dvvDesc,
+                                          stencilTable,
+                                          numStartEvents, startEvents, endEvent);
+        } else {
+            // Create an instance on demand (slow)
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc,
+                              deviceContext);
+            if (instance) {
+                bool r = instance->EvalStencils(srcBuffer, srcDesc,
+                                                dstBuffer, dstDesc,
+                                                duBuffer,  duDesc,
+                                                dvBuffer,  dvDesc,
+                                                duuBuffer, duuDesc,
+                                                duvBuffer, duvDesc,
+                                                dvvBuffer, dvvDesc,
+                                                stencilTable,
+                                                numStartEvents, startEvents, endEvent);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
     /// \brief Generic stencil function.
     ///
     /// @param srcBuffer      Input primvar buffer.
@@ -420,6 +582,100 @@ public:
                             numStartEvents, startEvents, endEvent);
     }
 
+    /// \brief Generic stencil function.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for read
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for results to be written
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for du results to be written
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for dv results to be written
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for du results to be written
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for du results to be written
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCLBuffer() method returning the
+    ///                       cl_mem object for dv results to be written
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param stencilTable   stencil table to be applied. The table must have
+    ///                       SSBO interfaces.
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+    bool EvalStencils(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        STENCIL_TABLE const *stencilTable,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) const {
+        return EvalStencils(srcBuffer->BindCLBuffer(_clCommandQueue), srcDesc,
+                            dstBuffer->BindCLBuffer(_clCommandQueue), dstDesc,
+                            duBuffer->BindCLBuffer(_clCommandQueue), duDesc,
+                            dvBuffer->BindCLBuffer(_clCommandQueue), dvDesc,
+                            duuBuffer->BindCLBuffer(_clCommandQueue), duuDesc,
+                            duvBuffer->BindCLBuffer(_clCommandQueue), duvDesc,
+                            dvvBuffer->BindCLBuffer(_clCommandQueue), dvvDesc,
+                            stencilTable->GetSizesBuffer(),
+                            stencilTable->GetOffsetsBuffer(),
+                            stencilTable->GetIndicesBuffer(),
+                            stencilTable->GetWeightsBuffer(),
+                            stencilTable->GetDuWeightsBuffer(),
+                            stencilTable->GetDvWeightsBuffer(),
+                            stencilTable->GetDuuWeightsBuffer(),
+                            stencilTable->GetDuvWeightsBuffer(),
+                            stencilTable->GetDvvWeightsBuffer(),
+                            0,
+                            stencilTable->GetNumStencils(),
+                            numStartEvents, startEvents, endEvent);
+    }
+
     /// Dispatch the CL compute kernel asynchronously.
     /// returns false if the kernel hasn't been compiled yet.
     bool EvalStencils(cl_mem src, BufferDescriptor const &srcDesc,
@@ -492,6 +748,94 @@ public:
                       cl_mem weights,
                       cl_mem duWeights,
                       cl_mem dvWeights,
+                      int start,
+                      int end,
+                      unsigned int numStartEvents=0,
+                      const cl_event* startEvents=NULL,
+                      cl_event* endEvent=NULL) const;
+
+    /// \brief Dispatch the CL compute kernel asynchronously.
+    /// returns false if the kernel hasn't been compiled yet.
+    ///
+    /// @param src              CL buffer of input primvar source data
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the srcBuffer
+    ///
+    /// @param dst              CL buffer of output primvar destination data
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the dstBuffer
+    ///
+    /// @param du               CL buffer of output derivative wrt u
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dv               CL buffer of output derivative wrt v
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duu              CL buffer of output 2nd derivative wrt u
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duv              CL buffer of output 2nd derivative wrt u and v
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvv              CL buffer of output 2nd derivative wrt v
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param sizes            CL buffer of the sizes in the stencil table
+    ///
+    /// @param offsets          CL buffer of the offsets in the stencil table
+    ///
+    /// @param indices          CL buffer of the indices in the stencil table
+    ///
+    /// @param weights          CL buffer of the weights in the stencil table
+    ///
+    /// @param duWeights        CL buffer of the du weights in the stencil table
+    ///
+    /// @param dvWeights        CL buffer of the dv weights in the stencil table
+    ///
+    /// @param duuWeights       CL buffer of the duu weights in the stencil table
+    ///
+    /// @param duvWeights       CL buffer of the duv weights in the stencil table
+    ///
+    /// @param dvvWeights       CL buffer of the dvv weights in the stencil table
+    ///
+    /// @param start            start index of stencil table
+    ///
+    /// @param end              end index of stencil table
+    ///
+    /// @param numStartEvents   the number of events in the array pointed to by
+    ///                         startEvents.
+    ///
+    /// @param startEvents      points to an array of cl_event which will determine
+    ///                         when it is safe for the OpenCL device to begin work
+    ///                         or NULL if it can begin immediately.
+    ///
+    /// @param endEvent         pointer to a cl_event which will receive a copy of
+    ///                         the cl_event which indicates when all work for this
+    ///                         call has completed.  This cl_event has an incremented
+    ///                         reference count and should be released via
+    ///                         clReleaseEvent().  NULL if not required.
+    ///
+    bool EvalStencils(cl_mem src, BufferDescriptor const &srcDesc,
+                      cl_mem dst, BufferDescriptor const &dstDesc,
+                      cl_mem du,  BufferDescriptor const &duDesc,
+                      cl_mem dv,  BufferDescriptor const &dvDesc,
+                      cl_mem duu, BufferDescriptor const &duuDesc,
+                      cl_mem duv, BufferDescriptor const &duvDesc,
+                      cl_mem dvv, BufferDescriptor const &dvvDesc,
+                      cl_mem sizes,
+                      cl_mem offsets,
+                      cl_mem indices,
+                      cl_mem weights,
+                      cl_mem duWeights,
+                      cl_mem dvWeights,
+                      cl_mem duuWeights,
+                      cl_mem duvWeights,
+                      cl_mem dvvWeights,
                       int start,
                       int end,
                       unsigned int numStartEvents=0,
@@ -713,6 +1057,140 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindCLBuffer() method returning an
+    ///                       array of PatchCoord struct
+    ///
+    /// @param patchTable     CLPatchTable or equivalent
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  client providing context class which supports
+    ///                         cL_context GetContext()
+    ///                         cl_command_queue GetCommandQueue()
+    ///                       methods.
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE,
+              typename DEVICE_CONTEXT>
+    static bool EvalPatches(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CLEvaluator const *instance,
+        DEVICE_CONTEXT deviceContext,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) {
+
+        if (instance) {
+            return instance->EvalPatches(srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         duuBuffer, duuDesc,
+                                         duvBuffer, duvDesc,
+                                         dvvBuffer, dvvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable,
+                                         numStartEvents, startEvents, endEvent);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc,
+                              deviceContext);
+            if (instance) {
+                bool r = instance->EvalPatches(srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               duuBuffer, duuDesc,
+                                               duvBuffer, duvDesc,
+                                               dvvBuffer, dvvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable,
+                                               numStartEvents, startEvents, endEvent);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
     /// @param numPatchCoords number of patchCoords.
     ///
     /// @param patchCoords    array of locations to be evaluated.
@@ -792,18 +1270,18 @@ public:
     ///
     /// @param patchTable       CLPatchTable or equivalent
     ///
-    /// @param numStartEvents   the number of events in the array pointed to by
-    ///                         startEvents.
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
     ///
-    /// @param startEvents      points to an array of cl_event which will determine
-    ///                         when it is safe for the OpenCL device to begin work
-    ///                         or NULL if it can begin immediately.
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
     ///
-    /// @param endEvent         pointer to a cl_event which will receive a copy of
-    ///                         the cl_event which indicates when all work for this
-    ///                         call has completed.  This cl_event has an incremented
-    ///                         reference count and should be released via
-    ///                         clReleaseEvent().  NULL if not required.
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
     ///
     template <typename SRC_BUFFER, typename DST_BUFFER,
               typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
@@ -831,10 +1309,123 @@ public:
                            numStartEvents, startEvents, endEvent);
     }
 
+    /// \brief Generic limit eval function with derivatives. This function has
+    ///        a same signature as other device kernels have so that it can be
+    ///        called in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCLBuffer() method returning a CL
+    ///                         buffer object of source data
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCLBuffer() method returning a CL
+    ///                         buffer object of destination data
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCLBuffer() method returning a CL
+    ///                         buffer object of destination data
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCLBuffer() method returning a CL
+    ///                         buffer object of destination data
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCLBuffer() method returning a CL
+    ///                         buffer object of destination data
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindCLBuffer() method returning a CL
+    ///                         buffer object of destination data
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCLBuffer() method returning a CL
+    ///                         buffer object of destination data
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CLPatchTable or equivalent
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatches(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) const {
+
+        return EvalPatches(srcBuffer->BindCLBuffer(_clCommandQueue), srcDesc,
+                           dstBuffer->BindCLBuffer(_clCommandQueue), dstDesc,
+                           duBuffer->BindCLBuffer(_clCommandQueue),  duDesc,
+                           dvBuffer->BindCLBuffer(_clCommandQueue),  dvDesc,
+                           duuBuffer->BindCLBuffer(_clCommandQueue), duuDesc,
+                           duvBuffer->BindCLBuffer(_clCommandQueue), duvDesc,
+                           dvvBuffer->BindCLBuffer(_clCommandQueue), dvvDesc,
+                           numPatchCoords,
+                           patchCoords->BindCLBuffer(_clCommandQueue),
+                           patchTable->GetPatchArrayBuffer(),
+                           patchTable->GetPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer(),
+                           numStartEvents, startEvents, endEvent);
+    }
+
     bool EvalPatches(cl_mem src, BufferDescriptor const &srcDesc,
                      cl_mem dst, BufferDescriptor const &dstDesc,
                      cl_mem du,  BufferDescriptor const &duDesc,
                      cl_mem dv,  BufferDescriptor const &dvDesc,
+                     int numPatchCoords,
+                     cl_mem patchCoordsBuffer,
+                     cl_mem patchArrayBuffer,
+                     cl_mem patchIndexBuffer,
+                     cl_mem patchParamsBuffer,
+                     unsigned int numStartEvents=0,
+                     const cl_event* startEvents=NULL,
+                     cl_event* endEvent=NULL) const;
+
+    bool EvalPatches(cl_mem src, BufferDescriptor const &srcDesc,
+                     cl_mem dst, BufferDescriptor const &dstDesc,
+                     cl_mem du,  BufferDescriptor const &duDesc,
+                     cl_mem dv,  BufferDescriptor const &dvDesc,
+                     cl_mem duu, BufferDescriptor const &duuDesc,
+                     cl_mem duv, BufferDescriptor const &duvDesc,
+                     cl_mem dvv, BufferDescriptor const &dvvDesc,
                      int numPatchCoords,
                      cl_mem patchCoordsBuffer,
                      cl_mem patchArrayBuffer,
@@ -1012,6 +1603,424 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindCLBuffer() method returning an
+    ///                       array of PatchCoord struct.
+    ///
+    /// @param patchTable     CLPatchTable or equivalent
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  client providing context class which supports
+    ///                         cL_context GetContext()
+    ///                         cl_command_queue GetCommandQueue()
+    ///                       methods.
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE,
+              typename DEVICE_CONTEXT>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CLEvaluator const *instance,
+        DEVICE_CONTEXT deviceContext,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable,
+                                         numStartEvents, startEvents, endEvent);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              deviceContext);
+            if (instance) {
+                bool r = instance->EvalPatchesVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable,
+                                               numStartEvents, startEvents, endEvent);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindCLBuffer() method returning an
+    ///                       array of PatchCoord struct.
+    ///
+    /// @param patchTable     CLPatchTable or equivalent
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) const {
+
+        return EvalPatches(srcBuffer->BindCLBuffer(_clCommandQueue), srcDesc,
+                           dstBuffer->BindCLBuffer(_clCommandQueue), dstDesc,
+                           duBuffer->BindCLBuffer(_clCommandQueue), duDesc,
+                           dvBuffer->BindCLBuffer(_clCommandQueue), dvDesc,
+                           numPatchCoords,
+                           patchCoords->BindCLBuffer(_clCommandQueue),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer(),
+                           numStartEvents, startEvents, endEvent);
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindCLBuffer() method returning an
+    ///                       array of PatchCoord struct.
+    ///
+    /// @param patchTable     CLPatchTable or equivalent
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  client providing context class which supports
+    ///                         cL_context GetContext()
+    ///                         cl_command_queue GetCommandQueue()
+    ///                       methods.
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE,
+              typename DEVICE_CONTEXT>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CLEvaluator const *instance,
+        DEVICE_CONTEXT deviceContext,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         duuBuffer, duuDesc,
+                                         duvBuffer, duvDesc,
+                                         dvvBuffer, dvvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable,
+                                         numStartEvents, startEvents, endEvent);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc,
+                              deviceContext);
+            if (instance) {
+                bool r = instance->EvalPatchesVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               duuBuffer, duuDesc,
+                                               duvBuffer, duvDesc,
+                                               dvvBuffer, dvvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable,
+                                               numStartEvents, startEvents, endEvent);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindCLBuffer() method returning an
+    ///                       array of PatchCoord struct.
+    ///
+    /// @param patchTable     CLPatchTable or equivalent
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) const {
+
+        return EvalPatches(srcBuffer->BindCLBuffer(_clCommandQueue), srcDesc,
+                           dstBuffer->BindCLBuffer(_clCommandQueue), dstDesc,
+                           duBuffer->BindCLBuffer(_clCommandQueue), duDesc,
+                           dvBuffer->BindCLBuffer(_clCommandQueue), dvDesc,
+                           duuBuffer->BindCLBuffer(_clCommandQueue), duuDesc,
+                           duvBuffer->BindCLBuffer(_clCommandQueue), duvDesc,
+                           dvvBuffer->BindCLBuffer(_clCommandQueue), dvvDesc,
+                           numPatchCoords,
+                           patchCoords->BindCLBuffer(_clCommandQueue),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer(),
+                           numStartEvents, startEvents, endEvent);
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
     /// @param numPatchCoords number of patchCoords.
     ///
     /// @param patchCoords    array of locations to be evaluated.
@@ -1154,6 +2163,435 @@ public:
                            numStartEvents, startEvents, endEvent);
     }
 
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindCLBuffer() method returning an
+    ///                       array of PatchCoord struct.
+    ///
+    /// @param patchTable     CLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  client providing context class which supports
+    ///                         cL_context GetContext()
+    ///                         cl_command_queue GetCommandQueue()
+    ///                       methods.
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE,
+              typename DEVICE_CONTEXT>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        CLEvaluator const *instance,
+        DEVICE_CONTEXT deviceContext,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesFaceVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable, fvarChannel,
+                                         numStartEvents, startEvents, endEvent);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc, deviceContext);
+            if (instance) {
+                bool r = instance->EvalPatchesFaceVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable, fvarChannel,
+                                               numStartEvents, startEvents, endEvent);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindCLBuffer() method returning an
+    ///                       array of PatchCoord struct.
+    ///
+    /// @param patchTable     CLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel = 0,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) const {
+
+        return EvalPatches(srcBuffer->BindCLBuffer(_clCommandQueue), srcDesc,
+                           dstBuffer->BindCLBuffer(_clCommandQueue), dstDesc,
+                           duBuffer->BindCLBuffer(_clCommandQueue), duDesc,
+                           dvBuffer->BindCLBuffer(_clCommandQueue), dvDesc,
+                           numPatchCoords,
+                           patchCoords->BindCLBuffer(_clCommandQueue),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel),
+                           numStartEvents, startEvents, endEvent);
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindCLBuffer() method returning an
+    ///                       array of PatchCoord struct.
+    ///
+    /// @param patchTable     CLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  client providing context class which supports
+    ///                         cL_context GetContext()
+    ///                         cl_command_queue GetCommandQueue()
+    ///                       methods.
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE,
+              typename DEVICE_CONTEXT>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        CLEvaluator const *instance,
+        DEVICE_CONTEXT deviceContext,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesFaceVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         duuBuffer, duuDesc,
+                                         duvBuffer, duvDesc,
+                                         dvvBuffer, dvvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable, fvarChannel,
+                                         numStartEvents, startEvents, endEvent);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc,
+                              deviceContext);
+            if (instance) {
+                bool r = instance->EvalPatchesFaceVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               duuBuffer, duuDesc,
+                                               duvBuffer, duvDesc,
+                                               dvvBuffer, dvvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable, fvarChannel,
+                                               numStartEvents, startEvents, endEvent);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCLBuffer() method returning a CL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindCLBuffer() method returning an
+    ///                       array of PatchCoord struct.
+    ///
+    /// @param patchTable     CLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    /// @param numStartEvents the number of events in the array pointed to by
+    ///                       startEvents.
+    ///
+    /// @param startEvents    points to an array of cl_event which will determine
+    ///                       when it is safe for the OpenCL device to begin work
+    ///                       or NULL if it can begin immediately.
+    ///
+    /// @param endEvent       pointer to a cl_event which will receive a copy of
+    ///                       the cl_event which indicates when all work for this
+    ///                       call has completed.  This cl_event has an incremented
+    ///                       reference count and should be released via
+    ///                       clReleaseEvent().  NULL if not required.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel = 0,
+        unsigned int numStartEvents=0,
+        const cl_event* startEvents=NULL,
+        cl_event* endEvent=NULL) const {
+
+        return EvalPatches(srcBuffer->BindCLBuffer(_clCommandQueue), srcDesc,
+                           dstBuffer->BindCLBuffer(_clCommandQueue), dstDesc,
+                           duBuffer->BindCLBuffer(_clCommandQueue), duDesc,
+                           dvBuffer->BindCLBuffer(_clCommandQueue), dvDesc,
+                           duuBuffer->BindCLBuffer(_clCommandQueue), duuDesc,
+                           duvBuffer->BindCLBuffer(_clCommandQueue), duvDesc,
+                           dvvBuffer->BindCLBuffer(_clCommandQueue), dvvDesc,
+                           numPatchCoords,
+                           patchCoords->BindCLBuffer(_clCommandQueue),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel),
+                           numStartEvents, startEvents, endEvent);
+    }
+
     /// ----------------------------------------------------------------------
     ///
     ///   Other methods
@@ -1164,8 +2602,11 @@ public:
     /// Returns false if it fails to compile the kernel.
     bool Compile(BufferDescriptor const &srcDesc,
                  BufferDescriptor const &dstDesc,
-                 BufferDescriptor const &duDesc,
-                 BufferDescriptor const &dvDesc);
+                 BufferDescriptor const &duDesc = BufferDescriptor(),
+                 BufferDescriptor const &dvDesc = BufferDescriptor(),
+                 BufferDescriptor const &duuDesc = BufferDescriptor(),
+                 BufferDescriptor const &duvDesc = BufferDescriptor(),
+                 BufferDescriptor const &dvvDesc = BufferDescriptor());
 
     /// Wait the OpenCL kernels finish.
     template <typename DEVICE_CONTEXT>

--- a/opensubdiv/osd/cpuEvaluator.h
+++ b/opensubdiv/osd/cpuEvaluator.h
@@ -26,10 +26,10 @@
 #define OPENSUBDIV3_OSD_CPU_EVALUATOR_H
 
 #include "../version.h"
-
-#include <cstddef>
 #include "../osd/bufferDescriptor.h"
 #include "../osd/types.h"
+
+#include <cstddef>
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
@@ -107,7 +107,6 @@ public:
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
     /// @param sizes          pointer to the sizes buffer of the stencil table
-    ///                       to apply for the range [start, end)
     ///
     /// @param offsets        pointer to the offsets buffer of the stencil table
     ///
@@ -120,8 +119,8 @@ public:
     /// @param end            end index of stencil table
     ///
     static bool EvalStencils(
-        const float *src,  BufferDescriptor const &srcDesc,
-        float *dst,        BufferDescriptor const &dstDesc,
+        const float *src, BufferDescriptor const &srcDesc,
+        float *dst,       BufferDescriptor const &dstDesc,
         const int * sizes,
         const int * offsets,
         const int * indices,
@@ -145,17 +144,17 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer       Output U-derivative buffer
+    /// @param duBuffer       Output buffer derivative wrt u
     ///                       must have BindCpuBuffer() method returning a
     ///                       float pointer for write
     ///
-    /// @param duDesc         vertex buffer descriptor for the output buffer
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer       Output V-derivative buffer
+    /// @param dvBuffer       Output buffer derivative wrt v
     ///                       must have BindCpuBuffer() method returning a
     ///                       float pointer for write
     ///
-    /// @param dvDesc         vertex buffer descriptor for the output buffer
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
     /// @param stencilTable   Far::StencilTable or equivalent
     ///
@@ -206,15 +205,15 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param du             Output U-derivatives pointer. An offset of
+    /// @param du             Output pointer derivative wrt u. An offset of
     ///                       duDesc will be applied internally.
     ///
-    /// @param duDesc         vertex buffer descriptor for the output buffer
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dv             Output V-derivatives pointer. An offset of
+    /// @param dv             Output pointer derivative wrt v. An offset of
     ///                       dvDesc will be applied internally.
     ///
-    /// @param dvDesc         vertex buffer descriptor for the output buffer
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
     /// @param sizes          pointer to the sizes buffer of the stencil table
     ///
@@ -318,13 +317,13 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer         Output U-derivatives buffer
+    /// @param duBuffer         Output buffer derivative wrt u
     ///                         must have BindCpuBuffer() method returning a
     ///                         float pointer for write
     ///
     /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer         Output V-derivatives buffer
+    /// @param dvBuffer         Output buffer derivative wrt v
     ///                         must have BindCpuBuffer() method returning a
     ///                         float pointer for write
     ///
@@ -354,6 +353,7 @@ public:
         PATCH_TABLE *patchTable,
         CpuEvaluator const *instance = NULL,
         void * deviceContext = NULL) {
+
         (void)instance;       // unused
         (void)deviceContext;  // unused
 
@@ -423,15 +423,15 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param du               Output U-derivatives pointer. An offset of
+    /// @param du               Output pointer derivative wrt u. An offset of
     ///                         duDesc will be applied internally.
     ///
-    /// @param duDesc           vertex buffer descriptor for the du buffer
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dv               Output V-derivatives pointer. An offset of
+    /// @param dv               Output pointer derivative wrt v. An offset of
     ///                         dvDesc will be applied internally.
     ///
-    /// @param dvDesc           vertex buffer descriptor for the dv buffer
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
     ///
     /// @param numPatchCoords   number of patchCoords.
     ///

--- a/opensubdiv/osd/cpuEvaluator.h
+++ b/opensubdiv/osd/cpuEvaluator.h
@@ -244,6 +244,177 @@ public:
         const float * dvWeights,
         int start, int end);
 
+    /// \brief Generic static eval stencils function with derivatives.
+    ///        This function has a same signature as other device kernels
+    ///        have so that it can be called in the same way from OsdMesh
+    ///        template interface.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       const float pointer for read
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param stencilTable   Far::StencilTable or equivalent
+    ///
+    /// @param instance       not used in the cpu kernel
+    ///                       (declared as a typed pointer to prevent
+    ///                        undesirable template resolution)
+    ///
+    /// @param deviceContext  not used in the cpu kernel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+    static bool EvalStencils(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        STENCIL_TABLE const *stencilTable,
+        const CpuEvaluator *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalStencils(srcBuffer->BindCpuBuffer(), srcDesc,
+                            dstBuffer->BindCpuBuffer(), dstDesc,
+                            duBuffer->BindCpuBuffer(),  duDesc,
+                            dvBuffer->BindCpuBuffer(),  dvDesc,
+                            duuBuffer->BindCpuBuffer(), duuDesc,
+                            duvBuffer->BindCpuBuffer(), duvDesc,
+                            dvvBuffer->BindCpuBuffer(), dvvDesc,
+                            &stencilTable->GetSizes()[0],
+                            &stencilTable->GetOffsets()[0],
+                            &stencilTable->GetControlIndices()[0],
+                            &stencilTable->GetWeights()[0],
+                            &stencilTable->GetDuWeights()[0],
+                            &stencilTable->GetDvWeights()[0],
+                            &stencilTable->GetDuuWeights()[0],
+                            &stencilTable->GetDuvWeights()[0],
+                            &stencilTable->GetDvvWeights()[0],
+                            /*start = */ 0,
+                            /*end   = */ stencilTable->GetNumStencils());
+    }
+
+    /// \brief Static eval stencils function with derivatives, which takes
+    ///        raw CPU pointers for input and output.
+    ///
+    /// @param src            Input primvar pointer. An offset of srcDesc
+    ///                       will be applied internally (i.e. the pointer
+    ///                       should not include the offset)
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst            Output primvar pointer. An offset of dstDesc
+    ///                       will be applied internally.
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param du             Output pointer derivative wrt u. An offset of
+    ///                       duDesc will be applied internally.
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dv             Output pointer derivative wrt v. An offset of
+    ///                       dvDesc will be applied internally.
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duu            Output pointer 2nd derivative wrt u. An offset of
+    ///                       duuDesc will be applied internally.
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duv            Output pointer 2nd derivative wrt u and v. An offset of
+    ///                       duvDesc will be applied internally.
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvv            Output pointer 2nd derivative wrt v. An offset of
+    ///                       dvvDesc will be applied internally.
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param sizes          pointer to the sizes buffer of the stencil table
+    ///
+    /// @param offsets        pointer to the offsets buffer of the stencil table
+    ///
+    /// @param indices        pointer to the indices buffer of the stencil table
+    ///
+    /// @param weights        pointer to the weights buffer of the stencil table
+    ///
+    /// @param duWeights      pointer to the du-weights buffer of the stencil table
+    ///
+    /// @param dvWeights      pointer to the dv-weights buffer of the stencil table
+    ///
+    /// @param duuWeights     pointer to the duu-weights buffer of the stencil table
+    ///
+    /// @param duvWeights     pointer to the duv-weights buffer of the stencil table
+    ///
+    /// @param dvvWeights     pointer to the dvv-weights buffer of the stencil table
+    ///
+    /// @param start          start index of stencil table
+    ///
+    /// @param end            end index of stencil table
+    ///
+    static bool EvalStencils(
+        const float *src, BufferDescriptor const &srcDesc,
+        float *dst,       BufferDescriptor const &dstDesc,
+        float *du,        BufferDescriptor const &duDesc,
+        float *dv,        BufferDescriptor const &dvDesc,
+        float *duu,       BufferDescriptor const &duuDesc,
+        float *duv,       BufferDescriptor const &duvDesc,
+        float *dvv,       BufferDescriptor const &dvvDesc,
+        const int * sizes,
+        const int * offsets,
+        const int * indices,
+        const float * weights,
+        const float * duWeights,
+        const float * dvWeights,
+        const float * duuWeights,
+        const float * duvWeights,
+        const float * dvvWeights,
+        int start, int end);
+
     /// ----------------------------------------------------------------------
     ///
     ///   Limit evaluations with PatchTable
@@ -373,6 +544,102 @@ public:
                            patchTable->GetPatchParamBuffer());
     }
 
+    /// \brief Generic limit eval function with derivatives. This function has
+    ///        a same signature as other device kernels have so that it can be
+    ///        called in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatches(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CpuEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        // XXX: PatchCoords is somewhat abusing vertex primvar buffer interop.
+        //      ideally all buffer classes should have templated by datatype
+        //      so that downcast isn't needed there.
+        //      (e.g. Osd::CpuBuffer<PatchCoord> )
+        //
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           duuBuffer->BindCpuBuffer(), duuDesc,
+                           duvBuffer->BindCpuBuffer(), duvDesc,
+                           dvvBuffer->BindCpuBuffer(), dvvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetPatchArrayBuffer(),
+                           patchTable->GetPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
     /// \brief Static limit eval function. It takes an array of PatchCoord
     ///        and evaluate limit values on given PatchTable.
     ///
@@ -457,6 +724,72 @@ public:
         const int *patchIndexBuffer,
         PatchParam const *patchParamBuffer);
 
+    /// \brief Static limit eval function. It takes an array of PatchCoord
+    ///        and evaluate limit values on given PatchTable.
+    ///
+    /// @param src              Input primvar pointer. An offset of srcDesc
+    ///                         will be applied internally (i.e. the pointer
+    ///                         should not include the offset)
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst              Output primvar pointer. An offset of dstDesc
+    ///                         will be applied internally.
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param du               Output pointer derivative wrt u. An offset of
+    ///                         duDesc will be applied internally.
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dv               Output pointer derivative wrt v. An offset of
+    ///                         dvDesc will be applied internally.
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duu              Output pointer 2nd derivative wrt u. An offset of
+    ///                         duuDesc will be applied internally.
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duv              Output pointer 2nd derivative wrt u and v. An offset of
+    ///                         duvDesc will be applied internally.
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvv              Output pointer 2nd derivative wrt v. An offset of
+    ///                         dvvDesc will be applied internally.
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchArrays      an array of Osd::PatchArray struct
+    ///                         indexed by PatchCoord::arrayIndex
+    ///
+    /// @param patchIndexBuffer an array of patch indices
+    ///                         indexed by PatchCoord::vertIndex
+    ///
+    /// @param patchParamBuffer an array of Osd::PatchParam struct
+    ///                         indexed by PatchCoord::patchIndex
+    ///
+    static bool EvalPatches(
+        const float *src, BufferDescriptor const &srcDesc,
+        float *dst,       BufferDescriptor const &dstDesc,
+        float *du,        BufferDescriptor const &duDesc,
+        float *dv,        BufferDescriptor const &dvDesc,
+        float *duu,       BufferDescriptor const &duuDesc,
+        float *duv,       BufferDescriptor const &duvDesc,
+        float *dvv,       BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PatchCoord const *patchCoords,
+        PatchArray const *patchArrays,
+        const int *patchIndexBuffer,
+        PatchParam const *patchParamBuffer);
+
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
     ///        in the same way.
@@ -524,6 +857,164 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CpuEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CpuEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           duuBuffer->BindCpuBuffer(), duuDesc,
+                           duvBuffer->BindCpuBuffer(), duvDesc,
+                           dvvBuffer->BindCpuBuffer(), dvvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
     /// @param numPatchCoords   number of patchCoords.
     ///
     /// @param patchCoords      array of locations to be evaluated.
@@ -555,6 +1046,170 @@ public:
 
         return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
                            dstBuffer->BindCpuBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        CpuEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        CpuEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           duuBuffer->BindCpuBuffer(), duuDesc,
+                           duvBuffer->BindCpuBuffer(), duvDesc,
+                           dvvBuffer->BindCpuBuffer(), dvvDesc,
                            numPatchCoords,
                            (const PatchCoord*)patchCoords->BindCpuBuffer(),
                            patchTable->GetFVarPatchArrayBuffer(fvarChannel),

--- a/opensubdiv/osd/cpuKernel.cpp
+++ b/opensubdiv/osd/cpuKernel.cpp
@@ -169,6 +169,76 @@ CpuEvalStencils(float const * src, BufferDescriptor const &srcDesc,
     }
 }
 
+void
+CpuEvalStencils(float const * src, BufferDescriptor const &srcDesc,
+                float * dst,       BufferDescriptor const &dstDesc,
+                float * dstDu,     BufferDescriptor const &dstDuDesc,
+                float * dstDv,     BufferDescriptor const &dstDvDesc,
+                float * dstDuu,    BufferDescriptor const &dstDuuDesc,
+                float * dstDuv,    BufferDescriptor const &dstDuvDesc,
+                float * dstDvv,    BufferDescriptor const &dstDvvDesc,
+                int const * sizes,
+                int const * offsets,
+                int const * indices,
+                float const * weights,
+                float const * duWeights,
+                float const * dvWeights,
+                float const * duuWeights,
+                float const * duvWeights,
+                float const * dvvWeights,
+                int start, int end) {
+    if (start > 0) {
+        sizes += start;
+        indices += offsets[start];
+        weights += offsets[start];
+        duWeights += offsets[start];
+        dvWeights += offsets[start];
+        duuWeights += offsets[start];
+        duvWeights += offsets[start];
+        dvvWeights += offsets[start];
+    }
+
+    src += srcDesc.offset;
+    dst += dstDesc.offset;
+    dstDu += dstDuDesc.offset;
+    dstDv += dstDvDesc.offset;
+    dstDuu += dstDuuDesc.offset;
+    dstDuv += dstDuvDesc.offset;
+    dstDvv += dstDvvDesc.offset;
+
+    int nOutLength = dstDesc.length + dstDuDesc.length + dstDvDesc.length
+                   + dstDuuDesc.length + dstDuvDesc.length + dstDvvDesc.length;
+    float * result   = (float*)alloca(nOutLength * sizeof(float));
+    float * resultDu = result + dstDesc.length;
+    float * resultDv = resultDu + dstDuDesc.length;
+    float * resultDuu = resultDv + dstDuuDesc.length;
+    float * resultDuv = resultDuu + dstDuvDesc.length;
+    float * resultDvv = resultDuv + dstDvvDesc.length;
+
+    int nStencils = end - start;
+    for (int i = 0; i < nStencils; ++i, ++sizes) {
+
+        // clear
+        memset(result, 0, nOutLength * sizeof(float));
+
+        for (int j=0; j<*sizes; ++j) {
+            addWithWeight(result,   src, *indices, *weights++,   srcDesc);
+            addWithWeight(resultDu, src, *indices, *duWeights++, srcDesc);
+            addWithWeight(resultDv, src, *indices, *dvWeights++, srcDesc);
+            addWithWeight(resultDuu, src, *indices, *duuWeights++, srcDesc);
+            addWithWeight(resultDuv, src, *indices, *duvWeights++, srcDesc);
+            addWithWeight(resultDvv, src, *indices, *dvvWeights++, srcDesc);
+            ++indices;
+        }
+        copy(dst,   i, result, dstDesc);
+        copy(dstDu, i, resultDu, dstDuDesc);
+        copy(dstDv, i, resultDv, dstDvDesc);
+        copy(dstDuu, i, resultDuu, dstDuuDesc);
+        copy(dstDuv, i, resultDuu, dstDuvDesc);
+        copy(dstDvv, i, resultDvv, dstDvvDesc);
+    }
+}
+
 }  // end namespace Osd
 
 }  // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/osd/cpuKernel.h
+++ b/opensubdiv/osd/cpuKernel.h
@@ -57,6 +57,25 @@ CpuEvalStencils(float const * src, BufferDescriptor const &srcDesc,
                 float const * dvWeights,
                 int start, int end);
 
+void
+CpuEvalStencils(float const * src, BufferDescriptor const &srcDesc,
+                float * dst,       BufferDescriptor const &dstDesc,
+                float * dstDu,     BufferDescriptor const &dstDuDesc,
+                float * dstDv,     BufferDescriptor const &dstDvDesc,
+                float * dstDuu,    BufferDescriptor const &dstDuuDesc,
+                float * dstDuv,    BufferDescriptor const &dstDuvDesc,
+                float * dstDvv,    BufferDescriptor const &dstDvvDesc,
+                int const * sizes,
+                int const * offsets,
+                int const * indices,
+                float const * weights,
+                float const * duWeights,
+                float const * dvWeights,
+                float const * duuWeights,
+                float const * duvWeights,
+                float const * dvvWeights,
+                int start, int end);
+
 //
 // SIMD ICC optimization of the stencil kernel
 //

--- a/opensubdiv/osd/cudaEvaluator.h
+++ b/opensubdiv/osd/cudaEvaluator.h
@@ -188,17 +188,17 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer       Output U-derivative buffer
+    /// @param duBuffer       Output buffer derivative wrt u
     ///                       must have BindCudaBuffer() method returning a
     ///                       float pointer for write
     ///
-    /// @param duDesc         vertex buffer descriptor for the output buffer
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer       Output V-derivative buffer
+    /// @param dvBuffer       Output buffer derivative wrt v
     ///                       must have BindCudaBuffer() method returning a
     ///                       float pointer for write
     ///
-    /// @param dvDesc         vertex buffer descriptor for the output buffer
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
     /// @param stencilTable   stencil table to be applied.
     ///
@@ -218,8 +218,8 @@ public:
         const CudaEvaluator *instance = NULL,
         void * deviceContext = NULL) {
 
-        (void)instance;   // unused
-        (void)deviceContext;   // unused
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
 
         return EvalStencils(srcBuffer->BindCudaBuffer(), srcDesc,
                             dstBuffer->BindCudaBuffer(), dstDesc,
@@ -249,15 +249,15 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param du             Output U-derivatives pointer. An offset of
+    /// @param du             Output pointer derivative wrt u. An offset of
     ///                       duDesc will be applied internally.
     ///
-    /// @param duDesc         vertex buffer descriptor for the output buffer
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dv             Output V-derivatives pointer. An offset of
+    /// @param dv             Output pointer derivative wrt v. An offset of
     ///                       dvDesc will be applied internally.
     ///
-    /// @param dvDesc         vertex buffer descriptor for the output buffer
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
     /// @param sizes          pointer to the sizes buffer of the stencil table
     ///
@@ -333,8 +333,8 @@ public:
         CudaEvaluator const *instance,
         void * deviceContext = NULL) {
 
-        (void)instance;   // unused
-        (void)deviceContext;   // unused
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
 
         return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
                            dstBuffer->BindCudaBuffer(), dstDesc,
@@ -361,13 +361,13 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer         Output U-derivatives buffer
+    /// @param duBuffer         Output buffer derivative wrt u
     ///                         must have BindCudaBuffer() method returning a
     ///                         float pointer for write
     ///
     /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer         Output V-derivatives buffer
+    /// @param dvBuffer         Output buffer derivative wrt v
     ///                         must have BindCudaBuffer() method returning a
     ///                         float pointer for write
     ///
@@ -460,15 +460,15 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param du               Output U-derivatives pointer. An offset of
+    /// @param du               Output pointer derivative wrt u. An offset of
     ///                         duDesc will be applied internally.
     ///
-    /// @param duDesc           vertex buffer descriptor for the du buffer
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dv               Output V-derivatives pointer. An offset of
+    /// @param dv               Output pointer derivative wrt v. An offset of
     ///                         dvDesc will be applied internally.
     ///
-    /// @param dvDesc           vertex buffer descriptor for the dv buffer
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
     ///
     /// @param numPatchCoords   number of patchCoords.
     ///
@@ -587,8 +587,8 @@ public:
         CudaEvaluator const *instance,
         void * deviceContext = NULL) {
 
-        (void)instance;   // unused
-        (void)deviceContext;   // unused
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
 
         return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
                            dstBuffer->BindCudaBuffer(), dstDesc,

--- a/opensubdiv/osd/cudaEvaluator.h
+++ b/opensubdiv/osd/cudaEvaluator.h
@@ -73,6 +73,9 @@ public:
     void *GetWeightsBuffer() const { return _weights; }
     void *GetDuWeightsBuffer() const { return _duWeights; }
     void *GetDvWeightsBuffer() const { return _dvWeights; }
+    void *GetDuuWeightsBuffer() const { return _duuWeights; }
+    void *GetDuvWeightsBuffer() const { return _duvWeights; }
+    void *GetDvvWeightsBuffer() const { return _dvvWeights; }
     int GetNumStencils() const { return _numStencils; }
 
 private:
@@ -81,7 +84,10 @@ private:
          * _indices,
          * _weights,
          * _duWeights,
-         * _dvWeights;
+         * _dvWeights,
+         * _duuWeights,
+         * _duvWeights,
+         * _dvvWeights;
     int _numStencils;
 };
 
@@ -288,6 +294,177 @@ public:
         const float * dvWeights,
         int start, int end);
 
+    /// \brief Generic static eval stencils function with derivatives.
+    ///        This function has a same signature as other device kernels
+    ///        have so that it can be called in the same way from OsdMesh
+    ///        template interface.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCudaBuffer() method returning a
+    ///                       const float pointer for read
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCudaBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCudaBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCudaBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCudaBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCudaBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCudaBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param stencilTable   stencil table to be applied.
+    ///
+    /// @param instance       not used in the cuda kernel
+    ///                       (declared as a typed pointer to prevent
+    ///                        undesirable template resolution)
+    ///
+    /// @param deviceContext  not used in the cuda kernel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+    static bool EvalStencils(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        STENCIL_TABLE const *stencilTable,
+        const CudaEvaluator *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalStencils(srcBuffer->BindCudaBuffer(), srcDesc,
+                            dstBuffer->BindCudaBuffer(), dstDesc,
+                            duBuffer->BindCudaBuffer(),  duDesc,
+                            dvBuffer->BindCudaBuffer(),  dvDesc,
+                            duuBuffer->BindCudaBuffer(), duuDesc,
+                            duvBuffer->BindCudaBuffer(), duvDesc,
+                            dvvBuffer->BindCudaBuffer(), dvvDesc,
+                            (int const *)stencilTable->GetSizesBuffer(),
+                            (int const *)stencilTable->GetOffsetsBuffer(),
+                            (int const *)stencilTable->GetIndicesBuffer(),
+                            (float const *)stencilTable->GetWeightsBuffer(),
+                            (float const *)stencilTable->GetDuWeightsBuffer(),
+                            (float const *)stencilTable->GetDvWeightsBuffer(),
+                            (float const *)stencilTable->GetDuuWeightsBuffer(),
+                            (float const *)stencilTable->GetDuvWeightsBuffer(),
+                            (float const *)stencilTable->GetDvvWeightsBuffer(),
+                            /*start = */ 0,
+                            /*end   = */ stencilTable->GetNumStencils());
+    }
+
+    /// \brief Static eval stencils function with derivatives, which takes
+    ///        raw cuda pointers for input and output.
+    ///
+    /// @param src            Input primvar pointer. An offset of srcDesc
+    ///                       will be applied internally (i.e. the pointer
+    ///                       should not include the offset)
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst            Output primvar pointer. An offset of dstDesc
+    ///                       will be applied internally.
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param du             Output pointer derivative wrt u. An offset of
+    ///                       duDesc will be applied internally.
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dv             Output pointer derivative wrt v. An offset of
+    ///                       dvDesc will be applied internally.
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duu            Output pointer 2nd derivative wrt u. An offset of
+    ///                       duuDesc will be applied internally.
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duv            Output pointer 2nd derivative wrt u and v. An offset of
+    ///                       duvDesc will be applied internally.
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvv            Output pointer 2nd derivative wrt v. An offset of
+    ///                       dvvDesc will be applied internally.
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param sizes          pointer to the sizes buffer of the stencil table
+    ///
+    /// @param offsets        pointer to the offsets buffer of the stencil table
+    ///
+    /// @param indices        pointer to the indices buffer of the stencil table
+    ///
+    /// @param weights        pointer to the weights buffer of the stencil table
+    ///
+    /// @param duWeights      pointer to the du-weights buffer of the stencil table
+    ///
+    /// @param dvWeights      pointer to the dv-weights buffer of the stencil table
+    ///
+    /// @param duuWeights     pointer to the duu-weights buffer of the stencil table
+    ///
+    /// @param duvWeights     pointer to the duv-weights buffer of the stencil table
+    ///
+    /// @param dvvWeights     pointer to the dvv-weights buffer of the stencil table
+    ///
+    /// @param start          start index of stencil table
+    ///
+    /// @param end            end index of stencil table
+    ///
+    static bool EvalStencils(
+        const float *src, BufferDescriptor const &srcDesc,
+        float *dst,       BufferDescriptor const &dstDesc,
+        float *du,        BufferDescriptor const &duDesc,
+        float *dv,        BufferDescriptor const &dvDesc,
+        float *duu,       BufferDescriptor const &duuDesc,
+        float *duv,       BufferDescriptor const &duvDesc,
+        float *dvv,       BufferDescriptor const &dvvDesc,
+        const int * sizes,
+        const int * offsets,
+        const int * indices,
+        const float * weights,
+        const float * duWeights,
+        const float * dvWeights,
+        const float * duuWeights,
+        const float * duvWeights,
+        const float * dvvWeights,
+        int start, int end);
+
     /// ----------------------------------------------------------------------
     ///
     ///   Limit evaluations with PatchTable
@@ -396,13 +573,102 @@ public:
         CudaEvaluator const *instance,
         void * deviceContext = NULL) {
 
-        (void)instance;   // unused
-        (void)deviceContext;   // unused
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
 
         return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
                            dstBuffer->BindCudaBuffer(), dstDesc,
                            duBuffer->BindCudaBuffer(),  duDesc,
                            dvBuffer->BindCudaBuffer(),  dvDesc,
+                           numPatchCoords,
+                           (const PatchCoord *)patchCoords->BindCudaBuffer(),
+                           (const PatchArray *)patchTable->GetPatchArrayBuffer(),
+                           (const int *)patchTable->GetPatchIndexBuffer(),
+                           (const PatchParam *)patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function with derivatives. This function has
+    ///        a same signature as other device kernels have so that it can be
+    ///        called in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CudaPatchTable or equivalent
+    ///
+    /// @param instance         not used in the cuda evaluator
+    ///
+    /// @param deviceContext    not used in the cuda evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatches(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CudaEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
+                           dstBuffer->BindCudaBuffer(), dstDesc,
+                           duBuffer->BindCudaBuffer(),  duDesc,
+                           dvBuffer->BindCudaBuffer(),  dvDesc,
+                           duuBuffer->BindCudaBuffer(), duuDesc,
+                           duvBuffer->BindCudaBuffer(), duvDesc,
+                           dvvBuffer->BindCudaBuffer(), dvvDesc,
                            numPatchCoords,
                            (const PatchCoord *)patchCoords->BindCudaBuffer(),
                            (const PatchArray *)patchTable->GetPatchArrayBuffer(),
@@ -489,10 +755,76 @@ public:
         float *du,        BufferDescriptor const &duDesc,
         float *dv,        BufferDescriptor const &dvDesc,
         int numPatchCoords,
-        const PatchCoord *patchCoords,
-        const PatchArray *patchArrays,
+        PatchCoord const *patchCoords,
+        PatchArray const *patchArrays,
         const int *patchIndices,
-        const PatchParam *patchParams);
+        PatchParam const *patchParams);
+
+    /// \brief Static limit eval function. It takes an array of PatchCoord
+    ///        and evaluate limit values on given PatchTable.
+    ///
+    /// @param src              Input primvar pointer. An offset of srcDesc
+    ///                         will be applied internally (i.e. the pointer
+    ///                         should not include the offset)
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst              Output primvar pointer. An offset of dstDesc
+    ///                         will be applied internally.
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param du               Output pointer derivative wrt u. An offset of
+    ///                         duDesc will be applied internally.
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dv               Output pointer derivative wrt v. An offset of
+    ///                         dvDesc will be applied internally.
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duu              Output pointer 2nd derivative wrt u. An offset of
+    ///                         duuDesc will be applied internally.
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duv              Output pointer 2nd derivative wrt u and v. An offset of
+    ///                         duvDesc will be applied internally.
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvv              Output pointer 2nd derivative wrt v. An offset of
+    ///                         dvvDesc will be applied internally.
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchArrays      an array of Osd::PatchArray struct
+    ///                         indexed by PatchCoord::arrayIndex
+    ///
+    /// @param patchIndices     an array of patch indices
+    ///                         indexed by PatchCoord::vertIndex
+    ///
+    /// @param patchParams      an array of Osd::PatchParam struct
+    ///                         indexed by PatchCoord::patchIndex
+    ///
+    static bool EvalPatches(
+        const float *src, BufferDescriptor const &srcDesc,
+        float *dst,       BufferDescriptor const &dstDesc,
+        float *du,        BufferDescriptor const &duDesc,
+        float *dv,        BufferDescriptor const &dvDesc,
+        float *duu,       BufferDescriptor const &duuDesc,
+        float *duv,       BufferDescriptor const &duvDesc,
+        float *dvv,       BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PatchCoord const *patchCoords,
+        PatchArray const *patchArrays,
+        const int *patchIndices,
+        PatchParam const *patchParams);
 
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
@@ -533,11 +865,169 @@ public:
         CudaEvaluator const *instance,
         void * deviceContext = NULL) {
 
-        (void)instance;   // unused
-        (void)deviceContext;   // unused
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
 
         return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
                            dstBuffer->BindCudaBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord *)patchCoords->BindCudaBuffer(),
+                           (const PatchArray *)patchTable->GetVaryingPatchArrayBuffer(),
+                           (const int *)patchTable->GetVaryingPatchIndexBuffer(),
+                           (const PatchParam *)patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///                         must have BindCudaBuffer() method returning an
+    ///                         array of PatchCoord struct in cuda memory.
+    ///
+    /// @param patchTable       CudaPatchTable or equivalent
+    ///
+    /// @param instance         not used in the cuda evaluator
+    ///
+    /// @param deviceContext    not used in the cuda evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CudaEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
+                           dstBuffer->BindCudaBuffer(), dstDesc,
+                           duBuffer->BindCudaBuffer(), duDesc,
+                           dvBuffer->BindCudaBuffer(), dvDesc,
+                           numPatchCoords,
+                           (const PatchCoord *)patchCoords->BindCudaBuffer(),
+                           (const PatchArray *)patchTable->GetVaryingPatchArrayBuffer(),
+                           (const int *)patchTable->GetVaryingPatchIndexBuffer(),
+                           (const PatchParam *)patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///                         must have BindCudaBuffer() method returning an
+    ///                         array of PatchCoord struct in cuda memory.
+    ///
+    /// @param patchTable       CudaPatchTable or equivalent
+    ///
+    /// @param instance         not used in the cuda evaluator
+    ///
+    /// @param deviceContext    not used in the cuda evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        CudaEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
+                           dstBuffer->BindCudaBuffer(), dstDesc,
+                           duBuffer->BindCudaBuffer(), duDesc,
+                           dvBuffer->BindCudaBuffer(), dvDesc,
+                           duuBuffer->BindCudaBuffer(), duuDesc,
+                           duvBuffer->BindCudaBuffer(), duvDesc,
+                           dvvBuffer->BindCudaBuffer(), dvvDesc,
                            numPatchCoords,
                            (const PatchCoord *)patchCoords->BindCudaBuffer(),
                            (const PatchArray *)patchTable->GetVaryingPatchArrayBuffer(),
@@ -587,11 +1077,175 @@ public:
         CudaEvaluator const *instance,
         void * deviceContext = NULL) {
 
+        (void)instance;   // unused
+        (void)deviceContext;   // unused
+
+        return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
+                           dstBuffer->BindCudaBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord *)patchCoords->BindCudaBuffer(),
+                           (const PatchArray *)patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           (const int *)patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           (const PatchParam *)patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///                         must have BindCudaBuffer() method returning an
+    ///                         array of PatchCoord struct in cuda memory.
+    ///
+    /// @param patchTable       CudaPatchTable or equivalent
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the cuda evaluator
+    ///
+    /// @param deviceContext    not used in the cuda evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer, BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer, BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        CudaEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        (void)instance;   // unused
+        (void)deviceContext;   // unused
+
+        return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
+                           dstBuffer->BindCudaBuffer(), dstDesc,
+                           duBuffer->BindCudaBuffer(), duDesc,
+                           dvBuffer->BindCudaBuffer(), dvDesc,
+                           numPatchCoords,
+                           (const PatchCoord *)patchCoords->BindCudaBuffer(),
+                           (const PatchArray *)patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           (const int *)patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           (const PatchParam *)patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCudaBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///                         must have BindCudaBuffer() method returning an
+    ///                         array of PatchCoord struct in cuda memory.
+    ///
+    /// @param patchTable       CudaPatchTable or equivalent
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the cuda evaluator
+    ///
+    /// @param deviceContext    not used in the cuda evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        CudaEvaluator const *instance,
+        void * deviceContext = NULL) {
+
         (void)instance;       // unused
         (void)deviceContext;  // unused
 
         return EvalPatches(srcBuffer->BindCudaBuffer(), srcDesc,
                            dstBuffer->BindCudaBuffer(), dstDesc,
+                           duBuffer->BindCudaBuffer(), duDesc,
+                           dvBuffer->BindCudaBuffer(), dvDesc,
+                           duuBuffer->BindCudaBuffer(), duuDesc,
+                           duvBuffer->BindCudaBuffer(), duvDesc,
+                           dvvBuffer->BindCudaBuffer(), dvvDesc,
                            numPatchCoords,
                            (const PatchCoord *)patchCoords->BindCudaBuffer(),
                            (const PatchArray *)patchTable->GetFVarPatchArrayBuffer(fvarChannel),

--- a/opensubdiv/osd/d3d11ComputeEvaluator.cpp
+++ b/opensubdiv/osd/d3d11ComputeEvaluator.cpp
@@ -172,6 +172,22 @@ D3D11ComputeEvaluator::Create(BufferDescriptor const &srcDesc,
                               BufferDescriptor const &duDesc,
                               BufferDescriptor const &dvDesc,
                               ID3D11DeviceContext *deviceContext) {
+    return Create(srcDesc, dstDesc, duDesc, dvDesc,
+                  BufferDescriptor(),
+                  BufferDescriptor(),
+                  BufferDescriptor(),
+                  deviceContext);
+}
+
+D3D11ComputeEvaluator *
+D3D11ComputeEvaluator::Create(BufferDescriptor const &srcDesc,
+                              BufferDescriptor const &dstDesc,
+                              BufferDescriptor const &duDesc,
+                              BufferDescriptor const &dvDesc,
+                              BufferDescriptor const &duuDesc,
+                              BufferDescriptor const &duvDesc,
+                              BufferDescriptor const &dvvDesc,
+                              ID3D11DeviceContext *deviceContext) {
     (void)deviceContext;  // not used
 
     // TODO: implements derivatives

--- a/opensubdiv/osd/d3d11ComputeEvaluator.h
+++ b/opensubdiv/osd/d3d11ComputeEvaluator.h
@@ -102,6 +102,15 @@ public:
                                           BufferDescriptor const &dvDesc,
                                           ID3D11DeviceContext *deviceContext);
 
+    static D3D11ComputeEvaluator * Create(BufferDescriptor const &srcDesc,
+                                          BufferDescriptor const &dstDesc,
+                                          BufferDescriptor const &duDesc,
+                                          BufferDescriptor const &dvDesc,
+                                          BufferDescriptor const &duuDesc,
+                                          BufferDescriptor const &duvDesc,
+                                          BufferDescriptor const &dvvDesc,
+                                          ID3D11DeviceContext *deviceContext);
+
     /// Constructor.
     D3D11ComputeEvaluator();
 

--- a/opensubdiv/osd/glComputeEvaluator.cpp
+++ b/opensubdiv/osd/glComputeEvaluator.cpp
@@ -44,6 +44,10 @@ static const char *shaderSource =
 
 template <class T> GLuint
 createSSBO(std::vector<T> const & src) {
+    if (src.empty()) {
+        return 0;
+    }
+
     GLuint devicePtr = 0;
     glGenBuffers(1, &devicePtr);
 
@@ -75,9 +79,11 @@ GLStencilTableSSBO::GLStencilTableSSBO(
         _indices = createSSBO(stencilTable->GetControlIndices());
         _weights = createSSBO(stencilTable->GetWeights());
         _duWeights = _dvWeights = 0;
+        _duuWeights = _duvWeights = _dvvWeights = 0;
     } else {
         _sizes = _offsets = _indices = _weights = 0;
         _duWeights = _dvWeights = 0;
+        _duuWeights = _duvWeights = _dvvWeights = 0;
     }
 }
 
@@ -91,9 +97,13 @@ GLStencilTableSSBO::GLStencilTableSSBO(
         _weights = createSSBO(limitStencilTable->GetWeights());
         _duWeights = createSSBO(limitStencilTable->GetDuWeights());
         _dvWeights = createSSBO(limitStencilTable->GetDvWeights());
+        _duuWeights = createSSBO(limitStencilTable->GetDuuWeights());
+        _duvWeights = createSSBO(limitStencilTable->GetDuvWeights());
+        _dvvWeights = createSSBO(limitStencilTable->GetDvvWeights());
     } else {
         _sizes = _offsets = _indices = _weights = 0;
         _duWeights = _dvWeights = 0;
+        _duuWeights = _duvWeights = _dvvWeights = 0;
     }
 }
 
@@ -104,6 +114,9 @@ GLStencilTableSSBO::~GLStencilTableSSBO() {
     if (_weights) glDeleteBuffers(1, &_weights);
     if (_duWeights) glDeleteBuffers(1, &_duWeights);
     if (_dvWeights) glDeleteBuffers(1, &_dvWeights);
+    if (_duuWeights) glDeleteBuffers(1, &_duuWeights);
+    if (_duvWeights) glDeleteBuffers(1, &_duvWeights);
+    if (_dvvWeights) glDeleteBuffers(1, &_dvvWeights);
 }
 
 // ---------------------------------------------------------------------------
@@ -120,8 +133,11 @@ GLComputeEvaluator::~GLComputeEvaluator() {
 static GLuint
 compileKernel(BufferDescriptor const &srcDesc,
               BufferDescriptor const &dstDesc,
-              BufferDescriptor const & /* duDesc */,
-              BufferDescriptor const & /* dvDesc */,
+              BufferDescriptor const & duDesc,
+              BufferDescriptor const & dvDesc,
+              BufferDescriptor const & duuDesc,
+              BufferDescriptor const & duvDesc,
+              BufferDescriptor const & dvvDesc,
               const char *kernelDefine,
               int workGroupSize) {
     GLuint program = glCreateProgram();
@@ -139,6 +155,16 @@ compileKernel(BufferDescriptor const &srcDesc,
             << "#define WORK_GROUP_SIZE " << workGroupSize << "\n"
             << kernelDefine << "\n"
             << patchBasisShaderSourceDefine << "\n";
+
+    bool deriv1 = (duDesc.length > 0 || dvDesc.length > 0);
+    bool deriv2 = (duuDesc.length > 0 || duvDesc.length > 0 || dvvDesc.length > 0);
+    if (deriv1) {
+        defines << "#define OPENSUBDIV_GLSL_COMPUTE_USE_1ST_DERIVATIVES\n";
+    }
+    if (deriv2) {
+        defines << "#define OPENSUBDIV_GLSL_COMPUTE_USE_2ND_DERIVATIVES\n";
+    }
+
     std::string defineStr = defines.str();
 
     const char *shaderSources[4] = {"#version 430\n", 0, 0, 0};
@@ -175,16 +201,23 @@ bool
 GLComputeEvaluator::Compile(BufferDescriptor const &srcDesc,
                             BufferDescriptor const &dstDesc,
                             BufferDescriptor const &duDesc,
-                            BufferDescriptor const &dvDesc) {
+                            BufferDescriptor const &dvDesc,
+                            BufferDescriptor const &duuDesc,
+                            BufferDescriptor const &duvDesc,
+                            BufferDescriptor const &dvvDesc) {
 
     // create a stencil kernel
-    if (!_stencilKernel.Compile(srcDesc, dstDesc, duDesc, dvDesc,
+    if (!_stencilKernel.Compile(srcDesc, dstDesc,
+                                duDesc, dvDesc,
+                                duuDesc, duvDesc, dvvDesc,
                                 _workGroupSize)) {
         return false;
     }
 
     // create a patch kernel
-    if (!_patchKernel.Compile(srcDesc, dstDesc, duDesc, dvDesc,
+    if (!_patchKernel.Compile(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc,
                               _workGroupSize)) {
         return false;
     }
@@ -214,6 +247,40 @@ GLComputeEvaluator::EvalStencils(
     GLuint dvWeightsBuffer,
     int start, int end) const {
 
+    return EvalStencils(srcBuffer, srcDesc,
+                        dstBuffer, dstDesc,
+                        duBuffer, duDesc,
+                        dvBuffer, dvDesc,
+                        0, BufferDescriptor(),
+                        0, BufferDescriptor(),
+                        0, BufferDescriptor(),
+                        sizesBuffer, offsetsBuffer, indicesBuffer,
+                        weightsBuffer,
+                        duWeightsBuffer, dvWeightsBuffer,
+                        0, 0, 0,
+                        start, end);
+}
+
+bool
+GLComputeEvaluator::EvalStencils(
+    GLuint srcBuffer, BufferDescriptor const &srcDesc,
+    GLuint dstBuffer, BufferDescriptor const &dstDesc,
+    GLuint duBuffer,  BufferDescriptor const &duDesc,
+    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+    GLuint duuBuffer, BufferDescriptor const &duuDesc,
+    GLuint duvBuffer, BufferDescriptor const &duvDesc,
+    GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
+    GLuint sizesBuffer,
+    GLuint offsetsBuffer,
+    GLuint indicesBuffer,
+    GLuint weightsBuffer,
+    GLuint duWeightsBuffer,
+    GLuint dvWeightsBuffer,
+    GLuint duuWeightsBuffer,
+    GLuint duvWeightsBuffer,
+    GLuint dvvWeightsBuffer,
+    int start, int end) const {
+
     if (!_stencilKernel.program) return false;
     int count = end - start;
     if (count <= 0) {
@@ -224,6 +291,9 @@ GLComputeEvaluator::EvalStencils(
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, dstBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, duBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, dvBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 10, duuBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 11, duvBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 12, dvvBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 4, sizesBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 5, offsetsBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 6, indicesBuffer);
@@ -232,6 +302,12 @@ GLComputeEvaluator::EvalStencils(
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 8, duWeightsBuffer);
     if (dvWeightsBuffer)
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 9, dvWeightsBuffer);
+    if (duuWeightsBuffer)
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 13, duuWeightsBuffer);
+    if (duvWeightsBuffer)
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 14, duvWeightsBuffer);
+    if (dvvWeightsBuffer)
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 15, dvvWeightsBuffer);
 
     glUseProgram(_stencilKernel.program);
 
@@ -247,13 +323,25 @@ GLComputeEvaluator::EvalStencils(
         glUniform3i(_stencilKernel.uniformDvDesc,
                     dvDesc.offset, dvDesc.length, dvDesc.stride);
     }
+    if (_stencilKernel.uniformDuuDesc > 0) {
+        glUniform3i(_stencilKernel.uniformDuuDesc,
+                    duuDesc.offset, duuDesc.length, duuDesc.stride);
+    }
+    if (_stencilKernel.uniformDuvDesc > 0) {
+        glUniform3i(_stencilKernel.uniformDuvDesc,
+                    duvDesc.offset, duvDesc.length, duvDesc.stride);
+    }
+    if (_stencilKernel.uniformDvvDesc > 0) {
+        glUniform3i(_stencilKernel.uniformDvvDesc,
+                    dvvDesc.offset, dvvDesc.length, dvvDesc.stride);
+    }
 
     glDispatchCompute((count + _workGroupSize - 1) / _workGroupSize, 1, 1);
 
     glUseProgram(0);
 
     glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT);
-    for (int i = 0; i < 10; ++i) {
+    for (int i = 0; i < 16; ++i) {
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, i, 0);
     }
 
@@ -272,12 +360,44 @@ GLComputeEvaluator::EvalPatches(
     GLuint patchIndexBuffer,
     GLuint patchParamsBuffer) const {
 
+    return EvalPatches(srcBuffer, srcDesc,
+                       dstBuffer, dstDesc,
+                       duBuffer, duDesc,
+                       dvBuffer, dvDesc,
+                       0, BufferDescriptor(),
+                       0, BufferDescriptor(),
+                       0, BufferDescriptor(),
+                       numPatchCoords,
+                       patchCoordsBuffer,
+                       patchArrays,
+                       patchIndexBuffer,
+                       patchParamsBuffer);
+}
+
+bool
+GLComputeEvaluator::EvalPatches(
+    GLuint srcBuffer, BufferDescriptor const &srcDesc,
+    GLuint dstBuffer, BufferDescriptor const &dstDesc,
+    GLuint duBuffer,  BufferDescriptor const &duDesc,
+    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+    GLuint duuBuffer, BufferDescriptor const &duuDesc,
+    GLuint duvBuffer, BufferDescriptor const &duvDesc,
+    GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
+    int numPatchCoords,
+    GLuint patchCoordsBuffer,
+    const PatchArrayVector &patchArrays,
+    GLuint patchIndexBuffer,
+    GLuint patchParamsBuffer) const {
+
     if (!_patchKernel.program) return false;
 
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, srcBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, dstBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, duBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, dvBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 10, duuBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 11, duvBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 12, dvvBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 4, patchCoordsBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 5, patchIndexBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 6, patchParamsBuffer);
@@ -288,8 +408,27 @@ GLComputeEvaluator::EvalPatches(
     glUniform1i(_patchKernel.uniformDstOffset, dstDesc.offset);
     glUniform4iv(_patchKernel.uniformPatchArray, (int)patchArrays.size(),
                  (const GLint*)&patchArrays[0]);
-    glUniform3i(_patchKernel.uniformDuDesc, duDesc.offset, duDesc.length, duDesc.stride);
-    glUniform3i(_patchKernel.uniformDvDesc, dvDesc.offset, dvDesc.length, dvDesc.stride);
+
+    if (_patchKernel.uniformDuDesc > 0) {
+        glUniform3i(_patchKernel.uniformDuDesc,
+                    duDesc.offset, duDesc.length, duDesc.stride);
+    }
+    if (_patchKernel.uniformDvDesc > 0) {
+        glUniform3i(_patchKernel.uniformDvDesc,
+                    dvDesc.offset, dvDesc.length, dvDesc.stride);
+    }
+    if (_patchKernel.uniformDuuDesc > 0) {
+        glUniform3i(_patchKernel.uniformDuuDesc,
+                    duuDesc.offset, duuDesc.length, duuDesc.stride);
+    }
+    if (_patchKernel.uniformDuvDesc > 0) {
+        glUniform3i(_patchKernel.uniformDuvDesc,
+                    duvDesc.offset, duvDesc.length, duvDesc.stride);
+    }
+    if (_patchKernel.uniformDvvDesc > 0) {
+        glUniform3i(_patchKernel.uniformDvvDesc,
+                    dvvDesc.offset, dvvDesc.length, dvvDesc.stride);
+    }
 
     glDispatchCompute((numPatchCoords + _workGroupSize - 1) / _workGroupSize, 1, 1);
 
@@ -302,6 +441,10 @@ GLComputeEvaluator::EvalPatches(
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 4, 0);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 5, 0);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 6, 0);
+
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 10, 0);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 11, 0);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 12, 0);
 
     return true;
 }
@@ -320,20 +463,21 @@ GLComputeEvaluator::_StencilKernel::Compile(BufferDescriptor const &srcDesc,
                                             BufferDescriptor const &dstDesc,
                                             BufferDescriptor const &duDesc,
                                             BufferDescriptor const &dvDesc,
+                                            BufferDescriptor const &duuDesc,
+                                            BufferDescriptor const &duvDesc,
+                                            BufferDescriptor const &dvvDesc,
                                             int workGroupSize) {
     // create stencil kernel
     if (program) {
         glDeleteProgram(program);
     }
 
-    bool derivatives = (duDesc.length > 0 || dvDesc.length > 0);
-    const char *kernelDef = derivatives
-        ? "#define OPENSUBDIV_GLSL_COMPUTE_KERNEL_EVAL_STENCILS\n"
-          "#define OPENSUBDIV_GLSL_COMPUTE_USE_DERIVATIVES\n"
-        : "#define OPENSUBDIV_GLSL_COMPUTE_KERNEL_EVAL_STENCILS\n";
+    const char * kernelDefine =
+        "#define OPENSUBDIV_GLSL_COMPUTE_KERNEL_EVAL_STENCILS\n";
 
-    program = compileKernel(srcDesc, dstDesc, duDesc, dvDesc, kernelDef,
-                            workGroupSize);
+    program = compileKernel(srcDesc, dstDesc,
+                            duDesc, dvDesc, duuDesc, duvDesc, dvvDesc,
+                            kernelDefine, workGroupSize);
     if (program == 0) return false;
 
     // cache uniform locations (TODO: use uniform block)
@@ -343,6 +487,9 @@ GLComputeEvaluator::_StencilKernel::Compile(BufferDescriptor const &srcDesc,
     uniformDstOffset = glGetUniformLocation(program, "dstOffset");
     uniformDuDesc    = glGetUniformLocation(program, "duDesc");
     uniformDvDesc    = glGetUniformLocation(program, "dvDesc");
+    uniformDuuDesc   = glGetUniformLocation(program, "duuDesc");
+    uniformDuvDesc   = glGetUniformLocation(program, "duvDesc");
+    uniformDvvDesc   = glGetUniformLocation(program, "dvvDesc");
 
     return true;
 }
@@ -362,20 +509,21 @@ GLComputeEvaluator::_PatchKernel::Compile(BufferDescriptor const &srcDesc,
                                           BufferDescriptor const &dstDesc,
                                           BufferDescriptor const &duDesc,
                                           BufferDescriptor const &dvDesc,
+                                          BufferDescriptor const &duuDesc,
+                                          BufferDescriptor const &duvDesc,
+                                          BufferDescriptor const &dvvDesc,
                                           int workGroupSize) {
     // create stencil kernel
     if (program) {
         glDeleteProgram(program);
     }
 
-    bool derivatives = (duDesc.length > 0 || dvDesc.length > 0);
-    const char *kernelDef = derivatives
-        ? "#define OPENSUBDIV_GLSL_COMPUTE_KERNEL_EVAL_PATCHES\n"
-          "#define OPENSUBDIV_GLSL_COMPUTE_USE_DERIVATIVES\n"
-        : "#define OPENSUBDIV_GLSL_COMPUTE_KERNEL_EVAL_PATCHES\n";
+    const char * kernelDefine =
+        "#define OPENSUBDIV_GLSL_COMPUTE_KERNEL_EVAL_PATCHES\n";
 
-    program = compileKernel(srcDesc, dstDesc, duDesc, dvDesc, kernelDef,
-                            workGroupSize);
+    program = compileKernel(srcDesc, dstDesc,
+                            duDesc, dvDesc, duuDesc, duvDesc, dvvDesc,
+                            kernelDefine, workGroupSize);
     if (program == 0) return false;
 
     // cache uniform locations
@@ -384,6 +532,9 @@ GLComputeEvaluator::_PatchKernel::Compile(BufferDescriptor const &srcDesc,
     uniformPatchArray = glGetUniformLocation(program, "patchArray");
     uniformDuDesc     = glGetUniformLocation(program, "duDesc");
     uniformDvDesc     = glGetUniformLocation(program, "dvDesc");
+    uniformDuuDesc    = glGetUniformLocation(program, "duuDesc");
+    uniformDuvDesc    = glGetUniformLocation(program, "duvDesc");
+    uniformDvvDesc    = glGetUniformLocation(program, "dvvDesc");
 
     return true;
 }

--- a/opensubdiv/osd/glComputeEvaluator.h
+++ b/opensubdiv/osd/glComputeEvaluator.h
@@ -97,7 +97,8 @@ public:
                                        void * deviceContext = NULL) {
         (void)deviceContext;  // not used
         GLComputeEvaluator *instance = new GLComputeEvaluator();
-        if (instance->Compile(srcDesc, dstDesc, duDesc, dvDesc)) return instance;
+        if (instance->Compile(srcDesc, dstDesc, duDesc, dvDesc))
+            return instance;
         delete instance;
         return NULL;
     }
@@ -114,19 +115,19 @@ public:
     ///
     /// ----------------------------------------------------------------------
 
-    /// \brief Generic static compute function. This function has a same
+    /// \brief Generic static stencil function. This function has a same
     ///        signature as other device kernels have so that it can be called
     ///        transparently from OsdMesh template interface.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindVBO() method returning a
-    ///                       GL buffer object of source data
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindVBO() method returning a
-    ///                       GL buffer object of destination data
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
@@ -154,7 +155,7 @@ public:
                                           dstBuffer, dstDesc,
                                           stencilTable);
         } else {
-            // Create a kernel on demand (slow)
+            // Create an instance on demand (slow)
             (void)deviceContext;  // unused
             instance = Create(srcDesc, dstDesc,
                               BufferDescriptor(),
@@ -170,31 +171,31 @@ public:
         }
     }
 
-    /// \brief Generic static compute function. This function has a same
+    /// \brief Generic static stencil function. This function has a same
     ///        signature as other device kernels have so that it can be called
     ///        transparently from OsdMesh template interface.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindVBO() method returning a
-    ///                       GL buffer object of source data
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindVBO() method returning a
-    ///                       GL buffer object of destination data
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dstDesc        vertex buffer descriptor for the dstBuffer
     ///
-    /// @param duBuffer       Output U-derivative buffer
-    ///                       must have BindVBO() method returning a
-    ///                       GL buffer object of destination data
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer       Output V-derivative buffer
-    ///                       must have BindVBO() method returning a
-    ///                       GL buffer object of destination data
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
@@ -226,7 +227,7 @@ public:
                                           dvBuffer,  dvDesc,
                                           stencilTable);
         } else {
-            // Create a kernel on demand (slow)
+            // Create an instance on demand (slow)
             (void)deviceContext;  // unused
             instance = Create(srcDesc, dstDesc, duDesc, dvDesc);
             if (instance) {
@@ -242,8 +243,23 @@ public:
         }
     }
 
-    /// Dispatch the GLSL compute kernel on GPU asynchronously.
-    /// returns false if the kernel hasn't been compiled yet.
+    /// \brief Generic stencil function.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param stencilTable   stencil table to be applied. The table must have
+    ///                       SSBO interfaces.
+    ///
     template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
     bool EvalStencils(
         SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
@@ -263,8 +279,35 @@ public:
                             /* end   = */ stencilTable->GetNumStencils());
     }
 
-    /// Dispatch the GLSL compute kernel on GPU asynchronously.
-    /// returns false if the kernel hasn't been compiled yet.
+    /// \brief Generic stencil function.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the dstBuffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param stencilTable   stencil table to be applied. The table must have
+    ///                       SSBO interfaces.
+    ///
     template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
     bool EvalStencils(
         SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
@@ -286,8 +329,41 @@ public:
                             /* end   = */ stencilTable->GetNumStencils());
     }
 
-    /// Dispatch the GLSL compute kernel on GPU asynchronously.
+    /// \brief Dispatch the GLSL compute kernel on GPU asynchronously
     /// returns false if the kernel hasn't been compiled yet.
+    ///
+    /// @param srcBuffer        GL buffer of input primvar source data
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the srcBuffer
+    ///
+    /// @param dstBuffer        GL buffer of output primvar destination data
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the dstBuffer
+    ///
+    /// @param duBuffer         GL buffer of output derivative wrt u
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         GL buffer of output derivative wrt v
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param sizesBuffer      GL buffer of the sizes in the stencil table
+    ///
+    /// @param offsetsBuffer    GL buffer of the offsets in the stencil table
+    ///
+    /// @param indicesBuffer    GL buffer of the indices in the stencil table
+    ///
+    /// @param weightsBuffer    GL buffer of the weights in the stencil table
+    ///
+    /// @param duWeightsBuffer  GL buffer of the du weights in the stencil table
+    ///
+    /// @param dvWeightsBuffer  GL buffer of the dv weights in the stencil table
+    ///
+    /// @param start            start index of stencil table
+    ///
+    /// @param end              end index of stencil table
+    ///
     bool EvalStencils(GLuint srcBuffer, BufferDescriptor const &srcDesc,
                       GLuint dstBuffer, BufferDescriptor const &dstDesc,
                       GLuint duBuffer,  BufferDescriptor const &duDesc,
@@ -389,13 +465,17 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
-    /// @param duDesc
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
-    /// @param dvDesc
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
     /// @param numPatchCoords number of patchCoords.
     ///
@@ -436,7 +516,8 @@ public:
         } else {
             // Create an instance on demand (slow)
             (void)deviceContext;  // unused
-            instance = Create(srcDesc, dstDesc, duDesc, dvDesc);
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc);
             if (instance) {
                 bool r = instance->EvalPatches(srcBuffer, srcDesc,
                                                dstBuffer, dstDesc,
@@ -456,14 +537,14 @@ public:
     ///        in the same way.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindVBO() method returning a
-    ///                       const float pointer for read
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindVBOBuffer() method returning a
-    ///                       float pointer for write
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
@@ -500,26 +581,26 @@ public:
     ///        called in the same way.
     ///
     /// @param srcBuffer        Input primvar buffer.
-    ///                         must have BindVBO() method returning a
-    ///                         const float pointer for read
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of source data
     ///
     /// @param srcDesc          vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer        Output primvar buffer
-    ///                         must have BindVBO() method returning a
-    ///                         float pointer for write
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer         Output U-derivatives buffer
-    ///                         must have BindVBO() method returning a
-    ///                         float pointer for write
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
     ///
     /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer         Output V-derivatives buffer
-    ///                         must have BindVBO() method returning a
-    ///                         float pointer for write
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
     ///
     /// @param dvDesc           vertex buffer descriptor for the dvBuffer
     ///
@@ -553,8 +634,8 @@ public:
 
     bool EvalPatches(GLuint srcBuffer, BufferDescriptor const &srcDesc,
                      GLuint dstBuffer, BufferDescriptor const &dstDesc,
-                     GLuint duBuffer, BufferDescriptor const &duDesc,
-                     GLuint dvBuffer, BufferDescriptor const &dvDesc,
+                     GLuint duBuffer,  BufferDescriptor const &duDesc,
+                     GLuint dvBuffer,  BufferDescriptor const &dvDesc,
                      int numPatchCoords,
                      GLuint patchCoordsBuffer,
                      const PatchArrayVector &patchArrays,
@@ -634,14 +715,14 @@ public:
     ///        in the same way.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindVBO() method returning a
-    ///                       const float pointer for read
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindVBOBuffer() method returning a
-    ///                       float pointer for write
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
@@ -749,14 +830,14 @@ public:
     ///        in the same way.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindVBO() method returning a
-    ///                       const float pointer for read
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindVBOBuffer() method returning a
-    ///                       float pointer for write
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
@@ -839,7 +920,6 @@ private:
         GLuint uniformPatchArray;
         GLuint uniformDuDesc;
         GLuint uniformDvDesc;
-
     } _patchKernel;
 
     int _workGroupSize;

--- a/opensubdiv/osd/glComputeEvaluator.h
+++ b/opensubdiv/osd/glComputeEvaluator.h
@@ -73,6 +73,9 @@ public:
     GLuint GetWeightsBuffer() const { return _weights; }
     GLuint GetDuWeightsBuffer() const { return _duWeights; }
     GLuint GetDvWeightsBuffer() const { return _dvWeights; }
+    GLuint GetDuuWeightsBuffer() const { return _duuWeights; }
+    GLuint GetDuvWeightsBuffer() const { return _duvWeights; }
+    GLuint GetDvvWeightsBuffer() const { return _dvvWeights; }
     int GetNumStencils() const { return _numStencils; }
 
 private:
@@ -82,6 +85,9 @@ private:
     GLuint _weights;
     GLuint _duWeights;
     GLuint _dvWeights;
+    GLuint _duuWeights;
+    GLuint _duvWeights;
+    GLuint _dvvWeights;
     int _numStencils;
 };
 
@@ -95,9 +101,25 @@ public:
                                        BufferDescriptor const &duDesc,
                                        BufferDescriptor const &dvDesc,
                                        void * deviceContext = NULL) {
+        return Create(srcDesc, dstDesc, duDesc, dvDesc,
+                      BufferDescriptor(),
+                      BufferDescriptor(),
+                      BufferDescriptor(),
+                      deviceContext);
+    }
+
+    static GLComputeEvaluator * Create(BufferDescriptor const &srcDesc,
+                                       BufferDescriptor const &dstDesc,
+                                       BufferDescriptor const &duDesc,
+                                       BufferDescriptor const &dvDesc,
+                                       BufferDescriptor const &duuDesc,
+                                       BufferDescriptor const &duvDesc,
+                                       BufferDescriptor const &dvvDesc,
+                                       void * deviceContext = NULL) {
         (void)deviceContext;  // not used
         GLComputeEvaluator *instance = new GLComputeEvaluator();
-        if (instance->Compile(srcDesc, dstDesc, duDesc, dvDesc))
+        if (instance->Compile(srcDesc, dstDesc, duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc))
             return instance;
         delete instance;
         return NULL;
@@ -243,6 +265,106 @@ public:
         }
     }
 
+    /// \brief Generic static stencil function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        transparently from OsdMesh template interface.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the dstBuffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param stencilTable   stencil table to be applied. The table must have
+    ///                       SSBO interfaces.
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLSL kernel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+    static bool EvalStencils(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        STENCIL_TABLE const *stencilTable,
+        GLComputeEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalStencils(srcBuffer, srcDesc,
+                                          dstBuffer, dstDesc,
+                                          duBuffer,  duDesc,
+                                          dvBuffer,  dvDesc,
+                                          duuBuffer, duuDesc,
+                                          duvBuffer, duvDesc,
+                                          dvvBuffer, dvvDesc,
+                                          stencilTable);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc, duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc);
+            if (instance) {
+                bool r = instance->EvalStencils(srcBuffer, srcDesc,
+                                                dstBuffer, dstDesc,
+                                                duBuffer,  duDesc,
+                                                dvBuffer,  dvDesc,
+                                                duuBuffer, duuDesc,
+                                                duvBuffer, duvDesc,
+                                                dvvBuffer, dvvDesc,
+                                                stencilTable);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
     /// \brief Generic stencil function.
     ///
     /// @param srcBuffer      Input primvar buffer.
@@ -329,6 +451,83 @@ public:
                             /* end   = */ stencilTable->GetNumStencils());
     }
 
+    /// \brief Generic stencil function.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the dstBuffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param stencilTable   stencil table to be applied. The table must have
+    ///                       SSBO interfaces.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+    bool EvalStencils(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        STENCIL_TABLE const *stencilTable) const {
+        return EvalStencils(srcBuffer->BindVBO(), srcDesc,
+                            dstBuffer->BindVBO(), dstDesc,
+                            duBuffer->BindVBO(),  duDesc,
+                            dvBuffer->BindVBO(),  dvDesc,
+                            duuBuffer->BindVBO(), duuDesc,
+                            duvBuffer->BindVBO(), duvDesc,
+                            dvvBuffer->BindVBO(), dvvDesc,
+                            stencilTable->GetSizesBuffer(),
+                            stencilTable->GetOffsetsBuffer(),
+                            stencilTable->GetIndicesBuffer(),
+                            stencilTable->GetWeightsBuffer(),
+                            stencilTable->GetDuWeightsBuffer(),
+                            stencilTable->GetDvWeightsBuffer(),
+                            stencilTable->GetDuuWeightsBuffer(),
+                            stencilTable->GetDuvWeightsBuffer(),
+                            stencilTable->GetDvvWeightsBuffer(),
+                            /* start = */ 0,
+                            /* end   = */ stencilTable->GetNumStencils());
+    }
+
     /// \brief Dispatch the GLSL compute kernel on GPU asynchronously
     /// returns false if the kernel hasn't been compiled yet.
     ///
@@ -374,6 +573,78 @@ public:
                       GLuint weightsBuffer,
                       GLuint duWeightsBuffer,
                       GLuint dvWeightsBuffer,
+                      int start,
+                      int end) const;
+
+    /// \brief Dispatch the GLSL compute kernel on GPU asynchronously
+    /// returns false if the kernel hasn't been compiled yet.
+    ///
+    /// @param srcBuffer        GL buffer of input primvar source data
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the srcBuffer
+    ///
+    /// @param dstBuffer        GL buffer of output primvar destination data
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the dstBuffer
+    ///
+    /// @param duBuffer         GL buffer of output derivative wrt u
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         GL buffer of output derivative wrt v
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        GL buffer of output 2nd derivative wrt u
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        GL buffer of output 2nd derivative wrt u and v
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        GL buffer of output 2nd derivative wrt v
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param sizesBuffer      GL buffer of the sizes in the stencil table
+    ///
+    /// @param offsetsBuffer    GL buffer of the offsets in the stencil table
+    ///
+    /// @param indicesBuffer    GL buffer of the indices in the stencil table
+    ///
+    /// @param weightsBuffer    GL buffer of the weights in the stencil table
+    ///
+    /// @param duWeightsBuffer  GL buffer of the du weights in the stencil table
+    ///
+    /// @param dvWeightsBuffer  GL buffer of the dv weights in the stencil table
+    ///
+    /// @param duuWeightsBuffer GL buffer of the duu weights in the stencil table
+    ///
+    /// @param duvWeightsBuffer GL buffer of the duv weights in the stencil table
+    ///
+    /// @param dvvWeightsBuffer GL buffer of the dvv weights in the stencil table
+    ///
+    /// @param start            start index of stencil table
+    ///
+    /// @param end              end index of stencil table
+    ///
+    bool EvalStencils(GLuint srcBuffer, BufferDescriptor const &srcDesc,
+                      GLuint dstBuffer, BufferDescriptor const &dstDesc,
+                      GLuint duBuffer,  BufferDescriptor const &duDesc,
+                      GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+                      GLuint duuBuffer, BufferDescriptor const &duuDesc,
+                      GLuint duvBuffer, BufferDescriptor const &duvDesc,
+                      GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
+                      GLuint sizesBuffer,
+                      GLuint offsetsBuffer,
+                      GLuint indicesBuffer,
+                      GLuint weightsBuffer,
+                      GLuint duWeightsBuffer,
+                      GLuint dvWeightsBuffer,
+                      GLuint duuWeightsBuffer,
+                      GLuint duvWeightsBuffer,
+                      GLuint dvvWeightsBuffer,
                       int start,
                       int end) const;
 
@@ -548,6 +819,117 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatches(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        GLComputeEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatches(srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         duuBuffer, duuDesc,
+                                         duvBuffer, duvDesc,
+                                         dvvBuffer, dvvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc);
+            if (instance) {
+                bool r = instance->EvalPatches(srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               duuBuffer, duuDesc,
+                                               duvBuffer, duvDesc,
+                                               dvvBuffer, dvvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
     /// @param numPatchCoords number of patchCoords.
     ///
     /// @param patchCoords    array of locations to be evaluated.
@@ -632,10 +1014,103 @@ public:
                            patchTable->GetPatchParamBuffer());
     }
 
+    /// \brief Generic limit eval function with derivatives. This function has
+    ///        a same signature as other device kernels have so that it can be
+    ///        called in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of source data
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       GLPatchTable or equivalent
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatches(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           duBuffer->BindVBO(),  duDesc,
+                           dvBuffer->BindVBO(),  dvDesc,
+                           duuBuffer->BindVBO(), duuDesc,
+                           duvBuffer->BindVBO(), duvDesc,
+                           dvvBuffer->BindVBO(), dvvDesc,
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetPatchArrays(),
+                           patchTable->GetPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
     bool EvalPatches(GLuint srcBuffer, BufferDescriptor const &srcDesc,
                      GLuint dstBuffer, BufferDescriptor const &dstDesc,
                      GLuint duBuffer,  BufferDescriptor const &duDesc,
                      GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+                     int numPatchCoords,
+                     GLuint patchCoordsBuffer,
+                     const PatchArrayVector &patchArrays,
+                     GLuint patchIndexBuffer,
+                     GLuint patchParamsBuffer) const;
+
+    bool EvalPatches(GLuint srcBuffer, BufferDescriptor const &srcDesc,
+                     GLuint dstBuffer, BufferDescriptor const &dstDesc,
+                     GLuint duBuffer,  BufferDescriptor const &duDesc,
+                     GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+                     GLuint duuBuffer, BufferDescriptor const &duuDesc,
+                     GLuint duvBuffer, BufferDescriptor const &duvDesc,
+                     GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
                      int numPatchCoords,
                      GLuint patchCoordsBuffer,
                      const PatchArrayVector &patchArrays,
@@ -770,6 +1245,344 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        GLComputeEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc);
+            if (instance) {
+                bool r = instance->EvalPatchesVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           duBuffer->BindVBO(),  duDesc,
+                           dvBuffer->BindVBO(),  dvDesc,
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetVaryingPatchArrays(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        GLComputeEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         duuBuffer, duuDesc,
+                                         duvBuffer, duvDesc,
+                                         dvvBuffer, dvvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc);
+            if (instance) {
+                bool r = instance->EvalPatchesVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               duuBuffer, duuDesc,
+                                               duvBuffer, duvDesc,
+                                               dvvBuffer, dvvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           duBuffer->BindVBO(), duDesc,
+                           dvBuffer->BindVBO(), dvDesc,
+                           duuBuffer->BindVBO(), duuDesc,
+                           duvBuffer->BindVBO(), duvDesc,
+                           dvvBuffer->BindVBO(), dvvDesc,
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetVaryingPatchArrays(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
     /// @param numPatchCoords number of patchCoords.
     ///
     /// @param patchCoords    array of locations to be evaluated.
@@ -872,6 +1685,356 @@ public:
                            patchTable->GetFVarPatchParamBuffer(fvarChannel));
     }
 
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        GLComputeEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesFaceVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable, fvarChannel);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc);
+            if (instance) {
+                bool r = instance->EvalPatchesFaceVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable, fvarChannel);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel = 0) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           duBuffer->BindVBO(), duDesc,
+                           dvBuffer->BindVBO(), dvDesc,
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetFVarPatchArrays(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        GLComputeEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesFaceVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         duuBuffer, duuDesc,
+                                         duvBuffer, duvDesc,
+                                         dvvBuffer, dvvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable, fvarChannel);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc);
+            if (instance) {
+                bool r = instance->EvalPatchesFaceVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               duuBuffer, duuDesc,
+                                               duvBuffer, duvDesc,
+                                               dvvBuffer, dvvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable, fvarChannel);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel = 0) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           duBuffer->BindVBO(), duDesc,
+                           dvBuffer->BindVBO(), dvDesc,
+                           duuBuffer->BindVBO(), duuDesc,
+                           duvBuffer->BindVBO(), duvDesc,
+                           dvvBuffer->BindVBO(), dvvDesc,
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetFVarPatchArrays(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
     /// ----------------------------------------------------------------------
     ///
     ///   Other methods
@@ -882,8 +2045,11 @@ public:
     /// calling this function. Returns false if it fails to compile the kernel.
     bool Compile(BufferDescriptor const &srcDesc,
                  BufferDescriptor const &dstDesc,
-                 BufferDescriptor const &duDesc,
-                 BufferDescriptor const &dvDesc);
+                 BufferDescriptor const &duDesc = BufferDescriptor(),
+                 BufferDescriptor const &dvDesc = BufferDescriptor(),
+                 BufferDescriptor const &duuDesc = BufferDescriptor(),
+                 BufferDescriptor const &duvDesc = BufferDescriptor(),
+                 BufferDescriptor const &dvvDesc = BufferDescriptor());
 
     /// Wait the dispatched kernel finishes.
     static void Synchronize(void *deviceContext);
@@ -896,6 +2062,9 @@ private:
                      BufferDescriptor const &dstDesc,
                      BufferDescriptor const &duDesc,
                      BufferDescriptor const &dvDesc,
+                     BufferDescriptor const &duuDesc,
+                     BufferDescriptor const &duvDesc,
+                     BufferDescriptor const &dvvDesc,
                      int workGroupSize);
         GLuint program;
         GLuint uniformStart;
@@ -904,6 +2073,9 @@ private:
         GLuint uniformDstOffset;
         GLuint uniformDuDesc;
         GLuint uniformDvDesc;
+        GLuint uniformDuuDesc;
+        GLuint uniformDuvDesc;
+        GLuint uniformDvvDesc;
     } _stencilKernel;
 
     struct _PatchKernel {
@@ -913,6 +2085,9 @@ private:
                      BufferDescriptor const &dstDesc,
                      BufferDescriptor const &duDesc,
                      BufferDescriptor const &dvDesc,
+                     BufferDescriptor const &duuDesc,
+                     BufferDescriptor const &duvDesc,
+                     BufferDescriptor const &dvvDesc,
                      int workGroupSize);
         GLuint program;
         GLuint uniformSrcOffset;
@@ -920,6 +2095,9 @@ private:
         GLuint uniformPatchArray;
         GLuint uniformDuDesc;
         GLuint uniformDvDesc;
+        GLuint uniformDuuDesc;
+        GLuint uniformDuvDesc;
+        GLuint uniformDvvDesc;
     } _patchKernel;
 
     int _workGroupSize;

--- a/opensubdiv/osd/glXFBEvaluator.cpp
+++ b/opensubdiv/osd/glXFBEvaluator.cpp
@@ -48,6 +48,10 @@ static const char *shaderSource =
 
 template <class T> GLuint
 createGLTextureBuffer(std::vector<T> const & src, GLenum type) {
+    if (src.empty()) {
+        return 0;
+    }
+
     GLint size = static_cast<int>(src.size()*sizeof(T));
     void const * ptr = &src.at(0);
 
@@ -95,9 +99,11 @@ GLStencilTableTBO::GLStencilTableTBO(
             stencilTable->GetControlIndices(), GL_R32I);
         _weights = createGLTextureBuffer(stencilTable->GetWeights(), GL_R32F);
         _duWeights = _dvWeights = 0;
+        _duuWeights = _duvWeights = _dvvWeights = 0;
     } else {
         _sizes = _offsets = _indices = _weights = 0;
         _duWeights = _dvWeights = 0;
+        _duuWeights = _duvWeights = _dvvWeights = 0;
     }
 }
 
@@ -118,9 +124,16 @@ GLStencilTableTBO::GLStencilTableTBO(
             limitStencilTable->GetDuWeights(), GL_R32F);
         _dvWeights = createGLTextureBuffer(
             limitStencilTable->GetDvWeights(), GL_R32F);
+        _duuWeights = createGLTextureBuffer(
+            limitStencilTable->GetDuuWeights(), GL_R32F);
+        _duvWeights = createGLTextureBuffer(
+            limitStencilTable->GetDuvWeights(), GL_R32F);
+        _dvvWeights = createGLTextureBuffer(
+            limitStencilTable->GetDvvWeights(), GL_R32F);
     } else {
         _sizes = _offsets = _indices = _weights = 0;
         _duWeights = _dvWeights = 0;
+        _duuWeights = _duvWeights = _dvvWeights = 0;
     }
 }
 
@@ -131,11 +144,16 @@ GLStencilTableTBO::~GLStencilTableTBO() {
     if (_weights) glDeleteTextures(1, &_weights);
     if (_duWeights) glDeleteTextures(1, &_duWeights);
     if (_dvWeights) glDeleteTextures(1, &_dvWeights);
+    if (_duuWeights) glDeleteTextures(1, &_duuWeights);
+    if (_duvWeights) glDeleteTextures(1, &_duvWeights);
+    if (_dvvWeights) glDeleteTextures(1, &_dvvWeights);
 }
 
 // ---------------------------------------------------------------------------
 
-GLXFBEvaluator::GLXFBEvaluator() : _srcBufferTexture(0) {
+GLXFBEvaluator::GLXFBEvaluator(bool sharedDerivativeBuffers)
+    : _srcBufferTexture(0),
+      _sharedDerivativeBuffers(sharedDerivativeBuffers) {
 }
 
 GLXFBEvaluator::~GLXFBEvaluator() {
@@ -149,7 +167,11 @@ compileKernel(BufferDescriptor const &srcDesc,
               BufferDescriptor const &dstDesc,
               BufferDescriptor const &duDesc,
               BufferDescriptor const &dvDesc,
-              const char *kernelDefine) {
+              BufferDescriptor const &duuDesc,
+              BufferDescriptor const &duvDesc,
+              BufferDescriptor const &dvvDesc,
+              const char *kernelDefine,
+              bool sharedDerivativeBuffers) {
 
     GLuint program = glCreateProgram();
 
@@ -165,8 +187,25 @@ compileKernel(BufferDescriptor const &srcDesc,
             << "#define VERTEX_SHADER\n"
             << kernelDefine << "\n"
             << patchBasisShaderSourceDefine << "\n";
-    std::string defineStr = defines.str();
 
+    bool deriv1 = (duDesc.length > 0 || dvDesc.length > 0);
+    bool deriv2 = (duuDesc.length > 0 || duvDesc.length > 0 || dvvDesc.length > 0);
+    if (deriv1) {
+        defines << "#define OPENSUBDIV_GLSL_XFB_USE_1ST_DERIVATIVES\n";
+        if (sharedDerivativeBuffers) {
+            defines <<
+                "#define OPENSUBDIV_GLSL_XFB_SHARED_1ST_DERIVATIVE_BUFFERS\n";
+        }
+    }
+    if (deriv2) {
+        defines << "#define OPENSUBDIV_GLSL_XFB_USE_2ND_DERIVATIVES\n";
+        if (sharedDerivativeBuffers) {
+            defines <<
+                "#define OPENSUBDIV_GLSL_XFB_SHARED_2ND_DERIVATIVE_BUFFERS\n";
+        }
+    }
+
+    std::string defineStr = defines.str();
 
     const char *shaderSources[4] = {"#version 410\n", NULL, NULL, NULL};
 
@@ -204,40 +243,147 @@ compileKernel(BufferDescriptor const &srcDesc,
             outputs.push_back("gl_SkipComponents1");
         }
     }
-    if (duDesc.length) {
-        //
-        // For derivatives, we use another buffer bindings so gl_NextBuffer
-        // is inserted here to switch the destination of transform feedback.
-        //
-        // Note that the destination buffers may or may not be shared between
-        // vertex and each derivatives. gl_NextBuffer seems still works well
-        // in either case.
-        //
+    //
+    // For derivatives, we use another buffer bindings so gl_NextBuffer
+    // is inserted here to switch the destination of transform feedback.
+    //
+    // Note that the destination buffers may or may not be shared between
+    // vertex and each derivatives. gl_NextBuffer seems still works well
+    // in either case.
+    //
+    // If we know that the buffers for derivatives are shared, then we
+    // can use fewer buffer bindings. This can be important, since most GL
+    // implementations will support only up to 4 transform feedback bindings.
+    //
+    if (deriv1 && sharedDerivativeBuffers) {
         outputs.push_back("gl_NextBuffer");
-        int primvarOffset = (duDesc.offset % duDesc.stride);
-        for (int i = 0; i < primvarOffset; ++i) {
+
+        int primvar1Offset = (duDesc.offset % duDesc.stride);
+        int primvar2Offset = (dvDesc.offset % dvDesc.stride);
+
+        for (int i = 0; i < primvar1Offset; ++i) {
             outputs.push_back("gl_SkipComponents1");
         }
         for (int i = 0; i < duDesc.length; ++i) {
-            snprintf(attrName, sizeof(attrName), "outDuBuffer[%d]", i);
+            snprintf(attrName, sizeof(attrName), "outDeriv1Buffer[%d]", i);
             outputs.push_back(attrName);
         }
-        for (int i = primvarOffset + duDesc.length; i < duDesc.stride; ++i) {
-            outputs.push_back("gl_SkipComponents1");
-        }
-    }
-    if (dvDesc.length) {
-        outputs.push_back("gl_NextBuffer");
-        int primvarOffset = (dvDesc.offset % dvDesc.stride);
-        for (int i = 0; i < primvarOffset; ++i) {
+        for (int i = primvar1Offset + duDesc.length; i < primvar2Offset; ++i) {
             outputs.push_back("gl_SkipComponents1");
         }
         for (int i = 0; i < dvDesc.length; ++i) {
-            snprintf(attrName, sizeof(attrName), "outDvBuffer[%d]", i);
+            snprintf(attrName, sizeof(attrName), "outDeriv1Buffer[%d]", i+duDesc.length);
             outputs.push_back(attrName);
         }
-        for (int i = primvarOffset + dvDesc.length; i < dvDesc.stride; ++i) {
+        for (int i = primvar2Offset + dvDesc.length; i < dvDesc.stride; ++i) {
             outputs.push_back("gl_SkipComponents1");
+        }
+    } else {
+        if (duDesc.length) {
+            outputs.push_back("gl_NextBuffer");
+            int primvarOffset = (duDesc.offset % duDesc.stride);
+            for (int i = 0; i < primvarOffset; ++i) {
+                outputs.push_back("gl_SkipComponents1");
+            }
+            for (int i = 0; i < duDesc.length; ++i) {
+                snprintf(attrName, sizeof(attrName), "outDuBuffer[%d]", i);
+                outputs.push_back(attrName);
+            }
+            for (int i = primvarOffset + duDesc.length; i < duDesc.stride; ++i) {
+                outputs.push_back("gl_SkipComponents1");
+            }
+        }
+        if (dvDesc.length) {
+            outputs.push_back("gl_NextBuffer");
+            int primvarOffset = (dvDesc.offset % dvDesc.stride);
+            for (int i = 0; i < primvarOffset; ++i) {
+                outputs.push_back("gl_SkipComponents1");
+            }
+            for (int i = 0; i < dvDesc.length; ++i) {
+                snprintf(attrName, sizeof(attrName), "outDvBuffer[%d]", i);
+                outputs.push_back(attrName);
+            }
+            for (int i = primvarOffset + dvDesc.length; i < dvDesc.stride; ++i) {
+                outputs.push_back("gl_SkipComponents1");
+            }
+        }
+    }
+    if (deriv2 && sharedDerivativeBuffers) {
+        outputs.push_back("gl_NextBuffer");
+
+        int primvar1Offset = (duuDesc.offset % duuDesc.stride);
+        int primvar2Offset = (duvDesc.offset % duvDesc.stride);
+        int primvar3Offset = (dvvDesc.offset % dvvDesc.stride);
+
+        for (int i = 0; i < primvar1Offset; ++i) {
+            outputs.push_back("gl_SkipComponents1");
+        }
+        for (int i = 0; i < duuDesc.length; ++i) {
+            snprintf(attrName, sizeof(attrName), "outDeriv2Buffer[%d]", i);
+            outputs.push_back(attrName);
+        }
+
+        for (int i = primvar1Offset + duuDesc.length; i < primvar2Offset; ++i) {
+            outputs.push_back("gl_SkipComponents1");
+        }
+        for (int i = 0; i < duvDesc.length; ++i) {
+            snprintf(attrName, sizeof(attrName), "outDeriv2Buffer[%d]", i+duuDesc.length);
+            outputs.push_back(attrName);
+        }
+
+        for (int i = primvar2Offset + duvDesc.length; i < primvar3Offset; ++i) {
+            outputs.push_back("gl_SkipComponents1");
+        }
+        for (int i = 0; i < dvvDesc.length; ++i) {
+            snprintf(attrName, sizeof(attrName), "outDeriv2Buffer[%d]", i+duuDesc.length+duvDesc.length);
+            outputs.push_back(attrName);
+        }
+
+        for (int i = primvar3Offset + dvvDesc.length; i < dvvDesc.stride; ++i) {
+            outputs.push_back("gl_SkipComponents1");
+        }
+    } else {
+        if (duuDesc.length) {
+            outputs.push_back("gl_NextBuffer");
+            int primvarOffset = (duuDesc.offset % duuDesc.stride);
+            for (int i = 0; i < primvarOffset; ++i) {
+                outputs.push_back("gl_SkipComponents1");
+            }
+            for (int i = 0; i < duuDesc.length; ++i) {
+                snprintf(attrName, sizeof(attrName), "outDuuBuffer[%d]", i);
+                outputs.push_back(attrName);
+            }
+            for (int i = primvarOffset + duuDesc.length; i < duuDesc.stride; ++i) {
+                outputs.push_back("gl_SkipComponents1");
+            }
+        }
+        if (duvDesc.length) {
+            outputs.push_back("gl_NextBuffer");
+            int primvarOffset = (duvDesc.offset % duvDesc.stride);
+            for (int i = 0; i < primvarOffset; ++i) {
+                outputs.push_back("gl_SkipComponents1");
+            }
+            for (int i = 0; i < duvDesc.length; ++i) {
+                snprintf(attrName, sizeof(attrName), "outDuvBuffer[%d]", i);
+                outputs.push_back(attrName);
+            }
+            for (int i = primvarOffset + duvDesc.length; i < duvDesc.stride; ++i) {
+                outputs.push_back("gl_SkipComponents1");
+            }
+        }
+        if (dvvDesc.length) {
+            outputs.push_back("gl_NextBuffer");
+            int primvarOffset = (dvvDesc.offset % dvvDesc.stride);
+            for (int i = 0; i < primvarOffset; ++i) {
+                outputs.push_back("gl_SkipComponents1");
+            }
+            for (int i = 0; i < dvvDesc.length; ++i) {
+                snprintf(attrName, sizeof(attrName), "outDvvBuffer[%d]", i);
+                outputs.push_back(attrName);
+            }
+            for (int i = primvarOffset + dvvDesc.length; i < dvvDesc.stride; ++i) {
+                outputs.push_back("gl_SkipComponents1");
+            }
         }
     }
     // convert to char* array
@@ -274,13 +420,20 @@ bool
 GLXFBEvaluator::Compile(BufferDescriptor const &srcDesc,
                         BufferDescriptor const &dstDesc,
                         BufferDescriptor const &duDesc,
-                        BufferDescriptor const &dvDesc) {
+                        BufferDescriptor const &dvDesc,
+                        BufferDescriptor const &duuDesc,
+                        BufferDescriptor const &duvDesc,
+                        BufferDescriptor const &dvvDesc) {
 
     // create a stencil kernel
-    _stencilKernel.Compile(srcDesc, dstDesc, duDesc, dvDesc);
+    _stencilKernel.Compile(srcDesc, dstDesc, duDesc, dvDesc,
+                           duuDesc, duvDesc, dvvDesc,
+                           _sharedDerivativeBuffers);
 
     // create a patch kernel
-    _patchKernel.Compile(srcDesc, dstDesc, duDesc, dvDesc);
+    _patchKernel.Compile(srcDesc, dstDesc, duDesc, dvDesc,
+                         duuDesc, duvDesc, dvvDesc,
+                         _sharedDerivativeBuffers);
 
     // create a texture for input buffer
     if (!_srcBufferTexture) {
@@ -314,12 +467,46 @@ GLXFBEvaluator::EvalStencils(
     GLuint dstBuffer, BufferDescriptor const &dstDesc,
     GLuint duBuffer,  BufferDescriptor const &duDesc,
     GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+    GLuint sizesBuffer,
+    GLuint offsetsBuffer,
+    GLuint indicesBuffer,
+    GLuint weightsBuffer,
+    GLuint duWeightsBuffer,
+    GLuint dvWeightsBuffer,
+    int start, int end) const {
+
+    return EvalStencils(srcBuffer, srcDesc,
+                        dstBuffer, dstDesc,
+                        duBuffer, duDesc,
+                        dvBuffer, dvDesc,
+                        0, BufferDescriptor(),
+                        0, BufferDescriptor(),
+                        0, BufferDescriptor(),
+                        sizesBuffer, offsetsBuffer, indicesBuffer,
+                        weightsBuffer,
+                        duWeightsBuffer, dvWeightsBuffer,
+                        0, 0, 0,
+                        start, end);
+}
+
+bool
+GLXFBEvaluator::EvalStencils(
+    GLuint srcBuffer, BufferDescriptor const &srcDesc,
+    GLuint dstBuffer, BufferDescriptor const &dstDesc,
+    GLuint duBuffer,  BufferDescriptor const &duDesc,
+    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+    GLuint duuBuffer, BufferDescriptor const &duuDesc,
+    GLuint duvBuffer, BufferDescriptor const &duvDesc,
+    GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
     GLuint sizesTexture,
     GLuint offsetsTexture,
     GLuint indicesTexture,
     GLuint weightsTexture,
     GLuint duWeightsTexture,
     GLuint dvWeightsTexture,
+    GLuint duuWeightsTexture,
+    GLuint duvWeightsTexture,
+    GLuint dvvWeightsTexture,
     int start, int end) const {
 
     if (!_stencilKernel.program) return false;
@@ -353,6 +540,14 @@ GLXFBEvaluator::EvalStencils(
         bindTexture(_stencilKernel.uniformDuWeightsTexture, duWeightsTexture, 5);
     if (_stencilKernel.uniformDvWeightsTexture >= 0 && dvWeightsTexture)
         bindTexture(_stencilKernel.uniformDvWeightsTexture, dvWeightsTexture, 6);
+    if (_stencilKernel.uniformDuWeightsTexture >= 0 && duWeightsTexture)
+        bindTexture(_stencilKernel.uniformDuWeightsTexture, duWeightsTexture, 5);
+    if (_stencilKernel.uniformDuuWeightsTexture >= 0 && duuWeightsTexture)
+        bindTexture(_stencilKernel.uniformDuuWeightsTexture, duuWeightsTexture, 5);
+    if (_stencilKernel.uniformDuvWeightsTexture >= 0 && duvWeightsTexture)
+        bindTexture(_stencilKernel.uniformDuvWeightsTexture, duvWeightsTexture, 6);
+    if (_stencilKernel.uniformDvvWeightsTexture >= 0 && dvvWeightsTexture)
+        bindTexture(_stencilKernel.uniformDvvWeightsTexture, dvvWeightsTexture, 6);
 
     // set batch range
     glUniform1i(_stencilKernel.uniformStart,     start);
@@ -392,6 +587,12 @@ GLXFBEvaluator::EvalStencils(
         (duDesc.offset - (duDesc.offset % duDesc.stride)) : 0;
     int dvBufferBindOffset = dvDesc.stride ?
         (dvDesc.offset - (dvDesc.offset % dvDesc.stride)) : 0;
+    int duuBufferBindOffset = duuDesc.stride ?
+        (duuDesc.offset - (duuDesc.offset % duuDesc.stride)) : 0;
+    int duvBufferBindOffset = duvDesc.stride ?
+        (duvDesc.offset - (duvDesc.offset % duvDesc.stride)) : 0;
+    int dvvBufferBindOffset = dvvDesc.stride ?
+        (dvvDesc.offset - (dvvDesc.offset % dvvDesc.stride)) : 0;
 
     // bind destination buffer
     glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
@@ -399,18 +600,53 @@ GLXFBEvaluator::EvalStencils(
                       dstBufferBindOffset * sizeof(float),
                       count * dstDesc.stride * sizeof(float));
 
-    if (duDesc.length > 0) {
+    if ((duDesc.length > 0) && _sharedDerivativeBuffers) {
         glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
                           1, duBuffer,
                           duBufferBindOffset * sizeof(float),
                           count * duDesc.stride * sizeof(float));
+    } else {
+        if (duDesc.length > 0) {
+            glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
+                              1, duBuffer,
+                              duBufferBindOffset * sizeof(float),
+                              count * duDesc.stride * sizeof(float));
+        }
+
+        if (dvDesc.length > 0) {
+            glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
+                              2, dvBuffer,
+                              dvBufferBindOffset * sizeof(float),
+                              count * dvDesc.stride * sizeof(float));
+        }
     }
 
-    if (dvDesc.length > 0) {
+    if ((duuDesc.length > 0) && _sharedDerivativeBuffers) {
         glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
-                          2, dvBuffer,
-                          dvBufferBindOffset * sizeof(float),
-                          count * dvDesc.stride * sizeof(float));
+                          2, duuBuffer,
+                          duuBufferBindOffset * sizeof(float),
+                          count * duuDesc.stride * sizeof(float));
+    } else {
+        if (duuDesc.length > 0) {
+            glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
+                              3, duuBuffer,
+                              duuBufferBindOffset * sizeof(float),
+                              count * duuDesc.stride * sizeof(float));
+        }
+
+        if (duvDesc.length > 0) {
+            glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
+                              4, duvBuffer,
+                              duvBufferBindOffset * sizeof(float),
+                              count * duvDesc.stride * sizeof(float));
+        }
+
+        if (dvvDesc.length > 0) {
+            glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
+                              5, dvvBuffer,
+                              dvvBufferBindOffset * sizeof(float),
+                              count * dvvDesc.stride * sizeof(float));
+        }
     }
 
     glBeginTransformFeedback(GL_POINTS);
@@ -419,7 +655,7 @@ GLXFBEvaluator::EvalStencils(
 
     glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, 0);
 
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 6; ++i) {
         glActiveTexture(GL_TEXTURE0 + i);
         glBindTexture(GL_TEXTURE_BUFFER, 0);
     }
@@ -448,7 +684,36 @@ GLXFBEvaluator::EvalPatches(
     GLuint patchIndexTexture,
     GLuint patchParamTexture) const {
 
-    bool derivatives = (duDesc.length > 0 || dvDesc.length > 0);
+    return EvalPatches(srcBuffer, srcDesc,
+                       dstBuffer, dstDesc,
+                       duBuffer, duDesc,
+                       dvBuffer, dvDesc,
+                       0, BufferDescriptor(),
+                       0, BufferDescriptor(),
+                       0, BufferDescriptor(),
+                       numPatchCoords,
+                       patchCoordsBuffer, patchArrays,
+                       patchIndexTexture,
+                       patchParamTexture);
+}
+
+bool
+GLXFBEvaluator::EvalPatches(
+    GLuint srcBuffer, BufferDescriptor const &srcDesc,
+    GLuint dstBuffer, BufferDescriptor const &dstDesc,
+    GLuint duBuffer,  BufferDescriptor const &duDesc,
+    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+    GLuint duuBuffer, BufferDescriptor const &duuDesc,
+    GLuint duvBuffer, BufferDescriptor const &duvDesc,
+    GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
+    int numPatchCoords,
+    GLuint patchCoordsBuffer,
+    const PatchArrayVector &patchArrays,
+    GLuint patchIndexTexture,
+    GLuint patchParamTexture) const {
+
+    bool deriv1 = (duDesc.length > 0 || dvDesc.length > 0);
+    bool deriv2 = (duuDesc.length > 0 || duvDesc.length > 0 || dvvDesc.length > 0);
 
     if (!_patchKernel.program) return false;
 
@@ -493,6 +758,15 @@ GLXFBEvaluator::EvalPatches(
     int dvBufferBindOffset = dvDesc.stride
         ? (dvDesc.offset - (dvDesc.offset % dvDesc.stride))
         : 0;
+    int duuBufferBindOffset = duuDesc.stride
+        ? (duuDesc.offset - (duuDesc.offset % duuDesc.stride))
+        : 0;
+    int duvBufferBindOffset = duvDesc.stride
+        ? (duvDesc.offset - (duvDesc.offset % duvDesc.stride))
+        : 0;
+    int dvvBufferBindOffset = dvvDesc.stride
+        ? (dvvDesc.offset - (dvvDesc.offset % dvvDesc.stride))
+        : 0;
 
     // bind destination buffer
     glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
@@ -500,7 +774,12 @@ GLXFBEvaluator::EvalPatches(
                       dstBufferBindOffset * sizeof(float),
                       numPatchCoords * dstDesc.stride * sizeof(float));
 
-    if (derivatives) {
+    if (deriv1 && _sharedDerivativeBuffers) {
+        glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
+                          1, duBuffer,
+                          duBufferBindOffset * sizeof(float),
+                          numPatchCoords * duDesc.stride * sizeof(float));
+    } else if (deriv1) {
         glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
                           1, duBuffer,
                           duBufferBindOffset * sizeof(float),
@@ -510,7 +789,27 @@ GLXFBEvaluator::EvalPatches(
                           2, dvBuffer,
                           dvBufferBindOffset * sizeof(float),
                           numPatchCoords * dvDesc.stride * sizeof(float));
+    }
+    if (deriv2 && _sharedDerivativeBuffers) {
+        glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
+                          2, duuBuffer,
+                          duuBufferBindOffset * sizeof(float),
+                          numPatchCoords * duuDesc.stride * sizeof(float));
+    } else if (deriv2) {
+        glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
+                          3, duuBuffer,
+                          duuBufferBindOffset * sizeof(float),
+                          numPatchCoords * duuDesc.stride * sizeof(float));
 
+        glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
+                          4, duvBuffer,
+                          duvBufferBindOffset * sizeof(float),
+                          numPatchCoords * duvDesc.stride * sizeof(float));
+
+        glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER,
+                          5, dvvBuffer,
+                          dvvBufferBindOffset * sizeof(float),
+                          numPatchCoords * dvvDesc.stride * sizeof(float));
     }
 
     glBeginTransformFeedback(GL_POINTS);
@@ -520,7 +819,7 @@ GLXFBEvaluator::EvalPatches(
     glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, 0);
 
     // unbind textures
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 6; ++i) {
         glActiveTexture(GL_TEXTURE0 + i);
         glBindTexture(GL_TEXTURE_BUFFER, 0);
     }
@@ -535,7 +834,6 @@ GLXFBEvaluator::EvalPatches(
     // revert vao
     glBindVertexArray(0);
     glDeleteVertexArrays(1, &vao);
-
 
     return true;
 }
@@ -554,32 +852,38 @@ bool
 GLXFBEvaluator::_StencilKernel::Compile(BufferDescriptor const &srcDesc,
                                         BufferDescriptor const &dstDesc,
                                         BufferDescriptor const &duDesc,
-                                        BufferDescriptor const &dvDesc) {
+                                        BufferDescriptor const &dvDesc,
+                                        BufferDescriptor const &duuDesc,
+                                        BufferDescriptor const &duvDesc,
+                                        BufferDescriptor const &dvvDesc,
+                                        bool sharedDerivativeBuffers) {
     // create stencil kernel
     if (program) {
         glDeleteProgram(program);
     }
 
-    bool derivatives = (duDesc.length > 0 || dvDesc.length > 0);
-    const char *kernelDef = derivatives
-        ? "#define OPENSUBDIV_GLSL_XFB_KERNEL_EVAL_STENCILS\n"
-          "#define OPENSUBDIV_GLSL_XFB_USE_DERIVATIVES\n"
-        : "#define OPENSUBDIV_GLSL_XFB_KERNEL_EVAL_STENCILS\n";
+    const char * kernelDefines =
+        "#define OPENSUBDIV_GLSL_XFB_KERNEL_EVAL_STENCILS\n";
 
-    program = compileKernel(srcDesc, dstDesc, duDesc, dvDesc, kernelDef);
+    program = compileKernel(srcDesc, dstDesc, duDesc, dvDesc,
+                            duuDesc, duvDesc, dvvDesc,
+                            kernelDefines, sharedDerivativeBuffers);
     if (program == 0) return false;
 
     // cache uniform locations (TODO: use uniform block)
-    uniformSrcBufferTexture = glGetUniformLocation(program, "vertexBuffer");
-    uniformSrcOffset        = glGetUniformLocation(program, "srcOffset");
-    uniformSizesTexture     = glGetUniformLocation(program, "sizes");
-    uniformOffsetsTexture   = glGetUniformLocation(program, "offsets");
-    uniformIndicesTexture   = glGetUniformLocation(program, "indices");
-    uniformWeightsTexture   = glGetUniformLocation(program, "weights");
-    uniformDuWeightsTexture = glGetUniformLocation(program, "duWeights");
-    uniformDvWeightsTexture = glGetUniformLocation(program, "dvWeights");
-    uniformStart            = glGetUniformLocation(program, "batchStart");
-    uniformEnd              = glGetUniformLocation(program, "batchEnd");
+    uniformSrcBufferTexture  = glGetUniformLocation(program, "vertexBuffer");
+    uniformSrcOffset         = glGetUniformLocation(program, "srcOffset");
+    uniformSizesTexture      = glGetUniformLocation(program, "sizes");
+    uniformOffsetsTexture    = glGetUniformLocation(program, "offsets");
+    uniformIndicesTexture    = glGetUniformLocation(program, "indices");
+    uniformWeightsTexture    = glGetUniformLocation(program, "weights");
+    uniformDuWeightsTexture  = glGetUniformLocation(program, "duWeights");
+    uniformDvWeightsTexture  = glGetUniformLocation(program, "dvWeights");
+    uniformDuuWeightsTexture = glGetUniformLocation(program, "duuWeights");
+    uniformDuvWeightsTexture = glGetUniformLocation(program, "duvWeights");
+    uniformDvvWeightsTexture = glGetUniformLocation(program, "dvvWeights");
+    uniformStart             = glGetUniformLocation(program, "batchStart");
+    uniformEnd               = glGetUniformLocation(program, "batchEnd");
 
     return true;
 }
@@ -598,19 +902,22 @@ bool
 GLXFBEvaluator::_PatchKernel::Compile(BufferDescriptor const &srcDesc,
                                       BufferDescriptor const &dstDesc,
                                       BufferDescriptor const &duDesc,
-                                      BufferDescriptor const &dvDesc) {
+                                      BufferDescriptor const &dvDesc,
+                                      BufferDescriptor const &duuDesc,
+                                      BufferDescriptor const &duvDesc,
+                                      BufferDescriptor const &dvvDesc,
+                                      bool sharedDerivativeBuffers) {
     // create stencil kernel
     if (program) {
         glDeleteProgram(program);
     }
 
-    bool derivatives = (duDesc.length > 0 || dvDesc.length > 0);
-    const char *kernelDef = derivatives
-        ? "#define OPENSUBDIV_GLSL_XFB_KERNEL_EVAL_PATCHES\n"
-          "#define OPENSUBDIV_GLSL_XFB_USE_DERIVATIVES\n"
-        : "#define OPENSUBDIV_GLSL_XFB_KERNEL_EVAL_PATCHES\n";
+    const char * kernelDefines =
+        "#define OPENSUBDIV_GLSL_XFB_KERNEL_EVAL_PATCHES\n";
 
-    program = compileKernel(srcDesc, dstDesc, duDesc, dvDesc, kernelDef);
+    program = compileKernel(srcDesc, dstDesc, duDesc, dvDesc,
+                            duuDesc, duvDesc, dvvDesc,
+                            kernelDefines, sharedDerivativeBuffers);
     if (program == 0) return false;
 
     // cache uniform locations
@@ -622,7 +929,6 @@ GLXFBEvaluator::_PatchKernel::Compile(BufferDescriptor const &srcDesc,
 
     return true;
 }
-
 
 }  // end namespace Osd
 

--- a/opensubdiv/osd/glXFBEvaluator.h
+++ b/opensubdiv/osd/glXFBEvaluator.h
@@ -75,6 +75,9 @@ public:
     GLuint GetWeightsTexture() const { return _weights; }
     GLuint GetDuWeightsTexture() const { return _duWeights; }
     GLuint GetDvWeightsTexture() const { return _dvWeights; }
+    GLuint GetDuuWeightsTexture() const { return _duuWeights; }
+    GLuint GetDuvWeightsTexture() const { return _duvWeights; }
+    GLuint GetDvvWeightsTexture() const { return _dvvWeights; }
     int GetNumStencils() const { return _numStencils; }
 
 private:
@@ -84,6 +87,9 @@ private:
     GLuint _weights;
     GLuint _duWeights;
     GLuint _dvWeights;
+    GLuint _duuWeights;
+    GLuint _duvWeights;
+    GLuint _dvvWeights;
     int _numStencils;
 };
 
@@ -97,16 +103,32 @@ public:
                                    BufferDescriptor const &duDesc,
                                    BufferDescriptor const &dvDesc,
                                    void * deviceContext = NULL) {
+        return Create(srcDesc, dstDesc, duDesc, dvDesc,
+                      BufferDescriptor(),
+                      BufferDescriptor(),
+                      BufferDescriptor(),
+                      deviceContext);
+    }
+
+    static GLXFBEvaluator * Create(BufferDescriptor const &srcDesc,
+                                   BufferDescriptor const &dstDesc,
+                                   BufferDescriptor const &duDesc,
+                                   BufferDescriptor const &dvDesc,
+                                   BufferDescriptor const &duuDesc,
+                                   BufferDescriptor const &duvDesc,
+                                   BufferDescriptor const &dvvDesc,
+                                   void * deviceContext = NULL) {
         (void)deviceContext;  // not used
         GLXFBEvaluator *instance = new GLXFBEvaluator();
-        if (instance->Compile(srcDesc, dstDesc, duDesc, dvDesc))
+        if (instance->Compile(srcDesc, dstDesc, duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc))
             return instance;
         delete instance;
         return NULL;
     }
 
     /// Constructor.
-    GLXFBEvaluator();
+    GLXFBEvaluator(bool sharedDerivativeBuffers = false);
 
     /// Destructor. note that the GL context must be made current.
     ~GLXFBEvaluator();
@@ -245,6 +267,107 @@ public:
         }
     }
 
+    /// \brief Generic static stencil function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        transparently from OsdMesh template interface.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the dstBuffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param stencilTable   stencil table to be applied. The table must have
+    ///                       Texture Buffer Object interfaces.
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLSLTransformFeedback kernel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+    static bool EvalStencils(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        STENCIL_TABLE const *stencilTable,
+        GLXFBEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalStencils(srcBuffer, srcDesc,
+                                          dstBuffer, dstDesc,
+                                          duBuffer,  duDesc,
+                                          dvBuffer,  dvDesc,
+                                          duuBuffer, duuDesc,
+                                          duvBuffer, duvDesc,
+                                          dvvBuffer, dvvDesc,
+                                          stencilTable);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc);
+            if (instance) {
+                bool r = instance->EvalStencils(srcBuffer, srcDesc,
+                                                dstBuffer, dstDesc,
+                                                duBuffer,  duDesc,
+                                                dvBuffer,  dvDesc,
+                                                duuBuffer, duuDesc,
+                                                duvBuffer, duvDesc,
+                                                dvvBuffer, dvvDesc,
+                                                stencilTable);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
     /// \brief Generic stencil function.
     ///
     /// @param srcBuffer      Input primvar buffer.
@@ -333,6 +456,84 @@ public:
                             /* end   = */ stencilTable->GetNumStencils());
     }
 
+    /// \brief Generic stencil function.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the dstBuffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param stencilTable   stencil table to be applied. The table must have
+    ///                       Texture Buffer Object interfaces.
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+    bool EvalStencils(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        STENCIL_TABLE const *stencilTable) const {
+
+        return EvalStencils(srcBuffer->BindVBO(), srcDesc,
+                            dstBuffer->BindVBO(), dstDesc,
+                            duBuffer->BindVBO(),  duDesc,
+                            dvBuffer->BindVBO(),  dvDesc,
+                            duuBuffer->BindVBO(), duuDesc,
+                            duvBuffer->BindVBO(), duvDesc,
+                            dvvBuffer->BindVBO(), dvvDesc,
+                            stencilTable->GetSizesTexture(),
+                            stencilTable->GetOffsetsTexture(),
+                            stencilTable->GetIndicesTexture(),
+                            stencilTable->GetWeightsTexture(),
+                            stencilTable->GetDuWeightsTexture(),
+                            stencilTable->GetDvWeightsTexture(),
+                            stencilTable->GetDuuWeightsTexture(),
+                            stencilTable->GetDuvWeightsTexture(),
+                            stencilTable->GetDvvWeightsTexture(),
+                            /* start = */ 0,
+                            /* end   = */ stencilTable->GetNumStencils());
+    }
+
     /// \brief Dispatch the GLSL XFB kernel on on GPU asynchronously
     /// returns false if the kernel hasn't been compiled yet.
     ///
@@ -378,6 +579,78 @@ public:
                       GLuint weightsBuffer,
                       GLuint duWeightsBuffer,
                       GLuint dvWeightsBuffer,
+                      int start,
+                      int end) const;
+
+    /// \brief Dispatch the GLSL XFB kernel on on GPU asynchronously
+    /// returns false if the kernel hasn't been compiled yet.
+    ///
+    /// @param srcBuffer        GL buffer of input primvar source data
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the srcBuffer
+    ///
+    /// @param dstBuffer        GL buffer of output primvar destination data
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the dstBuffer
+    ///
+    /// @param duBuffer         GL buffer of output derivative wrt u
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         GL buffer of output derivative wrt v
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        GL buffer of output 2nd derivative wrt u
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        GL buffer of output 2nd derivative wrt u and v
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        GL buffer of output 2nd derivative wrt v
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param sizesBuffer      GL buffer of the sizes in the stencil table
+    ///
+    /// @param offsetsBuffer    GL buffer of the offsets in the stencil table
+    ///
+    /// @param indicesBuffer    GL buffer of the indices in the stencil table
+    ///
+    /// @param weightsBuffer    GL buffer of the weights in the stencil table
+    ///
+    /// @param duWeightsBuffer  GL buffer of the du weights in the stencil table
+    ///
+    /// @param dvWeightsBuffer  GL buffer of the dv weights in the stencil table
+    ///
+    /// @param duuWeightsBuffer GL buffer of the duu weights in the stencil table
+    ///
+    /// @param duvWeightsBuffer GL buffer of the duv weights in the stencil table
+    ///
+    /// @param dvvWeightsBuffer GL buffer of the dvv weights in the stencil table
+    ///
+    /// @param start            start index of stencil table
+    ///
+    /// @param end              end index of stencil table
+    ///
+    bool EvalStencils(GLuint srcBuffer, BufferDescriptor const &srcDesc,
+                      GLuint dstBuffer, BufferDescriptor const &dstDesc,
+                      GLuint duBuffer,  BufferDescriptor const &duDesc,
+                      GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+                      GLuint duuBuffer, BufferDescriptor const &duuDesc,
+                      GLuint duvBuffer, BufferDescriptor const &duvDesc,
+                      GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
+                      GLuint sizesBuffer,
+                      GLuint offsetsBuffer,
+                      GLuint indicesBuffer,
+                      GLuint weightsBuffer,
+                      GLuint duWeightsBuffer,
+                      GLuint dvWeightsBuffer,
+                      GLuint duuWeightsBuffer,
+                      GLuint duvWeightsBuffer,
+                      GLuint dvvWeightsBuffer,
                       int start,
                       int end) const;
 
@@ -551,6 +824,117 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatches(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        GLXFBEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatches(srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         duuBuffer, duuDesc,
+                                         duvBuffer, duvDesc,
+                                         dvvBuffer, dvvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc);
+            if (instance) {
+                bool r = instance->EvalPatches(srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               duuBuffer, duuDesc,
+                                               duvBuffer, duvDesc,
+                                               dvvBuffer, dvvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
     /// @param numPatchCoords number of patchCoords.
     ///
     /// @param patchCoords    array of locations to be evaluated.
@@ -635,10 +1019,103 @@ public:
                            patchTable->GetPatchParamTextureBuffer());
     }
 
+    /// \brief Generic limit eval function with derivatives. This function has
+    ///        a same signature as other device kernels have so that it can be
+    ///        called in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of source data
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       GLPatchTable or equivalent
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatches(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           duBuffer->BindVBO(),  duDesc,
+                           dvBuffer->BindVBO(),  dvDesc,
+                           duuBuffer->BindVBO(), duuDesc,
+                           duvBuffer->BindVBO(), duvDesc,
+                           dvvBuffer->BindVBO(), dvvDesc,
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetPatchArrays(),
+                           patchTable->GetPatchIndexTextureBuffer(),
+                           patchTable->GetPatchParamTextureBuffer());
+    }
+
     bool EvalPatches(GLuint srcBuffer, BufferDescriptor const &srcDesc,
                      GLuint dstBuffer, BufferDescriptor const &dstDesc,
                      GLuint duBuffer,  BufferDescriptor const &duDesc,
                      GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+                     int numPatchCoords,
+                     GLuint patchCoordsBuffer,
+                     const PatchArrayVector &patchArrays,
+                     GLuint patchIndexBuffer,
+                     GLuint patchParamsBuffer) const;
+
+    bool EvalPatches(GLuint srcBuffer, BufferDescriptor const &srcDesc,
+                     GLuint dstBuffer, BufferDescriptor const &dstDesc,
+                     GLuint duBuffer,  BufferDescriptor const &duDesc,
+                     GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+                     GLuint duuBuffer, BufferDescriptor const &duuDesc,
+                     GLuint duvBuffer, BufferDescriptor const &duvDesc,
+                     GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
                      int numPatchCoords,
                      GLuint patchCoordsBuffer,
                      const PatchArrayVector &patchArrays,
@@ -773,6 +1250,344 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        GLXFBEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc);
+            if (instance) {
+                bool r = instance->EvalPatchesVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           duBuffer->BindVBO(), duDesc,
+                           dvBuffer->BindVBO(), dvDesc,
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetVaryingPatchArrays(),
+                           patchTable->GetVaryingPatchIndexTextureBuffer(),
+                           patchTable->GetPatchParamTextureBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        GLXFBEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         duuBuffer, duuDesc,
+                                         duvBuffer, duvDesc,
+                                         dvvBuffer, dvvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc);
+            if (instance) {
+                bool r = instance->EvalPatchesVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               duuBuffer, duuDesc,
+                                               duvBuffer, duvDesc,
+                                               dvvBuffer, dvvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           duBuffer->BindVBO(), duDesc,
+                           dvBuffer->BindVBO(), dvDesc,
+                           duuBuffer->BindVBO(), duuDesc,
+                           duvBuffer->BindVBO(), duvDesc,
+                           dvvBuffer->BindVBO(), dvvDesc,
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetVaryingPatchArrays(),
+                           patchTable->GetVaryingPatchIndexTextureBuffer(),
+                           patchTable->GetPatchParamTextureBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
     /// @param numPatchCoords number of patchCoords.
     ///
     /// @param patchCoords    array of locations to be evaluated.
@@ -875,6 +1690,356 @@ public:
                            patchTable->GetFVarPatchParamTextureBuffer(fvarChannel));
     }
 
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        GLXFBEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesFaceVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable, fvarChannel);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc);
+            if (instance) {
+                bool r = instance->EvalPatchesFaceVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable, fvarChannel);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel = 0) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           duBuffer->BindVBO(), duDesc,
+                           dvBuffer->BindVBO(), dvDesc,
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetFVarPatchArrays(fvarChannel),
+                           patchTable->GetFVarPatchIndexTextureBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamTextureBuffer(fvarChannel));
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    /// @param instance       cached compiled instance. Clients are supposed to
+    ///                       pre-compile an instance of this class and provide
+    ///                       to this function. If it's null the kernel still
+    ///                       compute by instantiating on-demand kernel although
+    ///                       it may cause a performance problem.
+    ///
+    /// @param deviceContext  not used in the GLXFB evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        GLXFBEvaluator const *instance,
+        void * deviceContext = NULL) {
+
+        if (instance) {
+            return instance->EvalPatchesFaceVarying(
+                                         srcBuffer, srcDesc,
+                                         dstBuffer, dstDesc,
+                                         duBuffer, duDesc,
+                                         dvBuffer, dvDesc,
+                                         duuBuffer, duuDesc,
+                                         duvBuffer, duvDesc,
+                                         dvvBuffer, dvvDesc,
+                                         numPatchCoords, patchCoords,
+                                         patchTable, fvarChannel);
+        } else {
+            // Create an instance on demand (slow)
+            (void)deviceContext;  // unused
+            instance = Create(srcDesc, dstDesc,
+                              duDesc, dvDesc,
+                              duuDesc, duvDesc, dvvDesc);
+            if (instance) {
+                bool r = instance->EvalPatchesFaceVarying(
+                                               srcBuffer, srcDesc,
+                                               dstBuffer, dstDesc,
+                                               duBuffer, duDesc,
+                                               dvBuffer, dvDesc,
+                                               duuBuffer, duuDesc,
+                                               duvBuffer, duvDesc,
+                                               dvvBuffer, dvvDesc,
+                                               numPatchCoords, patchCoords,
+                                               patchTable, fvarChannel);
+                delete instance;
+                return r;
+            }
+            return false;
+        }
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords number of patchCoords.
+    ///
+    /// @param patchCoords    array of locations to be evaluated.
+    ///                       must have BindVBO() method returning an
+    ///                       array of PatchCoord struct in VBO.
+    ///
+    /// @param patchTable     GLPatchTable or equivalent
+    ///
+    /// @param fvarChannel    face-varying channel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel = 0) const {
+
+        return EvalPatches(srcBuffer->BindVBO(), srcDesc,
+                           dstBuffer->BindVBO(), dstDesc,
+                           duBuffer->BindVBO(), duDesc,
+                           dvBuffer->BindVBO(), dvDesc,
+                           duuBuffer->BindVBO(), duuDesc,
+                           duvBuffer->BindVBO(), duvDesc,
+                           dvvBuffer->BindVBO(), dvvDesc,
+                           numPatchCoords,
+                           patchCoords->BindVBO(),
+                           patchTable->GetFVarPatchArrays(fvarChannel),
+                           patchTable->GetFVarPatchIndexTextureBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamTextureBuffer(fvarChannel));
+    }
+
     /// ----------------------------------------------------------------------
     ///
     ///   Other methods
@@ -885,14 +2050,18 @@ public:
     /// calling this function. Returns false if it fails to compile the kernel.
     bool Compile(BufferDescriptor const &srcDesc,
                  BufferDescriptor const &dstDesc,
-                 BufferDescriptor const &duDesc,
-                 BufferDescriptor const &dvDesc);
+                 BufferDescriptor const &duDesc = BufferDescriptor(),
+                 BufferDescriptor const &dvDesc = BufferDescriptor(),
+                 BufferDescriptor const &duuDesc = BufferDescriptor(),
+                 BufferDescriptor const &duvDesc = BufferDescriptor(),
+                 BufferDescriptor const &dvvDesc = BufferDescriptor());
 
     /// Wait the dispatched kernel finishes.
     static void Synchronize(void *kernel);
 
 private:
     GLuint _srcBufferTexture;
+    bool _sharedDerivativeBuffers;
 
     struct _StencilKernel {
         _StencilKernel();
@@ -900,7 +2069,11 @@ private:
         bool Compile(BufferDescriptor const &srcDesc,
                      BufferDescriptor const &dstDesc,
                      BufferDescriptor const &duDesc,
-                     BufferDescriptor const &dvDesc);
+                     BufferDescriptor const &dvDesc,
+                     BufferDescriptor const &duuDesc,
+                     BufferDescriptor const &duvDesc,
+                     BufferDescriptor const &dvvDesc,
+                     bool sharedDerivativeBuffers);
         GLuint program;
         GLint uniformSrcBufferTexture;
         GLint uniformSrcOffset;    // src buffer offset (in elements)
@@ -911,6 +2084,9 @@ private:
         GLint uniformWeightsTexture;
         GLint uniformDuWeightsTexture;
         GLint uniformDvWeightsTexture;
+        GLint uniformDuuWeightsTexture;
+        GLint uniformDuvWeightsTexture;
+        GLint uniformDvvWeightsTexture;
         GLint uniformStart;     // range
         GLint uniformEnd;
     } _stencilKernel;
@@ -921,7 +2097,11 @@ private:
         bool Compile(BufferDescriptor const &srcDesc,
                      BufferDescriptor const &dstDesc,
                      BufferDescriptor const &duDesc,
-                     BufferDescriptor const &dvDesc);
+                     BufferDescriptor const &dvDesc,
+                     BufferDescriptor const &duuDesc,
+                     BufferDescriptor const &duvDesc,
+                     BufferDescriptor const &dvvDesc,
+                     bool sharedDerivativeBuffers);
         GLuint program;
         GLint uniformSrcBufferTexture;
         GLint uniformSrcOffset;    // src buffer offset (in elements)

--- a/opensubdiv/osd/glXFBEvaluator.h
+++ b/opensubdiv/osd/glXFBEvaluator.h
@@ -122,14 +122,14 @@ public:
     ///        transparently from OsdMesh template interface.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindVBO() method returning a
-    ///                       const float pointer for read
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindVBO() method returning a
-    ///                       float pointer for write
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
@@ -178,28 +178,28 @@ public:
     ///        transparently from OsdMesh template interface.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindVBO() method returning a
-    ///                       const float pointer for read
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindVBO() method returning a
-    ///                       float pointer for write
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
-    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    /// @param dstDesc        vertex buffer descriptor for the dstBuffer
     ///
-    /// @param duBuffer       Output U-derivative buffer
-    ///                       must have BindVBO() method returning a
-    ///                       float pointer for write
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
-    /// @param duDesc         vertex buffer descriptor for the du output buffer
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer       Output V-derivative buffer
-    ///                       must have BindVBO() method returning a
-    ///                       float pointer for write
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
-    /// @param dvDesc         vertex buffer descriptor for the dv output buffer
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
     /// @param stencilTable   stencil table to be applied. The table must have
     ///                       Texture Buffer Object interfaces.
@@ -216,8 +216,8 @@ public:
     static bool EvalStencils(
         SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
         DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
-        DST_BUFFER *duBuffer, BufferDescriptor const &duDesc,
-        DST_BUFFER *dvBuffer, BufferDescriptor const &dvDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
         STENCIL_TABLE const *stencilTable,
         GLXFBEvaluator const *instance,
         void * deviceContext = NULL) {
@@ -235,8 +235,8 @@ public:
             if (instance) {
                 bool r = instance->EvalStencils(srcBuffer, srcDesc,
                                                 dstBuffer, dstDesc,
-                                                duBuffer, duDesc,
-                                                dvBuffer, dvDesc,
+                                                duBuffer,  duDesc,
+                                                dvBuffer,  dvDesc,
                                                 stencilTable);
                 delete instance;
                 return r;
@@ -245,7 +245,7 @@ public:
         }
     }
 
-    /// \brief Generic eval stencils function.
+    /// \brief Generic stencil function.
     ///
     /// @param srcBuffer      Input primvar buffer.
     ///                       must have BindVBO() method returning a GL
@@ -255,11 +255,12 @@ public:
     ///
     /// @param dstBuffer      Output primvar buffer
     ///                       must have BindVBO() method returning a GL
-    ///                       buffer object for destination data
+    ///                       buffer object of destination data
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param stencilTable   stencil table to be applied.
+    /// @param stencilTable   stencil table to be applied. The table must have
+    ///                       Texture Buffer Object interfaces.
     ///
     template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
     bool EvalStencils(
@@ -281,7 +282,7 @@ public:
                             /* end   = */ stencilTable->GetNumStencils());
     }
 
-    /// \brief Generic eval stencils function with derivative evaluation.
+    /// \brief Generic stencil function.
     ///
     /// @param srcBuffer      Input primvar buffer.
     ///                       must have BindVBO() method returning a GL
@@ -291,19 +292,24 @@ public:
     ///
     /// @param dstBuffer      Output primvar buffer
     ///                       must have BindVBO() method returning a GL
-    ///                       buffer object for destination data
+    ///                       buffer object of destination data
     ///
-    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    /// @param dstDesc        vertex buffer descriptor for the dstBuffer
     ///
-    /// @param duBuffer       GL buffer of output U-derivatives.
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer       GL buffer of output V-derivatives.
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
-    /// @param stencilTable   stencil table to be applied.
+    /// @param stencilTable   stencil table to be applied. The table must have
+    ///                       Texture Buffer Object interfaces.
     ///
     template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
     bool EvalStencils(
@@ -327,40 +333,40 @@ public:
                             /* end   = */ stencilTable->GetNumStencils());
     }
 
-    /// \brief dispatch eval stencils function with derivatives.
-    ///        dispatch the GLSL XFB kernel on GPU asynchronously.
+    /// \brief Dispatch the GLSL XFB kernel on on GPU asynchronously
+    /// returns false if the kernel hasn't been compiled yet.
     ///
-    /// @param srcBuffer       GL buffer of input primvars.
+    /// @param srcBuffer        GL buffer of input primvar source data
     ///
-    /// @param srcDesc         vertex buffer descriptor for the srcBuffer
+    /// @param srcDesc          vertex buffer descriptor for the srcBuffer
     ///
-    /// @param dstBuffer       GL buffer of output primvars.
+    /// @param dstBuffer        GL buffer of output primvar destination data
     ///
-    /// @param dstDesc         vertex buffer descriptor for the dstBuffer
+    /// @param dstDesc          vertex buffer descriptor for the dstBuffer
     ///
-    /// @param duBuffer        GL buffer of output U-derivatives.
+    /// @param duBuffer         GL buffer of output derivative wrt u
     ///
-    /// @param duDesc          vertex buffer descriptor for the duBuffer
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer        GL buffer of output V-derivatives.
+    /// @param dvBuffer         GL buffer of output derivative wrt v
     ///
-    /// @param dvDesc          vertex buffer descriptor for the dvBuffer
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
     ///
-    /// @param sizesBuffer     GL buffer of the sizes in the stencil table
+    /// @param sizesBuffer      GL buffer of the sizes in the stencil table
     ///
-    /// @param offsetsBuffer   GL buffer of the offsets in the stencil table
+    /// @param offsetsBuffer    GL buffer of the offsets in the stencil table
     ///
-    /// @param indicesBuffer   GL buffer of the indices in the stencil table
+    /// @param indicesBuffer    GL buffer of the indices in the stencil table
     ///
-    /// @param weightsBuffer   GL buffer of the weights in the stencil table
+    /// @param weightsBuffer    GL buffer of the weights in the stencil table
     ///
-    /// @param duWeightsBuffer GL buffer of the du weights in the stencil table
+    /// @param duWeightsBuffer  GL buffer of the du weights in the stencil table
     ///
-    /// @param dvWeightsBuffer GL buffer of the dv weights in the stencil table
+    /// @param dvWeightsBuffer  GL buffer of the dv weights in the stencil table
     ///
-    /// @param start           start index of stencil table
+    /// @param start            start index of stencil table
     ///
-    /// @param end             end index of stencil table
+    /// @param end              end index of stencil table
     ///
     bool EvalStencils(GLuint srcBuffer, BufferDescriptor const &srcDesc,
                       GLuint dstBuffer, BufferDescriptor const &dstDesc,
@@ -463,13 +469,17 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
-    /// @param duDesc
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
-    /// @param dvDesc
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
     /// @param numPatchCoords number of patchCoords.
     ///
@@ -530,14 +540,14 @@ public:
     ///        in the same way.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindVBO() method returning a
-    ///                       const float pointer for read
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindVBO() method returning a
-    ///                       float pointer for write
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
@@ -545,7 +555,7 @@ public:
     ///
     /// @param patchCoords    array of locations to be evaluated.
     ///                       must have BindVBO() method returning an
-    ///                       array of PatchCoord struct in cuda memory.
+    ///                       array of PatchCoord struct in VBO.
     ///
     /// @param patchTable     GLPatchTable or equivalent
     ///
@@ -574,26 +584,26 @@ public:
     ///        called in the same way.
     ///
     /// @param srcBuffer        Input primvar buffer.
-    ///                         must have BindVBO() method returning a
-    ///                         const float pointer for read
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of source data
     ///
     /// @param srcDesc          vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer        Output primvar buffer
-    ///                         must have BindVBO() method returning a
-    ///                         float pointer for write
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer         Output s-derivatives buffer
-    ///                         must have BindVBO() method returning a
-    ///                         float pointer for write
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
     ///
     /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer         Output t-derivatives buffer
-    ///                         must have BindVBO() method returning a
-    ///                         float pointer for write
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindVBO() method returning a GL
+    ///                         buffer object of destination data
     ///
     /// @param dvDesc           vertex buffer descriptor for the dvBuffer
     ///
@@ -627,15 +637,14 @@ public:
 
     bool EvalPatches(GLuint srcBuffer, BufferDescriptor const &srcDesc,
                      GLuint dstBuffer, BufferDescriptor const &dstDesc,
-                     GLuint duBuffer, BufferDescriptor const &duDesc,
-                     GLuint dvBuffer, BufferDescriptor const &dvDesc,
+                     GLuint duBuffer,  BufferDescriptor const &duDesc,
+                     GLuint dvBuffer,  BufferDescriptor const &dvDesc,
                      int numPatchCoords,
                      GLuint patchCoordsBuffer,
                      const PatchArrayVector &patchArrays,
                      GLuint patchIndexBuffer,
                      GLuint patchParamsBuffer) const;
 
-    ///
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
     ///        in the same way.
@@ -709,14 +718,14 @@ public:
     ///        in the same way.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindVBO() method returning a
-    ///                       const float pointer for read
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindVBO() method returning a
-    ///                       float pointer for write
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
@@ -724,7 +733,7 @@ public:
     ///
     /// @param patchCoords    array of locations to be evaluated.
     ///                       must have BindVBO() method returning an
-    ///                       array of PatchCoord struct in cuda memory.
+    ///                       array of PatchCoord struct in VBO.
     ///
     /// @param patchTable     GLPatchTable or equivalent
     ///
@@ -748,7 +757,6 @@ public:
                            patchTable->GetPatchParamTextureBuffer());
     }
 
-    ///
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
     ///        in the same way.
@@ -825,14 +833,14 @@ public:
     ///        in the same way.
     ///
     /// @param srcBuffer      Input primvar buffer.
-    ///                       must have BindVBO() method returning a
-    ///                       const float pointer for read
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of source data
     ///
     /// @param srcDesc        vertex buffer descriptor for the input buffer
     ///
     /// @param dstBuffer      Output primvar buffer
-    ///                       must have BindVBO() method returning a
-    ///                       float pointer for write
+    ///                       must have BindVBO() method returning a GL
+    ///                       buffer object of destination data
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
@@ -840,7 +848,7 @@ public:
     ///
     /// @param patchCoords    array of locations to be evaluated.
     ///                       must have BindVBO() method returning an
-    ///                       array of PatchCoord struct in cuda memory.
+    ///                       array of PatchCoord struct in VBO.
     ///
     /// @param patchTable     GLPatchTable or equivalent
     ///

--- a/opensubdiv/osd/glslXFBKernel.glsl
+++ b/opensubdiv/osd/glslXFBKernel.glsl
@@ -63,7 +63,22 @@ void writeVertex(Vertex v) {
 
 //------------------------------------------------------------------------------
 
-#if defined(OPENSUBDIV_GLSL_XFB_USE_DERIVATIVES)
+#if defined(OPENSUBDIV_GLSL_XFB_USE_1ST_DERIVATIVES) && \
+    defined(OPENSUBDIV_GLSL_XFB_SHARED_1ST_DERIVATIVE_BUFFERS)
+out float outDeriv1Buffer[2*LENGTH];
+
+void writeDu(Vertex v) {
+    for(int i = 0; i < LENGTH; i++) {
+        outDeriv1Buffer[i] = v.vertexData[i];
+    }
+}
+
+void writeDv(Vertex v) {
+    for(int i = 0; i < LENGTH; i++) {
+        outDeriv1Buffer[i+LENGTH] = v.vertexData[i];
+    }
+}
+#elif defined(OPENSUBDIV_GLSL_XFB_USE_1ST_DERIVATIVES)
 out float outDuBuffer[LENGTH];
 out float outDvBuffer[LENGTH];
 
@@ -80,6 +95,51 @@ void writeDv(Vertex v) {
 }
 #endif
 
+#if defined(OPENSUBDIV_GLSL_XFB_USE_2ND_DERIVATIVES) && \
+    defined(OPENSUBDIV_GLSL_XFB_SHARED_2ND_DERIVATIVE_BUFFERS)
+out float outDeriv2Buffer[3*LENGTH];
+
+void writeDuu(Vertex v) {
+    for(int i = 0; i < LENGTH; i++) {
+        outDeriv2Buffer[i] = v.vertexData[i];
+    }
+}
+
+void writeDuv(Vertex v) {
+    for(int i = 0; i < LENGTH; i++) {
+        outDeriv2Buffer[i+LENGTH] = v.vertexData[i];
+    }
+}
+
+void writeDvv(Vertex v) {
+    for(int i = 0; i < LENGTH; i++) {
+        outDeriv2Buffer[i+2*LENGTH] = v.vertexData[i];
+    }
+}
+#elif defined(OPENSUBDIV_GLSL_XFB_USE_2ND_DERIVATIVES)
+out float outDuuBuffer[LENGTH];
+out float outDuvBuffer[LENGTH];
+out float outDvvBuffer[LENGTH];
+
+void writeDuu(Vertex v) {
+    for(int i = 0; i < LENGTH; i++) {
+        outDuuBuffer[i] = v.vertexData[i];
+    }
+}
+
+void writeDuv(Vertex v) {
+    for(int i = 0; i < LENGTH; i++) {
+        outDuvBuffer[i] = v.vertexData[i];
+    }
+}
+
+void writeDvv(Vertex v) {
+    for(int i = 0; i < LENGTH; i++) {
+        outDvvBuffer[i] = v.vertexData[i];
+    }
+}
+#endif
+
 //------------------------------------------------------------------------------
 
 #if defined(OPENSUBDIV_GLSL_XFB_KERNEL_EVAL_STENCILS)
@@ -89,9 +149,15 @@ uniform isamplerBuffer offsets;
 uniform isamplerBuffer indices;
 uniform samplerBuffer  weights;
 
-#if defined(OPENSUBDIV_GLSL_XFB_USE_DERIVATIVES)
+#if defined(OPENSUBDIV_GLSL_XFB_USE_1ST_DERIVATIVES)
 uniform samplerBuffer  duWeights;
 uniform samplerBuffer  dvWeights;
+#endif
+
+#if defined(OPENSUBDIV_GLSL_XFB_USE_2ND_DERIVATIVES)
+uniform samplerBuffer  duuWeights;
+uniform samplerBuffer  duvWeights;
+uniform samplerBuffer  dvvWeights;
 #endif
 
 uniform int batchStart = 0;
@@ -104,10 +170,13 @@ void main() {
         return;
     }
 
-    Vertex dst, du, dv;
+    Vertex dst, du, dv, duu, duv, dvv;
     clear(dst);
     clear(du);
     clear(dv);
+    clear(duu);
+    clear(duv);
+    clear(dvv);
 
     int offset = texelFetch(offsets, current).x;
     uint size = texelFetch(sizes, current).x;
@@ -117,18 +186,31 @@ void main() {
         float weight = texelFetch(weights, offset+stencil).x;
         addWithWeight(dst, readVertex( index ), weight);
 
-#if defined(OPENSUBDIV_GLSL_XFB_USE_DERIVATIVES)
+#if defined(OPENSUBDIV_GLSL_XFB_USE_1ST_DERIVATIVES)
         float duWeight = texelFetch(duWeights, offset+stencil).x;
         float dvWeight = texelFetch(dvWeights, offset+stencil).x;
         addWithWeight(du,  readVertex(index), duWeight);
         addWithWeight(dv,  readVertex(index), dvWeight);
 #endif
+#if defined(OPENSUBDIV_GLSL_XFB_USE_2ND_DERIVATIVES)
+        float duuWeight = texelFetch(duuWeights, offset+stencil).x;
+        float duvWeight = texelFetch(duvWeights, offset+stencil).x;
+        float dvvWeight = texelFetch(dvvWeights, offset+stencil).x;
+        addWithWeight(duu,  readVertex(index), duuWeight);
+        addWithWeight(duv,  readVertex(index), duvWeight);
+        addWithWeight(dvv,  readVertex(index), dvvWeight);
+#endif
     }
     writeVertex(dst);
 
-#if defined(OPENSUBDIV_GLSL_XFB_USE_DERIVATIVES)
+#if defined(OPENSUBDIV_GLSL_XFB_USE_1ST_DERIVATIVES)
     writeDu(du);
     writeDv(dv);
+#endif
+#if defined(OPENSUBDIV_GLSL_XFB_USE_2ND_DERIVATIVES)
+    writeDuu(duu);
+    writeDuv(duv);
+    writeDvv(dvv);
 #endif
 }
 
@@ -213,31 +295,43 @@ void main() {
     int numControlVertices = 0;
     if (patchType == 3) {
         float wP4[4], wDs4[4], wDt4[4], wDss4[4], wDst4[4], wDtt4[4];
-        OsdGetBilinearPatchWeights(coord.s, coord.t, dScale, wP4, wDs4, wDt4, wDss4, wDst4, wDtt4);
+        OsdGetBilinearPatchWeights(coord.s, coord.t, dScale, wP4,
+                                   wDs4, wDt4, wDss4, wDst4, wDtt4);
         numControlVertices = 4;
         for (int i=0; i<numControlVertices; ++i) {
             wP[i] = wP4[i];
             wDs[i] = wDs4[i];
             wDt[i] = wDt4[i];
+            wDss[i] = wDss4[i];
+            wDst[i] = wDst4[i];
+            wDtt[i] = wDtt4[i];
         }
     } else if (patchType == 6) {
         float wP16[16], wDs16[16], wDt16[16], wDss16[16], wDst16[16], wDtt16[16];
-        OsdGetBSplinePatchWeights(coord.s, coord.t, dScale, boundary, wP16, wDs16, wDt16, wDss16, wDst16, wDtt16);
+        OsdGetBSplinePatchWeights(coord.s, coord.t, dScale, boundary, wP16,
+                                  wDs16, wDt16, wDss16, wDst16, wDtt16);
         numControlVertices = 16;
         for (int i=0; i<numControlVertices; ++i) {
             wP[i] = wP16[i];
             wDs[i] = wDs16[i];
             wDt[i] = wDt16[i];
+            wDss[i] = wDss16[i];
+            wDst[i] = wDst16[i];
+            wDtt[i] = wDtt16[i];
         }
     } else if (patchType == 9) {
-        OsdGetGregoryPatchWeights(coord.s, coord.t, dScale, wP, wDs, wDt, wDss, wDst, wDtt);
+        OsdGetGregoryPatchWeights(coord.s, coord.t, dScale, wP,
+                                  wDs, wDt, wDss, wDst, wDtt);
         numControlVertices = 20;
     }
 
-    Vertex dst, du, dv;
+    Vertex dst, du, dv, duu, duv, dvv;
     clear(dst);
     clear(du);
     clear(dv);
+    clear(duu);
+    clear(duv);
+    clear(dvv);
 
     int indexStride = getNumControlVertices(array.x);
     int indexBase = array.z + indexStride * (patchIndex - array.w);
@@ -247,15 +341,22 @@ void main() {
         addWithWeight(dst, readVertex(index), wP[cv]);
         addWithWeight(du,  readVertex(index), wDs[cv]);
         addWithWeight(dv,  readVertex(index), wDt[cv]);
+        addWithWeight(duu, readVertex(index), wDss[cv]);
+        addWithWeight(duv, readVertex(index), wDst[cv]);
+        addWithWeight(dvv, readVertex(index), wDtt[cv]);
     }
 
     writeVertex(dst);
 
-#if defined(OPENSUBDIV_GLSL_XFB_USE_DERIVATIVES)
+#if defined(OPENSUBDIV_GLSL_XFB_USE_1ST_DERIVATIVES)
     writeDu(du);
     writeDv(dv);
 #endif
-
+#if defined(OPENSUBDIV_GLSL_XFB_USE_2ND_DERIVATIVES)
+    writeDuu(duu);
+    writeDuv(duv);
+    writeDvv(dvv);
+#endif
 }
 
 #endif

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -175,7 +175,7 @@ convertToCompatibleStencilTable<Far::StencilTable, Far::StencilTable, ID3D11Devi
 // ---------------------------------------------------------------------------
 
 // Osd evaluator cache: for the GPU backends require compiled instance
-//   (GLXFB, GLCompue, CL)
+//   (GLXFB, GLCompute, CL)
 //
 // note: this is just an example usage and client applications are supposed
 //       to implement their own structure for Evaluator instance.
@@ -197,8 +197,27 @@ public:
               BufferDescriptor const &duDescArg,
               BufferDescriptor const &dvDescArg,
               EVALUATOR *evalArg) : srcDesc(srcDescArg), dstDesc(dstDescArg),
-                              duDesc(duDescArg), dvDesc(dvDescArg), evaluator(evalArg) {}
-        BufferDescriptor srcDesc, dstDesc, duDesc, dvDesc;
+                              duDesc(duDescArg), dvDesc(dvDescArg),
+                              duuDesc(BufferDescriptor()),
+                              duvDesc(BufferDescriptor()),
+                              dvvDesc(BufferDescriptor()),
+                              evaluator(evalArg) {}
+        Entry(BufferDescriptor const &srcDescArg,
+              BufferDescriptor const &dstDescArg,
+              BufferDescriptor const &duDescArg,
+              BufferDescriptor const &dvDescArg,
+              BufferDescriptor const &duuDescArg,
+              BufferDescriptor const &duvDescArg,
+              BufferDescriptor const &dvvDescArg,
+              EVALUATOR *evalArg) : srcDesc(srcDescArg), dstDesc(dstDescArg),
+                              duDesc(duDescArg), dvDesc(dvDescArg),
+                              duuDesc(duuDescArg),
+                              duvDesc(duvDescArg),
+                              dvvDesc(dvvDescArg),
+                              evaluator(evalArg) {}
+        BufferDescriptor srcDesc, dstDesc;
+        BufferDescriptor duDesc, dvDesc;
+        BufferDescriptor duuDesc, duvDesc, dvvDesc;
         EVALUATOR *evaluator;
     };
     typedef std::vector<Entry> Evaluators;
@@ -210,6 +229,9 @@ public:
         return GetEvaluator(srcDesc, dstDesc,
                             BufferDescriptor(),
                             BufferDescriptor(),
+                            BufferDescriptor(),
+                            BufferDescriptor(),
+                            BufferDescriptor(),
                             deviceContext);
     }
 
@@ -219,20 +241,43 @@ public:
                             BufferDescriptor const &duDesc,
                             BufferDescriptor const &dvDesc,
                             DEVICE_CONTEXT *deviceContext) {
+        return GetEvaluator(srcDesc, dstDesc,
+                            duDesc, dvDesc,
+                            BufferDescriptor(),
+                            BufferDescriptor(),
+                            BufferDescriptor(),
+                            deviceContext);
+    }
+
+    template <typename DEVICE_CONTEXT>
+    EVALUATOR *GetEvaluator(BufferDescriptor const &srcDesc,
+                            BufferDescriptor const &dstDesc,
+                            BufferDescriptor const &duDesc,
+                            BufferDescriptor const &dvDesc,
+                            BufferDescriptor const &duuDesc,
+                            BufferDescriptor const &duvDesc,
+                            BufferDescriptor const &dvvDesc,
+                            DEVICE_CONTEXT *deviceContext) {
 
         for(typename Evaluators::iterator it = _evaluators.begin();
             it != _evaluators.end(); ++it) {
             if (isEqual(srcDesc, it->srcDesc) &&
                 isEqual(dstDesc, it->dstDesc) &&
-                isEqual(duDesc, it->duDesc) &&
-                isEqual(dvDesc, it->dvDesc)) {
+                isEqual(duDesc,  it->duDesc) &&
+                isEqual(dvDesc,  it->dvDesc) &&
+                isEqual(duuDesc, it->duuDesc) &&
+                isEqual(duvDesc, it->duvDesc) &&
+                isEqual(dvvDesc, it->dvvDesc)) {
                 return it->evaluator;
             }
         }
         EVALUATOR *e = EVALUATOR::Create(srcDesc, dstDesc,
                                          duDesc, dvDesc,
+                                         duuDesc, duvDesc, dvvDesc,
                                          deviceContext);
-        _evaluators.push_back(Entry(srcDesc, dstDesc, duDesc, dvDesc, e));
+        _evaluators.push_back(Entry(srcDesc, dstDesc,
+                                    duDesc, dvDesc,
+                                    duuDesc, duvDesc, dvvDesc, e));
         return e;
     }
 
@@ -279,6 +324,25 @@ static EVALUATOR *GetEvaluator(
     BufferDescriptor const &dstDesc,
     BufferDescriptor const &duDesc,
     BufferDescriptor const &dvDesc,
+    BufferDescriptor const &duuDesc,
+    BufferDescriptor const &duvDesc,
+    BufferDescriptor const &dvvDesc,
+    DEVICE_CONTEXT deviceContext,
+    typename enable_if<instantiatable<EVALUATOR>::value, void>::type*t=0) {
+    (void)t;
+    if (cache == NULL) return NULL;
+    return cache->GetEvaluator(srcDesc, dstDesc,
+                               duDesc, dvDesc, duuDesc, duvDesc, dvvDesc,
+                               deviceContext);
+}
+
+template <typename EVALUATOR, typename DEVICE_CONTEXT>
+static EVALUATOR *GetEvaluator(
+    EvaluatorCacheT<EVALUATOR> *cache,
+    BufferDescriptor const &srcDesc,
+    BufferDescriptor const &dstDesc,
+    BufferDescriptor const &duDesc,
+    BufferDescriptor const &dvDesc,
     DEVICE_CONTEXT deviceContext,
     typename enable_if<instantiatable<EVALUATOR>::value, void>::type*t=0) {
     (void)t;
@@ -302,6 +366,22 @@ static EVALUATOR *GetEvaluator(
 }
 
 // fallback
+template <typename EVALUATOR, typename DEVICE_CONTEXT>
+static EVALUATOR *GetEvaluator(
+    EvaluatorCacheT<EVALUATOR> *,
+    BufferDescriptor const &,
+    BufferDescriptor const &,
+    BufferDescriptor const &,
+    BufferDescriptor const &,
+    BufferDescriptor const &,
+    BufferDescriptor const &,
+    BufferDescriptor const &,
+    DEVICE_CONTEXT,
+    typename enable_if<!instantiatable<EVALUATOR>::value, void>::type*t=0) {
+    (void)t;
+    return NULL;
+}
+
 template <typename EVALUATOR, typename DEVICE_CONTEXT>
 static EVALUATOR *GetEvaluator(
     EvaluatorCacheT<EVALUATOR> *,

--- a/opensubdiv/osd/ompEvaluator.cpp
+++ b/opensubdiv/osd/ompEvaluator.cpp
@@ -197,7 +197,7 @@ OmpEvaluator::EvalPatches(
 
 #pragma omp parallel for
     for (int i = 0; i < numPatchCoords; ++i) {
-        float wP[20], wDs[20], wDt[20];
+        float wP[20], wDu[20], wDv[20];
         BufferAdapter<float> dstT(dst + dstDesc.stride*i, dstDesc.length, dstDesc.stride);
         BufferAdapter<float> duT(du   + duDesc.stride*i, duDesc.length, duDesc.stride);
         BufferAdapter<float> dvT(dv   + dvDesc.stride*i, dvDesc.length, dvDesc.stride);
@@ -214,15 +214,15 @@ OmpEvaluator::EvalPatches(
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
             Far::internal::GetBSplineWeights(param,
-                                             coord.s, coord.t, wP, wDs, wDt);
+                                             coord.s, coord.t, wP, wDu, wDv);
             numControlVertices = 16;
         } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
             Far::internal::GetGregoryWeights(param,
-                                             coord.s, coord.t, wP, wDs, wDt);
+                                             coord.s, coord.t, wP, wDu, wDv);
             numControlVertices = 20;
         } else if (patchType == Far::PatchDescriptor::QUADS) {
             Far::internal::GetBilinearWeights(param,
-                                              coord.s, coord.t, wP, wDs, wDt);
+                                              coord.s, coord.t, wP, wDu, wDv);
             numControlVertices = 4;
         } else {
             continue;
@@ -239,12 +239,107 @@ OmpEvaluator::EvalPatches(
         dvT.Clear();
         for (int j = 0; j < numControlVertices; ++j) {
             dstT.AddWithWeight(srcT[cvs[j]], wP[j]);
-            duT.AddWithWeight(srcT[cvs[j]], wDs[j]);
-            dvT.AddWithWeight(srcT[cvs[j]], wDt[j]);
+            duT.AddWithWeight(srcT[cvs[j]], wDu[j]);
+            dvT.AddWithWeight(srcT[cvs[j]], wDv[j]);
         }
         ++dstT;
         ++duT;
         ++dvT;
+    }
+    return true;
+}
+
+/* static */
+bool
+OmpEvaluator::EvalPatches(
+    const float *src, BufferDescriptor const &srcDesc,
+    float *dst,       BufferDescriptor const &dstDesc,
+    float *du,        BufferDescriptor const &duDesc,
+    float *dv,        BufferDescriptor const &dvDesc,
+    float *duu,       BufferDescriptor const &duuDesc,
+    float *duv,       BufferDescriptor const &duvDesc,
+    float *dvv,       BufferDescriptor const &dvvDesc,
+    int numPatchCoords,
+    PatchCoord const *patchCoords,
+    PatchArray const *patchArrays,
+    const int *patchIndexBuffer,
+    PatchParam const *patchParamBuffer) {
+
+    src += srcDesc.offset;
+    if (dst) dst += dstDesc.offset;
+    if (du)  du += duDesc.offset;
+    if (dv)  dv += dvDesc.offset;
+    if (duu) duu += duuDesc.offset;
+    if (duv) duv += duvDesc.offset;
+    if (dvv) dvv += dvvDesc.offset;
+
+    BufferAdapter<const float> srcT(src, srcDesc.length, srcDesc.stride);
+
+#pragma omp parallel for
+    for (int i = 0; i < numPatchCoords; ++i) {
+        float wP[20], wDu[20], wDv[20], wDuu[20], wDuv[20], wDvv[20];
+        BufferAdapter<float> dstT(dst + dstDesc.stride*i, dstDesc.length, dstDesc.stride);
+        BufferAdapter<float> duT(du   + duDesc.stride*i, duDesc.length, duDesc.stride);
+        BufferAdapter<float> dvT(dv   + dvDesc.stride*i, dvDesc.length, dvDesc.stride);
+        BufferAdapter<float> duuT(duu + duuDesc.stride*i, duuDesc.length, duuDesc.stride);
+        BufferAdapter<float> duvT(duv + duvDesc.stride*i, duvDesc.length, duvDesc.stride);
+        BufferAdapter<float> dvvT(dvv + dvvDesc.stride*i, dvvDesc.length, dvvDesc.stride);
+
+        PatchCoord const &coord = patchCoords[i];
+        PatchArray const &array = patchArrays[coord.handle.arrayIndex];
+
+        Far::PatchParam const & param =
+            patchParamBuffer[coord.handle.patchIndex];
+        int patchType = param.IsRegular()
+            ? Far::PatchDescriptor::REGULAR
+            : array.GetPatchType();
+
+        int numControlVertices = 0;
+        if (patchType == Far::PatchDescriptor::REGULAR) {
+            Far::internal::GetBSplineWeights(param,
+                                             coord.s, coord.t, wP,
+                                             wDu, wDv, wDuu, wDuv, wDvv);
+            numControlVertices = 16;
+        } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
+            Far::internal::GetGregoryWeights(param,
+                                             coord.s, coord.t, wP,
+                                             wDu, wDv, wDuu, wDuv, wDvv);
+            numControlVertices = 20;
+        } else if (patchType == Far::PatchDescriptor::QUADS) {
+            Far::internal::GetBilinearWeights(param,
+                                              coord.s, coord.t, wP,
+                                              wDu, wDv, wDuu, wDuv, wDvv);
+            numControlVertices = 4;
+        } else {
+            continue;
+        }
+
+        int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
+        int indexBase = array.GetIndexBase() + indexStride *
+                (coord.handle.patchIndex - array.GetPrimitiveIdBase());
+
+        const int *cvs = &patchIndexBuffer[indexBase];
+
+        dstT.Clear();
+        duT.Clear();
+        dvT.Clear();
+        duuT.Clear();
+        duvT.Clear();
+        dvvT.Clear();
+        for (int j = 0; j < numControlVertices; ++j) {
+            dstT.AddWithWeight(srcT[cvs[j]], wP[j]);
+            duT.AddWithWeight(srcT[cvs[j]], wDu[j]);
+            dvT.AddWithWeight(srcT[cvs[j]], wDv[j]);
+            duuT.AddWithWeight(srcT[cvs[j]], wDuu[j]);
+            duvT.AddWithWeight(srcT[cvs[j]], wDuv[j]);
+            dvvT.AddWithWeight(srcT[cvs[j]], wDvv[j]);
+        }
+        ++dstT;
+        ++duT;
+        ++dvT;
+        ++duuT;
+        ++duvT;
+        ++dvvT;
     }
     return true;
 }

--- a/opensubdiv/osd/ompEvaluator.h
+++ b/opensubdiv/osd/ompEvaluator.h
@@ -244,6 +244,177 @@ public:
         const float * dvWeights,
         int start, int end);
 
+    /// \brief Generic static eval stencils function with derivatives.
+    ///        This function has a same signature as other device kernels
+    ///        have so that it can be called in the same way from OsdMesh
+    ///        template interface.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       const float pointer for read
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param stencilTable   Far::StencilTable or equivalent
+    ///
+    /// @param instance       not used in the omp kernel
+    ///                       (declared as a typed pointer to prevent
+    ///                        undesirable template resolution)
+    ///
+    /// @param deviceContext  not used in the omp kernel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+    static bool EvalStencils(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        STENCIL_TABLE const *stencilTable,
+        const OmpEvaluator *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalStencils(srcBuffer->BindCpuBuffer(), srcDesc,
+                            dstBuffer->BindCpuBuffer(), dstDesc,
+                            duBuffer->BindCpuBuffer(),  duDesc,
+                            dvBuffer->BindCpuBuffer(),  dvDesc,
+                            duuBuffer->BindCpuBuffer(), duuDesc,
+                            duvBuffer->BindCpuBuffer(), duvDesc,
+                            dvvBuffer->BindCpuBuffer(), dvvDesc,
+                            &stencilTable->GetSizes()[0],
+                            &stencilTable->GetOffsets()[0],
+                            &stencilTable->GetControlIndices()[0],
+                            &stencilTable->GetWeights()[0],
+                            &stencilTable->GetDuWeights()[0],
+                            &stencilTable->GetDvWeights()[0],
+                            &stencilTable->GetDuuWeights()[0],
+                            &stencilTable->GetDuvWeights()[0],
+                            &stencilTable->GetDvvWeights()[0],
+                            /*start = */ 0,
+                            /*end   = */ stencilTable->GetNumStencils());
+    }
+
+    /// \brief Static eval stencils function with derivatives, which takes
+    ///        raw CPU pointers for input and output.
+    ///
+    /// @param src            Input primvar pointer. An offset of srcDesc
+    ///                       will be applied internally (i.e. the pointer
+    ///                       should not include the offset)
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst            Output primvar pointer. An offset of dstDesc
+    ///                       will be applied internally.
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param du             Output pointer derivative wrt u. An offset of
+    ///                       duDesc will be applied internally.
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dv             Output pointer derivative wrt v. An offset of
+    ///                       dvDesc will be applied internally.
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duu            Output pointer 2nd derivative wrt u. An offset of
+    ///                       duuDesc will be applied internally.
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duv            Output pointer 2nd derivative wrt u and v. An offset of
+    ///                       duvDesc will be applied internally.
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvv            Output pointer 2nd derivative wrt v. An offset of
+    ///                       dvvDesc will be applied internally.
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param sizes          pointer to the sizes buffer of the stencil table
+    ///
+    /// @param offsets        pointer to the offsets buffer of the stencil table
+    ///
+    /// @param indices        pointer to the indices buffer of the stencil table
+    ///
+    /// @param weights        pointer to the weights buffer of the stencil table
+    ///
+    /// @param duWeights      pointer to the du-weights buffer of the stencil table
+    ///
+    /// @param dvWeights      pointer to the dv-weights buffer of the stencil table
+    ///
+    /// @param duuWeights     pointer to the duu-weights buffer of the stencil table
+    ///
+    /// @param duvWeights     pointer to the duv-weights buffer of the stencil table
+    ///
+    /// @param dvvWeights     pointer to the dvv-weights buffer of the stencil table
+    ///
+    /// @param start          start index of stencil table
+    ///
+    /// @param end            end index of stencil table
+    ///
+    static bool EvalStencils(
+        const float *src, BufferDescriptor const &srcDesc,
+        float *dst,       BufferDescriptor const &dstDesc,
+        float *du,        BufferDescriptor const &duDesc,
+        float *dv,        BufferDescriptor const &dvDesc,
+        float *duu,       BufferDescriptor const &duuDesc,
+        float *duv,       BufferDescriptor const &duvDesc,
+        float *dvv,       BufferDescriptor const &dvvDesc,
+        const int * sizes,
+        const int * offsets,
+        const int * indices,
+        const float * weights,
+        const float * duWeights,
+        const float * dvWeights,
+        const float * duuWeights,
+        const float * duvWeights,
+        const float * dvvWeights,
+        int start, int end);
+
     /// ----------------------------------------------------------------------
     ///
     ///   Limit evaluations with PatchTable
@@ -373,6 +544,102 @@ public:
                            patchTable->GetPatchParamBuffer());
     }
 
+    /// \brief Generic limit eval function with derivatives. This function has
+    ///        a same signature as other device kernels have so that it can be
+    ///        called in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the omp evaluator
+    ///
+    /// @param deviceContext    not used in the omp evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatches(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        OmpEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        // XXX: PatchCoords is somewhat abusing vertex primvar buffer interop.
+        //      ideally all buffer classes should have templated by datatype
+        //      so that downcast isn't needed there.
+        //      (e.g. Osd::CpuBuffer<PatchCoord> )
+        //
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           duuBuffer->BindCpuBuffer(), duuDesc,
+                           duvBuffer->BindCpuBuffer(), duvDesc,
+                           dvvBuffer->BindCpuBuffer(), dvvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetPatchArrayBuffer(),
+                           patchTable->GetPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
     /// \brief Static limit eval function. It takes an array of PatchCoord
     ///        and evaluate limit values on given PatchTable.
     ///
@@ -457,6 +724,72 @@ public:
         const int *patchIndexBuffer,
         PatchParam const *patchParamBuffer);
 
+    /// \brief Static limit eval function. It takes an array of PatchCoord
+    ///        and evaluate limit values on given PatchTable.
+    ///
+    /// @param src              Input primvar pointer. An offset of srcDesc
+    ///                         will be applied internally (i.e. the pointer
+    ///                         should not include the offset)
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst              Output primvar pointer. An offset of dstDesc
+    ///                         will be applied internally.
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param du               Output pointer derivative wrt u. An offset of
+    ///                         duDesc will be applied internally.
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dv               Output pointer derivative wrt v. An offset of
+    ///                         dvDesc will be applied internally.
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duu              Output pointer 2nd derivative wrt u. An offset of
+    ///                         duuDesc will be applied internally.
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duv              Output pointer 2nd derivative wrt u and v. An offset of
+    ///                         duvDesc will be applied internally.
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvv              Output pointer 2nd derivative wrt v. An offset of
+    ///                         dvvDesc will be applied internally.
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchArrays      an array of Osd::PatchArray struct
+    ///                         indexed by PatchCoord::arrayIndex
+    ///
+    /// @param patchIndexBuffer an array of patch indices
+    ///                         indexed by PatchCoord::vertIndex
+    ///
+    /// @param patchParamBuffer an array of Osd::PatchParam struct
+    ///                         indexed by PatchCoord::patchIndex
+    ///
+    static bool EvalPatches(
+        const float *src, BufferDescriptor const &srcDesc,
+        float *dst,       BufferDescriptor const &dstDesc,
+        float *du,        BufferDescriptor const &duDesc,
+        float *dv,        BufferDescriptor const &dvDesc,
+        float *duu,       BufferDescriptor const &duuDesc,
+        float *duv,       BufferDescriptor const &duvDesc,
+        float *dvv,       BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PatchCoord const *patchCoords,
+        PatchArray const *patchArrays,
+        const int *patchIndexBuffer,
+        PatchParam const *patchParamBuffer);
+
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
     ///        in the same way.
@@ -524,6 +857,164 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the omp evaluator
+    ///
+    /// @param deviceContext    not used in the omp evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        OmpEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the omp evaluator
+    ///
+    /// @param deviceContext    not used in the omp evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        OmpEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           duuBuffer->BindCpuBuffer(), duuDesc,
+                           duvBuffer->BindCpuBuffer(), duvDesc,
+                           dvvBuffer->BindCpuBuffer(), dvvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
     /// @param numPatchCoords   number of patchCoords.
     ///
     /// @param patchCoords      array of locations to be evaluated.
@@ -555,6 +1046,170 @@ public:
 
         return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
                            dstBuffer->BindCpuBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the omp evaluator
+    ///
+    /// @param deviceContext    not used in the omp evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        OmpEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the omp evaluator
+    ///
+    /// @param deviceContext    not used in the omp evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        OmpEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           duuBuffer->BindCpuBuffer(), duuDesc,
+                           duvBuffer->BindCpuBuffer(), duvDesc,
+                           dvvBuffer->BindCpuBuffer(), dvvDesc,
                            numPatchCoords,
                            (const PatchCoord*)patchCoords->BindCpuBuffer(),
                            patchTable->GetFVarPatchArrayBuffer(fvarChannel),

--- a/opensubdiv/osd/ompEvaluator.h
+++ b/opensubdiv/osd/ompEvaluator.h
@@ -26,10 +26,10 @@
 #define OPENSUBDIV3_OSD_OMP_EVALUATOR_H
 
 #include "../version.h"
-
-#include <cstddef>
 #include "../osd/bufferDescriptor.h"
 #include "../osd/types.h"
+
+#include <cstddef>
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
@@ -107,7 +107,6 @@ public:
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
     /// @param sizes          pointer to the sizes buffer of the stencil table
-    ///                       to apply for the range [start, end)
     ///
     /// @param offsets        pointer to the offsets buffer of the stencil table
     ///
@@ -120,8 +119,8 @@ public:
     /// @param end            end index of stencil table
     ///
     static bool EvalStencils(
-        const float *src,  BufferDescriptor const &srcDesc,
-        float *dst,        BufferDescriptor const &dstDesc,
+        const float *src, BufferDescriptor const &srcDesc,
+        float *dst,       BufferDescriptor const &dstDesc,
         const int * sizes,
         const int * offsets,
         const int * indices,
@@ -145,17 +144,17 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer       Output U-derivative buffer
+    /// @param duBuffer       Output buffer derivative wrt u
     ///                       must have BindCpuBuffer() method returning a
     ///                       float pointer for write
     ///
-    /// @param duDesc         vertex buffer descriptor for the output buffer
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer       Output V-derivative buffer
+    /// @param dvBuffer       Output buffer derivative wrt v
     ///                       must have BindCpuBuffer() method returning a
     ///                       float pointer for write
     ///
-    /// @param dvDesc         vertex buffer descriptor for the output buffer
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
     /// @param stencilTable   Far::StencilTable or equivalent
     ///
@@ -206,15 +205,15 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param du             Output U-derivatives pointer. An offset of
+    /// @param du             Output pointer derivative wrt u. An offset of
     ///                       duDesc will be applied internally.
     ///
-    /// @param duDesc         vertex buffer descriptor for the output buffer
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dv             Output V-derivatives pointer. An offset of
+    /// @param dv             Output pointer derivative wrt v. An offset of
     ///                       dvDesc will be applied internally.
     ///
-    /// @param dvDesc         vertex buffer descriptor for the output buffer
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
     /// @param sizes          pointer to the sizes buffer of the stencil table
     ///
@@ -318,13 +317,13 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer         Output U-derivatives buffer
+    /// @param duBuffer         Output buffer derivative wrt u
     ///                         must have BindCpuBuffer() method returning a
     ///                         float pointer for write
     ///
     /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer         Output V-derivatives buffer
+    /// @param dvBuffer         Output buffer derivative wrt v
     ///                         must have BindCpuBuffer() method returning a
     ///                         float pointer for write
     ///
@@ -354,6 +353,7 @@ public:
         PATCH_TABLE *patchTable,
         OmpEvaluator const *instance = NULL,
         void * deviceContext = NULL) {
+
         (void)instance;       // unused
         (void)deviceContext;  // unused
 
@@ -423,15 +423,15 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param du               Output U-derivatives pointer. An offset of
+    /// @param du               Output pointer derivative wrt u. An offset of
     ///                         duDesc will be applied internally.
     ///
-    /// @param duDesc           vertex buffer descriptor for the du buffer
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dv               Output V-derivatives pointer. An offset of
+    /// @param dv               Output pointer derivative wrt v. An offset of
     ///                         dvDesc will be applied internally.
     ///
-    /// @param dvDesc           vertex buffer descriptor for the dv buffer
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
     ///
     /// @param numPatchCoords   number of patchCoords.
     ///

--- a/opensubdiv/osd/ompKernel.h
+++ b/opensubdiv/osd/ompKernel.h
@@ -56,6 +56,25 @@ OmpEvalStencils(float const * src, BufferDescriptor const &srcDesc,
                 float const * dvWeights,
                 int start, int end);
 
+void
+OmpEvalStencils(float const * src, BufferDescriptor const &srcDesc,
+                float * dst,       BufferDescriptor const &dstDesc,
+                float * dstDu,     BufferDescriptor const &dstDuDesc,
+                float * dstDv,     BufferDescriptor const &dstDvDesc,
+                float * dstDuu,    BufferDescriptor const &dstDuuDesc,
+                float * dstDuv,    BufferDescriptor const &dstDuvDesc,
+                float * dstDvv,    BufferDescriptor const &dstDvvDesc,
+                int const * sizes,
+                int const * offsets,
+                int const * indices,
+                float const * weights,
+                float const * duWeights,
+                float const * dvWeights,
+                float const * duuWeights,
+                float const * duvWeights,
+                float const * dvvWeights,
+                int start, int end);
+
 } // end namespace Osd
 
 }  // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/osd/tbbEvaluator.cpp
+++ b/opensubdiv/osd/tbbEvaluator.cpp
@@ -75,8 +75,55 @@ TbbEvaluator::EvalStencils(
                     dst, dstDesc,
                     du,  duDesc,
                     dv,  dvDesc,
+                    NULL, BufferDescriptor(),
+                    NULL, BufferDescriptor(),
+                    NULL, BufferDescriptor(),
+                    sizes, offsets, indices,
+                    weights, duWeights, dvWeights, NULL, NULL, NULL,
+                    start, end);
+
+    return true;
+}
+
+/* static */
+bool
+TbbEvaluator::EvalStencils(
+    const float *src, BufferDescriptor const &srcDesc,
+    float *dst,       BufferDescriptor const &dstDesc,
+    float *du,        BufferDescriptor const &duDesc,
+    float *dv,        BufferDescriptor const &dvDesc,
+    float *duu,       BufferDescriptor const &duuDesc,
+    float *duv,       BufferDescriptor const &duvDesc,
+    float *dvv,       BufferDescriptor const &dvvDesc,
+    const int * sizes,
+    const int * offsets,
+    const int * indices,
+    const float * weights,
+    const float * duWeights,
+    const float * dvWeights,
+    const float * duuWeights,
+    const float * duvWeights,
+    const float * dvvWeights,
+    int start, int end) {
+
+    if (end <= start) return true;
+    if (srcDesc.length != dstDesc.length) return false;
+    if (srcDesc.length != duDesc.length) return false;
+    if (srcDesc.length != dvDesc.length) return false;
+    if (srcDesc.length != duuDesc.length) return false;
+    if (srcDesc.length != duvDesc.length) return false;
+    if (srcDesc.length != dvvDesc.length) return false;
+
+    TbbEvalStencils(src, srcDesc,
+                    dst, dstDesc,
+                    du,  duDesc,
+                    dv,  dvDesc,
+                    duu, duuDesc,
+                    duv, duvDesc,
+                    dvv, dvvDesc,
                     sizes, offsets, indices,
                     weights, duWeights, dvWeights,
+                    duuWeights, duvWeights, dvvWeights,
                     start, end);
 
     return true;
@@ -96,6 +143,9 @@ TbbEvaluator::EvalPatches(
     if (srcDesc.length != dstDesc.length) return false;
 
     TbbEvalPatches(src, srcDesc, dst, dstDesc,
+                   NULL, BufferDescriptor(),
+                   NULL, BufferDescriptor(),
+                   NULL, BufferDescriptor(),
                    NULL, BufferDescriptor(),
                    NULL, BufferDescriptor(),
                    numPatchCoords, patchCoords,
@@ -121,6 +171,36 @@ TbbEvaluator::EvalPatches(
 
     TbbEvalPatches(src, srcDesc, dst, dstDesc,
                    du,  duDesc,  dv,  dvDesc,
+                   NULL, BufferDescriptor(),
+                   NULL, BufferDescriptor(),
+                   NULL, BufferDescriptor(),
+                   numPatchCoords, patchCoords,
+                   patchArrayBuffer, patchIndexBuffer, patchParamBuffer);
+
+    return true;
+}
+
+/* static */
+bool
+TbbEvaluator::EvalPatches(
+    const float *src, BufferDescriptor const &srcDesc,
+    float *dst,       BufferDescriptor const &dstDesc,
+    float *du,        BufferDescriptor const &duDesc,
+    float *dv,        BufferDescriptor const &dvDesc,
+    float *duu,       BufferDescriptor const &duuDesc,
+    float *duv,       BufferDescriptor const &duvDesc,
+    float *dvv,       BufferDescriptor const &dvvDesc,
+    int numPatchCoords,
+    const PatchCoord *patchCoords,
+    const PatchArray *patchArrayBuffer,
+    const int *patchIndexBuffer,
+    const PatchParam *patchParamBuffer) {
+
+    if (srcDesc.length != dstDesc.length) return false;
+
+    TbbEvalPatches(src, srcDesc, dst, dstDesc,
+                   du,  duDesc,  dv,  dvDesc,
+                   duu, duuDesc, duv, duvDesc, dvv, dvvDesc,
                    numPatchCoords, patchCoords,
                    patchArrayBuffer, patchIndexBuffer, patchParamBuffer);
 

--- a/opensubdiv/osd/tbbEvaluator.h
+++ b/opensubdiv/osd/tbbEvaluator.h
@@ -26,9 +26,8 @@
 #define OPENSUBDIV3_OSD_TBB_EVALUATOR_H
 
 #include "../version.h"
-#include "../osd/types.h"
 #include "../osd/bufferDescriptor.h"
-#include "../far/patchTable.h"
+#include "../osd/types.h"
 
 #include <cstddef>
 
@@ -61,7 +60,7 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param stencilTable   stencil table to be applied.
+    /// @param stencilTable   Far::StencilTable or equivalent
     ///
     /// @param instance       not used in the tbb kernel
     ///                       (declared as a typed pointer to prevent
@@ -77,7 +76,7 @@ public:
         TbbEvaluator const *instance = NULL,
         void *deviceContext = NULL) {
 
-        (void)instance;   // unused
+        (void)instance;       // unused
         (void)deviceContext;  // unused
 
         if (stencilTable->GetNumStencils() == 0)
@@ -108,7 +107,6 @@ public:
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
     /// @param sizes          pointer to the sizes buffer of the stencil table
-    ///                       to apply for the range [start, end)
     ///
     /// @param offsets        pointer to the offsets buffer of the stencil table
     ///
@@ -123,10 +121,10 @@ public:
     static bool EvalStencils(
         const float *src, BufferDescriptor const &srcDesc,
         float *dst,       BufferDescriptor const &dstDesc,
-        const int *sizes,
-        const int *offsets,
-        const int *indices,
-        const float *weights,
+        const int * sizes,
+        const int * offsets,
+        const int * indices,
+        const float * weights,
         int start, int end);
 
     /// \brief Generic static eval stencils function with derivatives.
@@ -146,19 +144,19 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer       Output U-derivative buffer
+    /// @param duBuffer       Output buffer derivative wrt u
     ///                       must have BindCpuBuffer() method returning a
     ///                       float pointer for write
     ///
-    /// @param duDesc         vertex buffer descriptor for the output buffer
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer       Output V-derivative buffer
+    /// @param dvBuffer       Output buffer derivative wrt v
     ///                       must have BindCpuBuffer() method returning a
     ///                       float pointer for write
     ///
-    /// @param dvDesc         vertex buffer descriptor for the output buffer
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
-    /// @param stencilTable   stencil table to be applied.
+    /// @param stencilTable   Far::StencilTable or equivalent
     ///
     /// @param instance       not used in the tbb kernel
     ///                       (declared as a typed pointer to prevent
@@ -176,8 +174,8 @@ public:
         const TbbEvaluator *instance = NULL,
         void * deviceContext = NULL) {
 
-        (void)instance;   // unused
-        (void)deviceContext;   // unused
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
 
         return EvalStencils(srcBuffer->BindCpuBuffer(), srcDesc,
                             dstBuffer->BindCpuBuffer(), dstDesc,
@@ -207,18 +205,17 @@ public:
     ///
     /// @param dstDesc        vertex buffer descriptor for the output buffer
     ///
-    /// @param du             Output s-derivatives pointer. An offset of
+    /// @param du             Output pointer derivative wrt u. An offset of
     ///                       duDesc will be applied internally.
     ///
-    /// @param duDesc         vertex buffer descriptor for the output buffer
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
     ///
-    /// @param dv             Output t-derivatives pointer. An offset of
+    /// @param dv             Output pointer derivative wrt v. An offset of
     ///                       dvDesc will be applied internally.
     ///
-    /// @param dvDesc         vertex buffer descriptor for the output buffer
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
     ///
     /// @param sizes          pointer to the sizes buffer of the stencil table
-    ///                       to apply for the range [start, end)
     ///
     /// @param offsets        pointer to the offsets buffer of the stencil table
     ///
@@ -226,9 +223,9 @@ public:
     ///
     /// @param weights        pointer to the weights buffer of the stencil table
     ///
-    /// @param duWeights      pointer to the u-weights buffer of the stencil table
+    /// @param duWeights      pointer to the du-weights buffer of the stencil table
     ///
-    /// @param dvWeights      pointer to the v-weights buffer of the stencil table
+    /// @param dvWeights      pointer to the dv-weights buffer of the stencil table
     ///
     /// @param start          start index of stencil table
     ///
@@ -273,7 +270,9 @@ public:
     ///
     /// @param patchCoords      array of locations to be evaluated.
     ///
-    /// @param patchTable       Far::PatchTable
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
     ///
     /// @param instance         not used in the cpu evaluator
     ///
@@ -293,10 +292,8 @@ public:
         (void)instance;       // unused
         (void)deviceContext;  // unused
 
-        return EvalPatches(srcBuffer->BindCpuBuffer(),
-                           srcDesc,
-                           dstBuffer->BindCpuBuffer(),
-                           dstDesc,
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
                            numPatchCoords,
                            (const PatchCoord*)patchCoords->BindCpuBuffer(),
                            patchTable->GetPatchArrayBuffer(),
@@ -320,13 +317,13 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param duBuffer         Output s-derivatives buffer
+    /// @param duBuffer         Output buffer derivative wrt u
     ///                         must have BindCpuBuffer() method returning a
     ///                         float pointer for write
     ///
     /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dvBuffer         Output t-derivatives buffer
+    /// @param dvBuffer         Output buffer derivative wrt v
     ///                         must have BindCpuBuffer() method returning a
     ///                         float pointer for write
     ///
@@ -336,7 +333,9 @@ public:
     ///
     /// @param patchCoords      array of locations to be evaluated.
     ///
-    /// @param patchTable       Far::PatchTable
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
     ///
     /// @param instance         not used in the cpu evaluator
     ///
@@ -358,16 +357,20 @@ public:
         (void)instance;       // unused
         (void)deviceContext;  // unused
 
-        return EvalPatches(
-            srcBuffer->BindCpuBuffer(), srcDesc,
-            dstBuffer->BindCpuBuffer(), dstDesc,
-            duBuffer->BindCpuBuffer(),  duDesc,
-            dvBuffer->BindCpuBuffer(),  dvDesc,
-            numPatchCoords,
-            (const PatchCoord*)patchCoords->BindCpuBuffer(),
-            patchTable->GetPatchArrayBuffer(),
-            patchTable->GetPatchIndexBuffer(),
-            patchTable->GetPatchParamBuffer());
+        // XXX: PatchCoords is somewhat abusing vertex primvar buffer interop.
+        //      ideally all buffer classes should have templated by datatype
+        //      so that downcast isn't needed there.
+        //      (e.g. Osd::CpuBuffer<PatchCoord> )
+        //
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetPatchArrayBuffer(),
+                           patchTable->GetPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
     }
 
     /// \brief Static limit eval function. It takes an array of PatchCoord
@@ -420,15 +423,15 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
-    /// @param du               Output s-derivatives pointer. An offset of
+    /// @param du               Output pointer derivative wrt u. An offset of
     ///                         duDesc will be applied internally.
     ///
-    /// @param duDesc           vertex buffer descriptor for the du buffer
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
     ///
-    /// @param dv               Output t-derivatives pointer. An offset of
+    /// @param dv               Output pointer derivative wrt v. An offset of
     ///                         dvDesc will be applied internally.
     ///
-    /// @param dvDesc           vertex buffer descriptor for the dv buffer
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
     ///
     /// @param numPatchCoords   number of patchCoords.
     ///
@@ -449,10 +452,10 @@ public:
         float *du,        BufferDescriptor const &duDesc,
         float *dv,        BufferDescriptor const &dvDesc,
         int numPatchCoords,
-        const PatchCoord *patchCoords,
-        const PatchArray *patchArrays,
+        PatchCoord const *patchCoords,
+        PatchArray const *patchArrays,
         const int *patchIndexBuffer,
-        const PatchParam *patchParamBuffer);
+        PatchParam const *patchParamBuffer);
 
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
@@ -474,7 +477,9 @@ public:
     ///
     /// @param patchCoords      array of locations to be evaluated.
     ///
-    /// @param patchTable       Far::PatchTable
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
     ///
     /// @param instance         not used in the cpu evaluator
     ///
@@ -494,10 +499,8 @@ public:
         (void)instance;       // unused
         (void)deviceContext;  // unused
 
-        return EvalPatches(srcBuffer->BindCpuBuffer(),
-                           srcDesc,
-                           dstBuffer->BindCpuBuffer(),
-                           dstDesc,
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
                            numPatchCoords,
                            (const PatchCoord*)patchCoords->BindCpuBuffer(),
                            patchTable->GetVaryingPatchArrayBuffer(),
@@ -525,7 +528,9 @@ public:
     ///
     /// @param patchCoords      array of locations to be evaluated.
     ///
-    /// @param patchTable       Far::PatchTable
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
     ///
     /// @param fvarChannel      face-varying channel
     ///
@@ -548,10 +553,8 @@ public:
         (void)instance;       // unused
         (void)deviceContext;  // unused
 
-        return EvalPatches(srcBuffer->BindCpuBuffer(),
-                           srcDesc,
-                           dstBuffer->BindCpuBuffer(),
-                           dstDesc,
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
                            numPatchCoords,
                            (const PatchCoord*)patchCoords->BindCpuBuffer(),
                            patchTable->GetFVarPatchArrayBuffer(fvarChannel),

--- a/opensubdiv/osd/tbbEvaluator.h
+++ b/opensubdiv/osd/tbbEvaluator.h
@@ -244,6 +244,177 @@ public:
         const float * dvWeights,
         int start, int end);
 
+    /// \brief Generic static eval stencils function with derivatives.
+    ///        This function has a same signature as other device kernels
+    ///        have so that it can be called in the same way from OsdMesh
+    ///        template interface.
+    ///
+    /// @param srcBuffer      Input primvar buffer.
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       const float pointer for read
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer      Output primvar buffer
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer       Output buffer derivative wrt u
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer       Output buffer derivative wrt v
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer      Output buffer 2nd derivative wrt u
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+    ///                       must have BindCpuBuffer() method returning a
+    ///                       float pointer for write
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param stencilTable   Far::StencilTable or equivalent
+    ///
+    /// @param instance       not used in the tbb kernel
+    ///                       (declared as a typed pointer to prevent
+    ///                        undesirable template resolution)
+    ///
+    /// @param deviceContext  not used in the tbb kernel
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+    static bool EvalStencils(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        STENCIL_TABLE const *stencilTable,
+        const TbbEvaluator *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalStencils(srcBuffer->BindCpuBuffer(), srcDesc,
+                            dstBuffer->BindCpuBuffer(), dstDesc,
+                            duBuffer->BindCpuBuffer(),  duDesc,
+                            dvBuffer->BindCpuBuffer(),  dvDesc,
+                            duuBuffer->BindCpuBuffer(), duuDesc,
+                            duvBuffer->BindCpuBuffer(), duvDesc,
+                            dvvBuffer->BindCpuBuffer(), dvvDesc,
+                            &stencilTable->GetSizes()[0],
+                            &stencilTable->GetOffsets()[0],
+                            &stencilTable->GetControlIndices()[0],
+                            &stencilTable->GetWeights()[0],
+                            &stencilTable->GetDuWeights()[0],
+                            &stencilTable->GetDvWeights()[0],
+                            &stencilTable->GetDuuWeights()[0],
+                            &stencilTable->GetDuvWeights()[0],
+                            &stencilTable->GetDvvWeights()[0],
+                            /*start = */ 0,
+                            /*end   = */ stencilTable->GetNumStencils());
+    }
+
+    /// \brief Static eval stencils function with derivatives, which takes
+    ///        raw CPU pointers for input and output.
+    ///
+    /// @param src            Input primvar pointer. An offset of srcDesc
+    ///                       will be applied internally (i.e. the pointer
+    ///                       should not include the offset)
+    ///
+    /// @param srcDesc        vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst            Output primvar pointer. An offset of dstDesc
+    ///                       will be applied internally.
+    ///
+    /// @param dstDesc        vertex buffer descriptor for the output buffer
+    ///
+    /// @param du             Output pointer derivative wrt u. An offset of
+    ///                       duDesc will be applied internally.
+    ///
+    /// @param duDesc         vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dv             Output pointer derivative wrt v. An offset of
+    ///                       dvDesc will be applied internally.
+    ///
+    /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duu            Output pointer 2nd derivative wrt u. An offset of
+    ///                       duuDesc will be applied internally.
+    ///
+    /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duv            Output pointer 2nd derivative wrt u and v. An offset of
+    ///                       duvDesc will be applied internally.
+    ///
+    /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvv            Output pointer 2nd derivative wrt v. An offset of
+    ///                       dvvDesc will be applied internally.
+    ///
+    /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param sizes          pointer to the sizes buffer of the stencil table
+    ///
+    /// @param offsets        pointer to the offsets buffer of the stencil table
+    ///
+    /// @param indices        pointer to the indices buffer of the stencil table
+    ///
+    /// @param weights        pointer to the weights buffer of the stencil table
+    ///
+    /// @param duWeights      pointer to the du-weights buffer of the stencil table
+    ///
+    /// @param dvWeights      pointer to the dv-weights buffer of the stencil table
+    ///
+    /// @param duuWeights     pointer to the duu-weights buffer of the stencil table
+    ///
+    /// @param duvWeights     pointer to the duv-weights buffer of the stencil table
+    ///
+    /// @param dvvWeights     pointer to the dvv-weights buffer of the stencil table
+    ///
+    /// @param start          start index of stencil table
+    ///
+    /// @param end            end index of stencil table
+    ///
+    static bool EvalStencils(
+        const float *src, BufferDescriptor const &srcDesc,
+        float *dst,       BufferDescriptor const &dstDesc,
+        float *du,        BufferDescriptor const &duDesc,
+        float *dv,        BufferDescriptor const &dvDesc,
+        float *duu,       BufferDescriptor const &duuDesc,
+        float *duv,       BufferDescriptor const &duvDesc,
+        float *dvv,       BufferDescriptor const &dvvDesc,
+        const int * sizes,
+        const int * offsets,
+        const int * indices,
+        const float * weights,
+        const float * duWeights,
+        const float * dvWeights,
+        const float * duuWeights,
+        const float * duvWeights,
+        const float * dvvWeights,
+        int start, int end);
+
     /// ----------------------------------------------------------------------
     ///
     ///   Limit evaluations with PatchTable
@@ -373,6 +544,102 @@ public:
                            patchTable->GetPatchParamBuffer());
     }
 
+    /// \brief Generic limit eval function with derivatives. This function has
+    ///        a same signature as other device kernels have so that it can be
+    ///        called in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatches(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        TbbEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        // XXX: PatchCoords is somewhat abusing vertex primvar buffer interop.
+        //      ideally all buffer classes should have templated by datatype
+        //      so that downcast isn't needed there.
+        //      (e.g. Osd::CpuBuffer<PatchCoord> )
+        //
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           duuBuffer->BindCpuBuffer(), duuDesc,
+                           duvBuffer->BindCpuBuffer(), duvDesc,
+                           dvvBuffer->BindCpuBuffer(), dvvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetPatchArrayBuffer(),
+                           patchTable->GetPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
     /// \brief Static limit eval function. It takes an array of PatchCoord
     ///        and evaluate limit values on given PatchTable.
     ///
@@ -457,6 +724,72 @@ public:
         const int *patchIndexBuffer,
         PatchParam const *patchParamBuffer);
 
+    /// \brief Static limit eval function. It takes an array of PatchCoord
+    ///        and evaluate limit values on given PatchTable.
+    ///
+    /// @param src              Input primvar pointer. An offset of srcDesc
+    ///                         will be applied internally (i.e. the pointer
+    ///                         should not include the offset)
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dst              Output primvar pointer. An offset of dstDesc
+    ///                         will be applied internally.
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param du               Output pointer derivative wrt u. An offset of
+    ///                         duDesc will be applied internally.
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dv               Output pointer derivative wrt v. An offset of
+    ///                         dvDesc will be applied internally.
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duu              Output pointer 2nd derivative wrt u. An offset of
+    ///                         duuDesc will be applied internally.
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duv              Output pointer 2nd derivative wrt u and v. An offset of
+    ///                         duvDesc will be applied internally.
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvv              Output pointer 2nd derivative wrt v. An offset of
+    ///                         dvvDesc will be applied internally.
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchArrays      an array of Osd::PatchArray struct
+    ///                         indexed by PatchCoord::arrayIndex
+    ///
+    /// @param patchIndexBuffer an array of patch indices
+    ///                         indexed by PatchCoord::vertIndex
+    ///
+    /// @param patchParamBuffer an array of Osd::PatchParam struct
+    ///                         indexed by PatchCoord::patchIndex
+    ///
+    static bool EvalPatches(
+        const float *src, BufferDescriptor const &srcDesc,
+        float *dst,       BufferDescriptor const &dstDesc,
+        float *du,        BufferDescriptor const &duDesc,
+        float *dv,        BufferDescriptor const &dvDesc,
+        float *duu,       BufferDescriptor const &duuDesc,
+        float *duv,       BufferDescriptor const &duvDesc,
+        float *dvv,       BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PatchCoord const *patchCoords,
+        PatchArray const *patchArrays,
+        const int *patchIndexBuffer,
+        PatchParam const *patchParamBuffer);
+
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
     ///        in the same way.
@@ -524,6 +857,164 @@ public:
     ///
     /// @param dstDesc          vertex buffer descriptor for the output buffer
     ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        TbbEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        TbbEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           duuBuffer->BindCpuBuffer(), duuDesc,
+                           duvBuffer->BindCpuBuffer(), duvDesc,
+                           dvvBuffer->BindCpuBuffer(), dvvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetVaryingPatchArrayBuffer(),
+                           patchTable->GetVaryingPatchIndexBuffer(),
+                           patchTable->GetPatchParamBuffer());
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
     /// @param numPatchCoords   number of patchCoords.
     ///
     /// @param patchCoords      array of locations to be evaluated.
@@ -555,6 +1046,170 @@ public:
 
         return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
                            dstBuffer->BindCpuBuffer(), dstDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        TbbEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           numPatchCoords,
+                           (const PatchCoord*)patchCoords->BindCpuBuffer(),
+                           patchTable->GetFVarPatchArrayBuffer(fvarChannel),
+                           patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                           patchTable->GetFVarPatchParamBuffer(fvarChannel));
+    }
+
+    /// \brief Generic limit eval function. This function has a same
+    ///        signature as other device kernels have so that it can be called
+    ///        in the same way.
+    ///
+    /// @param srcBuffer        Input primvar buffer.
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         const float pointer for read
+    ///
+    /// @param srcDesc          vertex buffer descriptor for the input buffer
+    ///
+    /// @param dstBuffer        Output primvar buffer
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dstDesc          vertex buffer descriptor for the output buffer
+    ///
+    /// @param duBuffer         Output buffer derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duDesc           vertex buffer descriptor for the duBuffer
+    ///
+    /// @param dvBuffer         Output buffer derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+    ///
+    /// @param duuBuffer        Output buffer 2nd derivative wrt u
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+    ///
+    /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+    ///
+    /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+    ///                         must have BindCpuBuffer() method returning a
+    ///                         float pointer for write
+    ///
+    /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+    ///
+    /// @param numPatchCoords   number of patchCoords.
+    ///
+    /// @param patchCoords      array of locations to be evaluated.
+    ///
+    /// @param patchTable       CpuPatchTable or equivalent
+    ///                         XXX: currently Far::PatchTable can't be used
+    ///                              due to interface mismatch
+    ///
+    /// @param fvarChannel      face-varying channel
+    ///
+    /// @param instance         not used in the cpu evaluator
+    ///
+    /// @param deviceContext    not used in the cpu evaluator
+    ///
+    template <typename SRC_BUFFER, typename DST_BUFFER,
+              typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+    static bool EvalPatchesFaceVarying(
+        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+        DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+        DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+        DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+        int numPatchCoords,
+        PATCHCOORD_BUFFER *patchCoords,
+        PATCH_TABLE *patchTable,
+        int fvarChannel,
+        TbbEvaluator const *instance = NULL,
+        void * deviceContext = NULL) {
+
+        (void)instance;       // unused
+        (void)deviceContext;  // unused
+
+        return EvalPatches(srcBuffer->BindCpuBuffer(), srcDesc,
+                           dstBuffer->BindCpuBuffer(), dstDesc,
+                           duBuffer->BindCpuBuffer(),  duDesc,
+                           dvBuffer->BindCpuBuffer(),  dvDesc,
+                           duuBuffer->BindCpuBuffer(), duuDesc,
+                           duvBuffer->BindCpuBuffer(), duvDesc,
+                           dvvBuffer->BindCpuBuffer(), dvvDesc,
                            numPatchCoords,
                            (const PatchCoord*)patchCoords->BindCpuBuffer(),
                            patchTable->GetFVarPatchArrayBuffer(fvarChannel),

--- a/opensubdiv/osd/tbbKernel.h
+++ b/opensubdiv/osd/tbbKernel.h
@@ -62,10 +62,43 @@ TbbEvalStencils(float const * src, BufferDescriptor const &srcDesc,
                 int start, int end);
 
 void
+TbbEvalStencils(float const * src, BufferDescriptor const &srcDesc,
+                float * dst,       BufferDescriptor const &dstDesc,
+                float * dstDu,     BufferDescriptor const &dstDuDesc,
+                float * dstDv,     BufferDescriptor const &dstDvDesc,
+                float * dstDuu,    BufferDescriptor const &dstDuuDesc,
+                float * dstDuv,    BufferDescriptor const &dstDuvDesc,
+                float * dstDvv,    BufferDescriptor const &dstDvvDesc,
+                int const * sizes,
+                int const * offsets,
+                int const * indices,
+                float const * weights,
+                float const * duWeights,
+                float const * dvWeights,
+                float const * duuWeights,
+                float const * duvWeights,
+                float const * dvvWeights,
+                int start, int end);
+
+void
 TbbEvalPatches(float const *src, BufferDescriptor const &srcDesc,
                float *dst,       BufferDescriptor const &dstDesc,
                float *dstDu,     BufferDescriptor const &dstDuDesc,
                float *dstDv,     BufferDescriptor const &dstDvDesc,
+               int numPatchCoords,
+               const PatchCoord *patchCoords,
+               const PatchArray *patchArrayBuffer,
+               const int *patchIndexBuffer,
+               const PatchParam *patchParamBuffer);
+
+void
+TbbEvalPatches(float const *src, BufferDescriptor const &srcDesc,
+               float *dst,       BufferDescriptor const &dstDesc,
+               float *dstDu,     BufferDescriptor const &dstDuDesc,
+               float *dstDv,     BufferDescriptor const &dstDvDesc,
+               float *dstDuu,    BufferDescriptor const &dstDuuDesc,
+               float *dstDuv,    BufferDescriptor const &dstDuvDesc,
+               float *dstDvv,    BufferDescriptor const &dstDvvDesc,
                int numPatchCoords,
                const PatchCoord *patchCoords,
                const PatchArray *patchArrayBuffer,


### PR DESCRIPTION
This pull request is broken out into several parts:

The main change is to implement the Osd Evaluator methods
EvalStencils(), EvalPatches, EvalPatchesVarying, and
EvalPatchesFaceVarying to compute 1st and 2nd derivatives.

This also fixes several inconsistencies in the doxygen comments
for these classes.

And also includes the addition of the display of Mean Curvature
in the glEvalLimit viewer to help exercise the 2nd derivative
computations.