### PR TITLE
Populate Far::PatchTable with triangular patches for Loop scheme

### DIFF
--- a/opensubdiv/far/loopPatchBuilder.cpp
+++ b/opensubdiv/far/loopPatchBuilder.cpp
@@ -23,31 +23,1614 @@
 //
 
 #include "../far/loopPatchBuilder.h"
+#include "../vtr/stackBuffer.h"
+#include "../sdc/loopScheme.h"
 
 #include <cassert>
+#include <cmath>
 #include <cstdio>
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
-using Vtr::internal::Level;
-using Vtr::internal::FVarLevel;
-using Vtr::internal::Refinement;
+using Vtr::Array;
+using Vtr::ConstArray;
+using Vtr::internal::StackBuffer;
 
 namespace Far {
 
-namespace {
+//
+//  A simple struct with methods to compute Loop limit points (following
+//  the pattern established for Catmull-Clark limit points)
+//
+//  Unlike the corresponding Catmull-Clark struct, Loop limit points are
+//  computed using the limit masks provided by the Sdc Scheme for Loop.
+//
+template <typename REAL>
+struct LoopLimits {
+public:
+    //
+    //  Local classes to fulfill the interface requirements of template
+    //  arguments to the Sdc::Scheme methods
+    //
+    //  Class fulfilling <typename VERTEX>:
+    //
+    class LimitVertex {
+    public:
+        LimitVertex() : _nFaces(0), _nEdges(0) { }
+        LimitVertex(int faces, int edges) : _nFaces(faces), _nEdges(edges) { }
+
+        void Assign(int faces, int edges) { _nFaces = faces; _nEdges = edges; }
+
+        int GetNumEdges() const { return _nEdges; }
+        int GetNumFaces() const { return _nFaces; }
+
+        void GetSharpnessPerEdge(float sharpness[]) const {
+            sharpness[0] = Sdc::Crease::SHARPNESS_INFINITE;
+            for (int i = 1; i < _nEdges - 1; ++i) {
+                sharpness[i] = Sdc::Crease::SHARPNESS_SMOOTH;
+            }
+            sharpness[_nEdges - 1] = Sdc::Crease::SHARPNESS_INFINITE;
+        }
+
+    private:
+        int _nFaces;
+        int _nEdges;
+    };
 
     //
-    //  The patch type associated with each basis for Loop -- quickly indexed
-    //  from an array.
+    //  Class fulfilling <typename MASK>:
+    //
+    class LimitMask {
+    public:
+        typedef REAL Weight;  //  Also part of the expected interface
+
+    public:
+        LimitMask(Weight* w) : _weights(w), _valence(0) { }
+        ~LimitMask() { }
+
+    public:  //  Generic interface expected of <typename MASK>:
+        int GetNumVertexWeights() const { return 1; }
+        int GetNumEdgeWeights()   const { return _valence; }
+        int GetNumFaceWeights()   const { return 0; }
+
+        void SetNumVertexWeights(int)     { }
+        void SetNumEdgeWeights(int count) { _valence = count; }
+        void SetNumFaceWeights(int)       { }
+
+        Weight const& VertexWeight(int)     const { return _weights[0]; }
+        Weight const& EdgeWeight(int index) const { return _weights[1 + index]; }
+        Weight const& FaceWeight(int)       const { return _weights[0]; }
+
+        Weight& VertexWeight(int)       { return _weights[0]; }
+        Weight& EdgeWeight(  int index) { return _weights[1 + index]; }
+        Weight& FaceWeight(  int)       { return _weights[0]; }
+
+        bool AreFaceWeightsForFaceCenters() const  { return false; }
+        void SetFaceWeightsForFaceCenters(bool)    { }
+
+    private:
+        Weight* _weights;
+        int     _valence;
+    };
+public:
+    typedef Sdc::Scheme<Sdc::SCHEME_LOOP>   SchemeLoop;
+
+    static void ComputeInteriorPointWeights(int valence, int faceInRing,
+                REAL* pWeights, REAL* epWeights, REAL* emWeights);
+
+    static void ComputeBoundaryPointWeights(int valence, int faceInRing,
+                REAL* pWeights, REAL* epWeights, REAL* emWeights);
+};
+
+template <typename REAL>
+void
+LoopLimits<REAL>::ComputeInteriorPointWeights(int valence, int faceInRing,
+                REAL* pWeights, REAL* epWeights, REAL* emWeights) {
+
+    int ringSize = valence + 1;
+
+    LimitVertex vertex(valence, valence);
+
+    bool computeTangentPoints = epWeights && emWeights;
+    if (!computeTangentPoints) {
+        //
+        //  The interior position mask is symmetric -- no need to rotate
+        //  or otherwise account for orientation:
+        //
+        LimitMask pMask(pWeights);
+
+        SchemeLoop().ComputeVertexLimitMask(vertex, pMask,
+                Sdc::Crease::RULE_SMOOTH);
+    } else {
+        //
+        //  The interior tangent masks will be directed along the first
+        //  two edges (the second a rotation of the first).  Adjust the
+        //  tangent weights for a point along the tangent, then rotate
+        //  according to the face within the ring:
+        //
+        int weightWidth = valence + 1;
+        StackBuffer<REAL, 32, true> tWeights(2 * weightWidth);
+        REAL * t1Weights = &tWeights[0];
+        REAL * t2Weights = t1Weights + ringSize;
+
+        LimitMask pMask(pWeights);
+        LimitMask t1Mask(t1Weights);
+        LimitMask t2Mask(t2Weights);
+
+        SchemeLoop().ComputeVertexLimitMask(vertex, pMask, t1Mask, t2Mask,
+                Sdc::Crease::RULE_SMOOTH);
+
+        //
+        //  Use the subdominant eigenvalue to scale the limit tangent t1:
+        //
+        //      e = (3 + cos(2*PI/valence)) / 8
+        //
+        //  Combine it with a normalizing factor of (2 / valence) to account
+        //  for the scale inherent in the tangent weights, and (2 / 3) to
+        //  match desired placement of the cubic point in the regular case.
+        //
+        //  The weights for t1 can simply be rotated around the ring to yield
+        //  t2.  Combine the weights for the point in a single set for t2 and
+        //  then copy it into the appropriate orientation for ep and em:
+        //
+        double theta = 2.0 * M_PI / (double) valence;
+
+        REAL tanScale = (REAL) ((3.0 + 2.0 * std::cos(theta)) / (6.0 * valence));
+
+        for (int i = 0; i < ringSize; ++i) {
+            t2Weights[i] = pWeights[i] + t1Weights[i] * tanScale;
+        }
+
+        int n1 = faceInRing;
+        int n2 = valence - n1;
+
+        epWeights[0] = t2Weights[0];
+        std::memcpy(epWeights + 1,      t2Weights + 1 + n2, n1 * sizeof(REAL));
+        std::memcpy(epWeights + 1 + n1, t2Weights + 1,      n2 * sizeof(REAL));
+
+        n1 = (faceInRing + 1) % valence;
+        n2 = valence - n1;
+
+        emWeights[0] = t2Weights[0];
+        std::memcpy(emWeights + 1,      t2Weights + 1 + n2, n1 * sizeof(REAL));
+        std::memcpy(emWeights + 1 + n1, t2Weights + 1,      n2 * sizeof(REAL));
+    }
+}
+
+template <typename REAL>
+void
+LoopLimits<REAL>::ComputeBoundaryPointWeights(int valence, int faceInRing,
+                REAL* pWeights, REAL* epWeights, REAL* emWeights) {
+
+    LimitVertex vertex(valence - 1, valence);
+
+    bool computeTangentPoints = epWeights && emWeights;
+    if (!computeTangentPoints) {
+        //
+        //  The boundary position mask will be assigned non-zero weights
+        //  for the vertex and its first and last edges:
+        //
+        LimitMask pMask(pWeights);
+
+        SchemeLoop().ComputeVertexLimitMask(vertex, pMask,
+                Sdc::Crease::RULE_CREASE);
+    } else {
+        //
+        //  The boundary tangent masks need more explicit handling than
+        //  the interior.  One of the tangents will be along the boundary
+        //  and the other towards the interior, but one or both edge
+        //  points may be along interior edges.  A boundary edge point is
+        //  easy to deal with once identified, but interior edge points
+        //  need a numerical rotation of the interior tangent to orient it
+        //  along the desired edge.
+        //
+        int weightWidth = valence + 1;
+        StackBuffer<REAL, 32, true> tWeights(2 * weightWidth);
+        REAL * t1Weights = &tWeights[0];
+        REAL * t2Weights = t1Weights + weightWidth;
+
+        REAL t1Leading  =  (REAL) (1.0 / 6.0);
+        REAL t1Trailing = -(REAL) (1.0 / 6.0);
+
+        REAL t2Scale = (REAL) (1.0 / 24.0);
+
+        LimitMask pMask(pWeights);
+        LimitMask t1Mask(t1Weights);
+        LimitMask t2Mask(t2Weights);
+
+        SchemeLoop().ComputeVertexLimitMask(vertex, pMask, t1Mask, t2Mask,
+                Sdc::Crease::RULE_CREASE);
+
+        bool epOnLeadingEdge  = (faceInRing == 0);
+        bool emOnTrailingEdge = (faceInRing == (valence - 1));
+
+        if (epOnLeadingEdge) {
+            std::memset(&epWeights[0], 0, weightWidth * sizeof(REAL));
+
+            epWeights[0] = (REAL) (2.0 / 3.0);
+            epWeights[1] = (REAL) (1.0 / 3.0);
+        } else {
+            int  iEdgeNext     = faceInRing;
+            REAL faceAngle     = (REAL) (M_PI / (double)(valence - 1));
+            REAL faceAngleNext = faceAngle * (REAL)iEdgeNext;
+            REAL cosAngleNext  = std::cos(faceAngleNext);
+            REAL sinAngleNext  = std::sin(faceAngleNext);
+
+            for (int i = 0; i < weightWidth; ++i) {
+                epWeights[i] = t2Scale * t2Weights[i] * sinAngleNext;
+            }
+            epWeights[0]       += pWeights[0];
+            epWeights[1]       += pWeights[1]       + t1Leading  * cosAngleNext;
+            epWeights[valence] += pWeights[valence] + t1Trailing * cosAngleNext;
+        }
+
+        if (emOnTrailingEdge) {
+            std::memset(&emWeights[0], 0, weightWidth * sizeof(REAL));
+
+            emWeights[0]       = (REAL) (2.0 / 3.0);
+            emWeights[valence] = (REAL) (1.0 / 3.0);
+        } else {
+            int  iEdgePrev     = (faceInRing + 1) % valence;
+            REAL faceAngle     = (REAL) (M_PI / (double)(valence - 1));
+            REAL faceAnglePrev = faceAngle * (REAL)iEdgePrev;
+            REAL cosAnglePrev  = std::cos(faceAnglePrev);
+            REAL sinAnglePrev  = std::sin(faceAnglePrev);
+
+            for (int i = 0; i < weightWidth; ++i) {
+                emWeights[i] = t2Scale * t2Weights[i] * sinAnglePrev;
+            }
+            emWeights[0]       += pWeights[0];
+            emWeights[1]       += pWeights[1]       + t1Leading  * cosAnglePrev;
+            emWeights[valence] += pWeights[valence] + t1Trailing * cosAnglePrev;
+        }
+    }
+}
+
+
+//
+//  SparseMatrixRow
+//
+//  This was copied from the CatmarkPatchBuilder as a starting point, so
+//  comments below relate to the state of CatmarkPatchBuilder...
+//
+// This is a utility class representing a row of a SparseMatrix -- which
+// in turn corresponds to a point of a resulting patch.  Instances of this
+// class are intended to encapsulate the contributions of a point and be
+// passed to functions as such.
+//
+// (Consider moving this to PatchBuilder as a protected class or maybe a
+// public class within SparseMatrix itself, e.g. SparseMatrix<REAL>::Row.)
+//
+namespace {
+    template <typename REAL>
+    class SparseMatrixRow {
+    public:
+        SparseMatrixRow(SparseMatrix<REAL> & matrix, int row) :
+            _size(matrix.GetRowSize(row)),
+            _indices(matrix.SetRowColumns(row).begin()),
+            _weights(matrix.SetRowElements(row).begin()) { }
+
+        int GetSize() const { return _size; }
+
+        void Assign(int rowEntry, Index index, REAL weight) {
+            _indices[rowEntry] = index;
+            _weights[rowEntry] = weight;
+        }
+
+        void Copy(SparseMatrixRow<REAL> const & other) {
+            assert(GetSize() == other.GetSize());
+            std::memcpy(_indices, other._indices, _size * sizeof(Index));
+            std::memcpy(_weights, other._weights, _size * sizeof(REAL));
+        }
+
+    public:
+        int     _size;
+        Index * _indices;
+        REAL *  _weights;
+    };
+} // end namespace
+
+//
+//  Simple utility functions for dealing with SparseMatrix:
+//
+namespace {
+#ifdef __INTEL_COMPILER
+#pragma warning (push)
+#pragma warning disable 1572
+#endif
+    template <typename REAL>
+    inline bool _isZero(REAL w) { return (w == (REAL)0.0); }
+#ifdef __INTEL_COMPILER
+#pragma warning (pop)
+#endif
+
+    template <typename REAL>
+    void
+    _initializeFullMatrix(SparseMatrix<REAL> & M, int nRows, int nColumns) {
+
+        M.Resize(nRows, nColumns, nRows * nColumns);
+
+        //  Fill row 0 with index for every column:
+        M.SetRowSize(0, nColumns);
+        Array<int> row0Columns = M.SetRowColumns(0);
+        for (int i = 0; i < nColumns; ++i) {
+            row0Columns[i] = i;
+        }
+
+        //  Copy row 0's indices into all other rows:
+        for (int row = 1; row < nRows; ++row) {
+            M.SetRowSize(row, nColumns);
+            Array<int> dstRowColumns = M.SetRowColumns(row);
+            std::memcpy(&dstRowColumns[0], &row0Columns[0], nColumns * sizeof(int));
+        }
+    }
+
+    template <typename REAL>
+    void
+    _resizeMatrix(SparseMatrix<REAL> & matrix,
+                  int numRows, int numColumns, int numElements,
+                  int const rowSizes[]) {
+
+        matrix.Resize(numRows, numColumns, numElements);
+        for (int i = 0; i < numRows; ++i) {
+            matrix.SetRowSize(i, rowSizes[i]);
+        }
+        assert(matrix.GetNumElements() == numElements);
+    }
+
+    template <typename REAL>
+    void
+    _addSparsePointToFullRow(REAL * fullRow,
+                             SparseMatrixRow<REAL> const & p,
+                             REAL s, int * indexMask) {
+
+        for (int i = 0; i < p.GetSize(); ++i) {
+            int index = p._indices[i];
+
+            fullRow[index] += s * p._weights[i];
+
+            indexMask[index] = 1 + index;
+        }
+    }
+
+    template <typename REAL>
+    void
+    _addSparseRowToFull(REAL * fullRow,
+                        SparseMatrix<REAL> const & M, int sparseRow, REAL s) {
+
+        ConstArray<int>  indices = M.GetRowColumns(sparseRow);
+        ConstArray<REAL> weights = M.GetRowElements(sparseRow);
+
+        for (int i = 0; i < indices.size(); ++i) {
+            fullRow[indices[i]] += s * weights[i];
+        }
+    }
+
+    template <typename REAL>
+    void
+    _combineSparseMatrixRowsInFull(SparseMatrix<REAL> & dstMatrix, int dstRowIndex,
+           SparseMatrix<REAL> const & srcMatrix, int numSrcRows,
+           int const srcRowIndices[], REAL const * srcRowWeights) {
+
+        REAL * dstRow = &dstMatrix.SetRowElements(dstRowIndex)[0];
+
+        std::memset(dstRow, 0, dstMatrix.GetNumColumns() * sizeof(REAL));
+
+        for (int i = 0; i < numSrcRows; ++i) {
+            if (!_isZero(srcRowWeights[i])) {
+                _addSparseRowToFull(dstRow, srcMatrix, srcRowIndices[i], srcRowWeights[i]);
+            }
+        }
+    }
+
+    template <typename REAL>
+    void
+    _matrixPrintDensity(const char* prefix, SparseMatrix<REAL> const & M) {
+    
+        int fullSize = M.GetNumRows() * M.GetNumColumns();
+        int sparseSize = M.GetNumElements();
+
+        int nonZeroSize = 0;
+        for (int i = 0; i < M.GetNumRows(); ++i) {
+            ConstArray<REAL> elements = M.GetRowElements(i);
+            for (int j = 0; j < elements.size(); ++j) {
+                nonZeroSize += (elements[j] != 0);
+            }
+        }
+        printf("%s(%dx%d = %d):  elements = %d, non-zero = %d, density = %.1f\n",
+            prefix, M.GetNumRows(), M.GetNumColumns(), fullSize,
+            sparseSize, nonZeroSize, (REAL)nonZeroSize * 100.0f / (REAL)fullSize);
+    }
+
+    //
+    //  The valence-2 interior case poses problems for the way patch points
+    //  are computed as combinations of source points and stored as a row in
+    //  a SparseMatrix.  An interior vertex of valence-2 causes duplicate
+    //  vertices to appear in the 1-rings of its neighboring vertices and we
+    //  want the entries of a SparseMatrix row to be unique.
+    //
+    //  For the most part, this does not pose a problem while the matrix (set
+    //  of patch points) is being constructed, so we leave those duplicate
+    //  entries in place and deal with them as a post-process here.
+    //
+    //  The SourcePatch is also sensitive to the presence of such valence-2
+    //  vertices for its own reasons (it needs to identifiy a unique set of
+    //  source points from a set of corner rings), so a simple query of its
+    //  corners indicates when this post-process is necessary.  (And since
+    //  this case is a rare occurrence, efficiency is not a major concern.)
+    //
+    template <typename REAL>
+    void _removeValence2Duplicates(SparseMatrix<REAL> & M) {
+
+        //  This will later be determined by the PatchBuilder member:
+        int regFaceSize = 4;
+
+        SparseMatrix<REAL> T;
+        T.Resize(M.GetNumRows(), M.GetNumColumns(), M.GetNumElements());
+
+        int nRows = M.GetNumRows();
+        for (int row = 0; row < nRows; ++row) {
+            int srcRowSize = M.GetRowSize(row);
+
+            int const *  srcIndices = M.GetRowColumns(row).begin();
+            REAL const * srcWeights = M.GetRowElements(row).begin();
+
+            //  Scan the entries to see if there are duplicates -- copy
+            //  the row if not, otherwise, need to compress it:
+            bool cornerUsed[4] = { false, false, false, false };
+
+            int srcDupCount = 0;
+            for (int i = 0; i < srcRowSize; ++i) {
+                int srcIndex = srcIndices[i];
+                if (srcIndex < regFaceSize) {
+                    srcDupCount += (int) cornerUsed[srcIndex];
+                    cornerUsed[srcIndex] = true;
+                }
+            }
+
+            //  Size this row for the destination and copy or compress:
+            T.SetRowSize(row, srcRowSize - srcDupCount);
+
+            int*  dstIndices = T.SetRowColumns(row).begin();
+            REAL* dstWeights = T.SetRowElements(row).begin();
+
+            if (srcDupCount) {
+                REAL * cornerDstPtr[4] = { 0, 0, 0, 0 };
+
+                for (int i = 0; i < srcRowSize; ++i) {
+                    int  srcIndex  = *srcIndices++;
+                    REAL srcWeight = *srcWeights++;
+
+                    if (srcIndex < regFaceSize) {
+                        if (cornerDstPtr[srcIndex]) {
+                            *cornerDstPtr[srcIndex] += srcWeight;
+                            continue;
+                        } else {
+                            cornerDstPtr[srcIndex] = dstWeights;
+                        }
+                    }
+                    *dstIndices++ = srcIndex;
+                    *dstWeights++ = srcWeight;
+                }
+            } else {
+                std::memcpy(&dstIndices[0], &srcIndices[0], srcRowSize * sizeof(Index));
+                std::memcpy(&dstWeights[0], &srcWeights[0], srcRowSize * sizeof(REAL));
+            }
+        }
+        M.Swap(T);
+    }
+} // end namespace for SparseMatrix utilities
+
+
+//
+//  GregoryTriConverter
+//
+//  The GregoryTriConverter class provides a change-of-basis matrix from source
+//  vertices in a Loop mesh to the 15 control points of a Gregory triangle.
+//
+//  Control points are labeled using the convention adopted for quads, with
+//  Ep and Em referring to the "plus" and "minus" edge points and similarly
+//  for the face points Fp and Fm.
+//
+template <typename REAL>
+class GregoryTriConverter {
+public:
+    typedef REAL                    Weight;
+    typedef SparseMatrix<Weight>    Matrix;
+    typedef SparseMatrixRow<Weight> Point;
+public:
+    GregoryTriConverter() : _numSourcePoints(0) { }
+    GregoryTriConverter(SourcePatch const & sourcePatch);
+    GregoryTriConverter(SourcePatch const & sourcePatch, Matrix & sparseMatrix);
+
+    void Initialize(SourcePatch const & sourcePatch);
+
+    bool IsIsolatedInteriorPatch() const { return _isIsolatedInteriorPatch; }
+    bool HasVal2InteriorCorner() const { return _hasVal2InteriorCorner; }
+    int  GetIsolatedInteriorCorner() const { return _isolatedCorner; }
+    int  GetIsolatedInteriorValence() const { return _isolatedValence; }
+
+    void Convert(Matrix & sparseMatrix) const;
+
+private:
+    //
+    //  Local nested class for GregoryTriConverter to cache information for
+    //  the corners of the source patch.  It copies some information from the
+    //  SourcePatch so that we don't have to keep it around, but it contains
+    //  additional information relevant to the determination of the Gregory
+    //  points -- most notably classifications of the face-points and the
+    //  cosines of angles for the face corners that are used repeatedly.
+    //
+    struct CornerTopology {
+        //  Basic flags copied from the SourcePatch
+        unsigned int isBoundary  : 1;
+        unsigned int isSharp     : 1;
+        unsigned int isDart      : 1;
+        unsigned int isRegular   : 1;
+        unsigned int isVal2Int   : 1;
+        unsigned int isCorner    : 1;
+
+        //  Flags for edge- and face-points relating to adjacent corners:
+        unsigned int epOnBoundary : 1;
+        unsigned int emOnBoundary : 1;
+
+        unsigned int fpIsRegular : 1;
+        unsigned int fmIsRegular : 1;
+        unsigned int fpIsCopied  : 1;
+        unsigned int fmIsCopied  : 1;
+
+        //  Other values stored for repeated use:
+        int  valence;
+        int  numFaces;
+        int  faceInRing;
+
+        REAL faceAngle;
+        REAL cosFaceAngle;
+
+        //  Its useful to have the ring for each corner immediately available:
+        StackBuffer<int, 30, true> ringPoints;
+    };
+
+    //
+    //  Methods to resize the matrix before populating it:
+    //
+    void resizeMatrixUnisolated(Matrix & matrix) const;
+
+    void resizeMatrixIsolatedIrregular(Matrix & matrix, int irregCornerIndex,
+                                                        int irregValence) const;
+
+    //
+    //  Methods to compute the various rows of points in the matrix:
+    //
+    void assignRegularEdgePoints(int cornerIndex, Matrix & matrix) const;
+    void computeIrregularEdgePoints(int cornerIndex, Matrix & matrix,
+                                    Weight *weightBuffer) const;
+
+    void assignRegularFacePoints(int cornerIndex, Matrix & matrix) const;
+    void computeIrregularFacePoints(int cornerIndex, Matrix & matrix,
+                                    Weight *weightBuffer, int *indexBuffer) const;
+
+    void computeIrregularInteriorEdgePoints(int cornerIndex,
+                                            Point & P, Point & Ep, Point & Em,
+                                            Weight *weightBuffer) const;
+    void computeIrregularBoundaryEdgePoints(int cornerIndex,
+                                            Point & P, Point & Ep, Point & Em,
+                                            Weight *weightBuffer) const;
+
+    int  getIrregularFacePointSize(int cornerNear, int cornerFar) const;
+    void computeIrregularFacePoint(
+                int cornerNear, int edgeInNearRing, int cornerFar,
+                Point const & p, Point const & eNear, Point const & eFar,
+                Point & fNear, REAL signForSideOfEdge /* -1.0 or 1.0 */,
+                Weight *rowWeights, int *columnMask) const;
+
+private:
+    int _numSourcePoints;
+    int _maxValence;
+
+    bool _isIsolatedInteriorPatch;
+    bool _hasVal2InteriorCorner;
+    int  _isolatedCorner;
+    int  _isolatedValence;
+
+    CornerTopology _corners[3];
+};
+
+
+//
+//  GregoryTriConverter
+//
+//  Construction and initialization/computation of the change-of-basis
+//  matrix to a Gregory patch.
+//
+template <typename REAL>
+GregoryTriConverter<REAL>::GregoryTriConverter(
+        SourcePatch const & sourcePatch) {
+
+    Initialize(sourcePatch);
+}
+
+template <typename REAL>
+GregoryTriConverter<REAL>::GregoryTriConverter(
+        SourcePatch const & sourcePatch, Matrix & sparseMatrix) {
+
+    Initialize(sourcePatch);
+    Convert(sparseMatrix);
+}
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::Initialize(SourcePatch const & sourcePatch) {
+
+    //
+    //  Allocate and gather the 1-rings for the corner vertices and other
+    //  topological information for more immediate access:
+    //
+    int width = sourcePatch.GetNumSourcePoints();
+    _numSourcePoints = width;
+    _maxValence      = sourcePatch.GetMaxValence();
+
+    int boundaryCount = 0;
+    int irregularCount = 0;
+    int irregularCorner = -1;
+    int irregularValence = -1;
+    int sharpCount = 0;
+    int val2IntCount = 0;
+
+    for (int cIndex = 0; cIndex < 3; ++cIndex) {
+        SourcePatch::Corner srcCorner = sourcePatch._corners[cIndex];
+
+        CornerTopology& corner = _corners[cIndex];
+
+        corner.isBoundary = srcCorner._boundary;
+        corner.isSharp    = srcCorner._sharp;
+        corner.isDart     = srcCorner._dart;
+        corner.isCorner   = (srcCorner._numFaces == 1);
+        corner.numFaces   = srcCorner._numFaces;
+        corner.faceInRing = srcCorner._patchFace;
+        corner.isVal2Int  = srcCorner._val2Interior;
+        corner.valence    = corner.numFaces + corner.isBoundary;
+
+        corner.isRegular = ((corner.numFaces << corner.isBoundary) == 6)
+                         && !corner.isSharp;
+        if (corner.isRegular) {
+            corner.faceAngle = (REAL)(M_PI / 3.0);
+            corner.cosFaceAngle = 0.5f;
+        } else {
+            corner.faceAngle =
+                (corner.isBoundary ? REAL(M_PI) : REAL(2.0 * M_PI))
+                    / REAL(corner.numFaces);
+            corner.cosFaceAngle = std::cos(corner.faceAngle);
+        }
+
+        corner.ringPoints.SetSize(sourcePatch.GetCornerRingSize(cIndex));
+        sourcePatch.GetCornerRingPoints(cIndex, corner.ringPoints);
+
+        //  Accumulate topology information to categorize the patch as a whole:
+        boundaryCount += corner.isBoundary;
+        if (!corner.isRegular) {
+            irregularCount ++;
+            irregularCorner = cIndex;
+            irregularValence = corner.valence;
+        }
+        sharpCount += corner.isSharp;
+        val2IntCount += corner.isVal2Int;
+    }
+
+    //  Make a second pass to assign tags dependent on adjacent corners
+    for (int cIndex = 0; cIndex < 3; ++cIndex) {
+        CornerTopology& corner = _corners[cIndex];
+
+        int cNext = (cIndex + 1) % 3;
+        int cPrev = (cIndex + 2) % 3;
+
+        corner.epOnBoundary = false;
+        corner.emOnBoundary = false;
+
+        //
+        //  Identify if the face points are regular or shared/copied from
+        //  one of the pair:
+        //
+        corner.fpIsRegular = corner.isRegular && _corners[cNext].isRegular;
+        corner.fmIsRegular = corner.isRegular && _corners[cPrev].isRegular;
+
+        corner.fpIsCopied = false;
+        corner.fmIsCopied = false;
+
+        if (corner.isBoundary) {
+            corner.epOnBoundary = (corner.faceInRing == 0);
+            corner.emOnBoundary = (corner.faceInRing == (corner.numFaces - 1));
+
+            //  Both face points are same when one of the two corners' edges
+            //  is discontinuous -- one is then copied from the other (unless
+            //  regular)
+            if (corner.numFaces > 1) {
+                if (corner.epOnBoundary || _corners[cNext].isDart) {
+                    corner.fpIsRegular = corner.fmIsRegular;
+                    corner.fpIsCopied  = !corner.fpIsRegular;
+                }
+                if (corner.emOnBoundary || _corners[cPrev].isDart) {
+                    corner.fmIsRegular = corner.fpIsRegular;
+                    corner.fmIsCopied  = !corner.fmIsRegular;
+                }
+            } else {
+                //  The case of a corner patch is always regular
+                corner.fpIsRegular = true;
+                corner.fmIsRegular = true;
+            }
+        }
+    }
+    _isIsolatedInteriorPatch = (irregularCount == 1) && (boundaryCount == 0) &&
+                               (irregularValence > 2) && (sharpCount == 0);
+    if (_isIsolatedInteriorPatch) {
+        _isolatedCorner  = irregularCorner;
+        _isolatedValence = irregularValence;
+    }
+    _hasVal2InteriorCorner = (val2IntCount > 0);
+}
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::Convert(Matrix & matrix) const {
+
+    //
+    //  Initialize the sparse matrix to accomodate the coefficients for each
+    //  row/point -- identify common topological cases to treat more easily
+    //  (and note that specializing the population of the matrix may also be
+    //  worthwhile in such cases)
+    //
+    if (_isIsolatedInteriorPatch) {
+        resizeMatrixIsolatedIrregular(matrix, _isolatedCorner, _isolatedValence);
+    } else {
+        resizeMatrixUnisolated(matrix);
+    }
+
+    //
+    //  Compute the corner and edge points P, Ep and Em first.  Since face
+    //  points Fp and Fm involve edge points for two adjacent corners, their
+    //  computation must follow:
+    //
+    int maxRingSize      = 1 + _maxValence;
+    int weightBufferSize = std::max(3 * maxRingSize, 2 * _numSourcePoints);
+
+    StackBuffer<Weight, 128, true> weightBuffer(weightBufferSize);
+    StackBuffer<int, 128, true>    indexBuffer(weightBufferSize);
+
+    for (int cIndex = 0; cIndex < 3; ++cIndex) {
+        if (_corners[cIndex].isRegular) {
+            assignRegularEdgePoints(cIndex, matrix);
+        } else {
+            computeIrregularEdgePoints(cIndex, matrix, weightBuffer);
+        }
+    }
+
+    for (int cIndex = 0; cIndex < 3; ++cIndex) {
+        if (_corners[cIndex].fpIsRegular || _corners[cIndex].fmIsRegular) {
+            assignRegularFacePoints(cIndex, matrix);
+        }
+        if (!_corners[cIndex].fpIsRegular || !_corners[cIndex].fmIsRegular) {
+            computeIrregularFacePoints(cIndex, matrix, weightBuffer, indexBuffer);
+        }
+    }
+    if (_hasVal2InteriorCorner) {
+        _removeValence2Duplicates(matrix);
+    }
+}
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::resizeMatrixIsolatedIrregular(
+        Matrix & matrix, int cornerIndex, int cornerValence) const {
+
+    int irregRingSize = 1 + cornerValence;
+
+    int irregCorner   =  cornerIndex;
+    int irregPlus     = (cornerIndex + 1) % 3;
+    int irregMinus    = (cornerIndex + 2) % 3;
+
+    int   rowSizes[15];
+    int * rowSizePtr = 0;
+
+    rowSizePtr = rowSizes + irregCorner * 5;
+    *rowSizePtr++ = irregRingSize;
+    *rowSizePtr++ = irregRingSize;
+    *rowSizePtr++ = irregRingSize;
+    *rowSizePtr++ = 3 + irregRingSize;
+    *rowSizePtr++ = 3 + irregRingSize;
+
+    rowSizePtr = rowSizes + irregPlus * 5;
+    *rowSizePtr++ = 7;
+    *rowSizePtr++ = 7;
+    *rowSizePtr++ = 7;
+    *rowSizePtr++ = 5;
+    *rowSizePtr++ = 3 + irregRingSize;
+
+    rowSizePtr = rowSizes + irregMinus * 5;
+    *rowSizePtr++ = 7;
+    *rowSizePtr++ = 7;
+    *rowSizePtr++ = 7;
+    *rowSizePtr++ = 3 + irregRingSize;
+    *rowSizePtr++ = 5;
+
+    int numElements = 7*irregRingSize + 64;
+
+    _resizeMatrix(matrix, 15, _numSourcePoints, numElements, rowSizes);
+}
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::resizeMatrixUnisolated(Matrix & matrix) const {
+
+    int rowSizes[15];
+
+    int numElements = 0;
+
+    for (int cIndex = 0; cIndex < 3; ++cIndex) {
+        int * rowSize = rowSizes + cIndex*5;
+
+        CornerTopology const & corner = _corners[cIndex];
+
+        //  First, the corner and pair of edge points:
+        if (corner.isRegular) {
+            if (! corner.isBoundary) {
+                rowSize[0] = 7;
+                rowSize[1] = 7;
+                rowSize[2] = 7;
+            } else {
+                rowSize[0] = 3;
+                rowSize[1] = corner.epOnBoundary ? 2 : 4;
+                rowSize[2] = corner.emOnBoundary ? 2 : 4;
+            }
+        } else {
+            if (corner.isSharp) {
+                rowSize[0] = 1;
+                rowSize[1] = 2;
+                rowSize[2] = 2;
+            } else if (! corner.isBoundary) {
+                int ringSize = 1 + corner.valence;
+                rowSize[0] = ringSize;
+                rowSize[1] = ringSize;
+                rowSize[2] = ringSize;
+            } else if (corner.numFaces > 1) {
+                int ringSize = 1 + corner.valence;
+                rowSize[0] = 3;
+                rowSize[1] = corner.epOnBoundary ? 2 : ringSize;
+                rowSize[2] = corner.emOnBoundary ? 2 : ringSize;
+            } else {
+                rowSize[0] = 3;
+                rowSize[1] = 2;
+                rowSize[2] = 2;
+            }
+        }
+        numElements += rowSize[0] + rowSize[1] + rowSize[2];
+
+        //  Second, the pair of face points:
+        rowSize[3] = 5 - 2 * corner.isCorner;
+        rowSize[4] = 5 - 2 * corner.isCorner;
+        if (!corner.fpIsRegular || !corner.fmIsRegular) {
+            int cNext = (cIndex + 1) % 3;
+            int cPrev = (cIndex + 2) % 3;
+            if (!corner.fpIsRegular) {
+                rowSize[3] = getIrregularFacePointSize(cIndex,
+                                corner.fpIsCopied ? cPrev : cNext);
+            }
+            if (!corner.fmIsRegular) {
+                rowSize[4] = getIrregularFacePointSize(cIndex,
+                                corner.fmIsCopied ? cNext : cPrev);
+            }
+        }
+        numElements += rowSize[3] + rowSize[4];
+    }
+    _resizeMatrix(matrix, 15, _numSourcePoints, numElements, rowSizes);
+}
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::assignRegularEdgePoints(int cIndex, Matrix & matrix) const {
+
+    Point p (matrix, 5*cIndex + 0);
+    Point ep(matrix, 5*cIndex + 1);
+    Point em(matrix, 5*cIndex + 2);
+
+    CornerTopology const & corner = _corners[cIndex];
+
+    int const * cRing = corner.ringPoints;
+
+    if (! corner.isBoundary) {
+        REAL const pScale = (REAL) (1.0 / 12.0);
+
+        p.Assign(0, cIndex, 0.5f);
+        p.Assign(1, cRing[0], pScale);
+        p.Assign(2, cRing[1], pScale);
+        p.Assign(3, cRing[2], pScale);
+        p.Assign(4, cRing[3], pScale);
+        p.Assign(5, cRing[4], pScale);
+        p.Assign(6, cRing[5], pScale);
+        assert(p.GetSize() == 7);
+
+        //  Identify the edges along Ep and Em and those opposite them:
+        REAL const eWeights[6] = { 7.0f, 5.0f, 1.0f, -1.0f, 1.0f, 5.0f };
+        REAL const eScale = (REAL) (1.0 / 36.0);
+
+        int iEdgeEp =  corner.faceInRing;
+        int iEdgeEm = (corner.faceInRing + 1) % 6;
+
+        ep.Assign(0, cIndex, 0.5f);
+        ep.Assign(1, cRing[iEdgeEp],           eScale * eWeights[0]);
+        ep.Assign(2, cRing[(iEdgeEp + 1) % 6], eScale * eWeights[1]);
+        ep.Assign(3, cRing[(iEdgeEp + 2) % 6], eScale * eWeights[2]);
+        ep.Assign(4, cRing[(iEdgeEp + 3) % 6], eScale * eWeights[3]);
+        ep.Assign(5, cRing[(iEdgeEp + 4) % 6], eScale * eWeights[4]);
+        ep.Assign(6, cRing[(iEdgeEp + 5) % 6], eScale * eWeights[5]);
+        assert(ep.GetSize() == 7);
+
+        em.Assign(0, cIndex, 0.5f);
+        em.Assign(1, cRing[iEdgeEm],           eScale * eWeights[0]);
+        em.Assign(2, cRing[(iEdgeEm + 1) % 6], eScale * eWeights[1]);
+        em.Assign(3, cRing[(iEdgeEm + 2) % 6], eScale * eWeights[2]);
+        em.Assign(4, cRing[(iEdgeEm + 3) % 6], eScale * eWeights[3]);
+        em.Assign(5, cRing[(iEdgeEm + 4) % 6], eScale * eWeights[4]);
+        em.Assign(6, cRing[(iEdgeEm + 5) % 6], eScale * eWeights[5]);
+        assert(em.GetSize() == 7);
+    } else {
+        REAL oneThird  = (REAL) (1.0 / 3.0);
+        REAL twoThirds = (REAL) (2.0 / 3.0);
+        REAL oneSixth  = (REAL) (1.0 / 6.0);
+
+        p.Assign(0, cIndex,   twoThirds);
+        p.Assign(1, cRing[0], oneSixth);
+        p.Assign(2, cRing[3], oneSixth);
+        assert(p.GetSize() == 3);
+
+        //
+        //  We have three triangles here, and the two edge points may be along two
+        //  of four edges -- two of which are interior and require weights adjusted
+        //  from above to account for phantom points (yielding {1/2, 1/6, 1/6, 1/6})
+        //
+        if (corner.epOnBoundary) {
+            ep.Assign(0, cIndex,   twoThirds);
+            ep.Assign(1, cRing[0], oneThird);
+            assert(ep.GetSize() == 2);
+        } else {
+            ep.Assign(0, cIndex, 0.5f);
+            ep.Assign(1, cRing[1], oneSixth);
+            ep.Assign(2, cRing[2], oneSixth);
+            if (!corner.emOnBoundary) ep.Assign(3, cRing[0], oneSixth);
+            if ( corner.emOnBoundary) ep.Assign(3, cRing[3], oneSixth);
+            assert(ep.GetSize() == 4);
+        }
+
+        if (corner.emOnBoundary) {
+            em.Assign(0, cIndex,   twoThirds);
+            em.Assign(1, cRing[3], oneThird);
+            assert(em.GetSize() == 2);
+        } else {
+            em.Assign(0, cIndex, 0.5f);
+            em.Assign(1, cRing[1], oneSixth);
+            em.Assign(2, cRing[2], oneSixth);
+            if ( corner.epOnBoundary) em.Assign(3, cRing[0], oneSixth);
+            if (!corner.epOnBoundary) em.Assign(3, cRing[3], oneSixth);
+            assert(em.GetSize() == 4);
+        }
+    }
+}
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::computeIrregularEdgePoints(int cIndex,
+        Matrix & matrix, Weight *weightBuffer) const {
+
+    Point p (matrix, 5*cIndex + 0);
+    Point ep(matrix, 5*cIndex + 1);
+    Point em(matrix, 5*cIndex + 2);
+
+    //
+    //  The corner and edge points P, Ep and Em  are completely determined
+    //  by the 1-ring of vertices around (and including) the corner vertex.
+    //  We combine full sets of coefficients for the vertex and its 1-ring.
+    //
+    CornerTopology const & corner = _corners[cIndex];
+
+    if (corner.isSharp) {
+        //
+        //  The sharp case -- both interior and boundary...
+        //
+        p.Assign(0, cIndex, 1.0f);
+        assert(p.GetSize() == 1);
+
+        // Approximating these for now, pending future investigation...
+        ep.Assign(0, cIndex,         (REAL) (2.0 / 3.0));
+        ep.Assign(1, (cIndex+1) % 3, (REAL) (1.0 / 3.0));
+        assert(ep.GetSize() == 2);
+
+        em.Assign(0, cIndex,         (REAL) (2.0 / 3.0));
+        em.Assign(1, (cIndex+2) % 3, (REAL) (1.0 / 3.0));
+        assert(em.GetSize() == 2);
+    } else if (! corner.isBoundary) {
+        //
+        //  The irregular interior case:
+        //
+        computeIrregularInteriorEdgePoints(cIndex, p, ep, em, weightBuffer);
+    } else if (corner.numFaces > 1) {
+        //
+        //  The irregular boundary case:
+        //
+        computeIrregularBoundaryEdgePoints(cIndex, p, ep, em, weightBuffer);
+    } else {
+        //
+        //  The irregular/smooth corner case:
+        //
+        p.Assign(0, cIndex,         (REAL) (4.0 / 6.0));
+        p.Assign(1, (cIndex+1) % 3, (REAL) (1.0 / 6.0));
+        p.Assign(2, (cIndex+2) % 3, (REAL) (1.0 / 6.0));
+        assert(p.GetSize() == 3);
+
+        ep.Assign(0, cIndex,         (REAL) (2.0 / 3.0));
+        ep.Assign(1, (cIndex+1) % 3, (REAL) (1.0 / 3.0));
+        assert(ep.GetSize() == 2);
+
+        em.Assign(0, cIndex,         (REAL) (2.0 / 3.0));
+        em.Assign(1, (cIndex+2) % 3, (REAL) (1.0 / 3.0));
+        assert(em.GetSize() == 2);
+    }
+}
+
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::computeIrregularInteriorEdgePoints(
+        int cIndex,
+        Point& p, Point& ep, Point& em,
+        Weight *ringWeights) const {
+
+    CornerTopology const & corner = _corners[cIndex];
+
+    int valence = corner.valence;
+    int weightWidth = 1 + valence;
+
+    Weight* pWeights  = &ringWeights[0];
+    Weight* epWeights = pWeights + weightWidth;
+    Weight* emWeights = pWeights + weightWidth * 2;
+
+    //
+    //  The interior (smooth) case -- invoke the public static method that
+    //  computes pre-allocated ring weights for P, Ep and Em:
+    //
+    LoopLimits<REAL>::ComputeInteriorPointWeights(valence, corner.faceInRing,
+            pWeights, epWeights, emWeights);
+
+    //
+    //  Transer the weights for the ring into the stencil form of the required
+    //  Point type.  The limit mask for position involves all ring weights, and
+    //  since Ep and Em depend on it, there should be no need to filter weights
+    //  with value 0:
+    //
+    p.Assign( 0, cIndex, pWeights[0]);
+    ep.Assign(0, cIndex, epWeights[0]);
+    em.Assign(0, cIndex, emWeights[0]);
+
+    for (int i = 1; i < weightWidth; ++i) {
+        int pRingPoint = corner.ringPoints[i-1];
+
+        p.Assign( i, pRingPoint, pWeights[i]);
+        ep.Assign(i, pRingPoint, epWeights[i]);
+        em.Assign(i, pRingPoint, emWeights[i]);
+    }
+    assert(p.GetSize() == weightWidth);
+    assert(ep.GetSize() == weightWidth);
+    assert(em.GetSize() == weightWidth);
+}
+
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::computeIrregularBoundaryEdgePoints(
+        int cIndex,
+        Point& p, Point& ep, Point& em,
+        Weight *ringWeights) const {
+
+    CornerTopology const & corner = _corners[cIndex];
+
+    int valence = corner.valence;
+    int weightWidth = 1 + corner.valence;
+
+    Weight* pWeights  = &ringWeights[0];
+    Weight* epWeights = pWeights + weightWidth;
+    Weight* emWeights = pWeights + weightWidth * 2;
+
+    //
+    //  The boundary (smooth) case -- invoke the public static method that
+    //  computes pre-allocated ring weights for P, Ep and Em:
+    //
+    LoopLimits<REAL>::ComputeBoundaryPointWeights(valence, corner.faceInRing,
+                pWeights, epWeights, emWeights);
+
+    //
+    //  Transfer ring weights into points -- exploiting cases where they
+    //  are known to be non-zero only along the two boundary edges:
+    //
+    int N = weightWidth - 1;
+
+    int p0 = cIndex;
+    int p1 = corner.ringPoints[0];
+    int pN = corner.ringPoints[valence-1];
+
+    p.Assign(0, p0, pWeights[0]);
+    p.Assign(1, p1, pWeights[1]);
+    p.Assign(2, pN, pWeights[N]);
+    assert(p.GetSize() == 3);
+
+    //  If Ep is on the boundary edge, it has only two non-zero weights along
+    //  that edge:
+    ep.Assign(0, p0, epWeights[0]);
+    if (corner.epOnBoundary) {
+        ep.Assign(1, p1, epWeights[1]);
+        assert(ep.GetSize() == 2);
+    } else {
+        for (int i = 1; i < weightWidth; ++i) {
+            ep.Assign(i, corner.ringPoints[i-1], epWeights[i]);
+        }
+        assert(ep.GetSize() == weightWidth);
+    }
+
+    //  If Em is on the boundary edge, it has only two non-zero weights along
+    //  that edge:
+    em.Assign(0, p0, emWeights[0]);
+    if (corner.emOnBoundary) {
+        em.Assign(1, pN, emWeights[N]);
+        assert(em.GetSize() == 2);
+    } else {
+        for (int i = 1; i < weightWidth; ++i) {
+            em.Assign(i, corner.ringPoints[i-1], emWeights[i]);
+        }
+        assert(em.GetSize() == weightWidth);
+    }
+}
+
+
+template <typename REAL>
+int
+GregoryTriConverter<REAL>::getIrregularFacePointSize(
+        int cIndexNear, int cIndexFar) const {
+
+    CornerTopology const & corner    = _corners[cIndexNear];
+    CornerTopology const & adjCorner = _corners[cIndexFar];
+
+    int thisSize = corner.isSharp
+                 ?  4
+                 : (1 + corner.ringPoints.GetSize());
+
+    int adjSize = (adjCorner.isSharp || (adjCorner.numFaces < 2))
+                ? 0
+                : (1 + adjCorner.ringPoints.GetSize() - 4);
+
+    return thisSize + adjSize;
+}
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::computeIrregularFacePoint(
+        int cIndexNear, int edgeInNearCornerRing, int cIndexFar,
+        Point const & p, Point const & eNear, Point const & eFar, Point & fNear,
+        REAL signForSideOfEdge, Weight *rowWeights, int *columnMask) const {
+
+    CornerTopology const & cornerNear = _corners[cIndexNear];
+    CornerTopology const & cornerFar  = _corners[cIndexFar];
+
+    int valence = cornerNear.valence;
+
+    Weight cosNear = cornerNear.cosFaceAngle;
+    Weight cosFar  = cornerFar.cosFaceAngle;
+
+    //
+    //  From Loop, Schaefer et al, a face point F is computed as:
+    //
+    //    F = (1/d) * (c0 * P0 + (d - 2*c0 - c1) * E0 + 2*c1 * E1 + R)
+    //
+    //  where d = 3 for quads and d = 4 for triangles, and R is:
+    //
+    //    R = 1/3 (Mm + Mp) + 2/3 (Cm + Cp)
+    //
+    //  where Mm and Mp are the midpoints of the two adjacent edges
+    //  and Cm and Cp are the midpoints of the two adjacent faces.
+    //
+    Weight pCoeff     =                          cosFar  / 4.0f;
+    Weight eNearCoeff = (4.0f - 2.0f * cosNear - cosFar) / 4.0f;
+    Weight eFarCoeff  =         2.0f * cosNear           / 4.0f;
+
+    int fullRowSize = _numSourcePoints;
+    std::memset(&columnMask[0], 0, fullRowSize * sizeof(int));
+    std::memset(&rowWeights[0], 0, fullRowSize * sizeof(Weight));
+
+    _addSparsePointToFullRow(rowWeights, p,     pCoeff,     columnMask);
+    _addSparsePointToFullRow(rowWeights, eNear, eNearCoeff, columnMask);
+    _addSparsePointToFullRow(rowWeights, eFar,  eFarCoeff,  columnMask);
+
+    //  Remember that R is to be computed about an interior edge and is
+    //  comprised of the two pairs of points opposite the interior edge
+    //
+    int iEdgeInterior = edgeInNearCornerRing;
+    int iEdgePrev     = (iEdgeInterior + valence - 1) % valence;
+    int iEdgeNext     = (iEdgeInterior + 1) % valence;
+
+    Weight rScale = (REAL) (0.25 * (7.0 / 18.0));
+
+    rowWeights[cornerNear.ringPoints[iEdgePrev]] += -signForSideOfEdge * rScale;
+    rowWeights[cornerNear.ringPoints[iEdgeNext]] +=  signForSideOfEdge * rScale;
+
+    int nWeights = 0;
+    for (int i = 0; i < fullRowSize; ++i) {
+        if (columnMask[i]) {
+            fNear.Assign(nWeights++, columnMask[i] - 1, rowWeights[i]);
+        }
+    }
+
+    //  Complete the expected row size when val-2 corners induce duplicates:
+    if (_hasVal2InteriorCorner && (nWeights < fNear.GetSize())) {
+        while (nWeights < fNear.GetSize()) {
+            fNear.Assign(nWeights++, cIndexNear, 0.0f);
+        }
+    }
+    assert(fNear.GetSize() == nWeights);
+}
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::assignRegularFacePoints(int cIndex, Matrix & matrix) const {
+
+    CornerTopology const & corner = _corners[cIndex];
+
+    int cNext = (cIndex+1) % 3;
+    int cPrev = (cIndex+2) % 3;
+
+    int eNext = corner.isBoundary ? 0 : ((corner.faceInRing + 5) % 6);
+    int ePrev = corner.isBoundary ? 3 : ((corner.faceInRing + 2) % 6);
+
+    int const * cRing = corner.ringPoints;
+
+    //  Assign regular Fp and/or Fm:
+    if (corner.fpIsRegular) {
+        Point fp(matrix, 5*cIndex + 3);
+
+        if (corner.isCorner) {
+            fp.Assign(0, cIndex, 0.5f);
+            fp.Assign(1, cNext,  0.25f);
+            fp.Assign(2, cPrev,  0.25f);
+            assert(fp.GetSize() == 3);
+        } else if (corner.epOnBoundary) {
+            fp.Assign(0, cIndex,   (REAL) (11.0 / 24.0));
+            fp.Assign(1, cRing[0], (REAL) ( 7.0 / 24.0));
+            fp.Assign(2, cRing[1], (REAL) ( 5.0 / 24.0));
+            fp.Assign(3, cRing[2], (REAL) ( 1.0 / 24.0));
+            fp.Assign(4, cRing[3], (REAL) ( 0.0 / 24.0));
+            assert(fp.GetSize() == 5);
+        } else {
+            fp.Assign(0, cIndex,       (REAL) (10.0 / 24.0));
+            fp.Assign(1, cPrev,                 0.25f);
+            fp.Assign(2, cNext,                 0.25f);
+            fp.Assign(3, cRing[ePrev], (REAL) ( 1.0 / 24.0));
+            fp.Assign(4, cRing[eNext], (REAL) ( 1.0 / 24.0));
+            assert(fp.GetSize() == 5);
+        }
+    }
+    if (corner.fmIsRegular) {
+        Point fm(matrix, 5*cIndex + 4);
+
+        if (corner.isCorner) {
+            fm.Assign(0, cIndex, 0.5f);
+            fm.Assign(1, cNext,  0.25f);
+            fm.Assign(2, cPrev,  0.25f);
+            assert(fm.GetSize() == 3);
+        } else if (corner.emOnBoundary) {
+            fm.Assign(0, cIndex,   (REAL) (11.0 / 24.0));
+            fm.Assign(1, cRing[0], (REAL) ( 0.0 / 24.0));
+            fm.Assign(2, cRing[1], (REAL) ( 1.0 / 24.0));
+            fm.Assign(3, cRing[2], (REAL) ( 5.0 / 24.0));
+            fm.Assign(4, cRing[3], (REAL) ( 7.0 / 24.0));
+            assert(fm.GetSize() == 5);
+        } else {
+            fm.Assign(0, cIndex,       (REAL) (10.0 / 24.0));
+            fm.Assign(1, cNext,                 0.25f);
+            fm.Assign(2, cPrev,                 0.25f);
+            fm.Assign(3, cRing[ePrev], (REAL) ( 1.0 / 24.0));
+            fm.Assign(4, cRing[eNext], (REAL) ( 1.0 / 24.0));
+            assert(fm.GetSize() == 5);
+        }
+    }
+}
+
+template <typename REAL>
+void
+GregoryTriConverter<REAL>::computeIrregularFacePoints(int cIndex,
+        Matrix & matrix, Weight *rowWeights, int *columnMask) const {
+
+    //  Identify neighboring corners:
+    CornerTopology const & corner = _corners[cIndex];
+
+    int cNext = (cIndex+1) % 3;
+    int cPrev = (cIndex+2) % 3;
+
+    Point epPrev(matrix, 5*cPrev  + 1);
+    Point em    (matrix, 5*cIndex + 2);
+    Point p     (matrix, 5*cIndex + 0);
+    Point ep    (matrix, 5*cIndex + 1);
+    Point emNext(matrix, 5*cNext  + 2);
+
+    Point fp(matrix, 5*cIndex + 3);
+    Point fm(matrix, 5*cIndex + 4);
+
+    //
+    //  Compute the face points Fp and Fm in terms of the corner (P) and edge
+    //  points (Ep and Em) previously computed.  The caller provides a buffer
+    //  of the appropriate size (twice the width of the matrix) to use for
+    //  combining weights, along with an integer buffer used to identify
+    //  non-zero weights and preserve the sparsity of the combinations (note
+    //  they use index + 1 to detect index 0 when cleared with 0 entries).
+    //
+    if (!corner.fpIsRegular && !corner.fpIsCopied) {
+        int iEdgeP = corner.faceInRing;
+        computeIrregularFacePoint(cIndex, iEdgeP, cNext,
+                p, ep, emNext, fp, 1.0, rowWeights, columnMask);
+    }
+    if (!corner.fmIsRegular && !corner.fmIsCopied) {
+        int iEdgeM = (corner.faceInRing + 1) % corner.valence;
+        computeIrregularFacePoint(cIndex, iEdgeM, cPrev,
+                p, em, epPrev, fm, -1.0, rowWeights, columnMask);
+    }
+
+    //  Copy Fp or Fm now that any shared values were computed above:
+    if (corner.fpIsCopied) {
+        fp.Copy(fm);
+    }
+    if (corner.fmIsCopied) {
+        fm.Copy(fp);
+    }
+
+    if (!corner.fpIsRegular) assert(matrix.GetRowSize(5*cIndex + 3) == fp.GetSize());
+    if (!corner.fmIsRegular) assert(matrix.GetRowSize(5*cIndex + 4) == fm.GetSize());
+}
+
+namespace {
+    template <typename REAL>
+    void
+    _printPoint(SparseMatrixRow<REAL> const & p, bool printIndices = true,
+                                                 bool printWeights = true) {
+        printf("  Point size = %d:\n", p._size);
+        if (printIndices) {
+            printf("    Indices:  ");
+            for (int j = 0; j < p._size; ++j) {
+                printf("%6d ", p._indices[j]);
+            }
+            printf("\n");
+        }
+        if (printWeights) {
+            printf("    Weights:  ");
+            for (int j = 0; j < p._size; ++j) {
+                printf("%6.3f ", (REAL)p._weights[j]);
+            }
+            printf("\n");
+        }
+    }
+
+    template <typename REAL>
+    void
+    _printMatrix(SparseMatrix<REAL> const & matrix, bool printIndices = true,
+                                                    bool printWeights = true) {
+
+        printf("Matrix %d x %d, %d elements:\n",
+            matrix.GetNumRows(), matrix.GetNumColumns(), matrix.GetNumElements());
+
+        for (int i = 0; i < matrix.GetNumRows(); ++i) {
+            int rowSize = matrix.GetRowSize(i);
+            printf("  Row %d (size = %d):\n", i, rowSize);
+
+            if (printIndices) {
+                ConstArray<int> indices = matrix.GetRowColumns(i);
+                printf("    Indices:  ");
+                for (int j = 0; j < rowSize; ++j) {
+                    printf("%6d ", indices[j]);
+                }
+                printf("\n");
+            }
+            if (printWeights) {
+                ConstArray<REAL> weights = matrix.GetRowElements(i);
+                printf("    Weights:  ");
+                for (int j = 0; j < rowSize; ++j) {
+                    printf("%6.3f ", (REAL)weights[j]);
+                }
+                printf("\n");
+            }
+        }
+    }
+
+    void
+    _printSourcePatch(SourcePatch const & patch, bool printCornerInfo = true,
+                                                 bool printRingPoints = true) {
+
+        printf("SoucePatch - %d corners, %d points:\n",
+            patch._numCorners, patch._numSourcePoints);
+
+        if (printCornerInfo) {
+            printf("  Corner info:\n");
+            for (int i = 0; i < patch._numCorners; ++i) {
+                printf("%6d:  boundary = %d, sharp = %d, numFaces = %d, in-ring = %d, ringSize = %d\n", i,
+                    patch._corners[i]._boundary, patch._corners[i]._sharp, patch._corners[i]._numFaces,
+                    patch._corners[i]._patchFace, patch._ringSizes[i]);
+            }
+        }
+        if (printRingPoints) {
+            StackBuffer<Index,64,true> ringPoints;
+            printf("  Ring points:\n");
+            for (int i = 0; i < patch._numCorners; ++i) {
+                int ringSize = patch._ringSizes[i];
+
+                ringPoints.SetSize(ringSize);
+                patch.GetCornerRingPoints(i, ringPoints);
+
+                printf("%6d:  ", i);
+                for (int j = 0; j < ringSize; ++j) {
+                    printf("%d ", ringPoints[j]);
+                }
+                printf("\n");
+            }
+        }
+    }
+}
+
+
+//
+//  Not using the same "Converter" pattern used above and in the Catmark scheme,
+//  since the two remaining conversions are fairly trivial.
+//
+template <typename REAL>
+void
+convertToLinear(SourcePatch const & sourcePatch, SparseMatrix<REAL> & matrix) {
+
+    typedef REAL Weight;
+
+    StackBuffer<Index,64,true>  indexBuffer(1 + sourcePatch.GetMaxRingSize());
+    StackBuffer<Weight,64,true> weightBuffer(1 + sourcePatch.GetMaxRingSize());
+
+    int numElements = sourcePatch.GetCornerRingSize(0) +
+                      sourcePatch.GetCornerRingSize(1) +
+                      sourcePatch.GetCornerRingSize(2);
+
+    matrix.Resize(3, sourcePatch.GetNumSourcePoints(), numElements);
+
+    bool hasVal2InteriorCorner = false;
+
+    for (int cIndex = 0; cIndex < 3; ++cIndex) {
+        SourcePatch::Corner const & sourceCorner = sourcePatch._corners[cIndex];
+
+        int ringSize = sourcePatch.GetCornerRingSize(cIndex);
+        if (sourceCorner._sharp) {
+            matrix.SetRowSize(cIndex, 1);
+        } else if (sourceCorner._boundary) {
+            matrix.SetRowSize(cIndex, 3);
+        } else {
+            matrix.SetRowSize(cIndex, 1 + ringSize);
+        }
+
+        Array<Index>  rowIndices = matrix.SetRowColumns(cIndex);
+        Array<Weight> rowWeights = matrix.SetRowElements(cIndex);
+
+        indexBuffer[0] = cIndex;
+        sourcePatch.GetCornerRingPoints(cIndex, &indexBuffer[1]);
+
+        if (sourceCorner._sharp) {
+            rowIndices[0] = cIndex;
+            rowWeights[0] = 1.0f;
+        } else if (sourceCorner._boundary) {
+            LoopLimits<REAL>::ComputeBoundaryPointWeights(
+                    1 + sourceCorner._numFaces, sourceCorner._patchFace,
+                    &weightBuffer[0], 0, 0);
+
+            rowIndices[0] = indexBuffer[0];
+            rowIndices[1] = indexBuffer[1];
+            rowIndices[2] = indexBuffer[ringSize];
+
+            rowWeights[0] = weightBuffer[0];
+            rowWeights[1] = weightBuffer[1];
+            rowWeights[2] = weightBuffer[ringSize];
+        } else {
+            LoopLimits<REAL>::ComputeInteriorPointWeights(
+                    sourceCorner._numFaces, sourceCorner._patchFace,
+                    &weightBuffer[0], 0, 0);
+
+            std::memcpy(&rowIndices[0], indexBuffer, rowIndices.size() * sizeof(Index));
+            std::memcpy(&rowWeights[0], weightBuffer, rowWeights.size() * sizeof(Weight));
+        }
+        hasVal2InteriorCorner |= sourceCorner._val2Interior;
+    }
+    if (hasVal2InteriorCorner) {
+        _removeValence2Duplicates(matrix);
+    }
+}
+
+template <typename REAL>
+void
+convertToGregory(SourcePatch const & sourcePatch, SparseMatrix<REAL> & matrix) {
+
+    GregoryTriConverter<REAL> gregoryConverter(sourcePatch);
+    gregoryConverter.Convert(matrix);
+}
+
+template <typename REAL>
+void
+convertToLoop(SourcePatch const & sourcePatch, SparseMatrix<REAL> & matrix) {
+
+    //
+    //  Unlike quads, there are not enough degrees of freedom in the regular patch
+    //  to enforce interpolation of the limit point and tangent at the corner while
+    //  preserving the two adjoining boundary curves.  That requires constraining
+    //  7 control points but only 6 can be moved without affecting the opposite
+    //  boundary curve.  At minimum, we need to constrain 9 of the 12 patch points,
+    //  which reduces the advantages of a local solution compared to the 7 of 16
+    //  control points for the BSplines of Catmark.
+    //
+    //  So we might as well compute the Gregory solution and convert back for this
+    //  more common case -- in addition to the more general case where it is needed.
+    //  Tangent continuity is compromised regardless of what is done here.  If a
+    //  specific solution for the isolated corner case has advantages in terms of
+    //  either surface quality or performance, we can revisit it.
+    //
+    //  Use a full 12x12 conversion matrix from a cubic-quartic hybrid Bezier back
+    //  to a Box spline patch.  Matrix rows and columns are ordered according to
+    //  control point orientations used elsewhere.  Correllation of points between
+    //  the hybrid Bezier and hybrid Gregory points is as follows:
+    //
+    //     B0     B1    B2    B3     B4     B5     B6     B7    B8     B9    B10   B11
+    //     G0     G1    G7    G5     G2    G3,4   G8,9    G6    G11  G13,14  G12   G10
+    //
+    //  As with conversion from Gregory to BSpline for Catmark, one of the face
+    //  points (the positive) is chosen as a Bezier point in the conversion rather
+    //  than combining the pair.
+    //
+    REAL const gregoryToLoopMatrix[12][12] = {
+        { 6.0f,  1.0f,-3.5f, 0.0f,-10.0f,  4.0f,  6.0f, -0.5f, 5.0f, -8.0f,  1.0f, 0.0f },
+        { 0.0f,  3.5f, 5.0f, 0.0f, -0.5f, -2.0f, -8.0f,  1.0f, 1.0f,  0.0f,  1.0f, 0.0f },
+        { 0.0f,  3.0f,-1.5f, 6.0f,  6.0f,-20.0f, 14.0f,-12.5f,-3.0f,  8.0f,  1.0f, 0.0f },
+        { 6.0f,-10.0f, 5.0f, 0.0f,  1.0f,  4.0f, -8.0f,  1.0f,-3.5f,  6.0f, -0.5f, 0.0f },
+        { 0.0f,  1.5f,-1.5f, 0.0f,  1.5f, -2.0f,  2.0f, -0.5f,-1.5f,  2.0f, -0.5f, 0.0f },
+        { 0.0f, -2.0f, 1.0f, 0.0f, -1.0f,  4.0f,  0.0f,  1.0f, 0.5f, -2.0f, -0.5f, 0.0f },
+        { 0.0f, -2.5f,-5.5f, 6.0f, -6.5f, 22.0f,-14.0f,  5.5f, 2.5f, -6.0f, -0.5f, 0.0f },
+        { 0.0f, -0.5f, 1.0f, 0.0f,  3.5f, -2.0f,  0.0f,  1.0f, 5.0f, -8.0f,  1.0f, 0.0f },
+        { 0.0f, -1.0f, 0.5f, 0.0f, -2.0f,  4.0f, -2.0f, -0.5f, 1.0f,  0.0f,  1.0f, 0.0f },
+        { 0.0f,  7.5f,-3.0f, 0.0f,  7.5f,-26.0f,  8.0f,  1.0f,-3.0f,  8.0f,  1.0f, 0.0f },
+        { 0.0f,  6.0f,-3.0f, 0.0f,  3.0f,-20.0f,  8.0f,  1.0f,-1.5f, 14.0f,-12.5f, 6.0f },
+        { 0.0f, -6.5f, 2.5f, 0.0f, -2.5f, 22.0f, -6.0f, -0.5f,-5.5f,-14.0f,  5.5f, 6.0f }
+    };
+
+    int const gRowIndices[12] = { 0, 1, 7, 5, 2, 3, 8, 6, 11, 13, 12, 10 };
+
+    SparseMatrix<REAL> G;
+    convertToGregory<REAL>(sourcePatch, G);
+
+    _initializeFullMatrix(matrix, 12, G.GetNumColumns());
+
+    for (int i = 0; i < 12; ++i) {
+        REAL const * gRowWeights = gregoryToLoopMatrix[i];
+        _combineSparseMatrixRowsInFull(matrix, i, G, 12, gRowIndices, gRowWeights);
+    }
+}
+
+
+//
+//  Internal utilities more relevant to the LoopPatchBuilder:
+//
+namespace {
+    //
+    //  The patch type associated with each basis for Loop -- quickly
+    //  indexed from an array.  The patch type here is essentially the
+    //  triangle form of each basis.
     //
     PatchDescriptor::Type patchTypeFromBasisArray[] = {
-            PatchDescriptor::NON_PATCH,      // undefined
-            PatchDescriptor::LOOP,           // regular
-            PatchDescriptor::NON_PATCH,      // Gregory
-            PatchDescriptor::TRIANGLES,      // linear
-            PatchDescriptor::NON_PATCH };    // Bezier -- for future use
+            PatchDescriptor::NON_PATCH,        // undefined
+            PatchDescriptor::LOOP,             // regular
+            PatchDescriptor::GREGORY_TRIANGLE, // Gregory
+            PatchDescriptor::TRIANGLES,        // linear
+            PatchDescriptor::NON_PATCH };      // Bezier -- for future use
 };
 
 LoopPatchBuilder::LoopPatchBuilder(
@@ -78,13 +1661,18 @@ LoopPatchBuilder::convertSourcePatch(SourcePatch const &   sourcePatch,
                                      PatchDescriptor::Type patchType,
                                      SparseMatrix<REAL> &  matrix) const {
 
-    assert("Non-linear patches for Loop not yet supported" == 0);
+    assert(_schemeType == Sdc::SCHEME_LOOP);
 
-    //  For suppressing warnings until implemented...
-    if (sourcePatch.GetNumSourcePoints() == 0) return -1;
-    if (patchType == PatchDescriptor::NON_PATCH) return -1;
-    if (matrix.GetNumRows() <= 0) return -1;
-    return -1;
+    if (patchType == PatchDescriptor::LOOP) {
+        convertToLoop<REAL>(sourcePatch, matrix);
+    } else if (patchType == PatchDescriptor::TRIANGLES) {
+        convertToLinear<REAL>(sourcePatch, matrix);
+    } else if (patchType == PatchDescriptor::GREGORY_TRIANGLE) {
+        convertToGregory<REAL>(sourcePatch, matrix);
+    } else {
+        assert("Unknown or unsupported patch type" == 0);
+    }
+    return matrix.GetNumRows();
 }
 
 int

--- a/opensubdiv/far/patchBuilder.h
+++ b/opensubdiv/far/patchBuilder.h
@@ -84,7 +84,9 @@ public:
     SourcePatch() { std::memset(this, 0, sizeof(SourcePatch)); }
     ~SourcePatch() { }
 
-    void Finalize();  //  To be called after all Corners have been initialized
+    //  To be called after all Corners have been initialized (hope to
+    //  replace this with alternative constructor at some point)
+    void Finalize(int size3or4);
 
     int GetNumSourcePoints() const { return _numSourcePoints; }
     int GetMaxValence() const { return _maxValence; }
@@ -93,13 +95,12 @@ public:
     int GetCornerRingSize(int corner) const { return _ringSizes[corner]; }
     int GetCornerRingPoints(int corner, int points[]) const;
 
-    void Print(const char * label, const Index * patchPoints = 0);
-
 //  public/private access needs to be reviewed when/if used more publicly
 //private:
 public:
     //  The SourcePatch is fully defined by its Corner members
     Corner _corners[4];
+    int    _numCorners;
 
     //  Additional members (derived from Corners) to help assemble corner rings:
     int _numSourcePoints;
@@ -284,9 +285,6 @@ protected:
             Vtr::internal::Level::VSpan const cornerSpans[],
             SourcePatch &  sourcePatch,
             Index patchPoints[], int fvc) const;
-
-    //  Internal methods asserting features not yet completed:
-    void assertTriangularPatchesNotYetSupportedHere() const;
 
 protected:
     //


### PR DESCRIPTION
This set of changes populates the Far::PatchTable with triangular patches representing the limit surface of a Loop subdivision mesh.

PatchTable construction was previously factored to assemble the tables in more general terms, so no changes to the factory were necessary here.  The internal PatchBuilder base class and its LoopPatchBuilder subclass are extended here to support triangular patches.  The base class handles the topological inspection and extraction of regular patches while the subclass handles the conversion of irregular patches to the supported triangular patch types:  linear, Gregory and the regular Box-spline.

This completes support for Loop limit patches in Far, so tessellation of the limit surface for Loop is now possible via the PatchTable.  The various Osd evaluators and backends do require extension and/or the removal of Catmark/quad specific logic to varying degrees before Loop patches are fully supported.  That work is in progress.
~                              