### PR TITLE
Added more common utilities for Shapes from .obj files:

### DIFF
--- a/examples/common/objAnim.cpp
+++ b/examples/common/objAnim.cpp
@@ -88,7 +88,7 @@ ObjAnim::InterpolatePositions(float time, float * positions, int stride) const {
 }
 
 ObjAnim const *
-ObjAnim::Create(std::vector<char const *> objFiles, bool axis) {
+ObjAnim::Create(std::vector<char const *> objFiles, bool axis, Scheme scheme) {
 
     ObjAnim * anim=0;
 
@@ -118,7 +118,7 @@ ObjAnim::Create(std::vector<char const *> objFiles, bool axis) {
                 fflush(stdout);
                 std::string str = ss.str();
 
-                shape = Shape::parseObj(str.c_str(), kCatmark, false, axis);
+                shape = Shape::parseObj(str.c_str(), scheme, false, axis);
 
                 if (i==0) {
 

--- a/examples/common/objAnim.h
+++ b/examples/common/objAnim.h
@@ -25,16 +25,17 @@
 #ifndef OBJ_ANIM_H
 #define OBJ_ANIM_H
 
-#include <vector>
+#include "../../regression/common/shape_utils.h"
 
-struct Shape;
+#include <vector>
 
 class ObjAnim {
 
 public:
 
     // Factory function
-    static ObjAnim const * Create(std::vector<char const *> objFiles, bool axis=true);
+    static ObjAnim const * Create(std::vector<char const *> objFiles, bool axis=true,
+                                  Scheme scheme=kCatmark);
 
     // Destructor
     ~ObjAnim();

--- a/regression/common/far_utils.h
+++ b/regression/common/far_utils.h
@@ -36,17 +36,34 @@
 
 //------------------------------------------------------------------------------
 
+inline Scheme
+ConvertSdcTypeToShapeScheme(OpenSubdiv::Sdc::SchemeType sdcScheme) {
+
+    switch (sdcScheme) {
+        case OpenSubdiv::Sdc::SCHEME_BILINEAR: return kBilinear;
+        case OpenSubdiv::Sdc::SCHEME_CATMARK:  return kCatmark;
+        case OpenSubdiv::Sdc::SCHEME_LOOP:     return kLoop;
+        default: printf("unknown Sdc::SchemeType : %d\n", (int)sdcScheme); break;
+    }
+    return kCatmark;
+}
+
+inline OpenSubdiv::Sdc::SchemeType
+ConvertShapeSchemeToSdcType(Scheme shapeScheme) {
+
+    switch (shapeScheme) {
+        case kBilinear: return OpenSubdiv::Sdc::SCHEME_BILINEAR;
+        case kCatmark:  return OpenSubdiv::Sdc::SCHEME_CATMARK;
+        case kLoop:     return OpenSubdiv::Sdc::SCHEME_LOOP;
+        default: printf("unknown Shape Scheme : %d\n", (int)shapeScheme); break;
+    }
+    return OpenSubdiv::Sdc::SCHEME_CATMARK;
+}
+
 inline OpenSubdiv::Sdc::SchemeType
 GetSdcType(Shape const & shape) {
 
-    OpenSubdiv::Sdc::SchemeType type=OpenSubdiv::Sdc::SCHEME_CATMARK;
-
-    switch (shape.scheme) {
-        case kBilinear: type = OpenSubdiv::Sdc::SCHEME_BILINEAR; break;
-        case kCatmark : type = OpenSubdiv::Sdc::SCHEME_CATMARK; break;
-        case kLoop    : type = OpenSubdiv::Sdc::SCHEME_LOOP; break;
-    }
-    return type;
+    return ConvertShapeSchemeToSdcType(shape.scheme);
 }
 
 inline OpenSubdiv::Sdc::Options

--- a/tutorials/far/tutorial_9/far_tutorial_9.cpp
+++ b/tutorials/far/tutorial_9/far_tutorial_9.cpp
@@ -239,6 +239,7 @@ namespace {
     //
     Far::TopologyRefiner *
     createTopologyRefinerFromObj(std::string const & objFileName,
+                                 Sdc::SchemeType schemeType,
                                  PosVector & posVector) {
 
         const char *  filename = objFileName.c_str();
@@ -251,7 +252,8 @@ namespace {
             ifs.close();
             std::string shapeString = ss.str();
 
-            shape = Shape::parseObj(shapeString.c_str(), kCatmark, false);
+            shape = Shape::parseObj(
+                shapeString.c_str(), ConvertSdcTypeToShapeScheme(schemeType), false);
             if (shape == 0) {
                 fprintf(stderr, "Error:  Cannot create Shape from .obj file '%s'\n", filename);
                 return 0;
@@ -553,7 +555,8 @@ main(int argc, char **argv) {
 
     Far::TopologyRefiner * baseRefinerPtr = args.inputObjFile.empty() ?
             createTopologyRefinerDefault(args.geoMultiplier, basePositions) :
-            createTopologyRefinerFromObj(args.inputObjFile, basePositions);
+            createTopologyRefinerFromObj(args.inputObjFile, args.schemeType,
+                                         basePositions);
     assert(baseRefinerPtr);
     Far::TopologyRefiner & baseRefiner = *baseRefinerPtr;
 


### PR DESCRIPTION
These changes included a couple of additions making it easier for examples and tutorials to specify the subdivision scheme for a given .obj file (since the extended syntax does not include the scheme type).  The far/tutorial_9 was updated to make use of the new functionality.