### PR TITLE
Expose public option to improve sharp patches at smooth corners

### DIFF
--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -162,6 +162,7 @@ enum HudCheckBox { kHUD_CB_DISPLAY_CONTROL_MESH_EDGES,
                    kHUD_CB_FREEZE,
                    kHUD_CB_DISPLAY_PATCH_COUNTS,
                    kHUD_CB_ADAPTIVE,
+                   kHUD_CB_SMOOTH_CORNER_PATCH,
                    kHUD_CB_SINGLE_CREASE_PATCH,
                    kHUD_CB_INF_SHARP_PATCH };
 
@@ -182,6 +183,7 @@ int   g_fullscreen = 0,
       g_displayStyle = kDisplayStyleWireOnShaded,
       g_adaptive = 1,
       g_endCap = kEndCapBSplineBasis,
+      g_smoothCornerPatch = 0,
       g_singleCreasePatch = 1,
       g_infSharpPatch = 0,
       g_mbutton[3] = {0, 0, 0},
@@ -447,11 +449,13 @@ rebuildMesh() {
     // Adaptive refinement currently supported only for catmull-clark scheme
     bool doAdaptive = (g_adaptive!=0 && scheme==kCatmark);
     bool interleaveVarying = g_shadingMode == kShadingInterleavedVaryingColor;
+    bool doSmoothCornerPatch = (g_smoothCornerPatch!=0 && scheme==kCatmark);
     bool doSingleCreasePatch = (g_singleCreasePatch!=0 && scheme==kCatmark);
     bool doInfSharpPatch = (g_infSharpPatch!=0 && scheme==kCatmark);
 
     Osd::MeshBitset bits;
     bits.set(Osd::MeshAdaptive, doAdaptive);
+    bits.set(Osd::MeshUseSmoothCornerPatch, doSmoothCornerPatch);
     bits.set(Osd::MeshUseSingleCreasePatch, doSingleCreasePatch);
     bits.set(Osd::MeshUseInfSharpPatch, doInfSharpPatch);
     bits.set(Osd::MeshInterleaveVarying, interleaveVarying);
@@ -1402,6 +1406,10 @@ callbackCheckBox(bool checked, int button) {
             g_adaptive = checked;
             rebuildMesh();
             return;
+        case kHUD_CB_SMOOTH_CORNER_PATCH:
+            g_smoothCornerPatch = checked;
+            rebuildMesh();
+            return;
         case kHUD_CB_SINGLE_CREASE_PATCH:
             g_singleCreasePatch = checked;
             rebuildMesh();
@@ -1541,13 +1549,15 @@ initHUD() {
     if (GLUtils::SupportsAdaptiveTessellation()) {
         g_hud.AddCheckBox("Adaptive (`)", g_adaptive!=0,
                           10, 190, callbackCheckBox, kHUD_CB_ADAPTIVE, '`');
+        g_hud.AddCheckBox("Smooth Corner Patch (O)", g_smoothCornerPatch!=0,
+                          10, 210, callbackCheckBox, kHUD_CB_SMOOTH_CORNER_PATCH, 'o');
         g_hud.AddCheckBox("Single Crease Patch (S)", g_singleCreasePatch!=0,
-                          10, 210, callbackCheckBox, kHUD_CB_SINGLE_CREASE_PATCH, 's');
+                          10, 230, callbackCheckBox, kHUD_CB_SINGLE_CREASE_PATCH, 's');
         g_hud.AddCheckBox("Inf Sharp Patch (I)", g_infSharpPatch!=0,
-                          10, 230, callbackCheckBox, kHUD_CB_INF_SHARP_PATCH, 'i');
+                          10, 250, callbackCheckBox, kHUD_CB_INF_SHARP_PATCH, 'i');
 
         int endcap_pulldown = g_hud.AddPullDown(
-            "End cap (E)", 10, 250, 200, callbackEndCap, 'e');
+            "End cap (E)", 10, 270, 200, callbackEndCap, 'e');
         g_hud.AddPullDownButton(endcap_pulldown,"None",
                                 kEndCapNone,
                                 g_endCap == kEndCapNone);

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -312,9 +312,6 @@ public:
 
     Options const options;
 
-    //  Additional options eventually to be made public in Options above:
-    bool options_approxSmoothCornerWithSharp;
-
     PtexIndices const ptexIndices;
 
     // Counters accumulating each type of patch during topology traversal
@@ -339,9 +336,6 @@ PatchTableFactory::BuilderContext::BuilderContext(
     refiner(ref), options(opts), ptexIndices(refiner),
     numRegularPatches(0), numIrregularPatches(0),
     numIrregularBoundaryPatches(0) {
-
-    //  Eventually to be passed in as Options and assigned to member...
-    options_approxSmoothCornerWithSharp = true;
 
     if (options.generateFVarTables) {
         // If client-code does not select specific channels, default to all
@@ -623,7 +617,7 @@ PatchTableFactory::BuilderContext::IsPatchRegular(
     }
 
     //  Legacy option -- reinterpret an irregular smooth corner as sharp if specified:
-    if (!isRegular && options_approxSmoothCornerWithSharp) {
+    if (!isRegular && options.generateLegacySharpCornerPatches) {
         if (fCompVTag._xordinary && fCompVTag._boundary && !fCompVTag._nonManifold) {
             isRegular = IsPatchSmoothCorner(levelIndex, faceIndex, fvcRefiner);
         }
@@ -756,7 +750,7 @@ PatchTableFactory::BuilderContext::GetIrregularPatchCornerSpans(
         }
 
         //  Legacy option -- reinterpret an irregular smooth corner as sharp if specified:
-        if (!cornerSpans[i]._sharp && options_approxSmoothCornerWithSharp) {
+        if (!cornerSpans[i]._sharp && options.generateLegacySharpCornerPatches) {
             if (vTags[i]._xordinary && vTags[i]._boundary && !vTags[i]._nonManifold) {
                     int nFaces = cornerSpans[i].isAssigned() ? cornerSpans[i]._numFaces
                                : level.getVertexFaces(fVerts[i]).size();

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -65,6 +65,7 @@ public:
              shareEndCapPatchPoints(true),
              generateFVarTables(false),
              generateFVarLegacyLinearPatches(true),
+             generateLegacySharpCornerPatches(true),
              numFVarChannels(-1),
              fvarChannelIndices(0)
         { }
@@ -87,8 +88,12 @@ public:
                                                   ///< currently only work with GregoryBasis.
 
                      // face-varying
-                     generateFVarTables              : 1, ///< Generate face-varying patch tables
-                     generateFVarLegacyLinearPatches : 1; ///< Generate all linear face-varying patches (legacy)
+                     generateFVarTables  : 1, ///< Generate face-varying patch tables
+
+                     // legacy behaviors (default to true)
+                     generateFVarLegacyLinearPatches  : 1, ///< Generate all linear face-varying patches (legacy)
+                     generateLegacySharpCornerPatches : 1; ///< Generate sharp regular patches at smooth corners (legacy)
+
         int          numFVarChannels;          ///< Number of channel indices and interpolation modes passed
         int const *  fvarChannelIndices;       ///< List containing the indices of the channels selected for the factory
     };

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -51,12 +51,13 @@ enum MeshBits {
     MeshInterleaveVarying    = 1,
     MeshFVarData             = 2,
     MeshFVarAdaptive         = 3,
-    MeshUseSingleCreasePatch = 4,
-    MeshUseInfSharpPatch     = 5,
-    MeshEndCapBSplineBasis   = 6,  // exclusive
-    MeshEndCapGregoryBasis   = 7,  // exclusive
-    MeshEndCapLegacyGregory  = 8,  // exclusive
-    NUM_MESH_BITS            = 9,
+    MeshUseSmoothCornerPatch = 4,
+    MeshUseSingleCreasePatch = 5,
+    MeshUseInfSharpPatch     = 6,
+    MeshEndCapBSplineBasis   = 7,  // exclusive
+    MeshEndCapGregoryBasis   = 8,  // exclusive
+    MeshEndCapLegacyGregory  = 9,  // exclusive
+    NUM_MESH_BITS            = 10,
 };
 typedef std::bitset<NUM_MESH_BITS> MeshBitset;
 
@@ -529,6 +530,7 @@ private:
         Far::PatchTableFactory::Options poptions(level);
         poptions.generateFVarTables = bits.test(MeshFVarData);
         poptions.generateFVarLegacyLinearPatches = !bits.test(MeshFVarAdaptive);
+        poptions.generateLegacySharpCornerPatches = !bits.test(MeshUseSmoothCornerPatch);
         poptions.useSingleCreasePatch = bits.test(MeshUseSingleCreasePatch);
         poptions.useInfSharpPatch = bits.test(MeshUseInfSharpPatch);
 


### PR DESCRIPTION
Historically, smooth corner features have been approximated with regular B-Spline patches without any attempt to make the corner of the patch smooth to match the true limit surface.  So a smooth boundary is effectively approximated with a sharp one.  This is one of the few cases where the corners of the patch do not match the limit surface and makes for a poor approximation at low levels of isolation.

This set of changes exposes an internal option to use irregular patches at smooth corners to better approximate the true limit surface.  The legacy behavior of using sharp patches to approximate smooth corners is preserved by default but can now be overridden.  The new option has been exposed in examples/glViewer.

As a future improvement, when choosing B-Spline patches for irregular features (end-caps) there is a simple formula for extrapolating points for a smooth corner patch that matches the limit boundary and could be used instead of the current method that derives a Gregory patch and converts to B-Spline.