### PR TITLE
Simplify Vtr bitfield operations to avoid issues with older versions of GCC

### DIFF
--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -119,6 +119,10 @@ public:
         VTagSize _infSharpCrease  : 1;  // fixed
         VTagSize _infIrregular    : 1;  // fixed
 
+        //  Alternate constructor and accessor for dealing with integer bits directly:
+        explicit VTag(VTagSize bits) { *this = *reinterpret_cast<VTag const *>(&bits); }
+        VTagSize getBits() const { return *reinterpret_cast<VTagSize const *>(this); }
+
         static VTag BitwiseOr(VTag const vTags[], int size = 4);
     };
     struct ETag {
@@ -133,6 +137,10 @@ public:
         ETagSize _boundary     : 1;  // fixed
         ETagSize _infSharp     : 1;  // fixed
         ETagSize _semiSharp    : 1;  // variable
+
+        //  Alternate constructor and accessor for dealing with integer bits directly:
+        explicit ETag(ETagSize bits) { *this = *reinterpret_cast<ETag const *>(&bits); }
+        ETagSize getBits() const { return *reinterpret_cast<ETagSize const *>(this); }
 
         static ETag BitwiseOr(ETag const eTags[], int size = 4);
     };


### PR DESCRIPTION
Low-level bitfields that were designed to support bitwise operations make use of pointer casting in those operations, which causes problems when setting high levels of optimization in older versions of GCC.  Replacing the type casting with more explicit retrieval and assignment of the bits as integers avoids the issue and also simplifies the implementation.