### PR TITLE
Improved documentation of vertex indexing scheme for uniform PatchTables

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -921,6 +921,13 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
 
     BuilderContext context(refiner, options);
 
+    // Default behavior is to include base level vertices in the patch vertices for
+    // vertex and varying patches, but not face-varying.  Consider exposing these
+    // as public options in future so that clients can create consistent behavior:
+
+    bool includeBaseLevelIndices     = true;
+    bool includeBaseLevelFVarIndices = false;
+
     // ensure that triangulateQuads is only set for quadrilateral schemes
     options.triangulateQuads &= (refiner.GetSchemeType()==Sdc::SCHEME_BILINEAR ||
                                  refiner.GetSchemeType()==Sdc::SCHEME_CATMARK);
@@ -991,17 +998,20 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
     PatchParam    ** fpptr = 0;
 
     // we always skip level=0 vertices (control cages)
-    Index levelVertOffset = refiner.GetLevel(0).GetNumVertices();
+    Index levelVertOffset = includeBaseLevelIndices ?
+                            refiner.GetLevel(0).GetNumVertices() : 0;
 
     Index * levelFVarVertOffsets = 0;
     if (context.RequiresFVarPatches()) {
 
         levelFVarVertOffsets = (Index *)alloca(context.fvarChannelIndices.size()*sizeof(Index));
-        memset(levelFVarVertOffsets, 0, context.fvarChannelIndices.size()*sizeof(Index));
 
         fptr = (Index **)alloca(context.fvarChannelIndices.size()*sizeof(Index *));
         fpptr = (PatchParam **)alloca(context.fvarChannelIndices.size()*sizeof(PatchParam *));
         for (int fvc=0; fvc<(int)context.fvarChannelIndices.size(); ++fvc) {
+            levelFVarVertOffsets[fvc] = includeBaseLevelFVarIndices ?
+                                        refiner.GetLevel(0).GetNumFVarValues(fvc) : 0;
+
             fptr[fvc] = table->getFVarValues(fvc).begin();
             fpptr[fvc] = table->getFVarPatchParams(fvc).begin();
         }

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1005,6 +1005,7 @@ PatchTableFactory::createUniform(TopologyRefiner const & refiner, Options option
     if (context.RequiresFVarPatches()) {
 
         levelFVarVertOffsets = (Index *)alloca(context.fvarChannelIndices.size()*sizeof(Index));
+        memset(levelFVarVertOffsets, 0, context.fvarChannelIndices.size()*sizeof(Index));
 
         fptr = (Index **)alloca(context.fvarChannelIndices.size()*sizeof(Index *));
         fpptr = (PatchParam **)alloca(context.fvarChannelIndices.size()*sizeof(PatchParam *));

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -98,7 +98,25 @@ public:
         int const *  fvarChannelIndices;       ///< List containing the indices of the channels selected for the factory
     };
 
-    /// \brief Factory constructor for PatchTable
+    /// \brief Instantiates a PatchTable from a client-provided TopologyRefiner.
+    ///       
+    ///  A PatchTable can be constructed from a TopologyRefiner that has been
+    ///  either adaptively or uniformly refined.  In both cases, the resulting
+    ///  patches reference vertices in the various refined levels by index,
+    ///  and those indices accumulate with the levels in different ways.
+    ///
+    ///  For adaptively refined patches, patches are defined at different levels,
+    ///  including the base level, so the indices of patch vertices include
+    ///  vertices from all levels.
+    ///
+    ///  For uniformly refined patches, all patches are completely defined within
+    ///  the last level.  There is often no use for intermediate levels and they
+    ///  can usually be ignored.  Indices of patch vertices might therefore be
+    ///  expected to be defined solely within the last level.  While this is true
+    ///  for face-varying patches, for historical reasons it is not the case for
+    ///  vertex and varying patches.  Indices for vertex and varying patches include
+    ///  the base level in addition to the last level while indices for face-varying
+    ///  patches include only the last level.
     ///
     /// @param refiner              TopologyRefiner from which to generate patches
     ///


### PR DESCRIPTION
In response to Issue #737 (since it has arisen again), these changes improve documentation of Far::PatchTableFactory::Create() in the hope that its indexing scheme for a set of uniformly refined patches is better understood by those building a Far::PatchTable directly.

Doxygen comments were added the header file and internal options were added to the source so that it is more self-documenting should this arise again.  The internal options may be made public in a future minor release, pending further discussion in #737.