### PR TITLE
Fix initialization of PatchTable's varying patch descriptor

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -446,6 +446,8 @@ PatchTableBuilder::PatchTableBuilder(
     _table->_varyingPrecisionIsDouble = _options.setPatchPrecisionDouble;
     _table->_faceVaryingPrecisionIsDouble = _options.setFVarPatchPrecisionDouble;
 
+    _table->_varyingDesc = PatchDescriptor(_patchBuilder->GetLinearPatchType());
+
     //  State and helper to support LegacyGregory arrays in the PatchTable:
     _requiresLegacyGregoryTables = !_refiner.IsUniform() &&
         (_options.GetEndCapType() == Options::ENDCAP_LEGACY_GREGORY);


### PR DESCRIPTION
The varying descriptor of Far::PatchTable is used elsewhere to determine if the table contains triangular or quad patches, but that descriptor is not being initialized if generating varying patches is suppressed, e.g. in far/tutorial_9.  This change initializes the descriptor on construction regardless of whether varying patches are generated.  (Meanwhile alternatives to the use of the varying descriptor are under consideration.)