### PR TITLE
Extended Far topology tagging to better handle irregular faces

### DIFF
--- a/opensubdiv/far/patchBuilder.h
+++ b/opensubdiv/far/patchBuilder.h
@@ -304,7 +304,7 @@ protected:
 
     Sdc::SchemeType _schemeType;
     int             _schemeRegFaceSize;
-    int             _schemeNeighborhood;
+    bool            _schemeIsLinear;
 
     PatchDescriptor::Type _regPatchType;
     PatchDescriptor::Type _irregPatchType;

--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -236,6 +236,8 @@ private:
     void selectFeatureAdaptiveComponents(Vtr::internal::SparseSelector& selector,
                                          internal::FeatureMask const & mask,
                                          ConstIndexArray selectedFaces);
+    void selectLinearIrregularFaces(Vtr::internal::SparseSelector& selector,
+                                    ConstIndexArray selectedFaces);
 
     void initializeInventory();
     void updateInventory(Vtr::internal::Level const & newLevel);
@@ -249,9 +251,11 @@ private:
     Sdc::SchemeType _subdivType;
     Sdc::Options    _subdivOptions;
 
-    unsigned int _isUniform : 1,
-                 _hasHoles : 1,
-                 _maxLevel : 4;
+    unsigned int _isUniform     : 1;
+    unsigned int _hasHoles      : 1;
+    unsigned int _hasIrregFaces : 1;
+    unsigned int _regFaceSize   : 3;
+    unsigned int _maxLevel      : 4;
 
     //  Options assigned on refinement:
     UniformOptions  _uniformOptions;

--- a/opensubdiv/far/topologyRefinerFactory.cpp
+++ b/opensubdiv/far/topologyRefinerFactory.cpp
@@ -318,6 +318,20 @@ TopologyRefinerFactoryBase::prepareComponentTagsAndSharpness(TopologyRefiner& re
         }
 
         //
+        //  If any irregular faces are present, mark whether or not a vertex is incident
+        //  any irregular face:
+        //
+        if (refiner._hasIrregFaces) {
+            int regSize = refiner._regFaceSize;
+            for (int i = 0; i < vFaces.size(); ++i) {
+                if (baseLevel.getFaceVertices(vFaces[i]).size() != regSize) {
+                    vTag._incidIrregFace = true;
+                    break;
+                }
+            }
+        }
+
+        //
         //  Having just decided if a vertex is on a boundary, and with its incident faces
         //  available, mark incident faces as holes.
         //

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -438,6 +438,7 @@ template <class MESH>
 inline void
 TopologyRefinerFactory<MESH>::setNumBaseFaceVertices(TopologyRefiner & newRefiner, Index f, int count) {
     newRefiner._levels[0]->resizeFaceVertices(f, count);
+    newRefiner._hasIrregFaces |= (count != newRefiner._regFaceSize);
 }
 template <class MESH>
 inline void

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -112,7 +112,13 @@ public:
         VTagSize _semiSharp       : 1;  // variable
         VTagSize _semiSharpEdges  : 1;  // variable
         VTagSize _rule            : 4;  // variable when _semiSharp
-        VTagSize _incomplete      : 1;  // variable for sparse refinement
+
+        //  These next to tags are complementary -- the "incomplete" tag is only
+        //  relevant for refined levels while the "incident an irregular face" tag
+        //  is only relevant for the base level.  They could be combined as both
+        //  indicate "no full regular ring" around a vertex
+        VTagSize _incomplete      : 1;  // variable only set in refined levels
+        VTagSize _incidIrregFace  : 1;  // variable only set in base level
 
         //  Tags indicating incident infinitely-sharp (permanent) features
         VTagSize _infSharpEdges   : 1;  // fixed

--- a/opensubdiv/vtr/refinement.cpp
+++ b/opensubdiv/vtr/refinement.cpp
@@ -773,6 +773,7 @@ Refinement::populateVertexTagsFromParentVertices() {
     Index cVertEnd = cVert + getNumChildVerticesFromVertices();
     for ( ; cVert < cVertEnd; ++cVert) {
         _child->_vertTags[cVert] = _parent->_vertTags[_childVertexParentIndex[cVert]];
+        _child->_vertTags[cVert]._incidIrregFace = 0;
     }
 }
 


### PR DESCRIPTION
These changes add new vertex tags and members to improve the detection of irregular faces during adaptive refinement and patch construction.  With the recent addition of adaptive refinement and patches for a selected set of faces, the need to determine if a face is, or is incident to, an irregular face has become more necessary -- and detecting if a neighboring face is irregular requires a tedious topological search around the entire neighborhood of the face (inspection of all faces around all corner vertices).

A new vertex tag was added to indicate a vertex is incident one or more irregular faces while a new member was added to the TopologyRefiner to detect the presence of irregular faces in the base level (similar to that for face holes).  The new tag is explicitly assigned only when irregular faces are present.  Both adaptive refinement and patch construction can then detect this condition for an individual vertex or an entire face by using the same tests on individual or combined tags.

The handling of linear subdivision schemes (Bilinear) was also more clearly separated from the feature adaptive tests required for non-linear schemes to keep them free of its special cases.  Unlike the non-linear schemes, a face adjacent to an irregular face does not warrant special handling.