### PR TITLE
Improved Far::PatchBuilder's determination of patch properties

### DIFF
--- a/opensubdiv/far/patchBuilder.cpp
+++ b/opensubdiv/far/patchBuilder.cpp
@@ -626,7 +626,7 @@ PatchBuilder::IsPatchRegular(int levelIndex, Index faceIndex, int fvc) const {
     //  closer inspection of the single irregular feature:
     //
     bool mayHaveIrregFaces  = (_schemeRegFaceSize == 4);
-    bool needsExtraIsoLevel = fCompVTag._xordinary && mayHaveIrregFaces;
+    int  needsExtraIsoLevel = fCompVTag._xordinary && mayHaveIrregFaces;
 
     bool featureIsIsolated = levelIndex > needsExtraIsoLevel;
     if (featureIsIsolated) {

--- a/opensubdiv/far/patchBuilder.h
+++ b/opensubdiv/far/patchBuilder.h
@@ -265,8 +265,6 @@ protected:
     PatchBuilder(TopologyRefiner const& refiner, Options const& options);
 
     //  Internal methods supporting topology queries:
-    bool isPatchSmoothCorner(int level, Index face, int fvc) const;
-
     int getRegularFacePoints(int level, Index face,
             Index patchPoints[], int fvc) const;
 


### PR DESCRIPTION
These changes improve the Far::PatchBuilder's inspection and classification of patch properties to better deal with features that are not isolated.  Previous assumptions that features were isolated via adaptive refinement are not met in the case of Catmark subdivision at level 1 when non-quad faces are present in the base level, and logic to deal with this case was scattered in several places.

The initial test to determine if a patch is regular was re-organized (and better documented) to emphasize whether irregular features are isolated and to deal with one or all accordingly.  Greater use of bit masks is also applied here and elsewhere to simplify dealing with the public options that need to be supported while more efficient acceptance/rejection tests were also added to handle common cases.

The results should be free of assumptions regarding feature isolation of quads (either irregularities or boundaries) and so better able to deal with patches at the base level.