### PR TITLE
Improved XFB Evaluation of 1st and 2nd derivatives

### DIFF
--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -507,6 +507,15 @@ private:
     DEVICE_CONTEXT *_deviceContext;
 };
 
+// This example uses one shared interleaved buffer for evaluated
+// 1st derivatives and a second shared interleaved buffer for
+// evaluated 2nd derivatives. We use this specialized device
+// context to allow the XFB evaluator to take advantage of this
+// and make more efficient use of available XFB buffer bindings.
+struct XFBDeviceContext {
+    bool AreInterleavedDerivativeBuffers() const { return true; }
+} g_xfbDeviceContext;
+
 EvalOutputBase *g_evalOutput = NULL;
 STParticles * g_particles=0;
 
@@ -802,11 +811,12 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level) {
                                       Osd::GLVertexBuffer,
                                       Osd::GLStencilTableTBO,
                                       Osd::GLPatchTable,
-                                      Osd::GLXFBEvaluator>
+                                      Osd::GLXFBEvaluator,
+                                      XFBDeviceContext>
             (vertexStencils, varyingStencils, faceVaryingStencils,
             fvarChannel, fvarWidth,
             g_nParticles, g_patchTable,
-             &glXFBEvaluatorCache);
+             &glXFBEvaluatorCache, &g_xfbDeviceContext);
 #endif
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
     } else if (g_kernel == kGLCompute) {

--- a/opensubdiv/osd/glslXFBKernel.glsl
+++ b/opensubdiv/osd/glslXFBKernel.glsl
@@ -64,7 +64,7 @@ void writeVertex(Vertex v) {
 //------------------------------------------------------------------------------
 
 #if defined(OPENSUBDIV_GLSL_XFB_USE_1ST_DERIVATIVES) && \
-    defined(OPENSUBDIV_GLSL_XFB_SHARED_1ST_DERIVATIVE_BUFFERS)
+    defined(OPENSUBDIV_GLSL_XFB_INTERLEAVED_1ST_DERIVATIVE_BUFFERS)
 out float outDeriv1Buffer[2*LENGTH];
 
 void writeDu(Vertex v) {
@@ -96,7 +96,7 @@ void writeDv(Vertex v) {
 #endif
 
 #if defined(OPENSUBDIV_GLSL_XFB_USE_2ND_DERIVATIVES) && \
-    defined(OPENSUBDIV_GLSL_XFB_SHARED_2ND_DERIVATIVE_BUFFERS)
+    defined(OPENSUBDIV_GLSL_XFB_INTERLEAVED_2ND_DERIVATIVE_BUFFERS)
 out float outDeriv2Buffer[3*LENGTH];
 
 void writeDuu(Vertex v) {


### PR DESCRIPTION
Most GL implementations support a maximum of 4 transform
feedback buffer bindings. With the addition of 1st and 2nd
derivative evaluation up to 6 bindings might be required,
i.e. dst, du, dv, duu, duv, dvv.
    
This change extends the GLXFB Evaluator interface to allow
a client to specialize the evaluator when it is known that
(at least) the 1st derivative and 2nd derivative outputs
are interleaved together into shared buffers.
    
When this option is used, the maximum number of transform
feedback buffer bindings can be reduced to 3 instead of 6.
