### PR TITLE
Fixed Doxygen warning in far/topologyRefinerFactory.h

### DIFF
--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -125,7 +125,7 @@ public:
     ///
     /// @return           A new instance of TopologyRefiner or 0 for failure
     ///
-    static TopologyRefiner* Create(TopologyRefiner const & sourceOfBaseLevel);
+    static TopologyRefiner* Create(TopologyRefiner const & baseLevel);
 
 protected:
     typedef Vtr::internal::Level::TopologyError TopologyError;


### PR DESCRIPTION
Renamed a method argument to suppress Doxygen warnings for Far::TopologyRefinerFactory::Create().