### PR TITLE
Fixed regression in PatchTable construction with varying patches

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -926,7 +926,7 @@ PatchTableBuilder::populateAdaptivePatches() {
     struct PatchArrayBuilder {
         PatchArrayBuilder()
             : patchType(PatchDescriptor::NON_PATCH), numPatches(0)
-            , iptr(NULL), pptr(NULL), sptr(NULL) { }
+            , iptr(NULL), pptr(NULL), sptr(NULL), vptr(NULL) { }
 
         PatchDescriptor::Type patchType;
         int numPatches;
@@ -934,6 +934,7 @@ PatchTableBuilder::populateAdaptivePatches() {
         Index      *iptr;
         PatchParam *pptr;
         Index      *sptr;
+        Index      *vptr;
 
         StackBuffer<Index*,1>      fptr;   // fvar indices
         StackBuffer<PatchParam*,1> fpptr;  // fvar patch-params
@@ -1019,6 +1020,9 @@ PatchTableBuilder::populateAdaptivePatches() {
         arrayBuilder.pptr = _table->getPatchParams(arrayIndex).begin();
         if (_requiresSharpnessArray) {
             arrayBuilder.sptr = _table->getSharpnessIndices(arrayIndex);
+        }
+        if (_requiresVaryingPatches) {
+            arrayBuilder.vptr = _table->getPatchArrayVaryingVertices(arrayIndex).begin();
         }
 
         if (_requiresFVarPatches) {
@@ -1160,8 +1164,7 @@ PatchTableBuilder::populateAdaptivePatches() {
         }
 
         if (_requiresVaryingPatches) {
-            assignFacePoints(patch, &_table->_varyingVerts[
-                patchIndex * _patchBuilder->GetRegularFaceSize()]);
+            arrayBuilder->vptr += assignFacePoints(patch, arrayBuilder->vptr);
         }
     }
 


### PR DESCRIPTION
Recent refactoring of PatchTable construction (#966) introduced a regression with the construction of patches for Varying data.  The bilinear patches would be generated in an incorrect order when more than one array of patches was being constructed, i.e. Gregory patches were used for the irregular patches.  When both regular and irregular patches were represented with BSplines, use of a single patch array avoided the problem.