### PR TITLE
Added low-level support in Far for triangular patches

### DIFF
--- a/opensubdiv/far/patchBasis.h
+++ b/opensubdiv/far/patchBasis.h
@@ -45,22 +45,43 @@ namespace internal {
 // So this interface will be changing in future.
 //
 
+//
+// Quad patch types:
+//
 template <typename REAL>
-void GetBilinearWeights(PatchParam const & patchParam, REAL s, REAL t,
+int GetBilinearWeights(PatchParam const & patchParam, REAL s, REAL t,
     REAL wP[4], REAL wDs[4], REAL wDt[4], REAL wDss[4] = 0, REAL wDst[4] = 0, REAL wDtt[4] = 0);
 
 template <typename REAL>
-void GetBezierWeights(PatchParam const & patchParam, REAL s, REAL t,
+int GetBezierWeights(PatchParam const & patchParam, REAL s, REAL t,
     REAL wP[16], REAL wDs[16], REAL wDt[16], REAL wDss[16] = 0, REAL wDst[16] = 0, REAL wDtt[16] = 0);
 
 template <typename REAL>
-void GetBSplineWeights(PatchParam const & patchParam, REAL s, REAL t,
+int GetBSplineWeights(PatchParam const & patchParam, REAL s, REAL t,
     REAL wP[16], REAL wDs[16], REAL wDt[16], REAL wDss[16] = 0, REAL wDst[16] = 0, REAL wDtt[16] = 0);
 
 template <typename REAL>
-void GetGregoryWeights(PatchParam const & patchParam, REAL s, REAL t,
+int GetGregoryWeights(PatchParam const & patchParam, REAL s, REAL t,
     REAL wP[20], REAL wDs[20], REAL wDt[20], REAL wDss[20] = 0, REAL wDst[20] = 0, REAL wDtt[20] = 0);
 
+//
+// Triangle patch types:
+//
+template <typename REAL>
+int GetLinearTriWeights(PatchParam const & patchParam, REAL s, REAL t,
+    REAL wP[3], REAL wDs[3], REAL wDt[3], REAL wDss[3] = 0, REAL wDst[3] = 0, REAL wDtt[3] = 0);
+
+template <typename REAL>
+int GetBezierTriWeights(PatchParam const & patchParam, REAL s, REAL t,
+    REAL wP[12], REAL wDs[12], REAL wDt[12], REAL wDss[12] = 0, REAL wDst[12] = 0, REAL wDtt[12] = 0);
+
+template <typename REAL>
+int GetBoxSplineTriWeights(PatchParam const & patchParam, REAL s, REAL t,
+    REAL wP[12], REAL wDs[12], REAL wDt[12], REAL wDss[12] = 0, REAL wDst[12] = 0, REAL wDtt[12] = 0);
+
+template <typename REAL>
+int GetGregoryTriWeights(PatchParam const & patchParam, REAL s, REAL t,
+    REAL wP[15], REAL wDs[15], REAL wDt[15], REAL wDss[15] = 0, REAL wDst[15] = 0, REAL wDtt[15] = 0);
 
 } // end namespace internal
 } // end namespace Far

--- a/opensubdiv/far/patchDescriptor.cpp
+++ b/opensubdiv/far/patchDescriptor.cpp
@@ -44,6 +44,7 @@ PatchDescriptor::GetAdaptivePatchDescriptors(Sdc::SchemeType type) {
     static PatchDescriptor _loopDescriptors[] = {
         // XXXX work in progress !
         PatchDescriptor(LOOP),
+        PatchDescriptor(GREGORY_TRIANGLE),
     };
 
     static PatchDescriptor _catmarkDescriptors[] = {
@@ -72,7 +73,8 @@ void
 PatchDescriptor::print() const {
     static char const * types[13] = {
         "NON_PATCH", "POINTS", "LINES", "QUADS", "TRIANGLES", "LOOP",
-            "REGULAR", "GREGORY", "GREGORY_BOUNDARY", "GREGORY_BASIS" };
+            "REGULAR", "GREGORY", "GREGORY_BOUNDARY", "GREGORY_BASIS",
+            "GREGORY_TRIANGLE"};
 
     printf("    type %s\n",
         types[_type]);

--- a/opensubdiv/far/patchDescriptor.h
+++ b/opensubdiv/far/patchDescriptor.h
@@ -65,7 +65,8 @@ public:
         REGULAR,           ///< feature-adaptive bicubic patches
         GREGORY,
         GREGORY_BOUNDARY,
-        GREGORY_BASIS
+        GREGORY_BASIS,
+        GREGORY_TRIANGLE
     };
 
 public:
@@ -89,7 +90,7 @@ public:
 
     /// \brief Returns true if the type is an adaptive patch
     static inline bool IsAdaptive(Type type) {
-        return (type>=LOOP && type<=GREGORY_BASIS);
+        return (type>=LOOP && type<=GREGORY_TRIANGLE);
     }
 
     /// \brief Returns true if the type is an adaptive patch
@@ -149,10 +150,12 @@ inline short
 PatchDescriptor::GetNumControlVertices( Type type ) {
     switch (type) {
         case REGULAR           : return GetRegularPatchSize();
+        case LOOP              : return 12;
         case QUADS             : return 4;
         case GREGORY           :
         case GREGORY_BOUNDARY  : return GetGregoryPatchSize();
         case GREGORY_BASIS     : return GetGregoryBasisPatchSize();
+        case GREGORY_TRIANGLE  : return 15;
         case TRIANGLES         : return 3;
         case LINES             : return 2;
         case POINTS            : return 1;

--- a/opensubdiv/osd/clKernel.cl
+++ b/opensubdiv/osd/clKernel.cl
@@ -249,7 +249,7 @@ __kernel void computePatches(__global float *src, int srcOffset,
     float uv[2] = {coord.s, coord.t};
     normalizePatchCoord(patchBits, uv);
     float dScale = (float)(1 << getDepth(patchBits));
-    int boundary = (patchBits >> 8) & 0xf;
+    int boundary = (patchBits >> 7) & 0x1f;
 
     float wP[20], wDs[20], wDt[20], wDss[20], wDst[20], wDtt[20];
 

--- a/opensubdiv/osd/cudaKernel.cu
+++ b/opensubdiv/osd/cudaKernel.cu
@@ -335,7 +335,7 @@ computePatches(const float *src, float *dst,
         float t = coord.t;
         normalizePatchCoord(patchBits, &s, &t);
         float dScale = (float)(1 << getDepth(patchBits));
-        int boundary = int((patchBits >> 8) & 0xfU);
+        int boundary = int((patchBits >> 7) & 0x1fU);
 
         int numControlVertices = 0;
         if (patchType == 3) {

--- a/opensubdiv/osd/glslComputeKernel.glsl
+++ b/opensubdiv/osd/glslComputeKernel.glsl
@@ -308,7 +308,7 @@ void main() {
 
     vec2 uv = normalizePatchCoord(patchBits, vec2(coord.s, coord.t));
     float dScale = float(1 << getDepth(patchBits));
-    int boundary = int((patchBits >> 8) & 0xfU);
+    int boundary = int((patchBits >> 7) & 0x1fU);
 
     float wP[20], wDs[20], wDt[20], wDss[20], wDst[20], wDtt[20];
 

--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -172,7 +172,7 @@ int OsdGetPatchRefinementLevel(ivec3 patchParam)
 
 int OsdGetPatchBoundaryMask(ivec3 patchParam)
 {
-    return ((patchParam.y >> 8) & 0xf);
+    return ((patchParam.y >> 7) & 0x1f);
 }
 
 int OsdGetPatchTransitionMask(ivec3 patchParam)

--- a/opensubdiv/osd/glslXFBKernel.glsl
+++ b/opensubdiv/osd/glslXFBKernel.glsl
@@ -288,7 +288,7 @@ void main() {
     // normalize
     coord = normalizePatchCoord(patchBits, coord);
     float dScale = float(1 << getDepth(patchBits));
-    int boundary = int((patchBits >> 8) & 0xfU);
+    int boundary = int((patchBits >> 7) & 0x1fU);
 
     float wP[20], wDs[20], wDt[20], wDss[20], wDst[20], wDtt[20];
 

--- a/opensubdiv/osd/hlslPatchCommon.hlsl
+++ b/opensubdiv/osd/hlslPatchCommon.hlsl
@@ -147,7 +147,7 @@ int OsdGetPatchRefinementLevel(int3 patchParam)
 
 int OsdGetPatchBoundaryMask(int3 patchParam)
 {
-    return ((patchParam.y >> 8) & 0xf);
+    return ((patchParam.y >> 7) & 0x1f);
 }
 
 int OsdGetPatchTransitionMask(int3 patchParam)

--- a/opensubdiv/osd/mtlComputeKernel.metal
+++ b/opensubdiv/osd/mtlComputeKernel.metal
@@ -330,7 +330,7 @@ kernel void eval_patches(
     auto numControlVertices = getNumControlVertices(patchType);
     auto uv = normalizePatchCoord(patchBits, float2(patchCoord.s, patchCoord.t));
     auto dScale = float(1 << getDepth(patchBits));
-    auto boundary = int((patchBits >> 8) & 0xFU);
+    auto boundary = int((patchBits >> 7) & 0x1FU);
 
     float wP[20], wDs[20], wDt[20], wDss[20], wDst[20], wDtt[20];
 

--- a/opensubdiv/osd/mtlPatchCommon.metal
+++ b/opensubdiv/osd/mtlPatchCommon.metal
@@ -275,7 +275,7 @@ int OsdGetPatchRefinementLevel(int3 patchParam)
 
 int OsdGetPatchBoundaryMask(int3 patchParam)
 {
-    return ((patchParam.y >> 8) & 0xf);
+    return ((patchParam.y >> 7) & 0x1f);
 }
 
 int OsdGetPatchTransitionMask(int3 patchParam)


### PR DESCRIPTION
This set of changes lays the groundwork for upcoming PatchTables of triangular patches for Loop subdivision.  Minor extensions to some of the low level patch utility classes such as PatchDescriptor and PatchParam are made, basis evaluation is added for the new triangular patch types, and other related utilities such as PatchMap are updated.  All existing functionality for quad patches should remain unaffected.

One minor change with more significant impact is the extension of the boundary mask in PatchParam from four to five bits to support the needs of triangular patches (which can have boundary vertices without boundary edges).  Extending that mask by one bit shifts the four bits that are currently used, so all Osd evaluators that access the boundary field without the use of the Far::PatchParam methods were updated.