### PR TITLE
Added bilinear end-cap option to Osd::MeshBits

### DIFF
--- a/opensubdiv/osd/mesh.h
+++ b/opensubdiv/osd/mesh.h
@@ -54,10 +54,11 @@ enum MeshBits {
     MeshUseSmoothCornerPatch = 4,
     MeshUseSingleCreasePatch = 5,
     MeshUseInfSharpPatch     = 6,
-    MeshEndCapBSplineBasis   = 7,  // exclusive
-    MeshEndCapGregoryBasis   = 8,  // exclusive
-    MeshEndCapLegacyGregory  = 9,  // exclusive
-    NUM_MESH_BITS            = 10,
+    MeshEndCapBilinearBasis  = 7,  // exclusive
+    MeshEndCapBSplineBasis   = 8,  // exclusive
+    MeshEndCapGregoryBasis   = 9,  // exclusive
+    MeshEndCapLegacyGregory  = 10, // exclusive
+    NUM_MESH_BITS            = 11,
 };
 typedef std::bitset<NUM_MESH_BITS> MeshBitset;
 
@@ -614,14 +615,18 @@ private:
         poptions.useSingleCreasePatch = bits.test(MeshUseSingleCreasePatch);
         poptions.useInfSharpPatch = bits.test(MeshUseInfSharpPatch);
 
-        if (bits.test(MeshEndCapBSplineBasis)) {
+        // points on bilinear and gregory basis endcap boundaries can be
+        // shared among adjacent patches to save some stencils.
+        if (bits.test(MeshEndCapBilinearBasis)) {
+            poptions.SetEndCapType(
+                Far::PatchTableFactory::Options::ENDCAP_BILINEAR_BASIS);
+            poptions.shareEndCapPatchPoints = true;
+        } else if (bits.test(MeshEndCapBSplineBasis)) {
             poptions.SetEndCapType(
                 Far::PatchTableFactory::Options::ENDCAP_BSPLINE_BASIS);
         } else if (bits.test(MeshEndCapGregoryBasis)) {
             poptions.SetEndCapType(
                 Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS);
-            // points on gregory basis endcap boundary can be shared among
-            // adjacent patches to save some stencils.
             poptions.shareEndCapPatchPoints = true;
         } else if (bits.test(MeshEndCapLegacyGregory)) {
             poptions.SetEndCapType(


### PR DESCRIPTION
There has long been a bilinear end-cap option in Far::PatchTableFactory::Options but it has been missing from Osd::MeshBits.  This change adds it so the two sets of choices are consistent and we can start making use of the linear option in the example applications and elsewhere.  (Note that there is a bug with face-varying linear end-caps that is still being resolved.)