### PR TITLE
Minor refactoring of Far patch basis evaluation methods

### DIFF
--- a/opensubdiv/far/patchBasis.h
+++ b/opensubdiv/far/patchBasis.h
@@ -36,52 +36,68 @@ namespace Far {
 namespace internal {
 
 //
-// XXXX barfowl:  These functions are being kept in place while more complete
-// underlying support for all patch types is being worked out.  That support
-// will include a larger set of patch types (eventually including triangular
-// patches for Loop) and arbitrary differentiation of all (to support second
-// derivatives and other needs).
+// XXXX barfowl:  These functions are being kept internal while more complete
+// underlying support for all patch types is being worked out.  The set of
+// bases supported here is actually larger than PatchDescriptor::Type -- with
+// Bezier available for internal use.  A new and more complete set of types
+// is warranted (without the non-patch types associated with PatchDescriptor)
+// along with an interface to query properties associated with them.
 //
-// So this interface will be changing in future.
+// Note that with the high-level functions here that operate on all patch
+// types, it is not strictly necessary to expose the low-level methods in
+// currant usage.
 //
-
-//
-// Quad patch types:
-//
-template <typename REAL>
-int GetBilinearWeights(PatchParam const & patchParam, REAL s, REAL t,
-    REAL wP[4], REAL wDs[4], REAL wDt[4], REAL wDss[4] = 0, REAL wDst[4] = 0, REAL wDtt[4] = 0);
-
-template <typename REAL>
-int GetBezierWeights(PatchParam const & patchParam, REAL s, REAL t,
-    REAL wP[16], REAL wDs[16], REAL wDt[16], REAL wDss[16] = 0, REAL wDst[16] = 0, REAL wDtt[16] = 0);
-
-template <typename REAL>
-int GetBSplineWeights(PatchParam const & patchParam, REAL s, REAL t,
-    REAL wP[16], REAL wDs[16], REAL wDt[16], REAL wDss[16] = 0, REAL wDst[16] = 0, REAL wDtt[16] = 0);
-
-template <typename REAL>
-int GetGregoryWeights(PatchParam const & patchParam, REAL s, REAL t,
-    REAL wP[20], REAL wDs[20], REAL wDt[20], REAL wDss[20] = 0, REAL wDst[20] = 0, REAL wDtt[20] = 0);
 
 //
-// Triangle patch types:
+// Low-level basis evaluation (normalized, unscaled) for quad patch types:
 //
 template <typename REAL>
-int GetLinearTriWeights(PatchParam const & patchParam, REAL s, REAL t,
-    REAL wP[3], REAL wDs[3], REAL wDt[3], REAL wDss[3] = 0, REAL wDst[3] = 0, REAL wDtt[3] = 0);
+int EvalBasisLinear(REAL s, REAL t,
+    REAL wP[4], REAL wDs[4] = 0, REAL wDt[4] = 0, REAL wDss[4] = 0, REAL wDst[4] = 0, REAL wDtt[4] = 0);
 
 template <typename REAL>
-int GetBezierTriWeights(PatchParam const & patchParam, REAL s, REAL t,
-    REAL wP[12], REAL wDs[12], REAL wDt[12], REAL wDss[12] = 0, REAL wDst[12] = 0, REAL wDtt[12] = 0);
+int EvalBasisBezier(REAL s, REAL t,
+    REAL wP[16], REAL wDs[16] = 0, REAL wDt[16] = 0, REAL wDss[16] = 0, REAL wDst[16] = 0, REAL wDtt[16] = 0);
 
 template <typename REAL>
-int GetBoxSplineTriWeights(PatchParam const & patchParam, REAL s, REAL t,
-    REAL wP[12], REAL wDs[12], REAL wDt[12], REAL wDss[12] = 0, REAL wDst[12] = 0, REAL wDtt[12] = 0);
+int EvalBasisBSpline(REAL s, REAL t,
+    REAL wP[16], REAL wDs[16] = 0, REAL wDt[16] = 0, REAL wDss[16] = 0, REAL wDst[16] = 0, REAL wDtt[16] = 0);
 
 template <typename REAL>
-int GetGregoryTriWeights(PatchParam const & patchParam, REAL s, REAL t,
-    REAL wP[15], REAL wDs[15], REAL wDt[15], REAL wDss[15] = 0, REAL wDst[15] = 0, REAL wDtt[15] = 0);
+int EvalBasisGregory(REAL s, REAL t,
+    REAL wP[20], REAL wDs[20] = 0, REAL wDt[20] = 0, REAL wDss[20] = 0, REAL wDst[20] = 0, REAL wDtt[20] = 0);
+
+//
+// Low-level basis evaluation (normalized, unscaled) for triangular patch types:
+//
+template <typename REAL>
+int EvalBasisLinearTri(REAL s, REAL t,
+    REAL wP[3], REAL wDs[3] = 0, REAL wDt[3] = 0, REAL wDss[3] = 0, REAL wDst[3] = 0, REAL wDtt[3] = 0);
+
+template <typename REAL>
+int EvalBasisBezierTri(REAL s, REAL t,
+    REAL wP[12], REAL wDs[12] = 0, REAL wDt[12] = 0, REAL wDss[12] = 0, REAL wDst[12] = 0, REAL wDtt[12] = 0);
+
+template <typename REAL>
+int EvalBasisBoxSplineTri(REAL s, REAL t,
+    REAL wP[12], REAL wDs[12] = 0, REAL wDt[12] = 0, REAL wDss[12] = 0, REAL wDst[12] = 0, REAL wDtt[12] = 0);
+
+template <typename REAL>
+int EvalBasisGregoryTri(REAL s, REAL t,
+    REAL wP[15], REAL wDs[15] = 0, REAL wDt[15] = 0, REAL wDss[15] = 0, REAL wDst[15] = 0, REAL wDtt[15] = 0);
+
+
+//
+// High-level basis evaluation for all types using PatchParam:
+//
+template <typename REAL>
+int EvaluatePatchBasisNormalized(int patchType, PatchParam const & param, REAL s, REAL t,
+    REAL wP[], REAL wDs[] = 0, REAL wDt[] = 0, REAL wDss[] = 0, REAL wDst[] = 0, REAL wDtt[] = 0);
+
+template <typename REAL>
+int EvaluatePatchBasis(int patchType, PatchParam const & param, REAL s, REAL t,
+    REAL wP[], REAL wDs[] = 0, REAL wDt[] = 0, REAL wDss[] = 0, REAL wDst[] = 0, REAL wDtt[] = 0);
+
 
 } // end namespace internal
 } // end namespace Far

