### PR TITLE
Several improvements to CI building and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 
 # ignore build files
-/build*
+/build/*
 /inst*
 
 *.pyc

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Feel free to use it and let us know what you think.
 
 For more details about OpenSubdiv, see [Pixar Graphics Technologies](http://graphics.pixar.com).
 
-|        |  Linux  |  Windows  |  macOS | iOS |
-|:------:|:-------:|:---------:|:------:|:---:|
-| master | [![Linux Build Status](https://travis-ci.org/PixarAnimationStudios/OpenSubdiv.svg?branch=master)](https://travis-ci.org/PixarAnimationStudios/OpenSubdiv) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/mcmwg4q9m8kgi9im/branch/master?svg=true)](https://ci.appveyor.com/project/c64kernal/opensubdiv-ddr8q) |
+|        |  Linux and OSX |  Windows  |
+|:------:|:-------:|:---------:|
+| master | [![Linux and OSX Build Status](https://travis-ci.org/PixarAnimationStudios/OpenSubdiv.svg?branch=master)](https://travis-ci.org/PixarAnimationStudios/OpenSubdiv) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/mcmwg4q9m8kgi9im/branch/master?svg=true)](https://ci.appveyor.com/project/c64kernal/opensubdiv-ddr8q) |
 | dev | [![Linux Build Status](https://travis-ci.org/PixarAnimationStudios/OpenSubdiv.svg?branch=dev)](https://travis-ci.org/PixarAnimationStudios/OpenSubdiv) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/mcmwg4q9m8kgi9im/branch/dev?svg=true)](https://ci.appveyor.com/project/c64kernal/opensubdiv-ddr8q) |
 
 ## Documents

--- a/build_scripts/travis_before_script_linux.sh
+++ b/build_scripts/travis_before_script_linux.sh
@@ -1,0 +1,86 @@
+#
+#   Copyright 2017 Pixar
+#
+#   Licensed under the Apache License, Version 2.0 (the "Apache License")
+#   with the following modification; you may not use this file except in
+#   compliance with the Apache License and the following modification to it:
+#   Section 6. Trademarks. is deleted and replaced with:
+#
+#   6. Trademarks. This License does not grant permission to use the trade
+#      names, trademarks, service marks, or product names of the Licensor
+#      and its affiliates, except as required to comply with Section 4(c) of
+#      the License and to reproduce the content of the NOTICE file.
+#
+#   You may obtain a copy of the Apache License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the Apache License with the above modification is
+#   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#   KIND, either express or implied. See the Apache License for the specific
+#   language governing permissions and limitations under the Apache License.
+#
+
+
+# opensubdiv needs 2.8.8 or later.
+cmake --version
+
+###############################################################################
+# Install X11 dev libraries
+sudo apt-get install libxrandr-dev
+sudo apt-get install libxcursor-dev
+sudo apt-get install libxinerama-dev
+sudo apt-get install libxi-dev
+
+sudo apt-get update -qq
+
+# install glut and xxf86vm (for GL libs)
+sudo apt-get install freeglut3
+sudo apt-get install freeglut3-dev
+sudo apt-get install libxxf86vm1
+sudo apt-get install libxxf86vm-dev
+
+# install GLEW
+sudo apt-get install libglew1.10
+sudo apt-get install libglew-dev
+
+
+###############################################################################
+# Upgrade to get a version of Mesa that supports OGL 4
+sudo add-apt-repository ppa:ubuntu-x-swat/updates -y
+sudo apt-get update -qq
+sudo apt-get dist-upgrade
+
+
+###############################################################################
+# Build and install glfw
+mkdir glfw && pushd glfw
+git clone https://github.com/glfw/glfw
+mkdir build && cd build
+cmake ../glfw
+make
+sudo make install
+popd
+
+
+
+###############################################################################
+# Start an X Virtual Framebuffer so that we can do some basic imaging tests.
+export DISPLAY=:99.0
+sh -e /etc/init.d/xvfb start
+
+###############################################################################
+# Install TBB 4.3 update 1
+wget https://www.threadingbuildingblocks.org/sites/default/files/software_releases/linux/tbb43_20141023oss_lin.tgz -O /tmp/tbb.tgz
+tar -xvzf /tmp/tbb.tgz -C $HOME
+
+###############################################################################
+# Install PTex
+wget https://github.com/wdas/ptex/archive/v2.0.30.tar.gz -O /tmp/ptex.tgz
+tar -xvzf /tmp/ptex.tgz -C $HOME
+pushd $HOME/ptex-2.0.30/src
+make
+mkdir $HOME/ptex
+mv $HOME/ptex-2.0.30/install/* $HOME/ptex
+popd

--- a/build_scripts/travis_script_linux.sh
+++ b/build_scripts/travis_script_linux.sh
@@ -1,5 +1,6 @@
+#!/bin/bash
 #
-#   Copyright 2015 Pixar
+#   Copyright 2017 Pixar
 #
 #   Licensed under the Apache License, Version 2.0 (the "Apache License")
 #   with the following modification; you may not use this file except in
@@ -21,49 +22,18 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-language: cpp
 
-os:
-    - linux
-    - osx
+mkdir build && cd build
 
-osx_image: xcode9
+# On gcc, we can turn on OMP
+# On Linux, we'll also test TBB and Ptex
+cmake \
+    -DNO_CUDA=1 \
+    -DNO_OPENCL=1 \
+    -DPTEX_LOCATION=$HOME/ptex \
+    -DTBB_LOCATION=$HOME/tbb43_20141023oss \
+    .. || exit $?
 
-sudo: required
-dist: trusty
+make || exit $?
 
-compiler:
-    - gcc
-    - clang
-
-branches:
-  only:
-   - master
-   - dev
-
-matrix:
-
-    # On Linux build with gcc and on OSX build with clang
-    exclude:
-        - os: osx
-          compiler: gcc
-        - os: linux
-          compiler: clang
-
-# build environment
-before_script:
-   - if [ $TRAVIS_OS_NAME == osx ] ; then
-        echo "before_script on OSX" ;
-     elif [ $TRAVIS_OS_NAME == linux ] ; then
-        echo "before_script on Linux" ;
-        source build_scripts/travis_before_script_linux.sh ;
-     fi
-
-script:
-   - if [ $TRAVIS_OS_NAME == osx ] ; then
-        echo "script on OSX" ;
-        build_scripts/travis_script_osx.sh ;
-     elif [ $TRAVIS_OS_NAME == linux ] ; then
-        echo "script on Linux" ;
-        source build_scripts/travis_script_linux.sh ;
-     fi
+ctest --output-on-failure || exit $?

--- a/build_scripts/travis_script_osx.sh
+++ b/build_scripts/travis_script_osx.sh
@@ -1,5 +1,6 @@
+#!/bin/sh
 #
-#   Copyright 2015 Pixar
+#   Copyright 2017 Pixar
 #
 #   Licensed under the Apache License, Version 2.0 (the "Apache License")
 #   with the following modification; you may not use this file except in
@@ -21,49 +22,9 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-language: cpp
 
-os:
-    - linux
-    - osx
 
-osx_image: xcode9
-
-sudo: required
-dist: trusty
-
-compiler:
-    - gcc
-    - clang
-
-branches:
-  only:
-   - master
-   - dev
-
-matrix:
-
-    # On Linux build with gcc and on OSX build with clang
-    exclude:
-        - os: osx
-          compiler: gcc
-        - os: linux
-          compiler: clang
-
-# build environment
-before_script:
-   - if [ $TRAVIS_OS_NAME == osx ] ; then
-        echo "before_script on OSX" ;
-     elif [ $TRAVIS_OS_NAME == linux ] ; then
-        echo "before_script on Linux" ;
-        source build_scripts/travis_before_script_linux.sh ;
-     fi
-
-script:
-   - if [ $TRAVIS_OS_NAME == osx ] ; then
-        echo "script on OSX" ;
-        build_scripts/travis_script_osx.sh ;
-     elif [ $TRAVIS_OS_NAME == linux ] ; then
-        echo "script on Linux" ;
-        source build_scripts/travis_script_linux.sh ;
-     fi
+mkdir build && cd build
+cmake -DNO_TBB=1 -DNO_OMP=1 -DNO_CUDA=1 -DNO_OPENCL=1 -DNO_PTEX=1 -DNO_GLTESTS=1 .. || exit $?
+make || exit $?
+make test || exit $?

--- a/examples/common/glUtils.cpp
+++ b/examples/common/glUtils.cpp
@@ -147,12 +147,14 @@ PrintGLVersion() {
     std::cout << glGetString(GL_RENDERER) << "\n";
     std::cout << glGetString(GL_VERSION) << "\n";
 
-    int i;
+    int i = -1;
     std::cout << "Init OpenGL ";
     glGetIntegerv(GL_MAJOR_VERSION, &i);
     std::cout << i << ".";
     glGetIntegerv(GL_MINOR_VERSION, &i);
     std::cout << i << "\n";
+
+    CheckGLErrors("PrintGLVersion");
 }
 
 void

--- a/regression/osd_regression/main.cpp
+++ b/regression/osd_regression/main.cpp
@@ -623,6 +623,12 @@ parseArgs(int argc, char ** argv) {
     }
 }
 
+void _glfw_error_callback(int error, const char *description)
+{
+    printf("GLFW reported error %d: %s\n",
+            error, description);
+}
+
 //------------------------------------------------------------------------------
 int 
 main(int argc, char ** argv) {
@@ -632,8 +638,11 @@ main(int argc, char ** argv) {
     // "-backend <name>" tests one backend.
     parseArgs(argc, argv);
 
+    glfwSetErrorCallback(_glfw_error_callback);
+
     // Make sure we have an OpenGL context : create dummy GLFW window
     if (! glfwInit()) {
+        printf("DISPLAY set to '%s'\n", getenv("DISPLAY"));
         printf("Failed to initialize GLFW\n");
         return 1;
     }


### PR DESCRIPTION
- Added support for OSX CI builds and tests
- Cleaned up build scripts and moved to $ROOT/build_scripts
- On Linux: moved to trusty distro
- On Linux: enabled OpenMP, TBB and PTex build options
- On Linux: install and setup xvfb with newer mesa drivers to run our GL tests
- On Linux: enable GL tests