### PR TITLE
Fixed integer overflow bugs for large meshes in PatchTable factories

### DIFF
--- a/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapBSplineBasisPatchFactory.cpp
@@ -67,7 +67,7 @@ EndCapBSplineBasisPatchFactory::EndCapBSplineBasisPatchFactory(
     // we typically use 7 patch points for each bspline endcap.
     int numPatchPointsExpected = numMaxLevelFaces * 7;
     // limits to 100M (=800M bytes) entries for the reserved size.
-    int numStencilsExpected = std::min(numPatchPointsExpected * 16,
+    int numStencilsExpected = (int) std::min<long>((long)numPatchPointsExpected * 16,
                                        100*1024*1024);
     _vertexStencils->reserve(numPatchPointsExpected, numStencilsExpected);
     if (_varyingStencils) {

--- a/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
+++ b/opensubdiv/far/endCapGregoryBasisPatchFactory.cpp
@@ -60,7 +60,7 @@ EndCapGregoryBasisPatchFactory::EndCapGregoryBasisPatchFactory(
 
     int numPatchPointsExpected = numMaxLevelFaces * 20;
     // limits to 100M (=800M bytes) entries for the reserved size.
-    int numStencilsExpected = std::min(numPatchPointsExpected * 16,
+    int numStencilsExpected = (int) std::min<long>((long)numPatchPointsExpected * 16,
                                        100*1024*1024);
     _vertexStencils->reserve(numPatchPointsExpected, numStencilsExpected);
     if (_varyingStencils) {

--- a/opensubdiv/far/endCapLegacyGregoryPatchFactory.cpp
+++ b/opensubdiv/far/endCapLegacyGregoryPatchFactory.cpp
@@ -148,7 +148,7 @@ EndCapLegacyGregoryPatchFactory::Finalize(
     const int SizePerVertex = 2*maxValence + 1;
 
     PatchTable::VertexValenceTable & vTable = (*vertexValenceTable);
-    vTable.resize(_refiner.GetNumVerticesTotal() * SizePerVertex);
+    vTable.resize((long)_refiner.GetNumVerticesTotal() * SizePerVertex);
 
     int vOffset = 0;
     int levelLast = _refiner.GetMaxLevel();
@@ -158,7 +158,7 @@ EndCapLegacyGregoryPatchFactory::Finalize(
 
         if (i == levelLast) {
 
-            int vTableOffset = vOffset * SizePerVertex;
+            long vTableOffset = vOffset * SizePerVertex;
 
             for (int vIndex = 0; vIndex < level->getNumVertices(); ++vIndex) {
                 int* vTableEntry = &vTable[vTableOffset];


### PR DESCRIPTION
Fixed a couple of bugs reserving memory during creation of Far::PatchTables for large data sets.  Estimated upper bounds use the product of two sizes declared as "int"  which overflows and results in negative values passed to vector::reserve() (and so cast to "size_t" and crashing) instead of the smaller fixed positive size that was intended in such cases.