### PR TITLE
Fixed oversight deriving Far::LimitStencil from new template class

### DIFF
--- a/opensubdiv/far/stencilTable.h
+++ b/opensubdiv/far/stencilTable.h
@@ -380,7 +380,7 @@ private:
 
 /// \brief Limit point stencil class wrapping the template for compatibility.
 ///
-class LimitStencil : LimitStencilReal<float> {
+class LimitStencil : public LimitStencilReal<float> {
 protected:
     typedef LimitStencilReal<float>   BaseStencil;
 


### PR DESCRIPTION
As raised in Issue #992, this change fixes the omission of the "public" keyword when deriving Far::LimitStencil from the new template class Far::LimitStencilReal<float>.