### PR TITLE
Reverted PatchTable local point methods to address template issues

### DIFF
--- a/tutorials/far/tutorial_6/far_tutorial_6.cpp
+++ b/tutorials/far/tutorial_6/far_tutorial_6.cpp
@@ -182,7 +182,10 @@ int main(int, char **) {
     }
 
     // Evaluate local points from interpolated vertex primvars.
-    patchTable->ComputeLocalPointValues(&verts[0], &verts[nRefinerVertices]);
+    if (nLocalPoints) {
+        patchTable->GetLocalPointStencilTable<Real>()->UpdateValues(
+            &verts[0], &verts[nRefinerVertices]);
+    }
 
     // Create a Far::PatchMap to help locating patches in the table
     Far::PatchMap patchmap(*patchTable);

--- a/tutorials/far/tutorial_9/far_tutorial_9.cpp
+++ b/tutorials/far/tutorial_9/far_tutorial_9.cpp
@@ -86,10 +86,10 @@ namespace {
         //  Clear() and AddWithWeight() required for interpolation:
         void Clear( void * =0 ) { p[0] = p[1] = p[2] = 0.0f; }
 
-        void AddWithWeight(Pos const & src, double weight) {
-            p[0] += (float)weight * src.p[0];
-            p[1] += (float)weight * src.p[1];
-            p[2] += (float)weight * src.p[2];
+        void AddWithWeight(Pos const & src, float weight) {
+            p[0] += weight * src.p[0];
+            p[1] += weight * src.p[1];
+            p[2] += weight * src.p[2];
         }
 
         float p[3];
@@ -376,8 +376,9 @@ PatchGroup::PatchGroup(Far::PatchTableFactory::Options patchOptions,
         }
     }
     if (nLocalPoints) {
-        patchTable->ComputeLocalPointValues(&basePositions[0], nBaseVertices,
-                &localPositions[0], &localPositions[nRefinedVertices]);
+        patchTable->GetLocalPointStencilTable()->UpdateValues(
+                &basePositions[0], nBaseVertices, &localPositions[0],
+                &localPositions[nRefinedVertices]);
     }
 
     delete localRefiner;


### PR DESCRIPTION
As part of the changes providing double precision support (#980), the behavior of Far::PatchTable::ComputeLocalPointValues() et al was extended to apply the local point stencil tables to client primvar data conditionally, according to whether stored in the PatchTable as single or double precision.  This ends up requiring both single and double versions of generic stencil application to be instantiated, and the implementation of a client's primvar type T may not be written to support both -- often T::AddWithWeight() will produce warnings or errors when given a double precision stencil weight and expecting float.

Since ComputeLocalPointValues() et al are simple one-line wrappers around the stencil tables' UpdateValues() method, we are reverting their implementations to operate only in the original single precision and requiring clients to use UpdateValues() directly for any double precision or generic requirements (full generic access to the stencil table was provided in #980).  This also allows us to remove the overloads added in #990 in favor of direct usage of the overloaded UpdateValues().

All far/tutorials making use of the original or overloaded methods were also updated where necessary.
