### PR TITLE
More fixes for face-varying patches in uniform PatchTables

### DIFF
--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -98,7 +98,25 @@ public:
         int const *  fvarChannelIndices;       ///< List containing the indices of the channels selected for the factory
     };
 
-    /// \brief Factory constructor for PatchTable
+    /// \brief Instantiates a PatchTable from a client-provided TopologyRefiner.
+    ///
+    ///  A PatchTable can be constructed from a TopologyRefiner that has been
+    ///  either adaptively or uniformly refined.  In both cases, the resulting
+    ///  patches reference vertices in the various refined levels by index,
+    ///  and those indices accumulate with the levels in different ways.
+    ///
+    ///  For adaptively refined patches, patches are defined at different levels,
+    ///  including the base level, so the indices of patch vertices include
+    ///  vertices from all levels.
+    ///
+    ///  For uniformly refined patches, all patches are completely defined within
+    ///  the last level.  There is often no use for intermediate levels and they
+    ///  can usually be ignored.  Indices of patch vertices might therefore be
+    ///  expected to be defined solely within the last level.  While this is true
+    ///  for face-varying patches, for historical reasons it is not the case for
+    ///  vertex and varying patches.  Indices for vertex and varying patches include
+    ///  the base level in addition to the last level while indices for face-varying
+    ///  patches include only the last level.
     ///
     /// @param refiner              TopologyRefiner from which to generate patches
     ///


### PR DESCRIPTION
Corrected some minor issues related to indices of face-varying patches in uniform patch tables that may have caused problems in rare circumstances.  

In response to issue #737, also made the indexing discrepancy between vertex/varying patches and face-varying patches clearer with internal options and new Doxygen comments.