### PR TITLE
Fixed misuse of vector::capacity() in internal SparseMatrix class

### DIFF
--- a/opensubdiv/far/sparseMatrix.h
+++ b/opensubdiv/far/sparseMatrix.h
@@ -60,7 +60,7 @@ public:
 
 public:
     //  Declaration and access methods:
-    SparseMatrix() : _numRows(0), _numColumns(0) { }
+    SparseMatrix() : _numRows(0), _numColumns(0), _numElements(0) { }
 
     int GetNumRows() const { return _numRows; }
     int GetNumColumns() const { return _numColumns; }
@@ -122,7 +122,7 @@ template <typename REAL>
 inline int
 SparseMatrix<REAL>::GetCapacity() const {
 
-    return (int) _elements.capacity();
+    return (int) _elements.size();
 }
 
 template <typename REAL>


### PR DESCRIPTION
The SparseMatrix class in Far is currently allocating the appropriate number of elements to do its job as part of assembling a PatchTable, but the size of one of its std::vector members sometimes gets out of sync after reuse due to a call to capacity() instead of size().