### PR TITLE
Misc. typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ SDKROOT=$(xcrun --sdk iphoneos --show-sdk-path) cmake -D NO_PTEX=1 -D NO_DOC=1 \
       ..
 ```
 
-  * This will produce an "OpenSubdiv.xcodeproj" that can be open and the targets 'mtlViewer' and 'mtlPtexViewer' (if NO_PTEX is ommitted and libPtex.a is installed in the iOS SDK) that can be run
+  * This will produce an "OpenSubdiv.xcodeproj" that can be open and the targets 'mtlViewer' and 'mtlPtexViewer' (if NO_PTEX is omitted and libPtex.a is installed in the iOS SDK) that can be run
 
 ### Useful cmake options and environment variables
 

--- a/documentation/OpenSubdiv.doxy
+++ b/documentation/OpenSubdiv.doxy
@@ -985,7 +985,7 @@ HTML_STYLESHEET        =
 # user-defined cascading style sheet that is included after the standard
 # style sheets created by doxygen. Using this option one can overrule
 # certain style aspects. This is preferred over using HTML_STYLESHEET
-# since it does not replace the standard style sheet and is therefor more
+# since it does not replace the standard style sheet and is therefore more
 # robust against future updates. Doxygen will copy the style sheet file to
 # the output directory.
 

--- a/documentation/cmake_build.rst
+++ b/documentation/cmake_build.rst
@@ -138,7 +138,7 @@ through the following environment variables:
 Automated Script
 ________________
 
-The GUI solution will probably become a burden for active developpers who tend to
+The GUI solution will probably become a burden for active developers who tend to
 re-run the configuration step fairly often. A scripted solution can save a lot of
 time. Here is a typical workflow:
 
@@ -218,14 +218,14 @@ Using Intel's C++ Studio XE
 ___________________________
 
 OpenSubdiv can be also be built with `Intel's C++ compiler <http://software.intel.com/en-us/intel-compilers>`__
-(icc). The default compiler can be overriden in CMake with the following configuration options:
+(icc). The default compiler can be overridden in CMake with the following configuration options:
 
 .. code:: c++
 
     -DCMAKE_CXX_COMPILER=[path to icc executable]
     -DCMAKE_C_COMPILER=[path to icc executable]
 
-The installation location of the C++ Studio XE can be overriden with:
+The installation location of the C++ Studio XE can be overridden with:
 
 .. code:: c++
 
@@ -235,7 +235,7 @@ The installation location of the C++ Studio XE can be overriden with:
 Using Clang
 ___________
 
-CMake can also be overriden to use the `clang <http://clang.llvm.org/>`__ compilers by configuring the following options:
+CMake can also be overridden to use the `clang <http://clang.llvm.org/>`__ compilers by configuring the following options:
 
 .. code:: c++
 

--- a/documentation/dxptexviewer.rst
+++ b/documentation/dxptexviewer.rst
@@ -86,15 +86,15 @@ OPTIONS
   A ptex file containing RGB channels read as material albedo color.
   
 *ptex displacement file*
-  A single-channel ptex file (preferrably float precision) containing the 
+  A single-channel ptex file (preferably float precision) containing the 
   displacement values.
 
 *ptex occlusion file*
-  A single-channel ptex file (preferrably 8 bits precision) containing a 
+  A single-channel ptex file (preferably 8 bits precision) containing a 
   pre-computed ambient occlusion signal.
 
 *ptex specular file*
-  A single-channel ptex file (preferrably 8 bits precision) applied to modulate
+  A single-channel ptex file (preferably 8 bits precision) applied to modulate
   the specular reflectance of the material
   
 *objfile(s)*

--- a/documentation/osd_overview.rst
+++ b/documentation/osd_overview.rst
@@ -235,7 +235,7 @@ Cross-Platform Implementation
 
 One of the key goals of OpenSubdiv is to achieve as much cross-platform flexibility
 as possible and leverage all optimized hardware paths where available. This can
-be very challenging as there is a very large variety of plaftorms and APIs 
+be very challenging as there is a very large variety of platforms and APIs 
 available, with very distinct capabilities.
 
 In **Osd**, Evaluators don't care about interops between those APIs. All Evaluators

--- a/documentation/release_notes_2x.rst
+++ b/documentation/release_notes_2x.rst
@@ -60,7 +60,7 @@ Release 2.6.0
     - Fix a bug in the CUDA computeRestrictedEdge kernel
     - Fix duplicate variables with identical name
     - Fix osdutil build errors
-    - Fix cmake diagnostic messsage
+    - Fix cmake diagnostic message
 
 Release 2.5.1
 =============
@@ -103,7 +103,7 @@ Release 2.5.0
       Moved transient states (current vertex buffer etc) to controller
     - Fix adaptive isolation of sharp corner vertices
     - Fix incorrect FarMeshFactory logic for isolating multiple corner vertices in corner patches
