### PR TITLE
Fixed MtlComputeEvaluator docs and overloads

### DIFF
--- a/opensubdiv/osd/mtlComputeEvaluator.h
+++ b/opensubdiv/osd/mtlComputeEvaluator.h
@@ -70,6 +70,9 @@ namespace OpenSubdiv
                 id<MTLBuffer> GetWeightsBuffer() const { return _weightsBuffer; }
                 id<MTLBuffer> GetDuWeightsBuffer() const { return _duWeightsBuffer; }
                 id<MTLBuffer> GetDvWeightsBuffer() const { return _dvWeightsBuffer; }
+                id<MTLBuffer> GetDuuWeightsBuffer() const { return _duuWeightsBuffer; }
+                id<MTLBuffer> GetDuvWeightsBuffer() const { return _duvWeightsBuffer; }
+                id<MTLBuffer> GetDvvWeightsBuffer() const { return _dvvWeightsBuffer; }
 
                 int GetNumStencils() const  { return _numStencils; }
 
@@ -80,6 +83,9 @@ namespace OpenSubdiv
                 id<MTLBuffer> _weightsBuffer;
                 id<MTLBuffer> _duWeightsBuffer;
                 id<MTLBuffer> _dvWeightsBuffer;
+                id<MTLBuffer> _duuWeightsBuffer;
+                id<MTLBuffer> _duvWeightsBuffer;
+                id<MTLBuffer> _dvvWeightsBuffer;
 
                 int _numStencils;
             };
@@ -90,19 +96,19 @@ namespace OpenSubdiv
                 typedef bool Instantiatable;
 
                 static MTLComputeEvaluator * Create(BufferDescriptor const &srcDesc,
-                                                      BufferDescriptor const &dstDesc,
-                                                      BufferDescriptor const &duDesc,
-                                                      BufferDescriptor const &dvDesc,
-                                                      MTLContext* context);
+                                                    BufferDescriptor const &dstDesc,
+                                                    BufferDescriptor const &duDesc,
+                                                    BufferDescriptor const &dvDesc,
+                                                    MTLContext* context);
 
                 static MTLComputeEvaluator * Create(BufferDescriptor const &srcDesc,
-                                                      BufferDescriptor const &dstDesc,
-                                                      BufferDescriptor const &duDesc,
-                                                      BufferDescriptor const &dvDesc,
-                                                      BufferDescriptor const &duuDesc,
-                                                      BufferDescriptor const &duvDesc,
-                                                      BufferDescriptor const &dvvDesc,
-                                                      MTLContext* context);
+                                                    BufferDescriptor const &dstDesc,
+                                                    BufferDescriptor const &duDesc,
+                                                    BufferDescriptor const &dvDesc,
+                                                    BufferDescriptor const &duuDesc,
+                                                    BufferDescriptor const &duvDesc,
+                                                    BufferDescriptor const &dvvDesc,
+                                                    MTLContext* context);
 
                 MTLComputeEvaluator();
                 ~MTLComputeEvaluator();
@@ -113,7 +119,7 @@ namespace OpenSubdiv
                 ///
                 /// ----------------------------------------------------------------------
 
-                /// \brief Generic static compute function. This function has a same
+                /// \brief Generic static stencil function. This function has a same
                 ///        signature as other device kernels have so that it can be called
                 ///        transparently from OsdMesh template interface.
                 ///
@@ -138,16 +144,16 @@ namespace OpenSubdiv
                 ///                       compute by instantiating on-demand kernel although
                 ///                       it may cause a performance problem.
                 ///
