### PR TITLE
Fix rare non-manifold topology indexing issue in Vtr::Level

### DIFF
--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -1600,7 +1600,7 @@ namespace {
             for (int i = 0; i < _compCount; ++i) {
                 int count = _countsAndOffsets[2*i];
 
-                Index *dstMembers = &dstIndices[_countsAndOffsets[2*i + 1]];
+                Index *dstMembers = &dstIndices[0] + _countsAndOffsets[2*i + 1];
                 Index *srcMembers = 0;
                 
                 if (count <= _memberCountPerComp) {


### PR DESCRIPTION
This change fixes an indexing error that can occur in a rare non-manifold case but only when runtime bounds-checking is enabled for std::vector (originally identified in #955).  The case occurs when one or more of the last edge or vertex has 0 incident faces or edges.  Address arithmetic is now used to determine the end of the array to avoid the bounds-check errors triggered by use of vector[].