### PR TITLE
Fixed array index handlings of CpuPatchTable and Level

### DIFF
--- a/opensubdiv/osd/cpuPatchTable.cpp
+++ b/opensubdiv/osd/cpuPatchTable.cpp
@@ -97,7 +97,8 @@ CpuPatchTable::CpuPatchTable(const Far::PatchTable *farPatchTable) {
             // face-varying param
             Far::ConstPatchParamArray
                 fvarParam = farPatchTable->GetPatchArrayFVarPatchParams(j, fvc);
-            for (int k = 0; k < numPatches; ++k) {
+            int nPatch = farPatchTable->GetNumPatches(j);
+            for (int k = 0; k < nPatch; ++k) {
                 PatchParam param;
                 //param.patchParam = patchParamTable[patchIndex];
                 param.field0 = fvarParam[k].field0;

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -1599,12 +1599,8 @@ namespace {
             int memberMax = _memberCountPerComp;
             for (int i = 0; i < _compCount; ++i) {
                 int count = _countsAndOffsets[2*i];
-                if (count == 0)
-                {
-                    continue;
-                }
 
-                Index *dstMembers = &dstIndices[_countsAndOffsets[2*i + 1]];
+                Index *dstMembers = &dstIndices[0] + _countsAndOffsets[2*i + 1];
                 Index *srcMembers = 0;
                 
                 if (count <= _memberCountPerComp) {

--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -1599,6 +1599,10 @@ namespace {
             int memberMax = _memberCountPerComp;
             for (int i = 0; i < _compCount; ++i) {
                 int count = _countsAndOffsets[2*i];
+                if (count == 0)
+                {
+                    continue;
+                }
 
                 Index *dstMembers = &dstIndices[_countsAndOffsets[2*i + 1]];
                 Index *srcMembers = 0;


### PR DESCRIPTION
Fixed array index handlings of CpuPatchTable and Level that cause segmentation faluts.