--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -596,30 +596,6 @@ PatchTable::print() const {
 //
 //  Evaluate basis functions for vertex and derivatives at (s,t):
 //
-namespace {
-    template <typename REAL>
-    void evaluatePatchBasis(PatchDescriptor::Type patchType, PatchParam const & param,
-        REAL s, REAL t, REAL wP[], REAL wDs[], REAL wDt[],
-        REAL wDss[], REAL wDst[], REAL wDtt[]) {
-
-        if (patchType == PatchDescriptor::REGULAR) {
-            internal::GetBSplineWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
-        } else if (patchType == PatchDescriptor::GREGORY_BASIS) {
-            internal::GetGregoryWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
-        } else if (patchType == PatchDescriptor::QUADS) {
-            internal::GetBilinearWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
-        } else if (patchType == PatchDescriptor::TRIANGLES) {
-            internal::GetLinearTriWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
-        } else if (patchType == PatchDescriptor::LOOP) {
-            internal::GetBoxSplineTriWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
-        } else if (patchType == PatchDescriptor::GREGORY_TRIANGLE) {
-            internal::GetGregoryTriWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
-        } else {
-            assert(0);
-        }
-    }
-} // end namespace
-
 template <typename REAL>
 void
 PatchTable::EvaluateBasis(
@@ -630,7 +606,7 @@ PatchTable::EvaluateBasis(
     PatchParam const & param = _paramTable[handle.patchIndex];
     PatchDescriptor::Type patchType = GetPatchArrayDescriptor(handle.arrayIndex).GetType();
 
-    evaluatePatchBasis(patchType, param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+    internal::EvaluatePatchBasis(patchType, param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
 }
 
 //
@@ -646,13 +622,7 @@ PatchTable::EvaluateBasisVarying(
     PatchParam const & param = _paramTable[handle.patchIndex];
     PatchDescriptor::Type patchType = GetVaryingPatchDescriptor().GetType();
 
-    if (patchType == PatchDescriptor::QUADS) {
-        internal::GetBilinearWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
-    } else if (patchType == PatchDescriptor::TRIANGLES) {
-        internal::GetLinearTriWeights(param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
-    } else {
-        assert(0);
-    }
+    internal::EvaluatePatchBasis(patchType, param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
 }
 
 //
@@ -671,7 +641,7 @@ PatchTable::EvaluateBasisFaceVarying(
             ? GetFVarPatchDescriptorRegular(channel).GetType()
             : GetFVarPatchDescriptorIrregular(channel).GetType();
 
-    evaluatePatchBasis(patchType, param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+    internal::EvaluatePatchBasis(patchType, param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
 }
 
 

--- a/opensubdiv/osd/cpuEvaluator.cpp
+++ b/opensubdiv/osd/cpuEvaluator.cpp
@@ -189,23 +189,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
             ? array.GetPatchTypeRegular()
             : array.GetPatchTypeIrregular();
 
-        int numControlVertices = 0;
-        if (patchType == Far::PatchDescriptor::REGULAR) {
-            Far::internal::GetBSplineWeights(param,
-                                             coord.s, coord.t, wP, wDs, wDt);
-            numControlVertices = 16;
-        } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-            Far::internal::GetGregoryWeights(param,
-                                             coord.s, coord.t, wP, wDs, wDt);
-            numControlVertices = 20;
-        } else if (patchType == Far::PatchDescriptor::QUADS) {
-            Far::internal::GetBilinearWeights(param,
-                                              coord.s, coord.t, wP, wDs, wDt);
-            numControlVertices = 4;
-        } else {
-            assert(0);
-            return false;
-        }
+        int numControlVertices = Far::internal::EvaluatePatchBasis(patchType,
+                param, coord.s, coord.t, wP, wDs, wDt);
 
         int indexBase = array.GetIndexBase() + array.GetStride() *
                 (coord.handle.patchIndex - array.GetPrimitiveIdBase());
@@ -267,22 +252,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
             ? array.GetPatchTypeRegular()
             : array.GetPatchTypeIrregular();
 
-        int numControlVertices = 0;
-        if (patchType == Far::PatchDescriptor::REGULAR) {
-            Far::internal::GetBSplineWeights(param,
-                                             coord.s, coord.t, wP, wDs, wDt);
-            numControlVertices = 16;
-        } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-            Far::internal::GetGregoryWeights(param,
-                                             coord.s, coord.t, wP, wDs, wDt);
-            numControlVertices = 20;
-        } else if (patchType == Far::PatchDescriptor::QUADS) {
-            Far::internal::GetBilinearWeights(param,
-                                              coord.s, coord.t, wP, wDs, wDt);
-            numControlVertices = 4;
-        } else {
-            assert(0);
-        }
+        int numControlVertices = Far::internal::EvaluatePatchBasis(patchType,
+                param, coord.s, coord.t, wP, wDs, wDt);
 
         int indexBase = array.GetIndexBase() + array.GetStride() *
                 (coord.handle.patchIndex - array.GetPrimitiveIdBase());
@@ -368,25 +339,8 @@ CpuEvaluator::EvalPatches(const float *src, BufferDescriptor const &srcDesc,
             ? array.GetPatchTypeRegular()
             : array.GetPatchTypeIrregular();
 
-        int numControlVertices = 0;
-        if (patchType == Far::PatchDescriptor::REGULAR) {
-            Far::internal::GetBSplineWeights(param,
-                                             coord.s, coord.t, wP, wDu, wDv,
-                                             wDuu, wDuv, wDvv);
-            numControlVertices = 16;
-        } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-            Far::internal::GetGregoryWeights(param,
-                                             coord.s, coord.t, wP, wDu, wDv,
-                                             wDuu, wDuv, wDvv);
-            numControlVertices = 20;
-        } else if (patchType == Far::PatchDescriptor::QUADS) {
-            Far::internal::GetBilinearWeights(param,
-                                              coord.s, coord.t, wP, wDu, wDv,
-                                              wDuu, wDuv, wDvv);
-            numControlVertices = 4;
-        } else {
-            assert(0);
-        }
+        int numControlVertices = Far::internal::EvaluatePatchBasis(patchType,
+                param, coord.s, coord.t, wP, wDu, wDv, wDuu, wDuv, wDvv);
 
         int indexBase = array.GetIndexBase() + array.GetStride() *
                 (coord.handle.patchIndex - array.GetPrimitiveIdBase());

--- a/opensubdiv/osd/ompEvaluator.cpp
+++ b/opensubdiv/osd/ompEvaluator.cpp
@@ -188,22 +188,8 @@ OmpEvaluator::EvalPatches(
             ? Far::PatchDescriptor::REGULAR
             : array.GetPatchType();
 
-        int numControlVertices = 0;
-        if (patchType == Far::PatchDescriptor::REGULAR) {
-            Far::internal::GetBSplineWeights(param,
-                                             coord.s, coord.t, wP, wDs, wDt);
-            numControlVertices = 16;
-        } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-            Far::internal::GetGregoryWeights(param,
-                                             coord.s, coord.t, wP, wDs, wDt);
-            numControlVertices = 20;
-        } else if (patchType == Far::PatchDescriptor::QUADS) {
-            Far::internal::GetBilinearWeights(param,
-                                              coord.s, coord.t, wP, wDs, wDt);
-            numControlVertices = 4;
-        } else {
-            continue;
-        }
+        int numControlVertices = Far::internal::EvaluatePatchBasis(patchType,
+            param, coord.s, coord.t, wP, wDs, wDt);
 
         int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
         int indexBase = array.GetIndexBase() + indexStride *
@@ -255,22 +241,8 @@ OmpEvaluator::EvalPatches(
             ? Far::PatchDescriptor::REGULAR
             : array.GetPatchType();
 
-        int numControlVertices = 0;
-        if (patchType == Far::PatchDescriptor::REGULAR) {
-            Far::internal::GetBSplineWeights(param,
-                                             coord.s, coord.t, wP, wDu, wDv);
-            numControlVertices = 16;
-        } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-            Far::internal::GetGregoryWeights(param,
-                                             coord.s, coord.t, wP, wDu, wDv);
-            numControlVertices = 20;
-        } else if (patchType == Far::PatchDescriptor::QUADS) {
-            Far::internal::GetBilinearWeights(param,
-                                              coord.s, coord.t, wP, wDu, wDv);
-            numControlVertices = 4;
-        } else {
-            continue;
-        }
+        int numControlVertices = Far::internal::EvaluatePatchBasis(patchType,
+            param, coord.s, coord.t, wP, wDu, wDv);
 
         int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
         int indexBase = array.GetIndexBase() + indexStride *
@@ -338,25 +310,8 @@ OmpEvaluator::EvalPatches(
             ? Far::PatchDescriptor::REGULAR
             : array.GetPatchType();
 
-        int numControlVertices = 0;
-        if (patchType == Far::PatchDescriptor::REGULAR) {
-            Far::internal::GetBSplineWeights(param,
-                                             coord.s, coord.t, wP,
-                                             wDu, wDv, wDuu, wDuv, wDvv);
-            numControlVertices = 16;
-        } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-            Far::internal::GetGregoryWeights(param,
-                                             coord.s, coord.t, wP,
-                                             wDu, wDv, wDuu, wDuv, wDvv);
-            numControlVertices = 20;
-        } else if (patchType == Far::PatchDescriptor::QUADS) {
-            Far::internal::GetBilinearWeights(param,
-                                              coord.s, coord.t, wP,
-                                              wDu, wDv, wDuu, wDuv, wDvv);
-            numControlVertices = 4;
-        } else {
-            continue;
-        }
+        int numControlVertices = Far::internal::EvaluatePatchBasis(patchType,
+            param, coord.s, coord.t, wP, wDu, wDv, wDuu, wDuv, wDvv);
 
         int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
         int indexBase = array.GetIndexBase() + indexStride *

--- a/opensubdiv/osd/tbbKernel.cpp
+++ b/opensubdiv/osd/tbbKernel.cpp
@@ -402,25 +402,8 @@ public:
                 ? Far::PatchDescriptor::REGULAR
                 : array.GetPatchType();
 
-            int numControlVertices = 0;
-            if (patchType == Far::PatchDescriptor::REGULAR) {
-                Far::internal::GetBSplineWeights(param,
-                                                 coord.s, coord.t, wP,
-                                                 wDu, wDv);
-                numControlVertices = 16;
-            } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-                Far::internal::GetGregoryWeights(param,
-                                                 coord.s, coord.t, wP,
-                                                 wDu, wDv);
-                numControlVertices = 20;
-            } else if (patchType == Far::PatchDescriptor::QUADS) {
-                Far::internal::GetBilinearWeights(param,
-                                                  coord.s, coord.t, wP,
-                                                  wDu, wDv);
-                numControlVertices = 4;
-            } else {
-                assert(0);
-            }
+            int numControlVertices = Far::internal::EvaluatePatchBasis(patchType,
+                    param, coord.s, coord.t, wP, wDu, wDv);
 
             int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
             int indexBase = array.GetIndexBase() + indexStride *
@@ -464,25 +447,8 @@ public:
                 ? Far::PatchDescriptor::REGULAR
                 : array.GetPatchType();
 
-            int numControlVertices = 0;
-            if (patchType == Far::PatchDescriptor::REGULAR) {
-                Far::internal::GetBSplineWeights(param,
-                                                 coord.s, coord.t, wP,
-                                                 wDu, wDv);
-                numControlVertices = 16;
-            } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-                Far::internal::GetGregoryWeights(param,
-                                                 coord.s, coord.t, wP,
-                                                 wDu, wDv);
-                numControlVertices = 20;
-            } else if (patchType == Far::PatchDescriptor::QUADS) {
-                Far::internal::GetBilinearWeights(param,
-                                                  coord.s, coord.t,
-                                                  wP, wDu, wDv);
-                numControlVertices = 4;
-            } else {
-                assert(0);
-            }
+            int numControlVertices = Far::internal::EvaluatePatchBasis(patchType,
+                    param, coord.s, coord.t, wP, wDu, wDv);
 
             int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
             int indexBase = array.GetIndexBase() + indexStride *
@@ -544,25 +510,8 @@ public:
                 ? Far::PatchDescriptor::REGULAR
                 : array.GetPatchType();
 
-            int numControlVertices = 0;
-            if (patchType == Far::PatchDescriptor::REGULAR) {
-                Far::internal::GetBSplineWeights(param,
-                                                 coord.s, coord.t, wP,
-                                                 wDu, wDv, wDuu, wDuv, wDvv);
-                numControlVertices = 16;
-            } else if (patchType == Far::PatchDescriptor::GREGORY_BASIS) {
-                Far::internal::GetGregoryWeights(param,
-                                                 coord.s, coord.t, wP,
-                                                 wDu, wDv, wDuu, wDuv, wDvv);
-                numControlVertices = 20;
-            } else if (patchType == Far::PatchDescriptor::QUADS) {
-                Far::internal::GetBilinearWeights(param,
-                                                  coord.s, coord.t, wP,
-                                                 wDu, wDv, wDuu, wDuv, wDvv);
-                numControlVertices = 4;
-            } else {
-                assert(0);
-            }
+            int numControlVertices = Far::internal::EvaluatePatchBasis(patchType,
+                    param, coord.s, coord.t, wP, wDu, wDv, wDuu, wDuv, wDvv);
 
             int indexStride = Far::PatchDescriptor(array.GetPatchType()).GetNumControlVertices();
             int indexBase = array.GetIndexBase() + indexStride *


### PR DESCRIPTION
These changes simplify the internal patch basis evaluation functions in far/patchBasis.h.  The functions for each basis now deal purely in a normalized (s,t) space and are completely independent of Far::PatchParam.  A single pair of higher-level evaluation functions now deals with dependencies on Far::PatchParam (e.g. derivative magnitude scaling) and dispatches the basis evaluation for a given patch type.

Usage of the individual basis methods in Far::PatchTable and the Osd evaluators was replaced with one of the new functions taking a patch type and PatchParam.  Upcoming work in Osd will further align osd/patchBasisCommon and the Osd evaluators with these changes.