-    - Change EvalLimit Gregory patch kernels to the large weights table to accomodate higher valences
+    - Change EvalLimit Gregory patch kernels to the large weights table to accommodate higher valences
     - Fix calculation of screen space LOD tess factors for transition corner patches.
     - Add a public constructor to OsdMesh
     - Decrease compiler warning thresholds and fix outstanding warnings
@@ -203,7 +203,7 @@ Release 2.3.5
 **New Features**
     - Add the ability to read obj files to the dxViewer example
     - Add screen-capture function to ptexViewer
-    - Update documention for Xcode builds
+    - Update documentation for Xcode builds
     - Add documentation (boundary interpolation rules and face-varying boundary interpolation rules)
 
 **Changes**
@@ -324,7 +324,7 @@ Release 2.3.1
     - Optimize a bit of ptex mipmap lookup.
     - Show ptex memory usage in GL and DX11 ptexViewers
     - Improve ptex guttering
-    - Addding some video links to our collection of external resources
+    - Adding some video links to our collection of external resources
 
 **Bug Fixes**
     - Fix edge-only face-varying interpolation
@@ -448,7 +448,7 @@ Release 1.2.4
 **New Features**
 
     - Adding support for fractional tessellation of patches
-    - Adding a much needed API documention system based on Docutils RST markup
+    - Adding a much needed API documentation system based on Docutils RST markup
     - Adding support for face-varying interpolation in GLSL APIs
     - Adding varying data buffers to OsdMesh
     - Adding accessors to the vertex buffers in OsdGlMesh
@@ -496,7 +496,7 @@ Release 1.2.3
     - Face-varying data bug fixes : making sure the data is carried around appropriately
       Fixes for OpenCL use with the new batching APIs
     - GLSL general shader code cleanup & fixes for better portability
-    - GLSL Tranform Feedback initialization fix
+    - GLSL Transform Feedback initialization fix
     - Critical fix for FarMultiMesh batching (indexing was incorrect)
     - Fix osdutil CL implementation (protect #includes on systems with no OpenCL SDK
       installed)

--- a/examples/common/clDeviceContext.cpp
+++ b/examples/common/clDeviceContext.cpp
@@ -220,7 +220,7 @@ CLDeviceContext::Initialize() {
                             0, NULL, &devicesSize);
     int numDevices = int(devicesSize / sizeof(cl_device_id));
     if (numDevices == 0) {
-        error("No sharable devices.\n");
+        error("No shareable devices.\n");
         return false;
     }
     cl_device_id *clDevices = new cl_device_id[numDevices];

--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -1914,7 +1914,7 @@ void usage(const char *program) {
     printf("          -y                      : Y-up model\n");
     printf("          -m level                : max mimmap level (default=10)\n");
     printf("          -x <ptex limit MB>      : ptex target memory size\n");
-    printf("          --disp <scale>          : Displacment scale\n");
+    printf("          --disp <scale>          : Displacement scale\n");
 }
 
 //------------------------------------------------------------------------------

