### PR TITLE
Improve patch construction around non-manifold vertices to close gaps

### DIFF
--- a/opensubdiv/far/topologyRefinerFactory.cpp
+++ b/opensubdiv/far/topologyRefinerFactory.cpp
@@ -252,12 +252,14 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
         vTag._rule = (Vtr::internal::Level::VTag::VTagSize)creasing.DetermineVertexVertexRule(vSharpness, sharpEdgeCount);
 
         //
-        //  Assign topological tags -- note that the "xordinary" tag is not strictly
-        //  correct (or relevant) if non-manifold:
+        //  Assign topological tags -- note that the "xordinary" tag is not assigned
+        //  if non-manifold:
         //
         vTag._boundary = (boundaryEdgeCount > 0);
         vTag._corner = isTopologicalCorner && vTag._infSharp;
-        if (vTag._corner) {
+        if (vTag._nonManifold) {
+            vTag._xordinary = false;
+        } else if (vTag._corner) {
             vTag._xordinary = false;
         } else if (vTag._boundary) {
             vTag._xordinary = (vFaces.size() != schemeRegularBoundaryValence);

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -180,6 +180,7 @@ public:
 
         LocalIndex _numFaces;
         LocalIndex _startFace;
+        LocalIndex _cornerInSpan;
 
         unsigned short _periodic : 1;
         unsigned short _sharp    : 1;


### PR DESCRIPTION
Patches around non-manifold vertices have historically been approximated with regular patches, which leaves gaps when an irregular patch is warranted (the catmark_fan shape has illustrated this in the viewer examples).  This change constructs irregular patches where necessary to eliminate gaps.  The faces around a non-manifold vertex are now partitioned into groups delimited by boundary, non-manifold or inf-sharp edges, with each group containing a continuous set of patches.