### PR TITLE
Extended face-varying patch arrays to properly support two types

### DIFF
--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -157,7 +157,10 @@ struct PatchTable::FVarPatchChannel {
 
     Sdc::Options::FVarLinearInterpolation interpolation;
 
-    PatchDescriptor desc;
+    PatchDescriptor regDesc;
+    PatchDescriptor irregDesc;
+
+    int stride;
 
     std::vector<Index> patchValues;
     std::vector<PatchParam> patchParam;
@@ -186,10 +189,16 @@ PatchTable::allocateFVarPatchChannels(int numChannels) {
 }
 void
 PatchTable::allocateFVarPatchChannelValues(
-        PatchDescriptor desc, int numPatches, int channel) {
+        PatchDescriptor regDesc, PatchDescriptor irregDesc,
+        int numPatches, int channel) {
     FVarPatchChannel & c = getFVarPatchChannel(channel);
-    c.desc = desc;
-    c.patchValues.resize(numPatches*desc.GetNumControlVertices());
+    c.regDesc   = regDesc;
+    c.irregDesc = irregDesc;
+
+    c.stride = std::max(regDesc.GetNumControlVertices(),
+                        irregDesc.GetNumControlVertices());
+
+    c.patchValues.resize(numPatches * c.stride);
     c.patchParam.resize(numPatches);
 }
 void
@@ -487,14 +496,29 @@ PatchTable::GetFVarChannelLinearInterpolation(int channel) const {
     return c.interpolation;
 }
 PatchDescriptor
+PatchTable::GetFVarPatchDescriptorRegular(int channel) const {
+    FVarPatchChannel const & c = getFVarPatchChannel(channel);
+    return c.regDesc;
+}
+PatchDescriptor
+PatchTable::GetFVarPatchDescriptorIrregular(int channel) const {
+    FVarPatchChannel const & c = getFVarPatchChannel(channel);
+    return c.irregDesc;
+}
+PatchDescriptor
 PatchTable::GetFVarPatchDescriptor(int channel) const {
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
-    return c.desc;
+    return c.irregDesc;
 }
 ConstIndexArray
 PatchTable::GetFVarValues(int channel) const {
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
     return ConstIndexArray(&c.patchValues[0], (int)c.patchValues.size());
+}
+int
+PatchTable::GetFVarValueStride(int channel) const {
+    FVarPatchChannel const & c = getFVarPatchChannel(channel);
+    return c.stride;
 }
 IndexArray
 PatchTable::getFVarValues(int channel) {
@@ -504,10 +528,10 @@ PatchTable::getFVarValues(int channel) {
 ConstIndexArray
 PatchTable::getPatchFVarValues(int patch, int channel) const {
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
-    int ncvsPerPatch = c.desc.GetNumControlVertices();
     int ncvsThisPatch = c.patchParam[patch].IsRegular()
-                      ? c.desc.GetRegularPatchSize() : ncvsPerPatch;
-    return ConstIndexArray(&c.patchValues[patch * ncvsPerPatch], ncvsThisPatch);
+                      ? c.regDesc.GetNumControlVertices()
+                      : c.irregDesc.GetNumControlVertices();
+    return ConstIndexArray(&c.patchValues[patch * c.stride], ncvsThisPatch);
 }
 ConstIndexArray
 PatchTable::GetPatchFVarValues(PatchHandle const & handle, int channel) const {
@@ -521,7 +545,7 @@ ConstIndexArray
 PatchTable::GetPatchArrayFVarValues(int array, int channel) const {
     PatchArray const & pa = getPatchArray(array);
     FVarPatchChannel const & c = getFVarPatchChannel(channel);
-    int ncvs = c.desc.GetNumControlVertices();
+    int ncvs = c.stride;
     int start = pa.patchIndex * ncvs;
     int count = pa.numPatches * ncvs;
     return ConstIndexArray(&c.patchValues[start], count);
@@ -620,8 +644,8 @@ PatchTable::EvaluateBasisFaceVarying(
 
     PatchParam param = getPatchFVarPatchParam(handle.patchIndex, channel);
     PatchDescriptor::Type patchType = param.IsRegular()
-            ? PatchDescriptor::REGULAR
-            : GetFVarPatchDescriptor(channel).GetType();
+            ? GetFVarPatchDescriptorRegular(channel).GetType()
+            : GetFVarPatchDescriptorIrregular(channel).GetType();
 
     if (patchType == PatchDescriptor::REGULAR) {
         internal::GetBSplineWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -25,6 +25,7 @@
 #include "../far/patchTable.h"
 #include "../far/patchBasis.h"
 
+#include <algorithm>
 #include <cstring>
 #include <cstdio>
 

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -325,7 +325,13 @@ public:
     /// \brief Returns the number of face-varying channels
     int GetNumFVarChannels() const;
 
-    /// \brief Returns the patch descriptor for \p channel
+    /// \brief Returns the regular patch descriptor for \p channel
+    PatchDescriptor GetFVarPatchDescriptorRegular(int channel = 0) const;
+
+    /// \brief Returns the irregular patch descriptor for \p channel
+    PatchDescriptor GetFVarPatchDescriptorIrregular(int channel = 0) const;
+
+    /// \brief Returns the default/irregular patch descriptor for \p channel
     PatchDescriptor GetFVarPatchDescriptor(int channel = 0) const;
 
     /// \brief Returns the value indices for a given patch in \p channel
@@ -339,6 +345,9 @@ public:
 
     /// \brief Returns an array of value indices for the patches in \p channel
     ConstIndexArray GetFVarValues(int channel = 0) const;
+
+    /// \brief Returns the stride between patches in the value index array of \p channel
+    int GetFVarValueStride(int channel = 0) const;
 
     /// \brief Returns the value indices for a given patch in \p channel
     PatchParam GetPatchFVarPatchParam(PatchHandle const & handle, int channel = 0) const;
@@ -574,7 +583,8 @@ private:
 
     void allocateFVarPatchChannels(int numChannels);
     void allocateFVarPatchChannelValues(
-        PatchDescriptor desc, int numPatches, int channel);
+        PatchDescriptor regDesc, PatchDescriptor irregDesc,
+        int numPatches, int channel);
 
     // deprecated
     void setFVarPatchChannelLinearInterpolation(

--- a/opensubdiv/osd/cpuEvaluator.cpp
+++ b/opensubdiv/osd/cpuEvaluator.cpp
@@ -186,8 +186,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         Far::PatchParam const & param =
             patchParamBuffer[coord.handle.patchIndex];
         int patchType = param.IsRegular()
-            ? Far::PatchDescriptor::REGULAR
-            : array.GetPatchType();
+            ? array.GetPatchTypeRegular()
+            : array.GetPatchTypeIrregular();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -207,8 +207,7 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
             return false;
         }
 
-        int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
-        int indexBase = array.GetIndexBase() + indexStride *
+        int indexBase = array.GetIndexBase() + array.GetStride() *
                 (coord.handle.patchIndex - array.GetPrimitiveIdBase());
 
         const int *cvs = &patchIndexBuffer[indexBase];
@@ -265,8 +264,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         Far::PatchParam const & param =
             patchParamBuffer[coord.handle.patchIndex];
         int patchType = param.IsRegular()
-            ? Far::PatchDescriptor::REGULAR
-            : array.GetPatchType();
+            ? array.GetPatchTypeRegular()
+            : array.GetPatchTypeIrregular();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -285,8 +284,7 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
             assert(0);
         }
 
-        int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
-        int indexBase = array.GetIndexBase() + indexStride *
+        int indexBase = array.GetIndexBase() + array.GetStride() *
                 (coord.handle.patchIndex - array.GetPrimitiveIdBase());
 
         const int *cvs = &patchIndexBuffer[indexBase];
@@ -367,8 +365,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
         Far::PatchParam const & param =
             patchParamBuffer[coord.handle.patchIndex];
         int patchType = param.IsRegular()
-            ? Far::PatchDescriptor::REGULAR
-            : array.GetPatchType();
+            ? array.GetPatchTypeRegular()
+            : array.GetPatchTypeIrregular();
 
         int numControlVertices = 0;
         if (patchType == Far::PatchDescriptor::REGULAR) {
@@ -390,8 +388,7 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
             assert(0);
         }
 
-        int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
-        int indexBase = array.GetIndexBase() + indexStride *
+        int indexBase = array.GetIndexBase() + array.GetStride() *
                 (coord.handle.patchIndex - array.GetPrimitiveIdBase());
 
         const int *cvs = &patchIndexBuffer[indexBase];

--- a/opensubdiv/osd/cpuPatchTable.cpp
+++ b/opensubdiv/osd/cpuPatchTable.cpp
@@ -57,7 +57,7 @@ CpuPatchTable::CpuPatchTable(const Far::PatchTable *farPatchTable) {
     for (int fvc=0; fvc<farPatchTable->GetNumFVarChannels(); ++fvc) {
         _fvarPatchArrays[fvc].reserve(nPatchArrays);
         _fvarIndexBuffers[fvc].reserve(
-            numPatches*farPatchTable->GetFVarPatchDescriptor(fvc).GetNumControlVertices());
+            numPatches * farPatchTable->GetFVarValueStride(fvc));
         _fvarParamBuffers[fvc].reserve(numPatches);
     }
     _patchParamBuffer.reserve(numPatches);
@@ -86,7 +86,9 @@ CpuPatchTable::CpuPatchTable(const Far::PatchTable *farPatchTable) {
         // face-varying
         for (int fvc=0; fvc<farPatchTable->GetNumFVarChannels(); ++fvc) {
             PatchArray fvarPatchArray(
-                farPatchTable->GetFVarPatchDescriptor(fvc), numPatches, 0, 0);
+                farPatchTable->GetFVarPatchDescriptorRegular(fvc),
+                farPatchTable->GetFVarPatchDescriptorIrregular(fvc),
+                numPatches, 0, 0);
             _fvarPatchArrays[fvc].push_back(fvarPatchArray);
 
             Far::ConstIndexArray

--- a/opensubdiv/osd/types.h
+++ b/opensubdiv/osd/types.h
@@ -28,6 +28,8 @@
 #include "../version.h"
 #include "../far/patchTable.h"
 
+#include <algorithm>
+
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 

--- a/opensubdiv/osd/types.h
+++ b/opensubdiv/osd/types.h
@@ -63,30 +63,62 @@ struct PatchCoord {
 
 struct PatchArray {
     // 4-ints struct.
-    PatchArray(Far::PatchDescriptor desc_in, int numPatches_in,
-               int indexBase_in, int primitiveIdBase_in) :
-        desc(desc_in), numPatches(numPatches_in), indexBase(indexBase_in),
+    PatchArray(Far::PatchDescriptor desc_in,
+               int numPatches_in, int indexBase_in, int primitiveIdBase_in) :
+        regDesc(desc_in), desc(desc_in),
+        numPatches(numPatches_in), indexBase(indexBase_in),
+        stride(desc_in.GetNumControlVertices()),
+        primitiveIdBase(primitiveIdBase_in) {}
+
+    PatchArray(Far::PatchDescriptor regDesc_in, Far::PatchDescriptor irregDesc_in,
+               int numPatches_in, int indexBase_in, int primitiveIdBase_in) :
+        regDesc(regDesc_in), desc(irregDesc_in),
+        numPatches(numPatches_in), indexBase(indexBase_in),
+        stride(std::max(regDesc_in.GetNumControlVertices(),
+                        irregDesc_in.GetNumControlVertices())),
         primitiveIdBase(primitiveIdBase_in) {}
 
     Far::PatchDescriptor const &GetDescriptor() const {
+        return desc;
+    }
+    Far::PatchDescriptor const &GetDescriptorRegular() const {
+        return regDesc;
+    }
+    Far::PatchDescriptor const &GetDescriptorIrregular() const {
         return desc;
     }
 
     int GetPatchType() const {
         return desc.GetType();
     }
+    int GetPatchTypeRegular() const {
+        return regDesc.GetType();
+    }
+    int GetPatchTypeIrregular() const {
+        return desc.GetType();
+    }
+
     int GetNumPatches() const {
         return numPatches;
     }
     int GetIndexBase() const {
         return indexBase;
     }
+    int GetStride() const {
+        return stride;
+    }
     int GetPrimitiveIdBase() const {
         return primitiveIdBase;
     }
+
+    // Separate regular and irregular patch descriptors for cases where the
+    // array is mixed -- both will be equal if only a single type specified
+    Far::PatchDescriptor regDesc;
     Far::PatchDescriptor desc;
+
     int numPatches;
     int indexBase;        // an offset within the index buffer
+    int stride;           // stride in buffer between patches
     int primitiveIdBase;  // an offset within the patch param buffer
 };
 


### PR DESCRIPTION
This change extends the public interface of the Far::PatchTable and related Osd classes to allow proper handling of face-varying patch arrays -- which store patches of two different types in the same array.

Two changes are made in both areas:

- a second patch descriptor is now explicitly associated with the array and methods are provided to query both a "regular" and "irregular" patch type (typically in response to the result of the PatchParam::IsRegular() test).  Previously the irregular patch type was available in the descriptor and the regular type was assumed to be BSpline, which will not be the case if the subdivision scheme is not Catmark.
- a common stride for patches in the array is determined as the max of the regular and irregular patch sizes and provided with a new access method.  Previously the irregular size was used, which is not the larger when bilinear irregular patches are chosen.

These extensions should not impact existing usage -- they should enable past assumptions to be corrected.  We'll be fixing some of these assumptions in the example code and elsewhere in conjunction with other ongoing work.
