### PR TITLE
Removed shadowing warnings from source for core libraries

### DIFF
--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
@@ -360,14 +360,14 @@ EndCapBSplineBasisPatchFactory::getPatchPoints(
             int intFaceInVFaces  = (thisFaceInVFaces + 2) & 0x3;
             Index intFace    = vFaces[intFaceInVFaces];
             int   vInIntFace = vInFaces[intFaceInVFaces];
-            ConstIndexArray facePoints = level->getFaceVertices(intFace);
+            ConstIndexArray intFacePoints = level->getFaceVertices(intFace);
 
             patchPoints[pointIndex++] =
-                facePoints[(vInIntFace + 1)&3] + levelVertOffset;
+                intFacePoints[(vInIntFace + 1)&3] + levelVertOffset;
             patchPoints[pointIndex++] =
-                facePoints[(vInIntFace + 2)&3] + levelVertOffset;
+                intFacePoints[(vInIntFace + 2)&3] + levelVertOffset;
             patchPoints[pointIndex++] =
-                facePoints[(vInIntFace + 3)&3] + levelVertOffset;
+                intFacePoints[(vInIntFace + 3)&3] + levelVertOffset;
         } else {
             // irregular corner
             int thisFaceInVFaces = vFaces.FindIndex(thisFace);
@@ -377,9 +377,9 @@ EndCapBSplineBasisPatchFactory::getPatchPoints(
                 int intFaceInVFaces  = (thisFaceInVFaces + 1) % valence;
                 Index intFace    = vFaces[intFaceInVFaces];
                 int   vInIntFace = vInFaces[intFaceInVFaces];
-                ConstIndexArray facePoints = level->getFaceVertices(intFace);
+                ConstIndexArray intFacePoints = level->getFaceVertices(intFace);
                 patchPoints[pointIndex++] =
-                    facePoints[(vInIntFace+3)&3] + levelVertOffset;
+                    intFacePoints[(vInIntFace+3)&3] + levelVertOffset;
             }
             {
                 // middle: (n-vertices) needs a limit stencil. skip for now
@@ -390,9 +390,9 @@ EndCapBSplineBasisPatchFactory::getPatchPoints(
                 int intFaceInVFaces  = (thisFaceInVFaces + (valence-1)) %valence;
                 Index intFace    = vFaces[intFaceInVFaces];
                 int   vInIntFace = vInFaces[intFaceInVFaces];
-                ConstIndexArray facePoints = level->getFaceVertices(intFace);
+                ConstIndexArray intFacePoints = level->getFaceVertices(intFace);
                 patchPoints[pointIndex++] =
-                    facePoints[(vInIntFace+1)&3] + levelVertOffset;
+                    intFacePoints[(vInIntFace+1)&3] + levelVertOffset;
 
             }
         }

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
@@ -144,8 +144,8 @@ EndCapGregoryBasisPatchFactory::GetPatchPoints(
         //  Simple struct with encoding of <level,face> index as an unsigned int and a
         //  comparison method for use with std::bsearch
         struct LevelAndFaceIndex {
-            static inline unsigned int create(unsigned int levelIndex, Index faceIndex) {
-                return (levelIndex << 28) | (unsigned int) faceIndex;
+            static inline unsigned int create(unsigned int levelIndexArg, Index faceIndexArg) {
+                return (levelIndexArg << 28) | (unsigned int) faceIndexArg;
             }
             static int compare(void const * a, void const * b) {
                 return *(unsigned int const*)a - *(unsigned int const*)b;

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -235,8 +235,8 @@ public:
             : faceIndex(Vtr::INDEX_INVALID), levelIndex(-1) { }
         PatchTuple(PatchTuple const & p)
             : faceIndex(p.faceIndex), levelIndex(p.levelIndex) { }
-        PatchTuple(Index faceIndex, int levelIndex)
-            : faceIndex(faceIndex), levelIndex(levelIndex) { }
+        PatchTuple(Index faceIndexArg, int levelIndexArg)
+            : faceIndex(faceIndexArg), levelIndex(levelIndexArg) { }
 
         Index faceIndex;
         int   levelIndex;

--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -417,15 +417,15 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
         // regular patches, such as in a torus)
         // note: the control vertices of the mesh are added as single-index
         //       stencils of weight 1.0f
-        StencilTableFactory::Options options;
-        options.generateIntermediateLevels = uniform ? false :true;
-        options.generateControlVerts = true;
-        options.generateOffsets = true;
+        StencilTableFactory::Options stencilTableOptions;
+        stencilTableOptions.generateIntermediateLevels = uniform ? false :true;
+        stencilTableOptions.generateControlVerts = true;
+        stencilTableOptions.generateOffsets = true;
 
         // PERFORMANCE: We could potentially save some mem-copies by not
         // instantiating the stencil tables and work directly off the source
         // data.
-        cvstencils = StencilTableFactory::Create(refiner, options);
+        cvstencils = StencilTableFactory::Create(refiner, stencilTableOptions);
     } else {
         // Sanity checks
         //
@@ -447,13 +447,13 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
         // have been added to the refiner, maybe we can remove the need for the
         // patch table.
 
-        PatchTableFactory::Options options;
-        options.SetEndCapType(
+        PatchTableFactory::Options patchTableOptions;
+        patchTableOptions.SetEndCapType(
             Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS);
-        options.useInfSharpPatch = !uniform &&
+        patchTableOptions.useInfSharpPatch = !uniform &&
             refiner.GetAdaptiveOptions().useInfSharpPatch;
 
-        patchtable = PatchTableFactory::Create(refiner, options);
+        patchtable = PatchTableFactory::Create(refiner, patchTableOptions);
 
         if (! cvStencilsIn) {
             // if cvstencils is just created above, append endcap stencils


### PR DESCRIPTION
The warning flags for GCC do not enable shadowing warnings, which will appear for ICC.  Such warnings were eliminated in the 3.0 source but a few have crept into new code written since.  All of the occurrences are in opensubdiv/far and are corrected here.

I'd prefer we enable -Wshadow for GCC at some point -- even if only for the core library source -- as some of the cases not detected can be pitfalls for someone modifying existing code.

There are a manageable number of cases to deal with in the examples.  Unfortunately, the template-heavy code included from opensubdiv/hbr is riddled with such warnings -- we could eliminate these but since Hbr is being phased out, removing Hbr dependent code from the examples would be preferable.  There are also external header files included that will generate such warnings, particularly Ptex's <Ptexture.h>, but these could be dealt with locally in the few examples that use them.