### PR TITLE
Superficial header reordering in far/catmarkPatchBuilder.cpp

### DIFF
--- a/opensubdiv/far/catmarkPatchBuilder.cpp
+++ b/opensubdiv/far/catmarkPatchBuilder.cpp
@@ -22,12 +22,12 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include <cmath>
-#include <cstdio>
-#include <cassert>
-
 #include "../far/catmarkPatchBuilder.h"
 #include "../vtr/stackBuffer.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {


### PR DESCRIPTION
This is a trivial superficial change that was meant to be included in a recent pull request (#977) -- just reordering the header files in a single source file to conform to established convention.