--- a/opensubdiv/far/sparseMatrix.h
+++ b/opensubdiv/far/sparseMatrix.h
@@ -46,7 +46,7 @@ namespace Far {
 //  format (CSR) is used as it provides us with stencils for points that
 //  correspond to rows and so can be more directly and efficiently copied.
 //
-//  It has potential for other uses and so may eventually warrant a seperate
+//  It has potential for other uses and so may eventually warrant a separate
 //  header file of its own.  For now, in keeping with the trend of exposing
 //  classes only where used, it is defined with the PatchBuilder.
 //

--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -291,7 +291,7 @@ namespace internal {
         FeatureMask() { Clear(); }
         FeatureMask(Options const & options, Sdc::SchemeType sType) { Clear(); InitializeFeatures(options, sType); }
 
-        //  These are the two primary methods intended for use -- intialization via a set of Options
+        //  These are the two primary methods intended for use -- initialization via a set of Options
         //  and reduction of the subsequent feature set (which presumes prior initialization with the
         //  same set as give)
         //
@@ -326,7 +326,7 @@ namespace internal {
         //
         //  The inf-sharp single-crease case now corresponds to an inf-sharp regular crease
         //  in the interior -- and since such regular creases on the boundary are never
-        //  considered for selection (just as interior smoot regular faces are not), this
+        //  considered for selection (just as interior smooth regular faces are not), this
         //  feature is only relevant for the interior case.  So aside from it being used
         //  when regular inf-sharp features are all selected, it can also be used for the
         //  single-crease case.
@@ -508,7 +508,7 @@ namespace {
     //  Strictly speaking we should be testing all features and not returning based on
     //  the selection status of the most likely feature that warrants selection, but in
     //  practice, the separation of features and the typically common settings to groups
-    //  of features (i.e. it not yet possible, or even desireable, to select irregular
+    //  of features (i.e. it not yet possible, or even desirable, to select irregular
     //  creases deeper than irregular corners) makes that unnecessary.
     //
     inline bool

--- a/opensubdiv/hbr/creaseEdit.h
+++ b/opensubdiv/hbr/creaseEdit.h
@@ -75,7 +75,7 @@ public:
                 sharp = HbrHalfedge<T>::k_InfinitelySharp;
             // We have to make sure the neighbor of the edge exists at
             // this point. Otherwise, if it comes into being late, it
-            // will clobber the overriden sharpness and we will lose
+            // will clobber the overridden sharpness and we will lose
             // the edit.
             face->GetEdge(edgeid)->GuaranteeNeighbor();
             face->GetEdge(edgeid)->SetSharpness(sharp);

--- a/opensubdiv/hbr/hierarchicalEdit.h
+++ b/opensubdiv/hbr/hierarchicalEdit.h
@@ -92,10 +92,10 @@ public:
     // face in question
     bool IsRelevantToFace(HbrFace<T>* face) const;
 
-    // Applys edit to face. All subclasses may override this method
+    // Applies edit to face. All subclasses may override this method
     virtual void ApplyEditToFace(HbrFace<T>* /* face */) {}
 
-    // Applys edit to vertex. Subclasses may override this method.
+    // Applies edit to vertex. Subclasses may override this method.
     virtual void ApplyEditToVertex(HbrFace<T>* /* face */, HbrVertex<T>* /* vertex */) {}
 
 #ifdef PRMAN

--- a/opensubdiv/hbr/vertex.h
+++ b/opensubdiv/hbr/vertex.h
@@ -213,7 +213,7 @@ public:
     // around this vertex
     void ApplyOperatorSurroundingVertices(HbrVertexOperator<T> &op) const;
 
-    // Applys an operator to the ring of faces around this vertex
+    // Applies an operator to the ring of faces around this vertex
     void ApplyOperatorSurroundingFaces(HbrFaceOperator<T> &op) const;
 
     // Returns the parent, which can be a edge, face, or vertex

--- a/opensubdiv/osd/glXFBEvaluator.h
+++ b/opensubdiv/osd/glXFBEvaluator.h
@@ -186,7 +186,7 @@ public:
     /// \brief Constructor.
     ///
     /// The transform feedback evaluator can make more sparing use of
-    /// transform feeback buffer bindings when it is known that evaluator
+    /// transform feedback buffer bindings when it is known that evaluator
     /// output buffers are shared and the corresponding buffer descriptors
     /// are interleaved. When \a interleavedDerivativeBuffers is true
     /// then evaluation requires that either 1st derivative outputs are

--- a/opensubdiv/osd/mtlVertexBuffer.mm
+++ b/opensubdiv/osd/mtlVertexBuffer.mm
@@ -92,7 +92,7 @@ id<MTLBuffer> CPUMTLVertexBuffer::BindMTLBuffer(MTLContext* context)
 
 
 
-} //end namepsace Osd
+} //end namespace Osd
 } //end namespace OPENSUBDIV_VERSION
 using namespace OPENSUBDIV_VERSION;
 } //end namespace OpenSubdiv

--- a/opensubdiv/vtr/stackBuffer.h
+++ b/opensubdiv/vtr/stackBuffer.h
@@ -123,7 +123,7 @@ StackBuffer<TYPE,SIZE,POD_TYPE>::deallocate() {
 //
 //  Explicit element-wise construction and destruction within allocated memory.
 //  Compilers do not always optimize out the iteration here even when there is
-//  no construction or destruction, so the POD_TYPE arguement can be used to
+//  no construction or destruction, so the POD_TYPE argument can be used to
 //  force this when/if it becomes an issue (and it has been in some cases).
 //
 template <typename TYPE, unsigned int SIZE, bool POD_TYPE>

--- a/tutorials/far/tutorial_9/far_tutorial_9.cpp
+++ b/tutorials/far/tutorial_9/far_tutorial_9.cpp
@@ -393,7 +393,7 @@ void
 PatchGroup::TessellateBaseFace(int face, PosVector & tessPoints,
                                          TriVector & tessTris) const {
 
-    //  Tesselate the face with points at the midpoint of the face and at
+    //  Tessellate the face with points at the midpoint of the face and at
     //  each corner, and triangles connecting the midpoint to each edge.
     //  Irregular faces require an aribrary number of corners points, but
     //  all are at the origin of the child face of the irregular base face:


### PR DESCRIPTION
Found via `codespell -q 3 -I ../OpenSubdiv-word-whitelist.txt` where whitelist consists of:  
```
currenty
lod
uint
```