### PR TITLE
Added flags to Far::PatchTableFactory::Options to address open issues

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -427,8 +427,9 @@ PatchTableBuilder::PatchTableBuilder(
     _requiresSharpnessArray = _options.useSingleCreasePatch;
     _requiresFVarPatches = ! _fvarChannelIndices.empty();
 
-    _requiresVaryingPatches = true;      // eventually to be made public
-    _requiresVaryingLocalPoints = true;  // currently fixed
+    _requiresVaryingPatches = _options.generateVaryingTables;
+    _requiresVaryingLocalPoints = _options.generateVaryingTables &&
+                                  _options.generateVaryingLocalPoints;
 
     //
     //  Create and initialize the new PatchTable instance to be assembled:
@@ -723,8 +724,8 @@ PatchTableBuilder::BuildUniform() {
     // these as public options in future so that clients can create consistent
     // behavior:
 
-    bool includeBaseLevelIndices     = true;
-    bool includeBaseLevelFVarIndices = false;
+    bool includeBaseLevelIndices     = _options.includeBaseLevelIndices;
+    bool includeBaseLevelFVarIndices = _options.includeFVarBaseLevelIndices;
 
     // ensure that triangulateQuads is only set for quadrilateral schemes
     bool triangulateQuads =

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -56,12 +56,16 @@ public:
 
         Options(unsigned int maxIsolation=10) :
              generateAllLevels(false),
+             includeBaseLevelIndices(true),
+             includeFVarBaseLevelIndices(false),
              triangulateQuads(false),
              useSingleCreasePatch(false),
              useInfSharpPatch(false),
              maxIsolationLevel(maxIsolation),
              endCapType(ENDCAP_GREGORY_BASIS),
              shareEndCapPatchPoints(true),
+             generateVaryingTables(true),
+             generateVaryingLocalPoints(true),
              generateFVarTables(false),
              setPatchPrecisionDouble(false),
              setFVarPatchPrecisionDouble(false),
@@ -83,8 +87,11 @@ public:
         /// \brief Set precision of face-varying patches
         template <typename REAL> void SetFVarPatchPrecision();
 
-        unsigned int generateAllLevels    : 1, ///< Include levels from 'firstLevel' to 'maxLevel' (Uniform mode only)
-                     triangulateQuads     : 1, ///< Triangulate 'QUADS' primitives (Uniform mode only)
+        unsigned int generateAllLevels           : 1, ///< Generate levels from 'firstLevel' to 'maxLevel' (Uniform mode only)
+                     includeBaseLevelIndices     : 1, ///< Include base level in patch point indices (Uniform mode only)
+                     includeFVarBaseLevelIndices : 1, ///< Include base level in face-varying patch point indices (Uniform mode only)
+                     triangulateQuads            : 1, ///< Triangulate 'QUADS' primitives (Uniform mode only)
+
                      useSingleCreasePatch : 1, ///< Use single crease patch
                      useInfSharpPatch     : 1, ///< Use infinitely-sharp patch
                      maxIsolationLevel    : 4, ///< Cap adaptive feature isolation to the given level (max. 10)
@@ -93,6 +100,10 @@ public:
                      endCapType              : 3, ///< EndCapType
                      shareEndCapPatchPoints  : 1, ///< Share endcap patch points among adjacent endcap patches.
                                                   ///< currently only work with GregoryBasis.
+
+                     // varying
+                     generateVaryingTables      : 1, ///< Generate varying patch tables
+                     generateVaryingLocalPoints : 1, ///< Generate local points with varying patches
 
                      // face-varying
                      generateFVarTables  : 1, ///< Generate face-varying patch tables

--- a/tutorials/far/tutorial_6/far_tutorial_6.cpp
+++ b/tutorials/far/tutorial_6/far_tutorial_6.cpp
@@ -150,6 +150,7 @@ int main(int, char **) {
     // surface limit
     Far::PatchTableFactory::Options patchOptions;
     patchOptions.SetPatchPrecision<Real>();
+    patchOptions.generateVaryingTables = false;
     patchOptions.endCapType =
         Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS;
 
@@ -164,7 +165,7 @@ int main(int, char **) {
     // Create a buffer to hold the position of the refined verts and
     // local points, then copy the coarse positions at the beginning.
     std::vector<Vertex> verts(nRefinerVertices + nLocalPoints);
-    memcpy(&verts[0], g_verts, g_nverts*3*sizeof(Real));
+    std::memcpy(&verts[0], g_verts, g_nverts*3*sizeof(Real));
 
     // Adaptive refinement may result in fewer levels than maxIsolation.
     int nRefinedLevels = refiner->GetNumLevels();


### PR DESCRIPTION
Two sets of new flags are added here to Far::PatchTableFactory::Options to address a couple of identified issues.  The code supporting these new options has long been supported internally, so the code changes do nothing more than expose them in the public interface.

The first set addresses indexing consistency issues with Uniform PatchTables raised in #737.  The second set allows the generation of Varying patches and/or their local point StencilTables to be suppressed.  A tutorial was updated to illustrate use of the latter, but there is no tutorial that constructs a uniform PatchTable for the latter.
