### PR TITLE
Proposed abstraction of patch building tools into a PatchBuilder class

### DIFF
--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -695,11 +695,9 @@ createOsdMesh(ShapeDesc const & shapeDesc, int level) {
         // Generate bi-cubic patch table for the limit surface
         Far::PatchTableFactory::Options poptions(level);
         if (g_endCap == kEndCapBSplineBasis) {
-            poptions.SetEndCapType(
-                Far::PatchTableFactory::Options::ENDCAP_BSPLINE_BASIS);
+            poptions.SetEndCapType(Far::ENDCAP_BSPLINE_BASIS);
         } else {
-            poptions.SetEndCapType(
-                Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS);
+            poptions.SetEndCapType(Far::ENDCAP_GREGORY_BASIS);
         }
         poptions.useInfSharpPatch = doInfSharpPatch;
         poptions.generateFVarTables = hasFVarData;

--- a/examples/glShareTopology/sceneBase.cpp
+++ b/examples/glShareTopology/sceneBase.cpp
@@ -134,11 +134,9 @@ SceneBase::createStencilTable(Shape const *shape, int level, bool varying,
     {
         Far::PatchTableFactory::Options poptions(level);
         if (_options.endCap == kEndCapBSplineBasis) {
-            poptions.SetEndCapType(
-                Far::PatchTableFactory::Options::ENDCAP_BSPLINE_BASIS);
+            poptions.SetEndCapType(Far::ENDCAP_BSPLINE_BASIS);
         } else {
-            poptions.SetEndCapType(
-                Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS);
+            poptions.SetEndCapType(Far::ENDCAP_GREGORY_BASIS);
         }
         patchTable = Far::PatchTableFactory::Create(*refiner, poptions);
     }

--- a/opensubdiv/far/CMakeLists.txt
+++ b/opensubdiv/far/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCE_FILES
     endCapLegacyGregoryPatchFactory.cpp
     gregoryBasis.cpp
     patchBasis.cpp
+    patchBuilder.cpp
     patchDescriptor.cpp
     patchMap.cpp
     patchTable.cpp
@@ -50,6 +51,7 @@ set(PRIVATE_HEADER_FILES
     endCapGregoryBasisPatchFactory.h
     endCapLegacyGregoryPatchFactory.h
     patchBasis.h
+    patchBuilder.h
     stencilBuilder.h
 )
 

--- a/opensubdiv/far/patchBuilder.cpp
+++ b/opensubdiv/far/patchBuilder.cpp
@@ -1,0 +1,512 @@
+//
+//   Copyright 2016 NVIDIA CORPORATION
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#include "../far/error.h"
+#include "../far/patchBuilder.h"
+#include "../far/topologyRefiner.h"
+#include "../vtr/fvarLevel.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+
+namespace OpenSubdiv {
+namespace OPENSUBDIV_VERSION {
+
+
+namespace Far {
+
+using Vtr::internal::Refinement;
+using Vtr::internal::Level;
+using Vtr::internal::FVarLevel;
+
+namespace internal {
+
+//
+//  Local helper functions for identifying the subset of a ring around a
+//  corner that contributes to a patch -- parameterized by a mask that
+//  indicates what kind of edge is to delimit the span.
+//
+//  Note that the two main methods need both face-verts and face-edges for
+//  each corner, and that we don't really need the face-index once we have
+//  them -- consider passing the fVerts and fEdges as arguments as they
+//  will otherwise be retrieved repeatedly for each corner.
+//
+//  (As these mature it is likely they will be moved to Vtr, as a method
+//  to identify a VSpan would complement the existing method to gather
+//  the vertex/values associated with it.  The manifold vs non-manifold
+//  choice would then also be encapsulated -- provided both remain free
+//  of PatchTable-specific logic.)
+//
+inline Level::ETag
+getSingularEdgeMask(bool includeAllInfSharpEdges = false) {
+
+    Level::ETag eTagMask;
+    eTagMask.clear();
+    eTagMask._boundary = true;
+    eTagMask._nonManifold = true;
+    eTagMask._infSharp = includeAllInfSharpEdges;
+    return eTagMask;
+}
+
+inline bool
+isEdgeSingular(Level const & level,
+    FVarLevel const * fvarLevel, Index eIndex, Level::ETag eTagMask) {
+
+    Level::ETag eTag = level.getEdgeTag(eIndex);
+
+    if (fvarLevel) {
+        eTag = fvarLevel->getEdgeTag(eIndex).combineWithLevelETag(eTag);
+    }
+
+    Level::ETag::ETagSize * iTag  = reinterpret_cast<Level::ETag::ETagSize*>(&eTag);
+    Level::ETag::ETagSize * iMask = reinterpret_cast<Level::ETag::ETagSize*>(&eTagMask);
+    return (*iTag & *iMask) > 0;
+}
+
+void
+identifyManifoldCornerSpan(Level const & level, Index fIndex, int fCorner,
+    Level::ETag eTagMask, Level::VSpan & vSpan, int fvc = -1) {
+
+    FVarLevel const * fvarLevel = (fvc < 0) ? 0 : &level.getFVarLevel(fvc);
+
+    ConstIndexArray fVerts = level.getFaceVertices(fIndex);
+    ConstIndexArray fEdges = level.getFaceEdges(fIndex);
+
+    ConstIndexArray vEdges = level.getVertexEdges(fVerts[fCorner]);
+    int             nEdges = vEdges.size();
+
+    int iLeadingStart  = vEdges.FindIndex(fEdges[fCorner]);
+    int iTrailingStart = (iLeadingStart + 1) % nEdges;
+
+    vSpan.clear();
+    vSpan._numFaces = 1;
+
+    int iLeading  = iLeadingStart;
+    while (! isEdgeSingular(level, fvarLevel, vEdges[iLeading], eTagMask)) {
+        ++vSpan._numFaces;
+        iLeading = (iLeading + nEdges - 1) % nEdges;
+        if (iLeading == iTrailingStart) break;
+    }
+
+    int iTrailing = iTrailingStart;
+    while (! isEdgeSingular(level, fvarLevel, vEdges[iTrailing], eTagMask)) {
+        ++vSpan._numFaces;
+        iTrailing = (iTrailing + 1) % nEdges;
+        if (iTrailing == iLeadingStart) break;
+    }
+    vSpan._startFace = (LocalIndex) iLeading;
+}
+
+void
+identifyNonManifoldCornerSpan(Level const & level, Index fIndex, int fCorner,
+    Level::ETag /* eTagMask */, Level::VSpan & vSpan, int /* fvc */ = -1) {
+
+    //  For now, non-manifold patches revert to regular patches -- just identify
+    //  the single face now for a sharp corner patch.
+    //
+    //  Remember that the face may be incident the vertex multiple times when
+    //  non-manifold, so make sure the local index of the corner vertex in the
+    //  face identified additionally matches the corner.
+    //
+    //FVarLevel const * fvarLevel = (fvc < 0) ? 0 : &level.getFVarChannel(fvc);
+
+    Index vIndex = level.getFaceVertices(fIndex)[fCorner];
+
+    ConstIndexArray      vFaces  = level.getVertexFaces(vIndex);
+    ConstLocalIndexArray vInFace = level.getVertexFaceLocalIndices(vIndex);
+
+    vSpan.clear();
+    for (int i = 0; i < vFaces.size(); ++i) {
+        if ((vFaces[i] == fIndex) && ((int)vInFace[i] == fCorner)) {
+            vSpan._startFace = (LocalIndex) i;
+            vSpan._numFaces = 1;
+            vSpan._sharp = true;
+            break;
+        }
+    }
+    assert(vSpan._numFaces == 1);
+}
+
+PatchBuilder::PatchBuilder(TopologyRefiner const & refiner,
+    int numFVarChannels, int const * fvarChannelIndices,
+        bool useInfSharpPatch, bool generateLegacySharpCornerPatches) :
+            _refiner(refiner),
+            _useInfSharpPatch(useInfSharpPatch),
+            _generateLegacySharpCornerPatches(_generateLegacySharpCornerPatches) {
+
+    // If client-code does not select specific channels, default to all
+    // the channels in the refiner.
+    if (numFVarChannels==-1) {
+        _fvarChannelIndices.resize(refiner.GetNumFVarChannels());
+        for (int fvc=0;fvc<(int)_fvarChannelIndices.size(); ++fvc) {
+            _fvarChannelIndices[fvc] = fvc; // std::iota
+        }
+    } else {
+        _fvarChannelIndices.assign(
+            fvarChannelIndices, fvarChannelIndices+numFVarChannels);
+    }
+}
+
+Vtr::internal::Level const &
+PatchBuilder::GetVtrLevel(int levelIndex) const {
+    return _refiner.getLevel(levelIndex);
+}
+
+int
+PatchBuilder::GetRefinerFVarChannel(int fvcFactory) const {
+    return (fvcFactory >= 0) ? _fvarChannelIndices[fvcFactory] : -1;
+}
+
+
+bool
+PatchBuilder::DoesFaceVaryingPatchMatch(
+    int levelIndex, Index faceIndex, int fvcFactory) const {
+
+    return _refiner.getLevel(levelIndex).doesFaceFVarTopologyMatch(
+        faceIndex, GetRefinerFVarChannel(fvcFactory));
+}
+
+int
+PatchBuilder::GetDistinctRefinerFVarChannel(
+    int levelIndex, Index faceIndex, int fvcFactory) const {
+
+    return ((fvcFactory >= 0) &&
+            !DoesFaceVaryingPatchMatch(levelIndex, faceIndex, fvcFactory)) ?
+        GetRefinerFVarChannel(fvcFactory) : -1;
+}
+
+int
+PatchBuilder::GetTransitionMask(int levelIndex, Index faceIndex) const {
+    return (levelIndex == _refiner.GetMaxLevel()) ? 0 :
+        _refiner.getRefinement(levelIndex).
+                   getParentFaceSparseTag(faceIndex)._transitional;
+}
+
+
+bool
+PatchBuilder::IsPatchEligible(int levelIndex, Index faceIndex) const {
+
+    //
+    //  Patches that are not eligible correpond to the following faces:
+    //      - holes
+    //      - those in intermediate levels that are further refined (not leaves)
+    //      - those without complete neighborhoods that supporting other patches
+    //
+    Level const & level = _refiner.getLevel(levelIndex);
+
+    if (level.isFaceHole(faceIndex)) {
+        return false;
+    }
+
+    if (levelIndex < _refiner.GetMaxLevel()) {
+        if (_refiner.getRefinement(levelIndex).getParentFaceSparseTag(faceIndex)._selected) {
+            return false;
+        }
+    }
+
+    //
+    //  Faces that exist solely to support faces intended for patches will not have
+    //  their full neighborhood available and so are considered "incomplete":
+    //
+    Vtr::ConstIndexArray fVerts = level.getFaceVertices(faceIndex);
+    assert(fVerts.size() == 4);
+
+    if (level.getFaceCompositeVTag(fVerts)._incomplete) {
+        return false;
+    }
+    return true;
+}
+
+bool
+PatchBuilder::IsPatchSmoothCorner(
+    int levelIndex, Index faceIndex, int fvcFactory) const {
+
+    Level const & level = _refiner.getLevel(levelIndex);
+
+    //  Ignore the face-varying channel if the topology for the face is not distinct
+    int fvcRefiner = GetDistinctRefinerFVarChannel(levelIndex, faceIndex, fvcFactory);
+
+    Vtr::ConstIndexArray fVerts = level.getFaceVertices(faceIndex);
+    if (fVerts.size() != 4) return false;
+
+    Level::VTag vTags[4];
+    level.getFaceVTags(faceIndex, vTags, fvcRefiner);
+
+    //
+    //  Test the subdivision rules for the corners, rather than just the boundary/interior
+    //  tags, to ensure that inf-sharp vertices or edges are properly accounted for (and
+    //  the cases appropriately excluded) if inf-sharp patches are enabled:
+    //
+    int boundaryCount = 0;
+    if (_useInfSharpPatch) {
+        boundaryCount = (vTags[0]._infSharpEdges && (vTags[0]._rule == Sdc::Crease::RULE_CREASE))
+                      + (vTags[1]._infSharpEdges && (vTags[1]._rule == Sdc::Crease::RULE_CREASE))
+                      + (vTags[2]._infSharpEdges && (vTags[2]._rule == Sdc::Crease::RULE_CREASE))
+                      + (vTags[3]._infSharpEdges && (vTags[3]._rule == Sdc::Crease::RULE_CREASE));
+    } else {
+        boundaryCount = (vTags[0]._boundary && (vTags[0]._rule == Sdc::Crease::RULE_CREASE))
+                      + (vTags[1]._boundary && (vTags[1]._rule == Sdc::Crease::RULE_CREASE))
+                      + (vTags[2]._boundary && (vTags[2]._rule == Sdc::Crease::RULE_CREASE))
+                      + (vTags[3]._boundary && (vTags[3]._rule == Sdc::Crease::RULE_CREASE));
+    }
+    int xordinaryCount = vTags[0]._xordinary
+                       + vTags[1]._xordinary
+                       + vTags[2]._xordinary
+                       + vTags[3]._xordinary;
+
+    if ((boundaryCount == 3) && (xordinaryCount == 1)) {
+        //  This must be an isolated xordinary corner above level 1, otherwise we still
+        //  need to assure the xordinary vertex is opposite a smooth interior vertex:
+        //
+        if (levelIndex > 1) return true;
+
+        if (vTags[0]._xordinary) return (vTags[2]._rule == Sdc::Crease::RULE_SMOOTH);
+        if (vTags[1]._xordinary) return (vTags[3]._rule == Sdc::Crease::RULE_SMOOTH);
+        if (vTags[2]._xordinary) return (vTags[0]._rule == Sdc::Crease::RULE_SMOOTH);
+        if (vTags[3]._xordinary) return (vTags[1]._rule == Sdc::Crease::RULE_SMOOTH);
+    }
+    return false;
+}
+
+bool
+PatchBuilder::IsPatchRegular(
+    int levelIndex, Index faceIndex, int fvcFactory) const {
+
+    Level const & level = _refiner.getLevel(levelIndex);
+
+    //  Ignore the face-varying channel if the topology for the face is not distinct
+    int fvcRefiner = GetDistinctRefinerFVarChannel(levelIndex, faceIndex, fvcFactory);
+
+    //  Retrieve the composite VTag for the four corners:
+    Level::VTag fCompVTag = level.getFaceCompositeVTag(faceIndex, fvcRefiner);
+
+    //
+    //  Patches around non-manifold features are currently regular -- will need to revise
+    //  this when infinitely sharp patches are introduced later:
+    //
+    bool isRegular = ! fCompVTag._xordinary || fCompVTag._nonManifold;
+
+    //  Reconsider when using inf-sharp patches in presence of inf-sharp features:
+    if (_useInfSharpPatch && (fCompVTag._infSharp || fCompVTag._infSharpEdges)) {
+        if (fCompVTag._nonManifold || !fCompVTag._infIrregular) {
+            isRegular = true;
+        } else if (!fCompVTag._infSharpEdges) {
+            isRegular = false;
+        } else {
+            //
+            //   This is unfortunately a relatively complex case to determine... if a corner
+            //   vertex has been tagged has having an inf-sharp irregularity about it, the
+            //   neighborhood of the corner is partitioned into both regular and irregular
+            //   regions and the face must be more closely inspected to determine in which
+            //   it lies.
+            //
+            //   There could be a simpler test here to quickly accept/reject regularity given
+            //   how local it is -- involving no more than one or two (in the case of Loop)
+            //   adjacent faces -- but it will likely be messy and will need to inspect
+            //   adjacent faces and/or edges.  In the meantime, gathering and inspecting the
+            //   subset of the neighborhood delimited by inf-sharp edges will suffice (and
+            //   be comparable in all but cases of high valence)
+            //
+            Level::VTag vTags[4];
+            level.getFaceVTags(faceIndex, vTags, fvcRefiner);
+
+            Level::VSpan vSpan;
+            Level::ETag eMask = getSingularEdgeMask(true);
+
+            isRegular = true;
+            for (int i = 0; i < 4; ++i) {
+                if (vTags[i]._infIrregular) {
+
+                    identifyManifoldCornerSpan(level, faceIndex, i, eMask, vSpan, fvcRefiner);
+
+                    isRegular = (vSpan._numFaces == (vTags[i]._infSharpCrease ? 2 : 1));
+                    if (!isRegular) break;
+                }
+            }
+        }
+
+        //  When inf-sharp and extra-ordinary features are not isolated, need to inspect more
+        //  closely -- any smooth extra-ordinary corner makes the patch irregular:
+        if (fCompVTag._xordinary && (levelIndex < 2)) {
+            Level::VTag vTags[4];
+            level.getFaceVTags(faceIndex, vTags, fvcRefiner);
+            for (int i = 0; i < 4; ++i) {
+                if (vTags[i]._xordinary && (vTags[i]._rule == Sdc::Crease::RULE_SMOOTH)) {
+                    isRegular = false;
+                }
+            }
+        }
+    }
+
+    //  Legacy option -- reinterpret an irregular smooth corner as sharp if specified:
+    if (!isRegular && _generateLegacySharpCornerPatches) {
+        if (fCompVTag._xordinary && fCompVTag._boundary && !fCompVTag._nonManifold) {
+            isRegular = IsPatchSmoothCorner(levelIndex, faceIndex, fvcRefiner);
+        }
+    }
+    return isRegular;
+}
+
+void
+PatchBuilder::GetIrregularPatchCornerSpans(
+    int levelIndex, Index faceIndex, Level::VSpan cornerSpans[4], int fvcFactory) const {
+
+    Level const & level = _refiner.getLevel(levelIndex);
+
+    //  Ignore the face-varying channel if the topology for the face is not distinct
+    int fvcRefiner = GetDistinctRefinerFVarChannel(levelIndex, faceIndex, fvcFactory);
+
+    //  Retrieve tags and identify other information for the corner vertices:
+    Level::VTag vTags[4];
+    level.getFaceVTags(faceIndex, vTags, fvcRefiner);
+
+    FVarLevel::ValueTag fvarTags[4];
+    if (fvcRefiner >= 0) {
+        level.getFVarLevel(fvcRefiner).getFaceValueTags(faceIndex, fvarTags);
+    }
+
+    //
+    //  For each corner vertex, use the complete neighborhood when possible (which
+    //  does not require a search, otherwise identify the span of interest around
+    //  the vertex:
+    //
+    ConstIndexArray fVerts = level.getFaceVertices(faceIndex);
+
+    Level::ETag singularEdgeMask = getSingularEdgeMask(_useInfSharpPatch);
+
+    for (int i = 0; i < fVerts.size(); ++i) {
+        bool noFVarMisMatch = (fvcRefiner < 0) || !fvarTags[i]._mismatch;
+        bool testInfSharp   = _useInfSharpPatch &&
+                                (vTags[i]._infSharpEdges && (vTags[i]._rule != Sdc::Crease::RULE_DART));
+
+        if (noFVarMisMatch && !testInfSharp) {
+            cornerSpans[i].clear();
+        } else {
+            if (!vTags[i]._nonManifold) {
+                identifyManifoldCornerSpan(
+                    level, faceIndex, i, singularEdgeMask, cornerSpans[i], fvcRefiner);
+            } else {
+                identifyNonManifoldCornerSpan(
+                    level, faceIndex, i, singularEdgeMask, cornerSpans[i], fvcRefiner);
+            }
+        }
+        if (vTags[i]._corner) {
+            cornerSpans[i]._sharp = true;
+        } else if (_useInfSharpPatch) {
+            cornerSpans[i]._sharp = vTags[i]._infIrregular && (vTags[i]._rule == Sdc::Crease::RULE_CORNER);
+        }
+
+        //  Legacy option -- reinterpret an irregular smooth corner as sharp if specified:
+        if (!cornerSpans[i]._sharp && _generateLegacySharpCornerPatches) {
+            if (vTags[i]._xordinary && vTags[i]._boundary && !vTags[i]._nonManifold) {
+                int nFaces = cornerSpans[i].isAssigned() ? cornerSpans[i]._numFaces
+                           : level.getVertexFaces(fVerts[i]).size();
+                cornerSpans[i]._sharp = (nFaces == 1);
+            }
+        }
+    }
+}
+
+int
+PatchBuilder::GetRegularPatchBoundaryMask(
+    int levelIndex, Index faceIndex, int fvcFactory) const {
+
+    Level const & level = _refiner.getLevel(levelIndex);
+
+    //  Ignore the face-varying channel if the topology for the face is not distinct
+    int fvcRefiner = GetDistinctRefinerFVarChannel(levelIndex, faceIndex, fvcFactory);
+
+    //  Gather the VTags for the four corners.  Regardless of the options for
+    //  treating non-manifold or inf-sharp patches, for a regular patch we can
+    //  infer all that we need need from tags for the corner vertices:
+    //
+    Level::VTag vTags[4];
+    level.getFaceVTags(faceIndex, vTags, fvcRefiner);
+
+    Level::VTag fTag = Level::VTag::BitwiseOr(vTags);
+
+    //
+    //  Identify vertex tags for inf-sharp edges and/or boundaries, depending on
+    //  whether or not inf-sharp patches are in use:
+    //
+    int vBoundaryMask = 0;
+    if (fTag._infSharpEdges) {
+        if (_useInfSharpPatch) {
+            vBoundaryMask |= (vTags[0]._infSharpEdges << 0) |
+                             (vTags[1]._infSharpEdges << 1) |
+                             (vTags[2]._infSharpEdges << 2) |
+                             (vTags[3]._infSharpEdges << 3);
+        } else if (fTag._boundary) {
+            vBoundaryMask |= (vTags[0]._boundary << 0) |
+                             (vTags[1]._boundary << 1) |
+                             (vTags[2]._boundary << 2) |
+                             (vTags[3]._boundary << 3);
+        }
+    }
+
+    //
+    //  Non-manifold patches have been historically represented as regular in all
+    //  cases -- when a non-manifold vertex is sharp, it requires a regular corner
+    //  patch, and so both of its neighboring corners need to be re-interpreted as
+    //  boundaries.
+    //
+    //  With the introduction of sharp irregular patches, we are now better off
+    //  using irregular patches where appropriate, which will simplify the following
+    //  when this patch was already determined to be regular...
+    //
+    if (fTag._nonManifold) {
+        if (vTags[0]._nonManifold) vBoundaryMask |= (1 << 0) | (vTags[0]._infSharp ? 10 : 0);
+        if (vTags[1]._nonManifold) vBoundaryMask |= (1 << 1) | (vTags[1]._infSharp ?  5 : 0);
+        if (vTags[2]._nonManifold) vBoundaryMask |= (1 << 2) | (vTags[2]._infSharp ? 10 : 0);
+        if (vTags[3]._nonManifold) vBoundaryMask |= (1 << 3) | (vTags[3]._infSharp ?  5 : 0);
+
+        //  Force adjacent edges as boundaries if only one vertex in the resulting mask
+        //  (which would be an irregular boundary for Catmark, but not Loop):
+        if ((vBoundaryMask == (1 << 0)) || (vBoundaryMask == (1 << 2))) {
+            vBoundaryMask |= 10;
+        } else if ((vBoundaryMask == (1 << 1)) || (vBoundaryMask == (1 << 3))) {
+            vBoundaryMask |= 5;
+        }
+    }
+
+    //  Convert directly from a vertex- to edge-mask (no need to inspect edges):
+    int eBoundaryMask = 0;
+    if (vBoundaryMask) {
+        static int const vBoundaryMaskToEMask[16] =
+                { 0, -1, -1, 1, -1, -1, 2, 3, -1, 8, -1, 9, 4, 12, 6, -1 };
+        eBoundaryMask = vBoundaryMaskToEMask[vBoundaryMask];
+        assert(eBoundaryMask != -1);
+    }
+    return eBoundaryMask;
+}
+
+
+} // end namespace internal
+
+} // end namespace Far
+
+} // end namespace OPENSUBDIV_VERSION
+} // end namespace OpenSubdiv
+

--- a/opensubdiv/far/patchBuilder.h
+++ b/opensubdiv/far/patchBuilder.h
@@ -1,0 +1,128 @@
+//
+//   Copyright 2016 NVIDIA CORPORATION
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OPENSUBDIV3_FAR_PATCH_BUILDER_H
+#define OPENSUBDIV3_FAR_PATCH_BUILDER_H
+
+#include "../version.h"
+
+#include "../far/types.h"
+#include "../vtr/level.h"
+
+#include <vector>
+
+namespace OpenSubdiv {
+namespace OPENSUBDIV_VERSION {
+
+namespace Far {
+
+class TopologyRefiner;
+
+namespace internal {
+
+// PatchBuilder
+//
+// Private helper class aggregating transient contextual data structures during
+// the creation of feature-adaptive patches (this helps keeping the factory
+// classes stateless).
+//
+class PatchBuilder {
+
+public:
+
+    PatchBuilder(TopologyRefiner const & refiner,
+        int numFVarChannels, int const * fvarChannelIndices,
+            bool useInfSharpPatch, bool generateLegacySharpCornerPatches);
+
+    TopologyRefiner const & GetTopologyRefiner() const {
+        return _refiner;
+    }
+
+    std::vector<int> const & GetFVarChannelsIndices() const {
+        return _fvarChannelIndices;
+    }
+    bool UseInfSharpPatch() const {
+        return _useInfSharpPatch;
+    }
+
+    bool GenerateLegacySharpCornerPatches() const {
+        return _generateLegacySharpCornerPatches;
+    }
+
+    Vtr::internal::Level const & GetVtrLevel(int levelIndex) const;
+
+
+
+    // Methods to query patch properties for classification and construction.
+    bool IsPatchEligible(int levelIndex, Index faceIndex) const;
+
+    bool IsPatchSmoothCorner(int levelIndex, Index faceIndex, int fvcFactory = -1) const;
+
+    bool IsPatchRegular(int levelIndex, Index faceIndex, int fvcFactory = -1) const;
+
+    int GetRegularPatchBoundaryMask(int levelIndex, Index faceIndex, int fvcFactory = -1) const;
+
+    void GetIrregularPatchCornerSpans(int levelIndex, Index faceIndex,
+        Vtr::internal::Level::VSpan cornerSpans[4], int fvcFactory = -1) const;
+
+
+    // Additional simple queries -- most regarding face-varying channels that hide
+    // the mapping between channels in the source Refiner and corresponding channels
+    // in the Factory and PatchTable
+
+    // True if face-varying patches need to be generated for this topology
+    bool RequiresFVarPatches() const { return (!_fvarChannelIndices.empty()); }
+
+    int GetRefinerFVarChannel(int fvcFactory) const;
+
+    bool DoesFaceVaryingPatchMatch(int levelIndex, Index faceIndex, int fvcFactory) const;
+
+    int GetDistinctRefinerFVarChannel(int levelIndex, Index faceIndex, int fvcFactory) const;
+
+    int GetTransitionMask(int levelIndex, Index faceIndex) const;
+
+protected:
+
+    TopologyRefiner const & _refiner;
+
+    // These are the indices of face-varying channels in the refiner
+    // or empty if we are not populating face-varying data.
+    std::vector<int> _fvarChannelIndices;
+
+    bool _useInfSharpPatch,                  // Use infinitely-sharp patch
+         _generateLegacySharpCornerPatches;  // Generate sharp regular patches at smooth corners (legacy)
+};
+
+
+} // end namespace internal
+
+} // end namespace Far
+
+} // end namespace OPENSUBDIV_VERSION
+using namespace OPENSUBDIV_VERSION;
+
+} // end namespace OpenSubdiv
+
+
+#endif /* OPENSUBDIV3_FAR_PATCH_FACE_TAG_H */

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -63,37 +63,6 @@ inline bool isSharpnessEqual(float s1, float s2) { return (s1 == s2); }
 //
 //  Anonymous helper functions:
 //
-static inline void
-offsetAndPermuteIndices(Far::Index const indices[], int count,
-                        Far::Index offset, int const permutation[],
-                        Far::Index result[]) {
-
-    // The patch vertices for boundary and corner patches
-    // are assigned index values even though indices will
-    // be undefined along boundary and corner edges.
-    // When the resulting patch table is going to be used
-    // as indices for drawing, it is convenient for invalid
-    // indices to be replaced with known good values, such
-    // as the first un-permuted index, which is the index
-    // of the first vertex of the patch face.
-    Far::Index knownGoodIndex = indices[0];
-
-    if (permutation) {
-        for (int i = 0; i < count; ++i) {
-            if (permutation[i] < 0) {
-                result[i] = offset + knownGoodIndex;
-            } else {
-                result[i] = offset + indices[permutation[i]];
-            }
-        }
-    } else if (offset) {
-        for (int i = 0; i < count; ++i) {
-            result[i] = offset + indices[i];
-        }
-    } else {
-        std::memcpy(result, indices, count * sizeof(Far::Index));
-    }
-}
 
 inline int
 assignSharpnessIndex(float sharpness, std::vector<float> & sharpnessValues) {
@@ -272,7 +241,7 @@ PatchTableFactory::BuilderContext::GatherRegularPatchPoints(
         assert(bType <= 2);
     }
 
-    offsetAndPermuteIndices( patchVerts, 16, levelVertOffset, permutation, iptrs);
+    OffsetAndPermuteIndices( patchVerts, 16, levelVertOffset, permutation, iptrs);
     return 16;
 }
 

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -23,6 +23,7 @@
 //
 #include "../far/patchTableFactory.h"
 #include "../far/error.h"
+#include "../far/patchBuilder.h"
 #include "../far/ptexIndices.h"
 #include "../far/topologyRefiner.h"
 #include "../vtr/level.h"
@@ -60,114 +61,7 @@ inline bool isSharpnessEqual(float s1, float s2) { return (s1 == s2); }
 #endif
 
 //
-//  Local helper functions for identifying the subset of a ring around a
-//  corner that contributes to a patch -- parameterized by a mask that
-//  indicates what kind of edge is to delimit the span.
-//
-//  Note that the two main methods need both face-verts and face-edges for
-//  each corner, and that we don't really need the face-index once we have
-//  them -- consider passing the fVerts and fEdges as arguments as they
-//  will otherwise be retrieved repeatedly for each corner.
-//
-//  (As these mature it is likely they will be moved to Vtr, as a method
-//  to identify a VSpan would complement the existing method to gather
-//  the vertex/values associated with it.  The manifold vs non-manifold
-//  choice would then also be encapsulated -- provided both remain free
-//  of PatchTable-specific logic.)
-//
-inline Level::ETag
-getSingularEdgeMask(bool includeAllInfSharpEdges = false) {
-
-    Level::ETag eTagMask;
-    eTagMask.clear();
-    eTagMask._boundary = true;
-    eTagMask._nonManifold = true;
-    eTagMask._infSharp = includeAllInfSharpEdges;
-    return eTagMask;
-}
-
-inline bool
-isEdgeSingular(Level const & level, FVarLevel const * fvarLevel, Index eIndex,
-               Level::ETag eTagMask)
-{
-    Level::ETag eTag = level.getEdgeTag(eIndex);
-    if (fvarLevel) {
-        eTag = fvarLevel->getEdgeTag(eIndex).combineWithLevelETag(eTag);
-    }
-
-    Level::ETag::ETagSize * iTag  = reinterpret_cast<Level::ETag::ETagSize*>(&eTag);
-    Level::ETag::ETagSize * iMask = reinterpret_cast<Level::ETag::ETagSize*>(&eTagMask);
-    return (*iTag & *iMask) > 0;
-}
-
-void
-identifyManifoldCornerSpan(Level const & level, Index fIndex,
-                           int fCorner, Level::ETag eTagMask,
-                           Level::VSpan & vSpan, int fvc = -1)
-{
-    FVarLevel const * fvarLevel = (fvc < 0) ? 0 : &level.getFVarLevel(fvc);
-
-    ConstIndexArray fVerts = level.getFaceVertices(fIndex);
-    ConstIndexArray fEdges = level.getFaceEdges(fIndex);
-
-    ConstIndexArray vEdges = level.getVertexEdges(fVerts[fCorner]);
-    int             nEdges = vEdges.size();
-
-    int iLeadingStart  = vEdges.FindIndex(fEdges[fCorner]);
-    int iTrailingStart = (iLeadingStart + 1) % nEdges;
-
-    vSpan.clear();
-    vSpan._numFaces = 1;
-
-    int iLeading  = iLeadingStart;
-    while (! isEdgeSingular(level, fvarLevel, vEdges[iLeading], eTagMask)) {
-        ++vSpan._numFaces;
-        iLeading = (iLeading + nEdges - 1) % nEdges;
-        if (iLeading == iTrailingStart) break;
-    }
-
-    int iTrailing = iTrailingStart;
-    while (! isEdgeSingular(level, fvarLevel, vEdges[iTrailing], eTagMask)) {
-        ++vSpan._numFaces;
-        iTrailing = (iTrailing + 1) % nEdges;
-        if (iTrailing == iLeadingStart) break;
-    }
-    vSpan._startFace = (LocalIndex) iLeading;
-}
-
-void
-identifyNonManifoldCornerSpan(Level const & level, Index fIndex,
-                              int fCorner, Level::ETag /* eTagMask */,
-                              Level::VSpan & vSpan, int /* fvc */ = -1)
-{
-    //  For now, non-manifold patches revert to regular patches -- just identify
-    //  the single face now for a sharp corner patch.
-    //
-    //  Remember that the face may be incident the vertex multiple times when
-    //  non-manifold, so make sure the local index of the corner vertex in the
-    //  face identified additionally matches the corner.
-    //
-    //FVarLevel const * fvarLevel = (fvc < 0) ? 0 : &level.getFVarChannel(fvc);
-
-    Index vIndex = level.getFaceVertices(fIndex)[fCorner];
-
-    ConstIndexArray      vFaces  = level.getVertexFaces(vIndex);
-    ConstLocalIndexArray vInFace = level.getVertexFaceLocalIndices(vIndex);
-
-    vSpan.clear();
-    for (int i = 0; i < vFaces.size(); ++i) {
-        if ((vFaces[i] == fIndex) && ((int)vInFace[i] == fCorner)) {
-            vSpan._startFace = (LocalIndex) i;
-            vSpan._numFaces = 1;
-            vSpan._sharp = true;
-            break;
-        }
-    }
-    assert(vSpan._numFaces == 1);
-}
-
-//
-//  Additional anonymous helper functions:
+//  Anonymous helper functions:
 //
 static inline void
 offsetAndPermuteIndices(Far::Index const indices[], int count,
@@ -226,7 +120,7 @@ assignSharpnessIndex(float sharpness, std::vector<float> & sharpnessValues) {
 //
 // Note : struct members are not re-entrant nor are they intended to be !
 //
-struct PatchTableFactory::BuilderContext {
+struct PatchTableFactory::BuilderContext : public internal::PatchBuilder {
 
 public:
     // Simple struct to store <level,face> (and more?) info for a patch:
@@ -244,32 +138,19 @@ public:
     typedef std::vector<PatchTuple> PatchTupleVector;
 
 public:
+
     BuilderContext(TopologyRefiner const & refiner, Options options);
-
-    // Methods to query patch properties for classification and construction.
-    bool IsPatchEligible(int levelIndex, Index faceIndex) const;
-
-    bool IsPatchSmoothCorner(int levelIndex, Index faceIndex,
-                             int fvcFactory = -1) const;
-
-    bool IsPatchRegular(int levelIndex, Index faceIndex,
-                        int fvcFactory = -1) const;
-
-    int GetRegularPatchBoundaryMask(int levelIndex, Index faceIndex,
-                                    int fvcFactory = -1) const;
-
-    void GetIrregularPatchCornerSpans(int levelIndex, Index faceIndex,
-                                      Level::VSpan cornerSpans[4],
-                                      int fvcFactory = -1) const;
 
     // Methods to gather points associated with the different patch types
     int GatherLinearPatchPoints(Index * iptrs,
                                 PatchTuple const & patch,
                                 int fvcFactory = -1) const;
+
     int GatherRegularPatchPoints(Index * iptrs,
                                  PatchTuple const & patch,
                                  int boundaryMask,
                                  int fvcFactory = -1) const;
+
     template <class END_CAP_FACTORY_TYPE>
     int GatherIrregularPatchPoints(END_CAP_FACTORY_TYPE *endCapFactory,
                                    Index * iptrs,
@@ -277,38 +158,7 @@ public:
                                    Level::VSpan cornerSpans[4],
                                    int fvcFactory = -1) const;
 
-    // Additional simple queries -- most regarding face-varying channels that hide
-    // the mapping between channels in the source Refiner and corresponding channels
-    // in the Factory and PatchTable
-    //
-    // True if face-varying patches need to be generated for this topology
-    bool RequiresFVarPatches() const {
-        return (! fvarChannelIndices.empty());
-    }
-
-    int GetRefinerFVarChannel(int fvcFactory) const {
-        return (fvcFactory >= 0) ? fvarChannelIndices[fvcFactory] : -1;
-    }
-
-    bool DoesFaceVaryingPatchMatch(int levelIndex, Index faceIndex, int fvcFactory) const {
-        return refiner.getLevel(levelIndex).doesFaceFVarTopologyMatch(faceIndex,
-                        GetRefinerFVarChannel(fvcFactory));
-    }
-
-    int GetDistinctRefinerFVarChannel(int levelIndex, int faceIndex, int fvcFactory) const {
-        return ((fvcFactory >= 0) &&
-                !DoesFaceVaryingPatchMatch(levelIndex, faceIndex, fvcFactory)) ?
-            GetRefinerFVarChannel(fvcFactory) : -1;
-    }
-
-    int GetTransitionMask(int levelIndex, Index faceIndex) const {
-        return (levelIndex == refiner.GetMaxLevel()) ? 0 :
-            refiner.getRefinement(levelIndex).
-                       getParentFaceSparseTag(faceIndex)._transitional;
-    }
-
 public:
-    TopologyRefiner const & refiner;
 
     Options const options;
 
@@ -324,40 +174,28 @@ public:
 
     std::vector<int> levelVertOffsets;
     std::vector< std::vector<int> > levelFVarValueOffsets;
-
-    // These are the indices of face-varying channels in the refiner
-    // or empty if we are not populating face-varying data.
-    std::vector<int> fvarChannelIndices;
 };
 
 // Constructor
 PatchTableFactory::BuilderContext::BuilderContext(
-    TopologyRefiner const & ref, Options opts) :
-    refiner(ref), options(opts), ptexIndices(refiner),
-    numRegularPatches(0), numIrregularPatches(0),
-    numIrregularBoundaryPatches(0) {
-
-    if (options.generateFVarTables) {
-        // If client-code does not select specific channels, default to all
-        // the channels in the refiner.
-        if (options.numFVarChannels==-1) {
-            fvarChannelIndices.resize(refiner.GetNumFVarChannels());
-            for (int fvc=0;fvc<(int)fvarChannelIndices.size(); ++fvc) {
-                fvarChannelIndices[fvc] = fvc; // std::iota
-            }
-        } else {
-            fvarChannelIndices.assign(
-                options.fvarChannelIndices,
-                options.fvarChannelIndices+options.numFVarChannels);
-        }
-    }
+    TopologyRefiner const & refiner, Options opts) :
+        PatchBuilder(refiner,
+                     opts.generateFVarTables ? opts.numFVarChannels : 0,
+                     opts.fvarChannelIndices,
+                     opts.useInfSharpPatch,
+                     opts.generateLegacySharpCornerPatches),
+        options(opts),
+        ptexIndices(refiner),
+        numRegularPatches(0),
+        numIrregularPatches(0),
+        numIrregularBoundaryPatches(0) {
 }
 
 int
 PatchTableFactory::BuilderContext::GatherLinearPatchPoints(
         Index * iptrs, PatchTuple const & patch, int fvcFactory) const {
 
-    Level const & level = refiner.getLevel(patch.levelIndex);
+    Level const & level = _refiner.getLevel(patch.levelIndex);
 
     int levelVertOffset = (fvcFactory < 0)
                         ? levelVertOffsets[patch.levelIndex]
@@ -378,7 +216,7 @@ PatchTableFactory::BuilderContext::GatherRegularPatchPoints(
         Index * iptrs, PatchTuple const & patch, int boundaryMask,
         int fvcFactory) const {
 
-    Level const & level = refiner.getLevel(patch.levelIndex);
+    Level const & level = _refiner.getLevel(patch.levelIndex);
 
     int levelVertOffset = (fvcFactory < 0)
                         ? levelVertOffsets[patch.levelIndex]
@@ -446,7 +284,7 @@ PatchTableFactory::BuilderContext::GatherIrregularPatchPoints(
         Level::VSpan cornerSpans[4],
         int fvcFactory) const {
 
-    Level const & level = refiner.getLevel(patch.levelIndex);
+    Level const & level = _refiner.getLevel(patch.levelIndex);
 
     int levelVertOffset = (fvcFactory < 0)
                         ? levelVertOffsets[patch.levelIndex]
@@ -459,305 +297,6 @@ PatchTableFactory::BuilderContext::GatherIrregularPatchPoints(
 
     for (int i = 0; i < cvs.size(); ++i) iptrs[i] = cvs[i];
     return cvs.size();
-}
-
-bool
-PatchTableFactory::BuilderContext::IsPatchEligible(
-        int levelIndex, Index faceIndex) const {
-
-    //
-    //  Patches that are not eligible correpond to the following faces:
-    //      - holes
-    //      - those in intermediate levels that are further refined (not leaves)
-    //      - those without complete neighborhoods that supporting other patches
-    //
-    Level const & level = refiner.getLevel(levelIndex);
-
-    if (level.isFaceHole(faceIndex)) {
-        return false;
-    }
-
-    if (levelIndex < refiner.GetMaxLevel()) {
-        if (refiner.getRefinement(levelIndex).getParentFaceSparseTag(faceIndex)._selected) {
-            return false;
-        }
-    }
-
-    //
-    //  Faces that exist solely to support faces intended for patches will not have
-    //  their full neighborhood available and so are considered "incomplete":
-    //
-    Vtr::ConstIndexArray fVerts = level.getFaceVertices(faceIndex);
-    assert(fVerts.size() == 4);
-
-    if (level.getFaceCompositeVTag(fVerts)._incomplete) {
-        return false;
-    }
-    return true;
-}
-
-bool
-PatchTableFactory::BuilderContext::IsPatchSmoothCorner(
-        int levelIndex, Index faceIndex, int fvcFactory) const
-{
-    Level const & level = refiner.getLevel(levelIndex);
-
-    //  Ignore the face-varying channel if the topology for the face is not distinct
-    int fvcRefiner = GetDistinctRefinerFVarChannel(levelIndex, faceIndex, fvcFactory);
-
-    Vtr::ConstIndexArray fVerts = level.getFaceVertices(faceIndex);
-    if (fVerts.size() != 4) return false;
-
-    Level::VTag vTags[4];
-    level.getFaceVTags(faceIndex, vTags, fvcRefiner);
-
-    //
-    //  Test the subdivision rules for the corners, rather than just the boundary/interior
-    //  tags, to ensure that inf-sharp vertices or edges are properly accounted for (and
-    //  the cases appropriately excluded) if inf-sharp patches are enabled:
-    //
-    int boundaryCount = 0;
-    if (options.useInfSharpPatch) {
-        boundaryCount = (vTags[0]._infSharpEdges && (vTags[0]._rule == Sdc::Crease::RULE_CREASE))
-                      + (vTags[1]._infSharpEdges && (vTags[1]._rule == Sdc::Crease::RULE_CREASE))
-                      + (vTags[2]._infSharpEdges && (vTags[2]._rule == Sdc::Crease::RULE_CREASE))
-                      + (vTags[3]._infSharpEdges && (vTags[3]._rule == Sdc::Crease::RULE_CREASE));
-    } else {
-        boundaryCount = (vTags[0]._boundary && (vTags[0]._rule == Sdc::Crease::RULE_CREASE))
-                      + (vTags[1]._boundary && (vTags[1]._rule == Sdc::Crease::RULE_CREASE))
-                      + (vTags[2]._boundary && (vTags[2]._rule == Sdc::Crease::RULE_CREASE))
-                      + (vTags[3]._boundary && (vTags[3]._rule == Sdc::Crease::RULE_CREASE));
-    }
-    int xordinaryCount = vTags[0]._xordinary
-                       + vTags[1]._xordinary
-                       + vTags[2]._xordinary
-                       + vTags[3]._xordinary;
-
-    if ((boundaryCount == 3) && (xordinaryCount == 1)) {
-        //  This must be an isolated xordinary corner above level 1, otherwise we still
-        //  need to assure the xordinary vertex is opposite a smooth interior vertex:
-        //
-        if (levelIndex > 1) return true;
-
-        if (vTags[0]._xordinary) return (vTags[2]._rule == Sdc::Crease::RULE_SMOOTH);
-        if (vTags[1]._xordinary) return (vTags[3]._rule == Sdc::Crease::RULE_SMOOTH);
-        if (vTags[2]._xordinary) return (vTags[0]._rule == Sdc::Crease::RULE_SMOOTH);
-        if (vTags[3]._xordinary) return (vTags[1]._rule == Sdc::Crease::RULE_SMOOTH);
-    }
-    return false;
-}
-
-bool
-PatchTableFactory::BuilderContext::IsPatchRegular(
-        int levelIndex, Index faceIndex, int fvcFactory) const
-{
-    Level const & level = refiner.getLevel(levelIndex);
-
-    //  Ignore the face-varying channel if the topology for the face is not distinct
-    int fvcRefiner = GetDistinctRefinerFVarChannel(levelIndex, faceIndex, fvcFactory);
-
-    //  Retrieve the composite VTag for the four corners:
-    Level::VTag fCompVTag = level.getFaceCompositeVTag(faceIndex, fvcRefiner);
-
-    //
-    //  Patches around non-manifold features are currently regular -- will need to revise
-    //  this when infinitely sharp patches are introduced later:
-    //
-    bool isRegular = ! fCompVTag._xordinary || fCompVTag._nonManifold;
-
-    //  Reconsider when using inf-sharp patches in presence of inf-sharp features:
-    if (options.useInfSharpPatch && (fCompVTag._infSharp || fCompVTag._infSharpEdges)) {
-        if (fCompVTag._nonManifold || !fCompVTag._infIrregular) {
-            isRegular = true;
-        } else if (!fCompVTag._infSharpEdges) {
-            isRegular = false;
-        } else {
-            //
-            //   This is unfortunately a relatively complex case to determine... if a corner
-            //   vertex has been tagged has having an inf-sharp irregularity about it, the
-            //   neighborhood of the corner is partitioned into both regular and irregular
-            //   regions and the face must be more closely inspected to determine in which
-            //   it lies.
-            //
-            //   There could be a simpler test here to quickly accept/reject regularity given
-            //   how local it is -- involving no more than one or two (in the case of Loop)
-            //   adjacent faces -- but it will likely be messy and will need to inspect
-            //   adjacent faces and/or edges.  In the meantime, gathering and inspecting the
-            //   subset of the neighborhood delimited by inf-sharp edges will suffice (and
-            //   be comparable in all but cases of high valence)
-            //
-            Level::VTag vTags[4];
-            level.getFaceVTags(faceIndex, vTags, fvcRefiner);
-
-            Level::VSpan vSpan;
-            Level::ETag eMask = getSingularEdgeMask(true);
-
-            isRegular = true;
-            for (int i = 0; i < 4; ++i) {
-                if (vTags[i]._infIrregular) {
-                    identifyManifoldCornerSpan(level, faceIndex, i, eMask, vSpan, fvcRefiner);
-
-                    isRegular = (vSpan._numFaces == (vTags[i]._infSharpCrease ? 2 : 1));
-                    if (!isRegular) break;
-                }
-            }
-        }
-
-        //  When inf-sharp and extra-ordinary features are not isolated, need to inspect more
-        //  closely -- any smooth extra-ordinary corner makes the patch irregular:
-        if (fCompVTag._xordinary && (levelIndex < 2)) {
-            Level::VTag vTags[4];
-            level.getFaceVTags(faceIndex, vTags, fvcRefiner);
-            for (int i = 0; i < 4; ++i) {
-                if (vTags[i]._xordinary && (vTags[i]._rule == Sdc::Crease::RULE_SMOOTH)) {
-                    isRegular = false;
-                }
-            }
-        }
-    }
-
-    //  Legacy option -- reinterpret an irregular smooth corner as sharp if specified:
-    if (!isRegular && options.generateLegacySharpCornerPatches) {
-        if (fCompVTag._xordinary && fCompVTag._boundary && !fCompVTag._nonManifold) {
-            isRegular = IsPatchSmoothCorner(levelIndex, faceIndex, fvcRefiner);
-        }
-    }
-    return isRegular;
-}
-
-int
-PatchTableFactory::BuilderContext::GetRegularPatchBoundaryMask(
-        int levelIndex, Index faceIndex, int fvcFactory) const
-{
-    Level const & level = refiner.getLevel(levelIndex);
-
-    //  Ignore the face-varying channel if the topology for the face is not distinct
-    int fvcRefiner = GetDistinctRefinerFVarChannel(levelIndex, faceIndex, fvcFactory);
-
-    //  Gather the VTags for the four corners.  Regardless of the options for
-    //  treating non-manifold or inf-sharp patches, for a regular patch we can
-    //  infer all that we need need from tags for the corner vertices:
-    //
-    Level::VTag vTags[4];
-    level.getFaceVTags(faceIndex, vTags, fvcRefiner);
-
-    Level::VTag fTag = Level::VTag::BitwiseOr(vTags);
-
-    //
-    //  Identify vertex tags for inf-sharp edges and/or boundaries, depending on
-    //  whether or not inf-sharp patches are in use:
-    //
-    int vBoundaryMask = 0;
-    if (fTag._infSharpEdges) {
-        if (options.useInfSharpPatch) {
-            vBoundaryMask |= (vTags[0]._infSharpEdges << 0) |
-                             (vTags[1]._infSharpEdges << 1) |
-                             (vTags[2]._infSharpEdges << 2) |
-                             (vTags[3]._infSharpEdges << 3);
-        } else if (fTag._boundary) {
-            vBoundaryMask |= (vTags[0]._boundary << 0) |
-                             (vTags[1]._boundary << 1) |
-                             (vTags[2]._boundary << 2) |
-                             (vTags[3]._boundary << 3);
-        }
-    }
-
-    //
-    //  Non-manifold patches have been historically represented as regular in all
-    //  cases -- when a non-manifold vertex is sharp, it requires a regular corner
-    //  patch, and so both of its neighboring corners need to be re-interpreted as
-    //  boundaries.
-    //
-    //  With the introduction of sharp irregular patches, we are now better off
-    //  using irregular patches where appropriate, which will simplify the following
-    //  when this patch was already determined to be regular...
-    //
-    if (fTag._nonManifold) {
-        if (vTags[0]._nonManifold) vBoundaryMask |= (1 << 0) | (vTags[0]._infSharp ? 10 : 0);
-        if (vTags[1]._nonManifold) vBoundaryMask |= (1 << 1) | (vTags[1]._infSharp ?  5 : 0);
-        if (vTags[2]._nonManifold) vBoundaryMask |= (1 << 2) | (vTags[2]._infSharp ? 10 : 0);
-        if (vTags[3]._nonManifold) vBoundaryMask |= (1 << 3) | (vTags[3]._infSharp ?  5 : 0);
-
-        //  Force adjacent edges as boundaries if only one vertex in the resulting mask
-        //  (which would be an irregular boundary for Catmark, but not Loop):
-        if ((vBoundaryMask == (1 << 0)) || (vBoundaryMask == (1 << 2))) {
-            vBoundaryMask |= 10;
-        } else if ((vBoundaryMask == (1 << 1)) || (vBoundaryMask == (1 << 3))) {
-            vBoundaryMask |= 5;
-        }
-    }
-
-    //  Convert directly from a vertex- to edge-mask (no need to inspect edges):
-    int eBoundaryMask = 0;
-    if (vBoundaryMask) {
-        static int const vBoundaryMaskToEMask[16] =
-                { 0, -1, -1, 1, -1, -1, 2, 3, -1, 8, -1, 9, 4, 12, 6, -1 };
-        eBoundaryMask = vBoundaryMaskToEMask[vBoundaryMask];
-        assert(eBoundaryMask != -1);
-    }
-    return eBoundaryMask;
-}
-
-void
-PatchTableFactory::BuilderContext::GetIrregularPatchCornerSpans(
-        int levelIndex, Index faceIndex,
-        Level::VSpan cornerSpans[4],
-        int fvcFactory) const
-{
-    Level const & level = refiner.getLevel(levelIndex);
-
-    //  Ignore the face-varying channel if the topology for the face is not distinct
-    int fvcRefiner = GetDistinctRefinerFVarChannel(levelIndex, faceIndex, fvcFactory);
-
-    //  Retrieve tags and identify other information for the corner vertices:
-    Level::VTag vTags[4];
-    level.getFaceVTags(faceIndex, vTags, fvcRefiner);
-
-    FVarLevel::ValueTag fvarTags[4];
-    if (fvcRefiner >= 0) {
-        level.getFVarLevel(fvcRefiner).getFaceValueTags(faceIndex, fvarTags);
-    }
-
-    //
-    //  For each corner vertex, use the complete neighborhood when possible (which
-    //  does not require a search, otherwise identify the span of interest around
-    //  the vertex:
-    //
-    ConstIndexArray fVerts = level.getFaceVertices(faceIndex);
-
-    Level::ETag singularEdgeMask = getSingularEdgeMask(options.useInfSharpPatch);
-
-    for (int i = 0; i < fVerts.size(); ++i) {
-        bool noFVarMisMatch = (fvcRefiner < 0) || !fvarTags[i]._mismatch;
-        bool testInfSharp   = options.useInfSharpPatch &&
-                                (vTags[i]._infSharpEdges && (vTags[i]._rule != Sdc::Crease::RULE_DART));
-
-        if (noFVarMisMatch && !testInfSharp) {
-            cornerSpans[i].clear();
-        } else {
-            if (!vTags[i]._nonManifold) {
-                identifyManifoldCornerSpan(
-                        level, faceIndex, i, singularEdgeMask, cornerSpans[i], fvcRefiner);
-            } else {
-                identifyNonManifoldCornerSpan(
-                        level, faceIndex, i, singularEdgeMask, cornerSpans[i], fvcRefiner);
-            }
-        }
-        if (vTags[i]._corner) {
-            cornerSpans[i]._sharp = true;
-        } else if (options.useInfSharpPatch) {
-            cornerSpans[i]._sharp = vTags[i]._infIrregular && (vTags[i]._rule == Sdc::Crease::RULE_CORNER);
-        }
-
-        //  Legacy option -- reinterpret an irregular smooth corner as sharp if specified:
-        if (!cornerSpans[i]._sharp && options.generateLegacySharpCornerPatches) {
-            if (vTags[i]._xordinary && vTags[i]._boundary && !vTags[i]._nonManifold) {
-                    int nFaces = cornerSpans[i].isAssigned() ? cornerSpans[i]._numFaces
-                               : level.getVertexFaces(fVerts[i]).size();
-                    cornerSpans[i]._sharp = (nFaces == 1);
-            }
-        }
-    }
 }
 
 //
@@ -780,7 +319,7 @@ PatchTableFactory::allocateVertexTables(
 
     table->_paramTable.resize( npatches );
 
-    if (! context.refiner.IsUniform()) {
+    if (! context.GetTopologyRefiner().IsUniform()) {
         table->allocateVaryingVertices(
             PatchDescriptor(PatchDescriptor::QUADS), npatches);
     }
@@ -797,15 +336,17 @@ void
 PatchTableFactory::allocateFVarChannels(
         BuilderContext const & context, PatchTable * table) {
 
-    TopologyRefiner const & refiner = context.refiner;
+    TopologyRefiner const & refiner = context.GetTopologyRefiner();
+
+    std::vector<int> const & fvarChannelIndices = context.GetFVarChannelsIndices();
 
     int npatches = table->GetNumPatchesTotal();
 
-    table->allocateFVarPatchChannels((int)context.fvarChannelIndices.size());
+    table->allocateFVarPatchChannels((int)fvarChannelIndices.size());
 
     // Initialize each channel
-    for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
-        int refinerChannel = context.fvarChannelIndices[fvc];
+    for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
+        int refinerChannel = fvarChannelIndices[fvc];
 
         Sdc::Options::FVarLinearInterpolation interpolation =
             refiner.GetFVarLinearInterpolation(refinerChannel);
@@ -826,7 +367,7 @@ PatchTableFactory::allocateFVarChannels(
 
             PatchDescriptor::Type adaptiveType = allLinear
                     ? PatchDescriptor::QUADS
-                    : ((context.options.GetEndCapType() == Options::ENDCAP_GREGORY_BASIS)
+                    : ((context.options.GetEndCapType() == ENDCAP_GREGORY_BASIS)
                         ? PatchDescriptor::GREGORY_BASIS
                         : PatchDescriptor::REGULAR);
 
@@ -846,7 +387,7 @@ PatchTableFactory::computePatchParam(
     int depth, Index faceIndex,
     int boundaryMask, int transitionMask) {
 
-    TopologyRefiner const & refiner = context.refiner;
+    TopologyRefiner const & refiner = context.GetTopologyRefiner();
 
     // Move up the hierarchy accumulating u,v indices to the coarse level:
     int childIndexInParent = 0,
@@ -920,6 +461,8 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
     assert(refiner.IsUniform());
 
     BuilderContext context(refiner, options);
+
+    std::vector<int> const & fvarChannelIndices = context.GetFVarChannelsIndices();
 
     // ensure that triangulateQuads is only set for quadrilateral schemes
     options.triangulateQuads &= (refiner.GetSchemeType()==Sdc::SCHEME_BILINEAR ||
@@ -995,11 +538,11 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
     Index * levelFVarVertOffsets = 0;
     if (context.RequiresFVarPatches()) {
 
-        levelFVarVertOffsets = (Index *)alloca(context.fvarChannelIndices.size()*sizeof(Index));
-        memset(levelFVarVertOffsets, 0, context.fvarChannelIndices.size()*sizeof(Index));
+        levelFVarVertOffsets = (Index *)alloca(fvarChannelIndices.size()*sizeof(Index));
+        memset(levelFVarVertOffsets, 0, fvarChannelIndices.size()*sizeof(Index));
 
-        fptr = (Index **)alloca(context.fvarChannelIndices.size()*sizeof(Index *));
-        for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
+        fptr = (Index **)alloca(fvarChannelIndices.size()*sizeof(Index *));
+        for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
             fptr[fvc] = table->getFVarValues(fvc).begin();
         }
     }
@@ -1024,8 +567,8 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
                 *pptr++ = computePatchParam(context, level, face, /*boundary*/0, /*transition*/0);
 
                 if (context.RequiresFVarPatches()) {
-                    for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
-                        int refinerChannel = context.fvarChannelIndices[fvc];
+                    for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
+                        int refinerChannel = fvarChannelIndices[fvc];
 
                         ConstIndexArray fvalues = refLevel.GetFaceFVarValues(face, refinerChannel);
                         for (int vert=0; vert<fvalues.size(); ++vert) {
@@ -1047,7 +590,7 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
                     ++pptr;
 
                     if (context.RequiresFVarPatches()) {
-                        for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
+                        for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
                             *fptr[fvc] = *(fptr[fvc]-4); // copy fv0 index
                             ++fptr[fvc];
                             *fptr[fvc] = *(fptr[fvc]-3); // copy fv2 index
@@ -1060,8 +603,8 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
 
         if (options.generateAllLevels) {
             levelVertOffset += refiner.GetLevel(level).GetNumVertices();
-            for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
-                int refinerChannel = context.fvarChannelIndices[fvc];
+            for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
+                int refinerChannel = fvarChannelIndices[fvc];
                 levelFVarVertOffsets[fvc] += refiner.GetLevel(level).GetNumFVarValues(refinerChannel);
             }
         }
@@ -1107,7 +650,9 @@ PatchTableFactory::createAdaptive(TopologyRefiner const & refiner, Options optio
 void
 PatchTableFactory::identifyAdaptivePatches(BuilderContext & context) {
 
-    TopologyRefiner const & refiner = context.refiner;
+    TopologyRefiner const & refiner = context.GetTopologyRefiner();
+
+    std::vector<int> const & fvarChannelIndices = context.GetFVarChannelsIndices();
 
     //
     //  Iterate through the levels of refinement to inspect and tag components with information
@@ -1123,8 +668,8 @@ PatchTableFactory::identifyAdaptivePatches(BuilderContext & context) {
     context.patches.reserve(reservePatches);
 
     context.levelVertOffsets.push_back(0);
-    context.levelFVarValueOffsets.resize(context.fvarChannelIndices.size());
-    for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
+    context.levelFVarValueOffsets.resize(fvarChannelIndices.size());
+    for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
         context.levelFVarValueOffsets[fvc].push_back(0);
     }
 
@@ -1134,8 +679,8 @@ PatchTableFactory::identifyAdaptivePatches(BuilderContext & context) {
         context.levelVertOffsets.push_back(
                 context.levelVertOffsets.back() + level.getNumVertices());
 
-        for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
-            int refinerChannel = context.fvarChannelIndices[fvc];
+        for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
+            int refinerChannel = fvarChannelIndices[fvc];
             context.levelFVarValueOffsets[fvc].push_back(
                 context.levelFVarValueOffsets[fvc].back()
                 + level.getNumFVarValues(refinerChannel));
@@ -1155,7 +700,7 @@ PatchTableFactory::identifyAdaptivePatches(BuilderContext & context) {
 
                     // For legacy gregory patches we need to know how many
                     // irregular patches are also boundary patches.
-                    if (context.options.GetEndCapType() == Options::ENDCAP_LEGACY_GREGORY) {
+                    if (context.options.GetEndCapType() == ENDCAP_LEGACY_GREGORY) {
                         bool isBoundaryPatch = level.getFaceCompositeVTag(faceIndex)._boundary;
                         context.numIrregularBoundaryPatches += isBoundaryPatch;
                     }
@@ -1172,7 +717,9 @@ void
 PatchTableFactory::populateAdaptivePatches(
     BuilderContext & context, PatchTable * table) {
 
-    TopologyRefiner const & refiner = context.refiner;
+    TopologyRefiner const & refiner = context.GetTopologyRefiner();
+
+    std::vector<int> const & fvarChannelIndices = context.GetFVarChannelsIndices();
 
     // State needed to populate an array in the patch table.
     // Pointers in this structure are initialized after the patch array
@@ -1207,37 +754,37 @@ PatchTableFactory::populateAdaptivePatches(
     int numPatchArrays = (arrayBuilders[R].numPatches > 0);
 
     switch(context.options.GetEndCapType()) {
-    case Options::ENDCAP_BSPLINE_BASIS:
-        // Irregular patches are converted to bspline basis and
-        // will be packed into the same patch array as regular patches
-        IR = IRB = R;
-        arrayBuilders[R].numPatches += context.numIrregularPatches;
-        // Make sure we've counted this array even when
-        // there are no regular patches.
-        numPatchArrays = (arrayBuilders[R].numPatches > 0);
-        break;
-    case Options::ENDCAP_GREGORY_BASIS:
-        // Irregular patches (both interior and boundary) are converted
-        // to Gregory basis and will be packed into an additional patch array
-        IR = IRB = numPatchArrays;
-        arrayBuilders[IR].patchType = PatchDescriptor::GREGORY_BASIS;
-        arrayBuilders[IR].numPatches += context.numIrregularPatches;
-        numPatchArrays += (arrayBuilders[IR].numPatches > 0);
-        break;
-    case Options::ENDCAP_LEGACY_GREGORY:
-        // Irregular interior and irregular boundary patches each will be
-        // packed into separate additional patch arrays.
-        IR = numPatchArrays;
-        arrayBuilders[IR].patchType = PatchDescriptor::GREGORY;
-        arrayBuilders[IR].numPatches = context.numIrregularPatches
-                                     - context.numIrregularBoundaryPatches;
-        numPatchArrays += (arrayBuilders[IR].numPatches > 0);
+        case ENDCAP_BSPLINE_BASIS:
+            // Irregular patches are converted to bspline basis and
+            // will be packed into the same patch array as regular patches
+            IR = IRB = R;
+            arrayBuilders[R].numPatches += context.numIrregularPatches;
+            // Make sure we've counted this array even when
+            // there are no regular patches.
+            numPatchArrays = (arrayBuilders[R].numPatches > 0);
+            break;
+        case ENDCAP_GREGORY_BASIS:
+            // Irregular patches (both interior and boundary) are converted
+            // to Gregory basis and will be packed into an additional patch array
+            IR = IRB = numPatchArrays;
+            arrayBuilders[IR].patchType = PatchDescriptor::GREGORY_BASIS;
+            arrayBuilders[IR].numPatches += context.numIrregularPatches;
+            numPatchArrays += (arrayBuilders[IR].numPatches > 0);
+            break;
+        case ENDCAP_LEGACY_GREGORY:
+            // Irregular interior and irregular boundary patches each will be
+            // packed into separate additional patch arrays.
+            IR = numPatchArrays;
+            arrayBuilders[IR].patchType = PatchDescriptor::GREGORY;
+            arrayBuilders[IR].numPatches = context.numIrregularPatches
+                                         - context.numIrregularBoundaryPatches;
+            numPatchArrays += (arrayBuilders[IR].numPatches > 0);
 
-        IRB = numPatchArrays;
-        arrayBuilders[IRB].patchType = PatchDescriptor::GREGORY_BOUNDARY;
-        arrayBuilders[IRB].numPatches = context.numIrregularBoundaryPatches;
-        numPatchArrays += (arrayBuilders[IRB].numPatches > 0);
-        break;
+            IRB = numPatchArrays;
+            arrayBuilders[IRB].patchType = PatchDescriptor::GREGORY_BOUNDARY;
+            arrayBuilders[IRB].numPatches = context.numIrregularBoundaryPatches;
+            numPatchArrays += (arrayBuilders[IRB].numPatches > 0);
+            break;
     default:
         break;
     }
@@ -1271,10 +818,10 @@ PatchTableFactory::populateAdaptivePatches(
         }
 
         if (context.RequiresFVarPatches()) {
-            arrayBuilder.fptr.SetSize((int)context.fvarChannelIndices.size());
-            arrayBuilder.fpptr.SetSize((int)context.fvarChannelIndices.size());
+            arrayBuilder.fptr.SetSize((int)fvarChannelIndices.size());
+            arrayBuilder.fpptr.SetSize((int)fvarChannelIndices.size());
 
-            for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
+            for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
 
                 PatchDescriptor desc = table->GetFVarPatchDescriptor(fvc);
 
@@ -1300,54 +847,54 @@ PatchTableFactory::populateAdaptivePatches(
     Vtr::internal::StackBuffer<StencilTable*,1> localPointFVarStencils;
 
     switch(context.options.GetEndCapType()) {
-    case Options::ENDCAP_GREGORY_BASIS:
-        localPointStencils = new StencilTable(0);
-        localPointVaryingStencils = new StencilTable(0);
-        endCapGregoryBasis = new EndCapGregoryBasisPatchFactory(
-            refiner,
-            localPointStencils,
-            localPointVaryingStencils,
-            context.options.shareEndCapPatchPoints);
-        break;
-    case Options::ENDCAP_BSPLINE_BASIS:
-        localPointStencils = new StencilTable(0);
-        localPointVaryingStencils = new StencilTable(0);
-        endCapBSpline = new EndCapBSplineBasisPatchFactory(
-            refiner,
-            localPointStencils,
-            localPointVaryingStencils);
-        break;
-    case Options::ENDCAP_LEGACY_GREGORY:
-        endCapLegacyGregory = new EndCapLegacyGregoryPatchFactory(refiner);
-        break;
+        case ENDCAP_GREGORY_BASIS:
+            localPointStencils = new StencilTable(0);
+            localPointVaryingStencils = new StencilTable(0);
+            endCapGregoryBasis = new EndCapGregoryBasisPatchFactory(
+                refiner,
+                localPointStencils,
+                localPointVaryingStencils,
+                context.options.shareEndCapPatchPoints);
+            break;
+        case ENDCAP_BSPLINE_BASIS:
+            localPointStencils = new StencilTable(0);
+            localPointVaryingStencils = new StencilTable(0);
+            endCapBSpline = new EndCapBSplineBasisPatchFactory(
+                refiner,
+                localPointStencils,
+                localPointVaryingStencils);
+            break;
+        case ENDCAP_LEGACY_GREGORY:
+            endCapLegacyGregory = new EndCapLegacyGregoryPatchFactory(refiner);
+            break;
     default:
         break;
     }
 
     if (context.RequiresFVarPatches()) {
-        fvarEndCapBSpline.SetSize((int)context.fvarChannelIndices.size());
-        fvarEndCapGregoryBasis.SetSize((int)context.fvarChannelIndices.size());
-        localPointFVarStencils.SetSize((int)context.fvarChannelIndices.size());
+        fvarEndCapBSpline.SetSize((int)fvarChannelIndices.size());
+        fvarEndCapGregoryBasis.SetSize((int)fvarChannelIndices.size());
+        localPointFVarStencils.SetSize((int)fvarChannelIndices.size());
 
-        for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
+        for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
             switch(context.options.GetEndCapType()) {
-            case Options::ENDCAP_GREGORY_BASIS:
-                localPointFVarStencils[fvc] = new StencilTable(0);
-                fvarEndCapGregoryBasis[fvc] = new EndCapGregoryBasisPatchFactory(
-                    refiner,
-                    localPointFVarStencils[fvc],
-                    NULL,
-                    context.options.shareEndCapPatchPoints);
-                break;
-            case Options::ENDCAP_BSPLINE_BASIS:
-                localPointFVarStencils[fvc] = new StencilTable(0);
-                fvarEndCapBSpline[fvc] = new EndCapBSplineBasisPatchFactory(
-                    refiner,
-                    localPointFVarStencils[fvc],
-                    NULL);
-                break;
-            default:
-                break;
+                case ENDCAP_GREGORY_BASIS:
+                    localPointFVarStencils[fvc] = new StencilTable(0);
+                    fvarEndCapGregoryBasis[fvc] = new EndCapGregoryBasisPatchFactory(
+                        refiner,
+                        localPointFVarStencils[fvc],
+                        NULL,
+                        context.options.shareEndCapPatchPoints);
+                    break;
+                case ENDCAP_BSPLINE_BASIS:
+                    localPointFVarStencils[fvc] = new StencilTable(0);
+                    fvarEndCapBSpline[fvc] = new EndCapBSplineBasisPatchFactory(
+                        refiner,
+                        localPointFVarStencils[fvc],
+                        NULL);
+                    break;
+                default:
+                    break;
             }
         }
     }
@@ -1393,7 +940,7 @@ PatchTableFactory::populateAdaptivePatches(
                     }
                 }
             }
-            
+
             //  The single-crease patch is an interior patch so ignore boundary mask when gathering:
             if (isRegSingleCrease) {
                 arrayBuilder->iptr +=
@@ -1410,34 +957,34 @@ PatchTableFactory::populateAdaptivePatches(
 
             // switch endcap patch type by option
             switch(context.options.GetEndCapType()) {
-            case Options::ENDCAP_GREGORY_BASIS:
-                arrayBuilder->iptr +=
-                    context.GatherIrregularPatchPoints(
-                        endCapGregoryBasis, arrayBuilder->iptr, patch, irregCornerSpans);
-                break;
-            case Options::ENDCAP_BSPLINE_BASIS:
-                arrayBuilder->iptr +=
-                    context.GatherIrregularPatchPoints(
-                        endCapBSpline, arrayBuilder->iptr, patch, irregCornerSpans);
-                break;
-            case Options::ENDCAP_LEGACY_GREGORY:
-                // For legacy gregory patches we may need to switch to
-                // the irregular boundary patch array.
-                if (!faceVTags._boundary) {
+                case ENDCAP_GREGORY_BASIS:
                     arrayBuilder->iptr +=
                         context.GatherIrregularPatchPoints(
-                            endCapLegacyGregory, arrayBuilder->iptr, patch, irregCornerSpans);
-                } else {
-                    arrayBuilder = &arrayBuilders[IRB];
+                            endCapGregoryBasis, arrayBuilder->iptr, patch, irregCornerSpans);
+                    break;
+                case ENDCAP_BSPLINE_BASIS:
                     arrayBuilder->iptr +=
                         context.GatherIrregularPatchPoints(
-                            endCapLegacyGregory, arrayBuilder->iptr, patch, irregCornerSpans);
-                }
-                break;
-            case Options::ENDCAP_BILINEAR_BASIS:
-                // not implemented yet
-                assert(false);
-                break;
+                            endCapBSpline, arrayBuilder->iptr, patch, irregCornerSpans);
+                    break;
+                case ENDCAP_LEGACY_GREGORY:
+                    // For legacy gregory patches we may need to switch to
+                    // the irregular boundary patch array.
+                    if (!faceVTags._boundary) {
+                        arrayBuilder->iptr +=
+                            context.GatherIrregularPatchPoints(
+                                endCapLegacyGregory, arrayBuilder->iptr, patch, irregCornerSpans);
+                    } else {
+                        arrayBuilder = &arrayBuilders[IRB];
+                        arrayBuilder->iptr +=
+                            context.GatherIrregularPatchPoints(
+                                endCapLegacyGregory, arrayBuilder->iptr, patch, irregCornerSpans);
+                    }
+                    break;
+                case ENDCAP_BILINEAR_BASIS:
+                    // not implemented yet
+                    assert(false);
+                    break;
             default:
                 // no endcap
                 break;
@@ -1461,7 +1008,7 @@ PatchTableFactory::populateAdaptivePatches(
         }
 
         if (context.RequiresFVarPatches()) {
-            for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
+            for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
 
                 BuilderContext::PatchTuple fvarPatch(patch);
 
@@ -1554,32 +1101,31 @@ PatchTableFactory::populateAdaptivePatches(
     }
 
     switch(context.options.GetEndCapType()) {
-    case Options::ENDCAP_GREGORY_BASIS:
-        table->_localPointStencils = localPointStencils;
-        table->_localPointVaryingStencils = localPointVaryingStencils;
-        delete endCapGregoryBasis;
-        break;
-    case Options::ENDCAP_BSPLINE_BASIS:
-        table->_localPointStencils = localPointStencils;
-        table->_localPointVaryingStencils = localPointVaryingStencils;
-        delete endCapBSpline;
-        break;
-    case Options::ENDCAP_LEGACY_GREGORY:
-        endCapLegacyGregory->Finalize(
-            table->GetMaxValence(),
-            &table->_quadOffsetsTable,
-            &table->_vertexValenceTable);
-        delete endCapLegacyGregory;
-        break;
+        case ENDCAP_GREGORY_BASIS:
+            table->_localPointStencils = localPointStencils;
+            table->_localPointVaryingStencils = localPointVaryingStencils;
+            delete endCapGregoryBasis;
+            break;
+        case ENDCAP_BSPLINE_BASIS:
+            table->_localPointStencils = localPointStencils;
+            table->_localPointVaryingStencils = localPointVaryingStencils;
+            delete endCapBSpline;
+            break;
+        case ENDCAP_LEGACY_GREGORY:
+            endCapLegacyGregory->Finalize(
+                table->GetMaxValence(),
+                &table->_quadOffsetsTable,
+                &table->_vertexValenceTable);
+            delete endCapLegacyGregory;
+            break;
     default:
         break;
     }
 
     if (context.RequiresFVarPatches()) {
-        table->_localPointFaceVaryingStencils.resize(
-                                        context.fvarChannelIndices.size());
+        table->_localPointFaceVaryingStencils.resize(fvarChannelIndices.size());
 
-        for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
+        for (int fvc=0; fvc<(int)fvarChannelIndices.size(); ++fvc) {
             if (localPointFVarStencils[fvc]->GetNumStencils() > 0) {
                 localPointFVarStencils[fvc]->finalize();
             } else {
@@ -1588,14 +1134,14 @@ PatchTableFactory::populateAdaptivePatches(
             }
 
             switch(context.options.GetEndCapType()) {
-            case Options::ENDCAP_GREGORY_BASIS:
-                delete fvarEndCapGregoryBasis[fvc];
-                break;
-            case Options::ENDCAP_BSPLINE_BASIS:
-                delete fvarEndCapBSpline[fvc];
-                break;
-            default:
-                break;
+                case ENDCAP_GREGORY_BASIS:
+                    delete fvarEndCapGregoryBasis[fvc];
+                    break;
+                case ENDCAP_BSPLINE_BASIS:
+                    delete fvarEndCapBSpline[fvc];
+                    break;
+                default:
+                    break;
             }
 
             table->_localPointFaceVaryingStencils[fvc] =

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -47,14 +47,6 @@ public:
     ///
     struct Options {
 
-        enum EndCapType {
-            ENDCAP_NONE = 0,             ///< no endcap
-            ENDCAP_BILINEAR_BASIS,       ///< use bilinear quads (4 cp) as end-caps
-            ENDCAP_BSPLINE_BASIS,        ///< use BSpline basis patches (16 cp) as end-caps
-            ENDCAP_GREGORY_BASIS,        ///< use Gregory basis patches (20 cp) as end-caps
-            ENDCAP_LEGACY_GREGORY        ///< use legacy (2.x) Gregory patches (4 cp + valence table) as end-caps
-        };
-
         Options(unsigned int maxIsolation=10) :
              generateAllLevels(false),
              triangulateQuads(false),

--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -448,8 +448,7 @@ LimitStencilTableFactory::Create(TopologyRefiner const & refiner,
         // patch table.
 
         PatchTableFactory::Options patchTableOptions;
-        patchTableOptions.SetEndCapType(
-            Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS);
+        patchTableOptions.SetEndCapType(ENDCAP_GREGORY_BASIS);
         patchTableOptions.useInfSharpPatch = !uniform &&
             refiner.GetAdaptiveOptions().useInfSharpPatch;
 

--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -42,6 +42,10 @@ namespace Far { namespace internal { class FeatureMask; } }
 
 namespace Far {
 
+namespace internal {
+    class PatchBuilder;
+}
+
 template <class MESH> class TopologyRefinerFactory;
 
 ///
@@ -214,6 +218,7 @@ protected:
     friend class EndCapLegacyGregoryPatchFactory;
     friend class PtexIndices;
     friend class PrimvarRefiner;
+    friend class internal::PatchBuilder;
 
     Vtr::internal::Level & getLevel(int l) { return *_levels[l]; }
     Vtr::internal::Level const & getLevel(int l) const { return *_levels[l]; }

--- a/opensubdiv/far/types.h
+++ b/opensubdiv/far/types.h
@@ -52,6 +52,25 @@ inline bool IndexIsValid(Index index) { return Vtr::IndexIsValid(index); }
 static const Index INDEX_INVALID = Vtr::INDEX_INVALID;
 static const int   VALENCE_LIMIT = Vtr::VALENCE_LIMIT;
 
+inline unsigned int packBitfield(unsigned int value, int width, int offset) {
+    return (unsigned int)((value & ((1<<width)-1)) << offset);
+}
+
+inline unsigned int unpackBitfield(unsigned int value, int width, int offset) {
+    return (unsigned short)((value >> offset) & ((1<<width)-1));
+}
+
+///
+/// \brief Enumerated type for all end-cap patch types
+///
+enum EndCapType {
+    ENDCAP_NONE = 0,             ///< no endcap
+    ENDCAP_BILINEAR_BASIS,       ///< use bilinear quads (4 cp) as end-caps
+    ENDCAP_BSPLINE_BASIS,        ///< use BSpline basis patches (16 cp) as end-caps
+    ENDCAP_GREGORY_BASIS,        ///< use Gregory basis patches (20 cp) as end-caps
+    ENDCAP_LEGACY_GREGORY        ///< use legacy (2.x) Gregory patches (4 cp + valence table) as end-caps
+};
+
 } // end namespace Far
 
 } // end namespace OPENSUBDIV_VERSION

--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -616,16 +616,16 @@ private:
 
         if (bits.test(MeshEndCapBSplineBasis)) {
             poptions.SetEndCapType(
-                Far::PatchTableFactory::Options::ENDCAP_BSPLINE_BASIS);
+                Far::ENDCAP_BSPLINE_BASIS);
         } else if (bits.test(MeshEndCapGregoryBasis)) {
             poptions.SetEndCapType(
-                Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS);
+                Far::ENDCAP_GREGORY_BASIS);
             // points on gregory basis endcap boundary can be shared among
             // adjacent patches to save some stencils.
             poptions.shareEndCapPatchPoints = true;
         } else if (bits.test(MeshEndCapLegacyGregory)) {
             poptions.SetEndCapType(
-                Far::PatchTableFactory::Options::ENDCAP_LEGACY_GREGORY);
+                Far::ENDCAP_LEGACY_GREGORY);
         }
 
         _farPatchTable = Far::PatchTableFactory::Create(*_refiner, poptions);

--- a/regression/far_perf/far_perf.cpp
+++ b/regression/far_perf/far_perf.cpp
@@ -79,7 +79,7 @@ doPerf(const Shape *shape, int maxlevel, int endCapType)
     Far::PatchTable const * patchTable = NULL;
     {
         Far::PatchTableFactory::Options poptions(maxlevel);
-        poptions.SetEndCapType((Far::PatchTableFactory::Options::EndCapType)endCapType);
+        poptions.SetEndCapType((Far::EndCapType)endCapType);
         patchTable = Far::PatchTableFactory::Create(*refiner, poptions);
     }
 
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
 
     int maxlevel = 8;
     std::string str;
-    int endCapType = Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS;
+    int endCapType = Far::ENDCAP_GREGORY_BASIS;
 
     for (int i = 1; i < argc; ++i) {
         if (strstr(argv[i], ".obj")) {
@@ -141,9 +141,9 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i], "-e")) {
             const char *type = argv[++i];
             if (!strcmp(type, "bspline")) {
-                endCapType = Far::PatchTableFactory::Options::ENDCAP_BSPLINE_BASIS;
+                endCapType = Far::ENDCAP_BSPLINE_BASIS;
             } else if (!strcmp(type, "gregory")) {
-                endCapType = Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS;
+                endCapType = Far::ENDCAP_GREGORY_BASIS;
             } else {
                 printf("Unknown endcap type %s\n", type);
                 return 1;


### PR DESCRIPTION
Proposed abstraction of patch building tools into a PatchBuilder class to be shared between the PatchTableFactory and new topology hashing algorithms.

- add PatchBuilder class
- inherit PatchBuilderContext from PatchBuilder in PatchTableFactory
- move end cap types enum to types.h
- propagate 'fallout' from these changes