### PR TITLE
Fix uninitialized stack memory used in topology refiner

### DIFF
--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -263,7 +263,7 @@ namespace internal {
         bool IsEmpty() const { return *((int_type*)this) == 0; }
 
         FeatureMask() { Clear(); }
-        FeatureMask(Options const & options, Sdc::SchemeType sType) { InitializeFeatures(options, sType); }
+        FeatureMask(Options const & options, Sdc::SchemeType sType) { Clear(); InitializeFeatures(options, sType); }
 
         //  These are the two primary methods intended for use -- intialization via a set of Options
         //  and reduction of the subsequent feature set (which presumes prior initialization with the


### PR DESCRIPTION
The issue is that FeatureMask structure has size of an integer, but only
first 11 bytes are initialized, the rest is left non-initialized to a
stack memory of RefineAdaptive(). This will cause issues with IsEmpty()
which check whether any of integer's bits are set, effectively causing
jumps dependent on a non-initialized memory.