### PR TITLE
Fixed Far::PatchTable::IsFeatureAdaptive() to work for all schemes

### DIFF
--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -39,6 +39,7 @@ PatchTable::PatchTable(int maxvalence) :
     _localPointStencils(),
     _localPointVaryingStencils(),
     _varyingDesc(Far::PatchDescriptor::QUADS),
+    _isUniformLinear(false),
     _vertexPrecisionIsDouble(false),
     _varyingPrecisionIsDouble(false),
     _faceVaryingPrecisionIsDouble(false) {
@@ -60,6 +61,7 @@ PatchTable::PatchTable(PatchTable const & src) :
     _fvarChannels(src._fvarChannels),
     _sharpnessIndices(src._sharpnessIndices),
     _sharpnessValues(src._sharpnessValues),
+    _isUniformLinear(src._isUniformLinear),
     _vertexPrecisionIsDouble(src._vertexPrecisionIsDouble),
     _varyingPrecisionIsDouble(src._varyingPrecisionIsDouble),
     _faceVaryingPrecisionIsDouble(src._faceVaryingPrecisionIsDouble) {
@@ -386,17 +388,7 @@ PatchTable::GetPatchQuadOffsets(PatchHandle const & handle) const {
 bool
 PatchTable::IsFeatureAdaptive() const {
 
-    // XXX:
-    // revisit this function, since we'll add uniform cubic patches later.
-
-    for (int i=0; i<GetNumPatchArrays(); ++i) {
-        PatchDescriptor const & desc = _patchArrays[i].desc;
-        if (desc.GetType()>=PatchDescriptor::REGULAR &&
-            desc.GetType()<=PatchDescriptor::GREGORY_BASIS) {
-            return true;
-        }
-    }
-    return false;
+    return !_isUniformLinear;
 }
 
 PatchDescriptor

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -677,7 +677,6 @@ private:
     //
     // Varying data
     //
-
     PatchDescriptor _varyingDesc;
 
     std::vector<Index>   _varyingVerts;
@@ -685,7 +684,6 @@ private:
     //
     // Face-varying data
     //
-
     FVarPatchChannelVector _fvarChannels;
 
     std::vector<StencilTableHandler> _localPointFaceVaryingStencils;
@@ -693,9 +691,13 @@ private:
     //
     // 'single-crease' patch sharpness tables
     //
-
     std::vector<Index>   _sharpnessIndices; // Indices of single-crease sharpness (one per patch)
     std::vector<float>   _sharpnessValues;  // Sharpness values.
+
+    //
+    //  Construction history -- relevant to at least one public query:
+    //
+    unsigned int _isUniformLinear : 1;
 
     //
     //  Precision -- only applies to local-point stencil tables

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -755,6 +755,8 @@ PatchTableBuilder::BuildUniform() {
     //
     //  Allocate and initialize the table's members.
     //
+    _table->_isUniformLinear = true;
+
     _table->reservePatchArrays(nlevels);
 
     PatchDescriptor desc(ptype);


### PR DESCRIPTION
The little-used but public IsFeatureAdaptive() query of Far::PatchTable is hard-coded to use patch types used by the Catmark scheme to determine its result, so it does not work for PatchTables populated by the Loop or Bilinear schemes.

Since the result cannot be determined solely by inspecting the patch types (adaptive patches for Bilinear will all be quads) a new member was added to PatchTable and initialized on construction by the PatchTableFactory.  The member exists solely to support IsFeatureAdaptive() at this point -- which is used within the LimitStencilTableFactory -- and no additional public access to it is provided at this time.