-                /// @param deviceContext  used to obtain the MTLDevice objcet and command queue 
+                /// @param context        used to obtain the MTLDevice object and command queue
                 ///                       to obtain command buffers from.
                 ///
                 template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
                 static bool EvalStencils(
-                                         SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
-                                         DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
-                                         STENCIL_TABLE const *stencilTable,
-                                         MTLComputeEvaluator const *instance,
-                                         MTLContext* context)
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    STENCIL_TABLE const *stencilTable,
+                    MTLComputeEvaluator const *instance,
+                    MTLContext* context)
                 {
                     if (instance)
                     {
@@ -158,7 +164,7 @@ namespace OpenSubdiv
                     }
                     else
                     {
-                        // Create an instace on demand (slow)
+                        // Create an instance on demand (slow)
                         instance = Create(srcDesc, dstDesc,
                                           BufferDescriptor(),
                                           BufferDescriptor(),
@@ -176,7 +182,7 @@ namespace OpenSubdiv
                     }
                 }
 
-                /// \brief Generic static compute function. This function has a same
+                /// \brief Generic static stencil function. This function has a same
                 ///        signature as other device kernels have so that it can be called
                 ///        transparently from OsdMesh template interface.
                 ///
@@ -192,20 +198,20 @@ namespace OpenSubdiv
                 ///
                 /// @param dstDesc        vertex buffer descriptor for the dstBuffer
                 ///
-                /// @param duBuffer       Output U-derivative buffer
+                /// @param duBuffer       Output buffer derivative wrt u
                 ///                       must have BindVBO() method returning an
                 ///                       MTLBuffer object of destination data
                 ///
                 /// @param duDesc         vertex buffer descriptor for the duBuffer
                 ///
-                /// @param dvBuffer       Output V-derivative buffer
+                /// @param dvBuffer       Output buffer derivative wrt v
                 ///                       must have BindVBO() method returning an
                 ///                       MTLBuffer object of destination data
                 ///
                 /// @param dvDesc         vertex buffer descriptor for the dvBuffer
                 ///
                 /// @param stencilTable   stencil table to be applied. The table must have
-                ///                       SSBO interfaces.
+                ///                       MTLBuffer interfaces.
                 ///
                 /// @param instance       cached compiled instance. Clients are supposed to
                 ///                       pre-compile an instance of this class and provide
@@ -213,18 +219,18 @@ namespace OpenSubdiv
                 ///                       compute by instantiating on-demand kernel although
                 ///                       it may cause a performance problem.
                 ///
-                /// @param deviceContext  used to obtain the MTLDevice objcet and command queue 
+                /// @param context        used to obtain the MTLDevice object and command queue
                 ///                       to obtain command buffers from.
                 ///
                 template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
                 static bool EvalStencils(
-                                         SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
-                                         DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
-                                         DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
-                                         DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
-                                         STENCIL_TABLE const *stencilTable,
-                                         MTLComputeEvaluator const *instance,
-                                         MTLContext* context) {
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    STENCIL_TABLE const *stencilTable,
+                    MTLComputeEvaluator const *instance,
+                    MTLContext* context) {
 
                     if (instance) {
                         return instance->EvalStencils(srcBuffer, srcDesc,
@@ -234,7 +240,7 @@ namespace OpenSubdiv
                                                       stencilTable,
                                                       context);
                     } else {
-                        // Create a pipeline state on demand (slow)
+                        // Create an instance on demand (slow)
                         instance = Create(srcDesc, dstDesc, duDesc, dvDesc, context);
                         if (instance) {
                             bool r = instance->EvalStencils(srcBuffer, srcDesc,
@@ -250,8 +256,128 @@ namespace OpenSubdiv
                     }
                 }
 
-                /// Dispatch the compute pipeline on GPU asynchronously.
-                /// returns false if the kernel hasn't been compiled yet.
+                /// \brief Generic static stencil function. This function has a same
+                ///        signature as other device kernels have so that it can be called
+                ///        transparently from OsdMesh template interface.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the dstBuffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param duuBuffer      Output buffer 2nd derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+                ///
+                /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+                ///
+                /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+                ///
+                /// @param stencilTable   stencil table to be applied. The table must have
+                ///                       MTLBuffer interfaces.
+                ///
+                /// @param instance       cached compiled instance. Clients are supposed to
+                ///                       pre-compile an instance of this class and provide
+                ///                       to this function. If it's null the kernel still
+                ///                       compute by instantiating on-demand kernel although
+                ///                       it may cause a performance problem.
+                ///
+                /// @param context        used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+                static bool EvalStencils(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+                    DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+                    DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+                    STENCIL_TABLE const *stencilTable,
+                    MTLComputeEvaluator const *instance,
+                    MTLContext* context) {
+
+                    if (instance) {
+                        return instance->EvalStencils(srcBuffer, srcDesc,
+                                                      dstBuffer, dstDesc,
+                                                      duBuffer,  duDesc,
+                                                      dvBuffer,  dvDesc,
+                                                      duuBuffer, duuDesc,
+                                                      duvBuffer, duvDesc,
+                                                      dvvBuffer, dvvDesc,
+                                                      stencilTable,
+                                                      context);
+                    } else {
+                        // Create an instance on demand (slow)
+                        instance = Create(srcDesc, dstDesc, duDesc, dvDesc,
+                                          duuDesc, duvDesc, dvvDesc, context);
+                        if (instance) {
+                            bool r = instance->EvalStencils(srcBuffer, srcDesc,
+                                                            dstBuffer, dstDesc,
+                                                            duBuffer,  duDesc,
+                                                            dvBuffer,  dvDesc,
+                                                            duuBuffer, duuDesc,
+                                                            duvBuffer, duvDesc,
+                                                            dvvBuffer, dvvDesc,
+                                                            stencilTable,
+                                                            context);
+                            delete instance;
+                            return r;
+                        }
+                        return false;
+                    }
+                }
+
+                /// \brief Generic stencil function.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the output buffer
+                ///
+                /// @param stencilTable   stencil table to be applied. The table must have
+                ///                       MTLBuffer interfaces.
+                ///
+                /// @param context        used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
                 template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
                 bool EvalStencils(
                                   SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
@@ -274,21 +400,51 @@ namespace OpenSubdiv
                                         context);
                 }
 
-                /// Dispatch the compute pipeline on GPU asynchronously.
-                /// returns false if the kernel hasn't been compiled yet.
+                /// \brief Generic stencil function.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the dstBuffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param stencilTable   stencil table to be applied. The table must have
+                ///                       MTLBuffer interfaces.
+                ///
+                /// @param context        used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
                 template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
                 bool EvalStencils(
-                                  SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
-                                  DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
-                                  DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
-                                  DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
-                                  STENCIL_TABLE const *stencilTable,
-                                  MTLContext* context) const
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    STENCIL_TABLE const *stencilTable,
+                    MTLContext* context) const
                 {
-                    return EvalStencils(srcBuffer->BindVBO(), srcDesc,
-                                        dstBuffer->BindVBO(), dstDesc,
-                                        duBuffer->BindVBO(),  duDesc,
-                                        dvBuffer->BindVBO(),  dvDesc,
+                    return EvalStencils(srcBuffer->BindMTLBuffer(context), srcDesc,
+                                        dstBuffer->BindMTLBuffer(context), dstDesc,
+                                        duBuffer->BindMTLBuffer(context),  duDesc,
+                                        dvBuffer->BindMTLBuffer(context),  dvDesc,
                                         stencilTable->GetSizesBuffer(),
                                         stencilTable->GetOffsetsBuffer(),
                                         stencilTable->GetIndicesBuffer(),
@@ -300,8 +456,127 @@ namespace OpenSubdiv
                                         context);
                 }
 
-                /// Dispatch the compute pipeline on GPU asynchronously.
+                /// \brief Generic stencil function.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the dstBuffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param duuBuffer      Output buffer 2nd derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duuDesc         vertex buffer descriptor for the duuBuffer
+                ///
+                /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+                ///
+                /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+                ///
+                /// @param stencilTable   stencil table to be applied. The table must have
+                ///                       MTLBuffer interfaces.
+                ///
+                /// @param context        used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER, typename STENCIL_TABLE>
+                bool EvalStencils(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+                    DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+                    DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+                    STENCIL_TABLE const *stencilTable,
+                    MTLContext* context) const
+                {
+                    return EvalStencils(srcBuffer->BindMTLBuffer(context), srcDesc,
+                                        dstBuffer->BindMTLBuffer(context), dstDesc,
+                                        duBuffer->BindMTLBuffer(context),  duDesc,
+                                        dvBuffer->BindMTLBuffer(context),  dvDesc,
+                                        duuBuffer->BindMTLBuffer(context), duuDesc,
+                                        duvBuffer->BindMTLBuffer(context), duvDesc,
+                                        dvvBuffer->BindMTLBuffer(context), dvvDesc,
+                                        stencilTable->GetSizesBuffer(),
+                                        stencilTable->GetOffsetsBuffer(),
+                                        stencilTable->GetIndicesBuffer(),
+                                        stencilTable->GetWeightsBuffer(),
+                                        stencilTable->GetDuWeightsBuffer(),
+                                        stencilTable->GetDvWeightsBuffer(),
+                                        stencilTable->GetDuuWeightsBuffer(),
+                                        stencilTable->GetDuvWeightsBuffer(),
+                                        stencilTable->GetDvvWeightsBuffer(),
+                                        /* start = */ 0,
+                                        /* end   = */ stencilTable->GetNumStencils(),
+                                        context);
+                }
+
+                /// \brief Dispatch the MTL compute kernel on GPU asynchronously
                 /// returns false if the kernel hasn't been compiled yet.
+                ///
+                /// @param srcBuffer        MTLBuffer of input primvar source data
+                ///
+                /// @param srcDesc          vertex buffer descriptor for the srcBuffer
+                ///
+                /// @param dstBuffer        MTLBuffer of output primvar destination data
+                ///
+                /// @param dstDesc          vertex buffer descriptor for the dstBuffer
+                ///
+                /// @param duBuffer         MTLBuffer of output derivative wrt u
+                ///
+                /// @param duDesc           vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer         MTLBuffer of output derivative wrt v
+                ///
+                /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param sizesBuffer      MTLBuffer of the sizes in the stencil table
+                ///
+                /// @param offsetsBuffer    MTLBuffer of the offsets in the stencil table
+                ///
+                /// @param indicesBuffer    MTLBuffer of the indices in the stencil table
+                ///
+                /// @param weightsBuffer    MTLBuffer of the weights in the stencil table
+                ///
+                /// @param duWeightsBuffer  MTLBuffer of the du weights in the stencil table
+                ///
+                /// @param dvWeightsBuffer  MTLBuffer of the dv weights in the stencil table
+                ///
+                /// @param start            start index of stencil table
+                ///
+                /// @param end              end index of stencil table
+                ///
+                /// @param context          used to obtain the MTLDevice object and command queue
+                ///                         to obtain command buffers from.
+                ///
                 bool EvalStencils(id<MTLBuffer> srcBuffer, BufferDescriptor const &srcDesc,
                                   id<MTLBuffer> dstBuffer, BufferDescriptor const &dstDesc,
                                   id<MTLBuffer> duBuffer,  BufferDescriptor const &duDesc,
@@ -316,19 +591,94 @@ namespace OpenSubdiv
                                   int end,
                                   MTLContext* context) const;
 
+                /// \brief Dispatch the MTL compute kernel on GPU asynchronously
+                /// returns false if the kernel hasn't been compiled yet.
+                ///
+                /// @param srcBuffer        MTLBuffer of input primvar source data
+                ///
+                /// @param srcDesc          vertex buffer descriptor for the srcBuffer
+                ///
+                /// @param dstBuffer        MTLBuffer of output primvar destination data
+                ///
+                /// @param dstDesc          vertex buffer descriptor for the dstBuffer
+                ///
+                /// @param duBuffer         MTLBuffer of output derivative wrt u
+                ///
+                /// @param duDesc           vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer         MTLBuffer of output derivative wrt v
+                ///
+                /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param duuBuffer        MTLBuffer of output 2nd derivative wrt u
+                ///
+                /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+                ///
+                /// @param duvBuffer        MTLBuffer of output 2nd derivative wrt u and v
+                ///
+                /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+                ///
+                /// @param dvvBuffer        MTLBuffer of output 2nd derivative wrt v
+                ///
+                /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
+                ///
+                /// @param sizesBuffer      MTLBuffer of the sizes in the stencil table
+                ///
+                /// @param offsetsBuffer    MTLBuffer of the offsets in the stencil table
+                ///
+                /// @param indicesBuffer    MTLBuffer of the indices in the stencil table
+                ///
+                /// @param weightsBuffer    MTLBuffer of the weights in the stencil table
+                ///
+                /// @param duWeightsBuffer  MTLBuffer of the du weights in the stencil table
+                ///
+                /// @param dvWeightsBuffer  MTLBuffer of the dv weights in the stencil table
+                ///
+                /// @param duuWeightsBuffer MTLBuffer of the duu weights in the stencil table
+                ///
+                /// @param duvWeightsBuffer MTLBuffer of the duv weights in the stencil table
+                ///
+                /// @param dvvWeightsBuffer MTLBuffer of the dvv weights in the stencil table
+                ///
+                /// @param start            start index of stencil table
+                ///
+                /// @param end              end index of stencil table
+                ///
+                /// @param context          used to obtain the MTLDevice object and command queue
+                ///                         to obtain command buffers from.
+                ///
+                bool EvalStencils(id<MTLBuffer> srcBuffer, BufferDescriptor const &srcDesc,
+                                  id<MTLBuffer> dstBuffer, BufferDescriptor const &dstDesc,
+                                  id<MTLBuffer> duBuffer,  BufferDescriptor const &duDesc,
+                                  id<MTLBuffer> dvBuffer,  BufferDescriptor const &dvDesc,
+                                  id<MTLBuffer> duuBuffer, BufferDescriptor const &duuDesc,
+                                  id<MTLBuffer> duvBuffer, BufferDescriptor const &duvDesc,
+                                  id<MTLBuffer> dvvBuffer, BufferDescriptor const &dvvDesc,
+                                  id<MTLBuffer> sizesBuffer,
+                                  id<MTLBuffer> offsetsBuffer,
+                                  id<MTLBuffer> indicesBuffer,
+                                  id<MTLBuffer> weightsBuffer,
+                                  id<MTLBuffer> duWeightsBuffer,
+                                  id<MTLBuffer> dvWeightsBuffer,
+                                  id<MTLBuffer> duuWeightsBuffer,
+                                  id<MTLBuffer> duvWeightsBuffer,
+                                  id<MTLBuffer> dvvWeightsBuffer,
+                                  int start,
+                                  int end,
+                                  MTLContext* context) const;
 
                 /// ----------------------------------------------------------------------
                 ///
                 ///   Limit evaluations with PatchTable
                 ///
                 /// ----------------------------------------------------------------------
-                ///
+
                 /// \brief Generic limit eval function. This function has a same
                 ///        signature as other device kernels have so that it can be called
                 ///        in the same way.
                 ///
                 /// @param srcBuffer      Input primvar buffer.
-                ///                       must have BindVBO() method returning an 
+                ///                       must have BindVBO() method returning an
                 ///                       MTLBuffer object of source data
                 ///
                 /// @param srcDesc        vertex buffer descriptor for the input buffer
@@ -353,19 +703,19 @@ namespace OpenSubdiv
                 ///                       compute by instantiating on-demand kernel although
                 ///                       it may cause a performance problem.
                 ///
-                /// @param deviceContext  used to obtain the MTLDevice objcet and command queue 
+                /// @param context        used to obtain the MTLDevice object and command queue
                 ///                       to obtain command buffers from.
                 ///
                 template <typename SRC_BUFFER, typename DST_BUFFER,
-                typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
                 static bool EvalPatches(
-                                        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
-                                        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
-                                        int numPatchCoords,
-                                        PATCHCOORD_BUFFER *patchCoords,
-                                        PATCH_TABLE *patchTable,
-                                        MTLComputeEvaluator const *instance,
-                                        MTLContext* context) {
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    MTLComputeEvaluator const *instance,
+                    MTLContext* context) {
 
                     if (instance) {
                         return instance->EvalPatches(srcBuffer, srcDesc,
@@ -377,7 +727,8 @@ namespace OpenSubdiv
                         // Create an instance on demand (slow)
                         instance = Create(srcDesc, dstDesc,
                                           BufferDescriptor(),
-                                          BufferDescriptor(), context );
+                                          BufferDescriptor(),
+                                          context);
                         if (instance) {
                             bool r = instance->EvalPatches(srcBuffer, srcDesc,
                                                            dstBuffer, dstDesc,
@@ -407,13 +758,17 @@ namespace OpenSubdiv
                 ///
                 /// @param dstDesc        vertex buffer descriptor for the output buffer
                 ///
-                /// @param duBuffer
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
                 ///
-                /// @param duDesc
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
                 ///
-                /// @param dvBuffer
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
                 ///
-                /// @param dvDesc
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
                 ///
                 /// @param numPatchCoords number of patchCoords.
                 ///
@@ -429,21 +784,21 @@ namespace OpenSubdiv
                 ///                       compute by instantiating on-demand kernel although
                 ///                       it may cause a performance problem.
                 ///
-                /// @param deviceContext  used to obtain the MTLDevice objcet and command queue 
+                /// @param context        used to obtain the MTLDevice object and command queue
                 ///                       to obtain command buffers from.
                 ///
                 template <typename SRC_BUFFER, typename DST_BUFFER,
-                typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
                 static bool EvalPatches(
-                                        SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
-                                        DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
-                                        DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
-                                        DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
-                                        int numPatchCoords,
-                                        PATCHCOORD_BUFFER *patchCoords,
-                                        PATCH_TABLE *patchTable,
-                                        MTLComputeEvaluator* instance,
-                                        MTLContext* context) {
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    MTLComputeEvaluator* instance,
+                    MTLContext* context) {
 
                     if (instance) {
                         return instance->EvalPatches(srcBuffer, srcDesc,
@@ -455,7 +810,8 @@ namespace OpenSubdiv
                                                      context);
                     } else {
                         // Create an instance on demand (slow)
-                        instance = Create(srcDesc, dstDesc, duDesc, dvDesc, context);
+                        instance = Create(srcDesc, dstDesc,
+                                          duDesc, dvDesc, context);
                         if (instance) {
                             bool r = instance->EvalPatches(srcBuffer, srcDesc,
                                                            dstBuffer, dstDesc,
@@ -476,14 +832,127 @@ namespace OpenSubdiv
                 ///        in the same way.
                 ///
                 /// @param srcBuffer      Input primvar buffer.
-                ///                       must have BindVBO() method returning a
-                ///                       const float pointer for read
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
                 ///
                 /// @param srcDesc        vertex buffer descriptor for the input buffer
                 ///
                 /// @param dstBuffer      Output primvar buffer
-                ///                       must have BindVBOBuffer() method returning a
-                ///                       float pointer for write
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the output buffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param duuBuffer      Output buffer 2nd derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+                ///
+                /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+                ///
+                /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvvDesc       vertex buffer descriptor for the dvvBuffer
+                ///
+                /// @param numPatchCoords number of patchCoords.
+                ///
+                /// @param patchCoords    array of locations to be evaluated.
+                ///                       must have BindVBO() method returning an
+                ///                       array of PatchCoord struct in VBO.
+                ///
+                /// @param patchTable     MTLPatchTable or equivalent
+                ///
+                /// @param instance       cached compiled instance. Clients are supposed to
+                ///                       pre-compile an instance of this class and provide
+                ///                       to this function. If it's null the kernel still
+                ///                       compute by instantiating on-demand kernel although
+                ///                       it may cause a performance problem.
+                ///
+                /// @param context        used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER,
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                static bool EvalPatches(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+                    DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+                    DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    MTLComputeEvaluator* instance,
+                    MTLContext* context) {
+
+                    if (instance) {
+                        return instance->EvalPatches(srcBuffer, srcDesc,
+                                                     dstBuffer, dstDesc,
+                                                     duBuffer, duDesc,
+                                                     dvBuffer, dvDesc,
+                                                     duuBuffer, duuDesc,
+                                                     duvBuffer, duvDesc,
+                                                     dvvBuffer, dvvDesc,
+                                                     numPatchCoords, patchCoords,
+                                                     patchTable,
+                                                     context);
+                    } else {
+                        // Create an instance on demand (slow)
+                        instance = Create(srcDesc, dstDesc,
+                                          duDesc, dvDesc,
+                                          duuDesc, duvDesc, dvvDesc, context);
+                        if (instance) {
+                            bool r = instance->EvalPatches(srcBuffer, srcDesc,
+                                                           dstBuffer, dstDesc,
+                                                           duBuffer, duDesc,
+                                                           dvBuffer, dvDesc,
+                                                           duuBuffer, duuDesc,
+                                                           duvBuffer, duvDesc,
+                                                           dvvBuffer, dvvDesc,
+                                                           numPatchCoords, patchCoords,
+                                                           patchTable,
+                                                           context);
+                            delete instance;
+                            return r;
+                        }
+                        return false;
+                    }
+                }
+
+                /// \brief Generic limit eval function. This function has a same
+                ///        signature as other device kernels have so that it can be called
+                ///        in the same way.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBOBuffer() method returning an
+                ///                       MTLBuffer object of destination data
                 ///
                 /// @param dstDesc        vertex buffer descriptor for the output buffer
                 ///
@@ -495,25 +964,86 @@ namespace OpenSubdiv
                 ///
                 /// @param patchTable     MTLPatchTable or equivalent
                 ///
-                /// @param deviceContext  used to obtain the MTLDevice objcet and command queue 
+                /// @param context        used to obtain the MTLDevice object and command queue
                 ///                       to obtain command buffers from.
                 ///
                 template <typename SRC_BUFFER, typename DST_BUFFER,
-                typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
                 bool EvalPatches(
-                                 SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
-                                 DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
-                                 int numPatchCoords,
-                                 PATCHCOORD_BUFFER *patchCoords,
-                                 PATCH_TABLE *patchTable,
-                                 MTLContext* context) const {
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    MTLContext* context) const {
 
-                    return EvalPatches(srcBuffer->BindVBO(), srcDesc,
-                                       dstBuffer->BindVBO(), dstDesc,
+                    return EvalPatches(srcBuffer->BindMTLBuffer(context), srcDesc,
+                                       dstBuffer->BindMTLBuffer(context), dstDesc,
                                        0, BufferDescriptor(),
                                        0, BufferDescriptor(),
                                        numPatchCoords,
-                                       patchCoords->BindVBO(),
+                                       patchCoords->BindMTLBuffer(context),
+                                       patchTable->GetPatchArrays(),
+                                       patchTable->GetPatchIndexBuffer(),
+                                       patchTable->GetPatchParamBuffer(),
+                                       context);
+                }
+
+                /// \brief Generic limit eval function with derivatives. This function has
+                ///        a same signature as other device kernels have so that it can be
+                ///        called in the same way.
+                ///
+                /// @param srcBuffer        Input primvar buffer.
+                ///                         must have BindVBO() method returning an
+                ///                         MTLBuffer object of source data
+                ///
+                /// @param srcDesc          vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer        Output primvar buffer
+                ///                         must have BindVBO() method returning an
+                ///                         MTLBuffer object of destination data
+                ///
+                /// @param dstDesc          vertex buffer descriptor for the output buffer
+                ///
+                /// @param duBuffer         Output buffer derivative wrt u
+                ///                         must have BindVBO() method returning an
+                ///                         MTLBuffer object of destination data
+                ///
+                /// @param duDesc           vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer         Output buffer derivative wrt v
+                ///                         must have BindVBO() method returning an
+                ///                         MTLBuffer object of destination data
+                ///
+                /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param numPatchCoords   number of patchCoords.
+                ///
+                /// @param patchCoords      array of locations to be evaluated.
+                ///
+                /// @param patchTable       MTLPatchTable or equivalent
+                ///
+                /// @param context          used to obtain the MTLDevice object and command queue
+                ///                         to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER,
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                bool EvalPatches(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    MTLContext* context) const {
+
+                    return EvalPatches(srcBuffer->BindMTLBuffer(context), srcDesc,
+                                       dstBuffer->BindMTLBuffer(context), dstDesc,
+                                       duBuffer->BindMTLBuffer(context),  duDesc,
+                                       dvBuffer->BindMTLBuffer(context),  dvDesc,
+                                       numPatchCoords,
+                                       patchCoords->BindMTLBuffer(context),
                                        patchTable->GetPatchArrays(),
                                        patchTable->GetPatchIndexBuffer(),
                                        patchTable->GetPatchParamBuffer(),
@@ -526,27 +1056,45 @@ namespace OpenSubdiv
                 ///
                 /// @param srcBuffer        Input primvar buffer.
                 ///                         must have BindVBO() method returning a
-                ///                         const float pointer for read
+                ///                         MTLBuffer object of source data
                 ///
                 /// @param srcDesc          vertex buffer descriptor for the input buffer
                 ///
                 /// @param dstBuffer        Output primvar buffer
                 ///                         must have BindVBO() method returning a
-                ///                         float pointer for write
+                ///                         MTLBuffer object of destination data
                 ///
                 /// @param dstDesc          vertex buffer descriptor for the output buffer
                 ///
-                /// @param duBuffer         Output U-derivatives buffer
+                /// @param duBuffer         Output buffer derivative wrt u
                 ///                         must have BindVBO() method returning a
-                ///                         float pointer for write
+                ///                         MTLBuffer object of destination data
                 ///
                 /// @param duDesc           vertex buffer descriptor for the duBuffer
                 ///
-                /// @param dvBuffer         Output V-derivatives buffer
+                /// @param dvBuffer         Output buffer derivative wrt v
                 ///                         must have BindVBO() method returning a
-                ///                         float pointer for write
+                ///                         MTLBuffer object of destination data
                 ///
                 /// @param dvDesc           vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param duuBuffer        Output buffer 2nd derivative wrt u
+                ///                         must have BindVBO() method returning a
+                ///                         MTLBuffer object of destination data
+                ///
+                /// @param duuDesc          vertex buffer descriptor for the duuBuffer
+                ///
+                /// @param duvBuffer        Output buffer 2nd derivative wrt u and v
+                ///                         must have BindVBO() method returning a
+                ///                         MTLBuffer object of destination data
+                ///
+                /// @param duvDesc          vertex buffer descriptor for the duvBuffer
+                ///
+                /// @param dvvBuffer        Output buffer 2nd derivative wrt v
+                ///                         must have BindVBO() method returning a
+                ///                         MTLBuffer object of destination data
+                ///
+                /// @param dvvDesc          vertex buffer descriptor for the dvvBuffer
                 ///
                 /// @param numPatchCoords   number of patchCoords.
                 ///
@@ -554,27 +1102,33 @@ namespace OpenSubdiv
                 ///
                 /// @param patchTable       MTLPatchTable or equivalent
                 ///
-                /// @param deviceContext  used to obtain the MTLDevice objcet and command queue 
-                ///                       to obtain command buffers from.
+                /// @param context          used to obtain the MTLDevice object and command queue
+                ///                         to obtain command buffers from.
                 ///
                 template <typename SRC_BUFFER, typename DST_BUFFER,
-                typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
                 bool EvalPatches(
-                                 SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
-                                 DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
-                                 DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
-                                 DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
-                                 int numPatchCoords,
-                                 PATCHCOORD_BUFFER *patchCoords,
-                                 PATCH_TABLE *patchTable,
-                                 MTLContext* context) const {
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+                    DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+                    DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    MTLContext* context) const {
 
-                    return EvalPatches(srcBuffer->BindVBO(), srcDesc,
-                                       dstBuffer->BindVBO(), dstDesc,
-                                       duBuffer->BindVBO(),  duDesc,
-                                       dvBuffer->BindVBO(),  dvDesc,
+                    return EvalPatches(srcBuffer->BindMTLBuffer(context), srcDesc,
+                                       dstBuffer->BindMTLBuffer(context), dstDesc,
+                                       duBuffer->BindMTLBuffer(context),  duDesc,
+                                       dvBuffer->BindMTLBuffer(context),  dvDesc,
+                                       duuBuffer->BindMTLBuffer(context), duuDesc,
+                                       duvBuffer->BindMTLBuffer(context), duvDesc,
+                                       dvvBuffer->BindMTLBuffer(context), dvvDesc,
                                        numPatchCoords,
-                                       patchCoords->BindVBO(),
+                                       patchCoords->BindMTLBuffer(context),
                                        patchTable->GetPatchArrays(),
                                        patchTable->GetPatchIndexBuffer(),
                                        patchTable->GetPatchParamBuffer(),
@@ -583,8 +1137,8 @@ namespace OpenSubdiv
 
                 bool EvalPatches(id<MTLBuffer> srcBuffer, BufferDescriptor const &srcDesc,
                                  id<MTLBuffer> dstBuffer, BufferDescriptor const &dstDesc,
-                                 id<MTLBuffer> duBuffer, BufferDescriptor const &duDesc,
-                                 id<MTLBuffer> dvBuffer, BufferDescriptor const &dvDesc,
+                                 id<MTLBuffer> duBuffer,  BufferDescriptor const &duDesc,
+                                 id<MTLBuffer> dvBuffer,  BufferDescriptor const &dvDesc,
                                  int numPatchCoords,
                                  id<MTLBuffer> patchCoordsBuffer,
                                  const PatchArrayVector &patchArrays,
@@ -592,20 +1146,33 @@ namespace OpenSubdiv
                                  id<MTLBuffer> patchParamsBuffer,
                                  MTLContext* context) const;
 
+                bool EvalPatches(id<MTLBuffer> srcBuffer, BufferDescriptor const &srcDesc,
+                                 id<MTLBuffer> dstBuffer, BufferDescriptor const &dstDesc,
+                                 id<MTLBuffer> duBuffer,  BufferDescriptor const &duDesc,
+                                 id<MTLBuffer> dvBuffer,  BufferDescriptor const &dvDesc,
+                                 id<MTLBuffer> duuBuffer, BufferDescriptor const &duuDesc,
+                                 id<MTLBuffer> duvBuffer, BufferDescriptor const &duvDesc,
+                                 id<MTLBuffer> dvvBuffer, BufferDescriptor const &dvvDesc,
+                                 int numPatchCoords,
+                                 id<MTLBuffer> patchCoordsBuffer,
+                                 const PatchArrayVector &patchArrays,
+                                 id<MTLBuffer> patchIndexBuffer,
+                                 id<MTLBuffer> patchParamsBuffer,
+                                 MTLContext* context) const;
 
                 /// \brief Generic limit eval function. This function has a same
                 ///        signature as other device kernels have so that it can be called
                 ///        in the same way.
                 ///
                 /// @param srcBuffer      Input primvar buffer.
-                ///                       must have BindVBO() method returning a GL
-                ///                       buffer object of source data
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
                 ///
                 /// @param srcDesc        vertex buffer descriptor for the input buffer
                 ///
                 /// @param dstBuffer      Output primvar buffer
-                ///                       must have BindVBO() method returning a GL
-                ///                       buffer object of destination data
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
                 ///
                 /// @param dstDesc        vertex buffer descriptor for the output buffer
                 ///
@@ -623,7 +1190,7 @@ namespace OpenSubdiv
                 ///                       compute by instantiating on-demand kernel although
                 ///                       it may cause a performance problem.
                 ///
-                /// @param deviceContext  used to obtain the MTLDevice objcet and command queue 
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
                 ///                       to obtain command buffers from.
                 ///
                 template <typename SRC_BUFFER, typename DST_BUFFER,
@@ -669,14 +1236,14 @@ namespace OpenSubdiv
                 ///        in the same way.
                 ///
                 /// @param srcBuffer      Input primvar buffer.
-                ///                       must have BindVBO() method returning a
-                ///                       const float pointer for read
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
                 ///
                 /// @param srcDesc        vertex buffer descriptor for the input buffer
                 ///
                 /// @param dstBuffer      Output primvar buffer
-                ///                       must have BindVBOBuffer() method returning a
-                ///                       float pointer for write
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
                 ///
                 /// @param dstDesc        vertex buffer descriptor for the output buffer
                 ///
@@ -688,7 +1255,7 @@ namespace OpenSubdiv
                 ///
                 /// @param patchTable     MTLPatchTable or equivalent
                 ///
-                /// @param deviceContext  used to obtain the MTLDevice objcet and command queue 
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
                 ///                       to obtain command buffers from.
                 ///
                 template <typename SRC_BUFFER, typename DST_BUFFER,
@@ -701,12 +1268,12 @@ namespace OpenSubdiv
                     PATCH_TABLE *patchTable,
                     MTLContext* deviceContext) const {
 
-                    return EvalPatches(srcBuffer->BindVBO(), srcDesc,
-                                       dstBuffer->BindVBO(), dstDesc,
+                    return EvalPatches(srcBuffer->BindMTLBuffer(deviceContext), srcDesc,
+                                       dstBuffer->BindMTLBuffer(deviceContext), dstDesc,
                                        0, BufferDescriptor(),
                                        0, BufferDescriptor(),
                                        numPatchCoords,
-                                       patchCoords->BindVBO(),
+                                       patchCoords->BindMTLBuffer(deviceContext),
                                        patchTable->GetVaryingPatchArrays(),
                                        patchTable->GetVaryingPatchIndexBuffer(),
                                        patchTable->GetPatchParamBuffer(),
@@ -719,14 +1286,371 @@ namespace OpenSubdiv
                 ///        in the same way.
                 ///
                 /// @param srcBuffer      Input primvar buffer.
-                ///                       must have BindVBO() method returning a GL
-                ///                       buffer object of source data
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
                 ///
                 /// @param srcDesc        vertex buffer descriptor for the input buffer
                 ///
                 /// @param dstBuffer      Output primvar buffer
-                ///                       must have BindVBO() method returning a GL
-                ///                       buffer object of destination data
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the output buffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param numPatchCoords number of patchCoords.
+                ///
+                /// @param patchCoords    array of locations to be evaluated.
+                ///                       must have BindVBO() method returning an
+                ///                       array of PatchCoord struct in VBO.
+                ///
+                /// @param patchTable     MTLPatchTable or equivalent
+                ///
+                /// @param instance       cached compiled instance. Clients are supposed to
+                ///                       pre-compile an instance of this class and provide
+                ///                       to this function. If it's null the kernel still
+                ///                       compute by instantiating on-demand kernel although
+                ///                       it may cause a performance problem.
+                ///
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER,
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                static bool EvalPatchesVarying(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    MTLComputeEvaluator const *instance,
+                    MTLContext* deviceContext) {
+
+                    if (instance) {
+                        return instance->EvalPatchesVarying(
+                                                     srcBuffer, srcDesc,
+                                                     dstBuffer, dstDesc,
+                                                     duBuffer, duDesc,
+                                                     dvBuffer, dvDesc,
+                                                     numPatchCoords, patchCoords,
+                                                     patchTable,
+                                                     deviceContext);
+                    } else {
+                        // Create an instance on demand (slow)
+                        instance = Create(srcDesc, dstDesc,
+                                          duDesc, dvDesc,
+                                          deviceContext);
+                        if (instance) {
+                            bool r = instance->EvalPatchesVarying(
+                                                           srcBuffer, srcDesc,
+                                                           dstBuffer, dstDesc,
+                                                           duBuffer, duDesc,
+                                                           dvBuffer, dvDesc,
+                                                           numPatchCoords, patchCoords,
+                                                           patchTable,
+                                                           deviceContext);
+                            delete instance;
+                            return r;
+                        }
+                        return false;
+                    }
+                }
+
+                /// \brief Generic limit eval function. This function has a same
+                ///        signature as other device kernels have so that it can be called
+                ///        in the same way.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the output buffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param numPatchCoords number of patchCoords.
+                ///
+                /// @param patchCoords    array of locations to be evaluated.
+                ///                       must have BindVBO() method returning an
+                ///                       array of PatchCoord struct in VBO.
+                ///
+                /// @param patchTable     MTLPatchTable or equivalent
+                ///
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER,
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                bool EvalPatchesVarying(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    MTLContext* deviceContext) const {
+
+                    return EvalPatches(srcBuffer->BindMTLBuffer(deviceContext), srcDesc,
+                                       dstBuffer->BindMTLBuffer(deviceContext), dstDesc,
+                                       duBuffer->BindMTLBuffer(deviceContext),  duDesc,
+                                       dvBuffer->BindMTLBuffer(deviceContext),  dvDesc,
+                                       numPatchCoords,
+                                       patchCoords->BindMTLBuffer(deviceContext),
+                                       patchTable->GetVaryingPatchArrays(),
+                                       patchTable->GetVaryingPatchIndexBuffer(),
+                                       patchTable->GetPatchParamBuffer(),
+                                       deviceContext
+                                       );
+                }
+
+
+                /// \brief Generic limit eval function. This function has a same
+                ///        signature as other device kernels have so that it can be called
+                ///        in the same way.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the output buffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param duuBuffer      Output buffer 2nd derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+                ///
+                /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+                ///
+                /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvvDesc       vertex buffer descriptor for the dvvBuffer
+                ///
+                /// @param numPatchCoords number of patchCoords.
+                ///
+                /// @param patchCoords    array of locations to be evaluated.
+                ///                       must have BindVBO() method returning an
+                ///                       array of PatchCoord struct in VBO.
+                ///
+                /// @param patchTable     MTLPatchTable or equivalent
+                ///
+                /// @param instance       cached compiled instance. Clients are supposed to
+                ///                       pre-compile an instance of this class and provide
+                ///                       to this function. If it's null the kernel still
+                ///                       compute by instantiating on-demand kernel although
+                ///                       it may cause a performance problem.
+                ///
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER,
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                static bool EvalPatchesVarying(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+                    DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+                    DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    MTLComputeEvaluator const *instance,
+                    MTLContext* deviceContext) {
+
+                    if (instance) {
+                        return instance->EvalPatchesVarying(
+                                                     srcBuffer, srcDesc,
+                                                     dstBuffer, dstDesc,
+                                                     duBuffer, duDesc,
+                                                     dvBuffer, dvDesc,
+                                                     duuBuffer, duuDesc,
+                                                     duvBuffer, duvDesc,
+                                                     dvvBuffer, dvvDesc,
+                                                     numPatchCoords, patchCoords,
+                                                     patchTable,
+                                                     deviceContext);
+                    } else {
+                        // Create an instance on demand (slow)
+                        instance = Create(srcDesc, dstDesc,
+                                          duDesc, dvDesc,
+                                          duuDesc, duvDesc, dvvDesc,
+                                          deviceContext);
+                        if (instance) {
+                            bool r = instance->EvalPatchesVarying(
+                                                           srcBuffer, srcDesc,
+                                                           dstBuffer, dstDesc,
+                                                           duBuffer, duDesc,
+                                                           dvBuffer, dvDesc,
+                                                           duuBuffer, duuDesc,
+                                                           duvBuffer, duvDesc,
+                                                           dvvBuffer, dvvDesc,
+                                                           numPatchCoords, patchCoords,
+                                                           patchTable,
+                                                           deviceContext);
+                            delete instance;
+                            return r;
+                        }
+                        return false;
+                    }
+                }
+
+                /// \brief Generic limit eval function. This function has a same
+                ///        signature as other device kernels have so that it can be called
+                ///        in the same way.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the output buffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param duuBuffer      Output buffer 2nd derivative wrt u
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+                ///
+                /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+                ///
+                /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+                ///
+                /// @param numPatchCoords number of patchCoords.
+                ///
+                /// @param patchCoords    array of locations to be evaluated.
+                ///                       must have BindVBO() method returning an
+                ///                       array of PatchCoord struct in VBO.
+                ///
+                /// @param patchTable     MTLPatchTable or equivalent
+                ///
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER,
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                bool EvalPatchesVarying(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+                    DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+                    DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    MTLContext* deviceContext) const {
+
+                    return EvalPatches(srcBuffer->BindMTLBuffer(deviceContext), srcDesc,
+                                       dstBuffer->BindMTLBuffer(deviceContext), dstDesc,
+                                       duBuffer->BindMTLBuffer(deviceContext),  duDesc,
+                                       dvBuffer->BindMTLBuffer(deviceContext),  dvDesc,
+                                       duuBuffer->BindMTLBuffer(deviceContext), duuDesc,
+                                       duvBuffer->BindMTLBuffer(deviceContext), duvDesc,
+                                       dvvBuffer->BindMTLBuffer(deviceContext), dvvDesc,
+                                       numPatchCoords,
+                                       patchCoords->BindMTLBuffer(deviceContext),
+                                       patchTable->GetVaryingPatchArrays(),
+                                       patchTable->GetVaryingPatchIndexBuffer(),
+                                       patchTable->GetPatchParamBuffer(),
+                                       deviceContext
+                                       );
+                }
+
+                /// \brief Generic limit eval function. This function has a same
+                ///        signature as other device kernels have so that it can be called
+                ///        in the same way.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
                 ///
                 /// @param dstDesc        vertex buffer descriptor for the output buffer
                 ///
@@ -746,7 +1670,7 @@ namespace OpenSubdiv
                 ///                       compute by instantiating on-demand kernel although
                 ///                       it may cause a performance problem.
                 ///
-                /// @param deviceContext  used to obtain the MTLDevice objcet and command queue 
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
                 ///                       to obtain command buffers from.
                 ///
                 template <typename SRC_BUFFER, typename DST_BUFFER,
@@ -766,7 +1690,8 @@ namespace OpenSubdiv
                                                      srcBuffer, srcDesc,
                                                      dstBuffer, dstDesc,
                                                      numPatchCoords, patchCoords,
-                                                     patchTable, fvarChannel,
+                                                     patchTable,
+                                                     fvarChannel,
                                                      deviceContext);
                     } else {
                         // Create an instance on demand (slow)
@@ -779,7 +1704,8 @@ namespace OpenSubdiv
                                                            srcBuffer, srcDesc,
                                                            dstBuffer, dstDesc,
                                                            numPatchCoords, patchCoords,
-                                                           patchTable, fvarChannel,
+                                                           patchTable,
+                                                           fvarChannel,
                                                            deviceContext);
                             delete instance;
                             return r;
@@ -794,13 +1720,13 @@ namespace OpenSubdiv
                 ///
                 /// @param srcBuffer      Input primvar buffer.
                 ///                       must have BindVBO() method returning a
-                ///                       const float pointer for read
+                ///                       MTLBuffer object of source data
                 ///
                 /// @param srcDesc        vertex buffer descriptor for the input buffer
                 ///
                 /// @param dstBuffer      Output primvar buffer
-                ///                       must have BindVBOBuffer() method returning a
-                ///                       float pointer for write
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
                 ///
                 /// @param dstDesc        vertex buffer descriptor for the output buffer
                 ///
@@ -814,7 +1740,7 @@ namespace OpenSubdiv
                 ///
                 /// @param fvarChannel    face-varying channel
                 ///
-                /// @param deviceContext  used to obtain the MTLDevice objcet and command queue 
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
                 ///                       to obtain command buffers from.
                 ///
                 template <typename SRC_BUFFER, typename DST_BUFFER,
@@ -825,20 +1751,393 @@ namespace OpenSubdiv
                     int numPatchCoords,
                     PATCHCOORD_BUFFER *patchCoords,
                     PATCH_TABLE *patchTable,
-                    MTLContext* deviceContext,
-                    int fvarChannel = 0
-                    ) const {
+                    int fvarChannel,
+                    MTLContext* deviceContext) const {
 
-                    return EvalPatches(srcBuffer->BindVBO(), srcDesc,
-                                       dstBuffer->BindVBO(), dstDesc,
+                    return EvalPatches(srcBuffer->BindMTLBuffer(deviceContext), srcDesc,
+                                       dstBuffer->BindMTLBuffer(deviceContext), dstDesc,
                                        0, BufferDescriptor(),
                                        0, BufferDescriptor(),
                                        numPatchCoords,
-                                       patchCoords->BindVBO(),
+                                       patchCoords->BindMTLBuffer(deviceContext),
                                        patchTable->GetFVarPatchArrays(fvarChannel),
                                        patchTable->GetFVarPatchIndexBuffer(fvarChannel),
                                        patchTable->GetFVarPatchParamBuffer(fvarChannel),
-                                       deviceContext);
+                                       deviceContext
+                                       );
+                }
+
+                /// \brief Generic limit eval function. This function has a same
+                ///        signature as other device kernels have so that it can be called
+                ///        in the same way.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the output buffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param numPatchCoords number of patchCoords.
+                ///
+                /// @param patchCoords    array of locations to be evaluated.
+                ///                       must have BindVBO() method returning an
+                ///                       array of PatchCoord struct in VBO.
+                ///
+                /// @param patchTable     MTLPatchTable or equivalent
+                ///
+                /// @param fvarChannel    face-varying channel
+                ///
+                /// @param instance       cached compiled instance. Clients are supposed to
+                ///                       pre-compile an instance of this class and provide
+                ///                       to this function. If it's null the kernel still
+                ///                       compute by instantiating on-demand kernel although
+                ///                       it may cause a performance problem.
+                ///
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER,
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                static bool EvalPatchesFaceVarying(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    int fvarChannel,
+                    MTLComputeEvaluator const *instance,
+                    MTLContext* deviceContext) {
+
+                    if (instance) {
+                        return instance->EvalPatchesFaceVarying(
+                                                     srcBuffer, srcDesc,
+                                                     dstBuffer, dstDesc,
+                                                     duBuffer, duDesc,
+                                                     dvBuffer, dvDesc,
+                                                     numPatchCoords, patchCoords,
+                                                     patchTable,
+                                                     fvarChannel,
+                                                     deviceContext);
+                    } else {
+                        // Create an instance on demand (slow)
+                        instance = Create(srcDesc, dstDesc,
+                                          duDesc, dvDesc,
+                                          deviceContext);
+                        if (instance) {
+                            bool r = instance->EvalPatchesFaceVarying(
+                                                           srcBuffer, srcDesc,
+                                                           dstBuffer, dstDesc,
+                                                           duBuffer, duDesc,
+                                                           dvBuffer, dvDesc,
+                                                           numPatchCoords, patchCoords,
+                                                           patchTable,
+                                                           fvarChannel,
+                                                           deviceContext);
+                            delete instance;
+                            return r;
+                        }
+                        return false;
+                    }
+                }
+
+                /// \brief Generic limit eval function. This function has a same
+                ///        signature as other device kernels have so that it can be called
+                ///        in the same way.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the output buffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param numPatchCoords number of patchCoords.
+                ///
+                /// @param patchCoords    array of locations to be evaluated.
+                ///                       must have BindVBO() method returning an
+                ///                       array of PatchCoord struct in VBO.
+                ///
+                /// @param patchTable     MTLPatchTable or equivalent
+                ///
+                /// @param fvarChannel    face-varying channel
+                ///
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER,
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                bool EvalPatchesFaceVarying(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    int fvarChannel,
+                    MTLContext* deviceContext) const {
+
+                    return EvalPatches(srcBuffer->BindMTLBuffer(deviceContext), srcDesc,
+                                       dstBuffer->BindMTLBuffer(deviceContext), dstDesc,
+                                       duBuffer->BindMTLBuffer(deviceContext),  duDesc,
+                                       dvBuffer->BindMTLBuffer(deviceContext),  dvDesc,
+                                       numPatchCoords,
+                                       patchCoords->BindMTLBuffer(deviceContext),
+                                       patchTable->GetFVarPatchArrays(fvarChannel),
+                                       patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                                       patchTable->GetFVarPatchParamBuffer(fvarChannel),
+                                       deviceContext
+                                       );
+                }
+
+                /// \brief Generic limit eval function. This function has a same
+                ///        signature as other device kernels have so that it can be called
+                ///        in the same way.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the output buffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param duuBuffer      Output buffer 2nd derivative wrt u
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+                ///
+                /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+                ///
+                /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+                ///                       must have BindVBO() method returning an
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvvDesc       vertex buffer descriptor for the dvvBuffer
+                ///
+                /// @param numPatchCoords number of patchCoords.
+                ///
+                /// @param patchCoords    array of locations to be evaluated.
+                ///                       must have BindVBO() method returning an
+                ///                       array of PatchCoord struct in VBO.
+                ///
+                /// @param patchTable     MTLPatchTable or equivalent
+                ///
+                /// @param fvarChannel    face-varying channel
+                ///
+                /// @param instance       cached compiled instance. Clients are supposed to
+                ///                       pre-compile an instance of this class and provide
+                ///                       to this function. If it's null the kernel still
+                ///                       compute by instantiating on-demand kernel although
+                ///                       it may cause a performance problem.
+                ///
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER,
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                static bool EvalPatchesFaceVarying(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+                    DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+                    DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    int fvarChannel,
+                    MTLComputeEvaluator const *instance,
+                    MTLContext* deviceContext) {
+
+                    if (instance) {
+                        return instance->EvalPatchesFaceVarying(
+                                                     srcBuffer, srcDesc,
+                                                     dstBuffer, dstDesc,
+                                                     duBuffer, duDesc,
+                                                     dvBuffer, dvDesc,
+                                                     duuBuffer, duuDesc,
+                                                     duvBuffer, duvDesc,
+                                                     dvvBuffer, dvvDesc,
+                                                     numPatchCoords, patchCoords,
+                                                     patchTable,
+                                                     fvarChannel,
+                                                     deviceContext);
+                    } else {
+                        // Create an instance on demand (slow)
+                        instance = Create(srcDesc, dstDesc,
+                                          duDesc, dvDesc,
+                                          duuDesc, duvDesc, dvvDesc,
+                                          deviceContext);
+                        if (instance) {
+                            bool r = instance->EvalPatchesFaceVarying(
+                                                           srcBuffer, srcDesc,
+                                                           dstBuffer, dstDesc,
+                                                           duBuffer, duDesc,
+                                                           dvBuffer, dvDesc,
+                                                           duuBuffer, duuDesc,
+                                                           duvBuffer, duvDesc,
+                                                           dvvBuffer, dvvDesc,
+                                                           numPatchCoords, patchCoords,
+                                                           patchTable,
+                                                           fvarChannel,
+                                                           deviceContext);
+                            delete instance;
+                            return r;
+                        }
+                        return false;
+                    }
+                }
+
+                /// \brief Generic limit eval function. This function has a same
+                ///        signature as other device kernels have so that it can be called
+                ///        in the same way.
+                ///
+                /// @param srcBuffer      Input primvar buffer.
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of source data
+                ///
+                /// @param srcDesc        vertex buffer descriptor for the input buffer
+                ///
+                /// @param dstBuffer      Output primvar buffer
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dstDesc        vertex buffer descriptor for the output buffer
+                ///
+                /// @param duBuffer       Output buffer derivative wrt u
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duDesc         vertex buffer descriptor for the duBuffer
+                ///
+                /// @param dvBuffer       Output buffer derivative wrt v
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvDesc         vertex buffer descriptor for the dvBuffer
+                ///
+                /// @param duuBuffer      Output buffer 2nd derivative wrt u
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duuDesc        vertex buffer descriptor for the duuBuffer
+                ///
+                /// @param duvBuffer      Output buffer 2nd derivative wrt u and v
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param duvDesc        vertex buffer descriptor for the duvBuffer
+                ///
+                /// @param dvvBuffer      Output buffer 2nd derivative wrt v
+                ///                       must have BindVBO() method returning a
+                ///                       MTLBuffer object of destination data
+                ///
+                /// @param dvvDesc        vertex buffer descriptor for the dvvBuffer
+                ///
+                /// @param numPatchCoords number of patchCoords.
+                ///
+                /// @param patchCoords    array of locations to be evaluated.
+                ///                       must have BindVBO() method returning an
+                ///                       array of PatchCoord struct in VBO.
+                ///
+                /// @param patchTable     MTLPatchTable or equivalent
+                ///
+                /// @param fvarChannel    face-varying channel
+                ///
+                /// @param deviceContext  used to obtain the MTLDevice object and command queue
+                ///                       to obtain command buffers from.
+                ///
+                template <typename SRC_BUFFER, typename DST_BUFFER,
+                          typename PATCHCOORD_BUFFER, typename PATCH_TABLE>
+                bool EvalPatchesFaceVarying(
+                    SRC_BUFFER *srcBuffer, BufferDescriptor const &srcDesc,
+                    DST_BUFFER *dstBuffer, BufferDescriptor const &dstDesc,
+                    DST_BUFFER *duBuffer,  BufferDescriptor const &duDesc,
+                    DST_BUFFER *dvBuffer,  BufferDescriptor const &dvDesc,
+                    DST_BUFFER *duuBuffer, BufferDescriptor const &duuDesc,
+                    DST_BUFFER *duvBuffer, BufferDescriptor const &duvDesc,
+                    DST_BUFFER *dvvBuffer, BufferDescriptor const &dvvDesc,
+                    int numPatchCoords,
+                    PATCHCOORD_BUFFER *patchCoords,
+                    PATCH_TABLE *patchTable,
+                    int fvarChannel,
+                    MTLContext* deviceContext) const {
+
+                    return EvalPatches(srcBuffer->BindMTLBuffer(deviceContext), srcDesc,
+                                       dstBuffer->BindMTLBuffer(deviceContext), dstDesc,
+                                       duBuffer->BindMTLBuffer(deviceContext),  duDesc,
+                                       dvBuffer->BindMTLBuffer(deviceContext),  dvDesc,
+                                       duuBuffer->BindMTLBuffer(deviceContext), duuDesc,
+                                       duvBuffer->BindMTLBuffer(deviceContext), duvDesc,
+                                       dvvBuffer->BindMTLBuffer(deviceContext), dvvDesc,
+                                       numPatchCoords,
+                                       patchCoords->BindMTLBuffer(deviceContext),
+                                       patchTable->GetFVarPatchArrays(fvarChannel),
+                                       patchTable->GetFVarPatchIndexBuffer(fvarChannel),
+                                       patchTable->GetFVarPatchParamBuffer(fvarChannel),
+                                       fvarChannel,
+                                       deviceContext
+                                       );
                 }
 
                 /// Configure compute pipline state. Returns false if it fails to create the pipeline state.
@@ -846,6 +2145,9 @@ namespace OpenSubdiv
                              BufferDescriptor const &dstDesc,
                              BufferDescriptor const &duDesc,
                              BufferDescriptor const &dvDesc,
+                             BufferDescriptor const &duuDesc,
+                             BufferDescriptor const &duvDesc,
+                             BufferDescriptor const &dvvDesc,
                              MTLContext* context);
 
                 /// Wait for the dispatched kernel to finish.


### PR DESCRIPTION
Updated MtlComputeEvaluator documentation to be
consistent with the documentation for other compute
evaluator implementations and fixed missing or
incorrect doxygen tags.

Also, updated the overloads for the EvalStencils
and EvalPatches methods to account for 1st and
2nd derivative evaluation.