### PR TITLE
Improved patch basis eval for Osd to match Far

### DIFF
--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -53,7 +53,9 @@ set(PUBLIC_HEADER_FILES
 )
 
 list(APPEND KERNEL_FILES
+    patchBasisCommonTypes.h
     patchBasisCommon.h
+    patchBasisCommonEval.h
 )
 
 set(DOXY_HEADER_FILES ${PUBLIC_HEADER_FILES})

--- a/opensubdiv/osd/clEvaluator.cpp
+++ b/opensubdiv/osd/clEvaluator.cpp
@@ -41,8 +41,14 @@ namespace Osd {
 static const char *clSource =
 #include "clKernel.gen.h"
 ;
+static const char *patchBasisTypesSource =
+#include "patchBasisCommonTypes.gen.h"
+;
 static const char *patchBasisSource =
 #include "patchBasisCommon.gen.h"
+;
+static const char *patchBasisEvalSource =
+#include "patchBasisCommonEval.gen.h"
 ;
 
 // ----------------------------------------------------------------------------
@@ -166,8 +172,12 @@ CLEvaluator::Compile(BufferDescriptor const &srcDesc,
             << "#define OSD_PATCH_BASIS_OPENCL\n";
     std::string defineStr = defines.str();
 
-    const char *sources[] = { defineStr.c_str(), patchBasisSource, clSource };
-    _program = clCreateProgramWithSource(_clContext, 3, sources, 0, &errNum);
+    const char *sources[] = { defineStr.c_str(),
+                              patchBasisTypesSource,
+                              patchBasisSource,
+                              patchBasisEvalSource,
+                              clSource };
+    _program = clCreateProgramWithSource(_clContext, 5, sources, 0, &errNum);
     if (errNum != CL_SUCCESS) {
         Far::Error(Far::FAR_RUNTIME_ERROR,
                    "clCreateProgramWithSource (%d)", errNum);

--- a/opensubdiv/osd/glComputeEvaluator.h
+++ b/opensubdiv/osd/glComputeEvaluator.h
@@ -2101,6 +2101,7 @@ private:
     } _patchKernel;
 
     int _workGroupSize;
+    GLuint _patchArraysSSBO;
 };
 
 }  // end namespace Osd

--- a/opensubdiv/osd/glXFBEvaluator.h
+++ b/opensubdiv/osd/glXFBEvaluator.h
@@ -2129,6 +2129,7 @@ public:
 
 private:
     GLuint _srcBufferTexture;
+    GLuint _patchArraysUBO;
     bool _interleavedDerivativeBuffers;
 
     struct _StencilKernel {
@@ -2174,7 +2175,7 @@ private:
         GLint uniformSrcBufferTexture;
         GLint uniformSrcOffset;    // src buffer offset (in elements)
 
-        GLint uniformPatchArray;
+        GLint uniformPatchArraysUBOBinding;
         GLint uniformPatchParamTexture;
         GLint uniformPatchIndexTexture;
     } _patchKernel;

--- a/opensubdiv/osd/glslComputeKernel.glsl
+++ b/opensubdiv/osd/glslComputeKernel.glsl
@@ -81,22 +81,25 @@ layout(binding=15) buffer stencilDvvWeights { float  _dvvWeights[]; };
 
 #if defined(OPENSUBDIV_GLSL_COMPUTE_KERNEL_EVAL_PATCHES)
 
-struct PatchCoord {
-   int arrayIndex;
-   int patchIndex;
-   int vertIndex;
-   float s;
-   float t;
-};
-struct PatchParam {
-    uint field0;
-    uint field1;
-    float sharpness;
-};
-uniform ivec4 patchArray[2];
-layout(binding=4) buffer patchCoord_buffer { PatchCoord patchCoords[]; };
-layout(binding=5) buffer patchIndex_buffer { int patchIndexBuffer[]; };
-layout(binding=6) buffer patchParam_buffer { PatchParam patchParamBuffer[]; };
+layout(binding=4) buffer patchArray_buffer { OsdPatchArray patchArrayBuffer[]; };
+layout(binding=5) buffer patchCoord_buffer { OsdPatchCoord patchCoords[]; };
+layout(binding=6) buffer patchIndex_buffer { int patchIndexBuffer[]; };
+layout(binding=7) buffer patchParam_buffer { OsdPatchParam patchParamBuffer[]; };
+
+OsdPatchCoord GetPatchCoord(int coordIndex)
+{
+    return patchCoords[coordIndex];
+}
+
+OsdPatchArray GetPatchArray(int arrayIndex)
+{
+    return patchArrayBuffer[arrayIndex];
+}
+
+OsdPatchParam GetPatchParam(int patchIndex)
+{
+    return patchParamBuffer[patchIndex];
+}
 
 #endif
 
@@ -248,99 +251,19 @@ void main() {
 
 // PERFORMANCE: stride could be constant, but not as significant as length
 
-//struct PatchArray {
-//    int patchType;
-//    int numPatches;
-//    int indexBase;        // an offset within the index buffer
-//    int primitiveIdBase;  // an offset within the patch param buffer
-//};
-// # of patcharrays is 1 or 2.
-
-uint getDepth(uint patchBits) {
-    return (patchBits & 0xf);
-}
-
-float getParamFraction(uint patchBits) {
-    uint nonQuadRoot = (patchBits >> 4) & 0x1;
-    uint depth = getDepth(patchBits);
-    if (nonQuadRoot == 1) {
-        return 1.0f / float( 1 << (depth-1) );
-    } else {
-        return 1.0f / float( 1 << depth );
-    }
-}
-
-vec2 normalizePatchCoord(uint patchBits, vec2 uv) {
-    float frac = getParamFraction(patchBits);
-
-    uint iu = (patchBits >> 22) & 0x3ff;
-    uint iv = (patchBits >> 12) & 0x3ff;
-
-    // top left corner
-    float pu = float(iu*frac);
-    float pv = float(iv*frac);
-
-    // normalize u,v coordinates
-    return vec2((uv.x - pu) / frac, (uv.y - pv) / frac);
-}
-
-bool isRegular(uint patchBits) {
-    return (((patchBits >> 5) & 0x1u) != 0);
-}
-
-int getNumControlVertices(int patchType) {
-    return (patchType == 3) ? 4 :
-           (patchType == 6) ? 16 :
-           (patchType == 9) ? 20 : 0;
-}
-
 void main() {
 
     int current = int(gl_GlobalInvocationID.x);
 
-    PatchCoord coord = patchCoords[current];
-    int patchIndex = coord.patchIndex;
+    OsdPatchCoord coord = GetPatchCoord(current);
+    OsdPatchArray array = GetPatchArray(coord.arrayIndex);
+    OsdPatchParam param = GetPatchParam(coord.patchIndex);
 
-    ivec4 array = patchArray[coord.arrayIndex];
+    int patchType = OsdPatchParamIsRegular(param) ? array.regDesc : array.desc;
 
-    uint patchBits = patchParamBuffer[patchIndex].field1;
-    int patchType = isRegular(patchBits) ? 6 : array.x;
-
-    vec2 uv = normalizePatchCoord(patchBits, vec2(coord.s, coord.t));
-    float dScale = float(1 << getDepth(patchBits));
-    int boundary = int((patchBits >> 7) & 0x1fU);
-
-    float wP[20], wDs[20], wDt[20], wDss[20], wDst[20], wDtt[20];
-
-    int numControlVertices = 0;
-    if (patchType == 3) {
-        float wP4[4], wDs4[4], wDt4[4], wDss4[4], wDst4[4], wDtt4[4];
-        OsdGetBilinearPatchWeights(uv.s, uv.t, dScale, wP4, wDs4, wDt4, wDss4, wDst4, wDtt4);
-        numControlVertices = 4;
-        for (int i=0; i<numControlVertices; ++i) {
-            wP[i] = wP4[i];
-            wDs[i] = wDs4[i];
-            wDt[i] = wDt4[i];
-            wDss[i] = wDss4[i];
-            wDst[i] = wDst4[i];
-            wDtt[i] = wDtt4[i];
-        }
-    } else if (patchType == 6) {
-        float wP16[16], wDs16[16], wDt16[16], wDss16[16], wDst16[16], wDtt16[16];
-        OsdGetBSplinePatchWeights(uv.s, uv.t, dScale, boundary, wP16, wDs16, wDt16, wDss16, wDst16, wDtt16);
-        numControlVertices = 16;
-        for (int i=0; i<numControlVertices; ++i) {
-            wP[i] = wP16[i];
-            wDs[i] = wDs16[i];
-            wDt[i] = wDt16[i];
-            wDss[i] = wDss16[i];
-            wDst[i] = wDst16[i];
-            wDtt[i] = wDtt16[i];
-        }
-    } else if (patchType == 9) {
-        OsdGetGregoryPatchWeights(uv.s, uv.t, dScale, wP, wDs, wDt, wDss, wDst, wDtt);
-        numControlVertices = 20;
-    }
+    float wP[20], wDu[20], wDv[20], wDuu[20], wDuv[20], wDvv[20];
+    int nPoints = OsdEvaluatePatchBasis(patchType, param,
+        coord.s, coord.t, wP, wDu, wDv, wDuu, wDuv, wDvv);
 
     Vertex dst, du, dv, duu, duv, dvv;
     clear(dst);
@@ -350,17 +273,17 @@ void main() {
     clear(duv);
     clear(dvv);
 
-    int indexStride = getNumControlVertices(array.x);
-    int indexBase = array.z + indexStride * (patchIndex - array.w);
+    int indexBase = array.indexBase + array.stride *
+                (coord.patchIndex - array.primitiveIdBase);
 
-    for (int cv = 0; cv < numControlVertices; ++cv) {
+    for (int cv = 0; cv < nPoints; ++cv) {
         int index = patchIndexBuffer[indexBase + cv];
         addWithWeight(dst, readVertex(index), wP[cv]);
-        addWithWeight(du, readVertex(index), wDs[cv]);
-        addWithWeight(dv, readVertex(index), wDt[cv]);
-        addWithWeight(duu, readVertex(index), wDss[cv]);
-        addWithWeight(duv, readVertex(index), wDst[cv]);
-        addWithWeight(dvv, readVertex(index), wDtt[cv]);
+        addWithWeight(du, readVertex(index), wDu[cv]);
+        addWithWeight(dv, readVertex(index), wDv[cv]);
+        addWithWeight(duu, readVertex(index), wDuu[cv]);
+        addWithWeight(duv, readVertex(index), wDuv[cv]);
+        addWithWeight(dvv, readVertex(index), wDvv[cv]);
     }
     writeVertex(current, dst);
 

--- a/opensubdiv/osd/glslPatchShaderSource.cpp
+++ b/opensubdiv/osd/glslPatchShaderSource.cpp
@@ -34,8 +34,14 @@ namespace Osd {
 static const char *commonShaderSource =
 #include "glslPatchCommon.gen.h"
 ;
+static const char *patchBasisTypesShaderSource =
+#include "patchBasisCommonTypes.gen.h"
+;
 static const char *patchBasisShaderSource =
 #include "patchBasisCommon.gen.h"
+;
+static const char *patchBasisEvalShaderSource =
+#include "patchBasisCommonEval.gen.h"
 ;
 static const char *bsplineShaderSource =
 #include "glslPatchBSpline.gen.h"
@@ -60,7 +66,9 @@ GLSLPatchShaderSource::GetPatchBasisShaderSource() {
 #if defined(OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES)
     ss << "#define OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES\n";
 #endif
+    ss << std::string(patchBasisTypesShaderSource);
     ss << std::string(patchBasisShaderSource);
+    ss << std::string(patchBasisEvalShaderSource);
     return ss.str();
 }
 

--- a/opensubdiv/osd/hlslPatchShaderSource.cpp
+++ b/opensubdiv/osd/hlslPatchShaderSource.cpp
@@ -36,8 +36,14 @@ namespace Osd {
 static const char *commonShaderSource =
 #include "hlslPatchCommon.gen.h"
 ;
+static const char *patchBasisTypesShaderSource =
+#include "patchBasisCommonTypes.gen.h"
+;
 static const char *patchBasisShaderSource =
 #include "patchBasisCommon.gen.h"
+;
+static const char *patchBasisEvalShaderSource =
+#include "patchBasisCommonEval.gen.h"
 ;
 static const char *bsplineShaderSource =
 #include "hlslPatchBSpline.gen.h"
@@ -62,7 +68,9 @@ HLSLPatchShaderSource::GetPatchBasisShaderSource() {
 #if defined(OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES)
     ss << "#define OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES\n";
 #endif
+    ss << std::string(patchBasisTypesShaderSource);
     ss << std::string(patchBasisShaderSource);
+    ss << std::string(patchBasisEvalShaderSource);
     return ss.str();
 }
 

--- a/opensubdiv/osd/mtlPatchShaderSource.mm
+++ b/opensubdiv/osd/mtlPatchShaderSource.mm
@@ -37,9 +37,15 @@ namespace OpenSubdiv {
             static std::string commonShaderSource(
 #include "mtlPatchCommon.gen.h"
 );
-            static std::string patchBasisShaderSource( 
+            static std::string patchBasisTypesShaderSource(
+#include "patchBasisCommonTypes.gen.h"
+);
+            static std::string patchBasisShaderSource(
 #include "patchBasisCommon.gen.h"
-);             
+);
+            static std::string patchBasisEvalShaderSource(
+#include "patchBasisCommonEval.gen.h"
+);
             static std::string bsplineShaderSource(
 #include "mtlPatchBSpline.gen.h"
 );
@@ -105,7 +111,9 @@ namespace OpenSubdiv {
 #if defined(OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES)
                 ss << "#define OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES 1\n";
 #endif
+                ss << patchBasisTypesShaderSource;
                 ss << patchBasisShaderSource;
+                ss << patchBasisEvalShaderSource;
                 return ss.str();
             }
             

--- a/opensubdiv/osd/patchBasisCommon.h
+++ b/opensubdiv/osd/patchBasisCommon.h
@@ -1,5 +1,5 @@
 //
-//   Copyright 2016 Pixar
+//   Copyright 2016-2018 Pixar
 //
 //   Licensed under the Apache License, Version 2.0 (the "Apache License")
 //   with the following modification; you may not use this file except in
@@ -25,220 +25,19 @@
 #ifndef OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_H
 #define OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_H
 
-#if defined(OSD_PATCH_BASIS_GLSL)
-
-    #define OSD_FUNCTION_STORAGE_CLASS
-    #define OSD_DATA_STORAGE_CLASS
-    #define OSD_OPTIONAL(a) true
-    #define OSD_OPTIONAL_INIT(a,b) b
-    #define OSD_OUT out
-    #define OSD_INOUT inout
-    #define OSD_TYPE_ARRAY(elementType, identifier, arraySize) elementType identifier[arraySize]
-    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
-            elementType[](a0,a1,a2,a3,a4,a5,a6,a7)
-    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
-            elementType[](a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11)
-
-#elif defined(OSD_PATCH_BASIS_HLSL)
-
-    #define OSD_FUNCTION_STORAGE_CLASS
-    #define OSD_DATA_STORAGE_CLASS
-    #define OSD_OPTIONAL(a) true
-    #define OSD_OPTIONAL_INIT(a,b) b
-    #define OSD_OUT out
-    #define OSD_INOUT inout
-    #define OSD_TYPE_ARRAY(elementType, identifier, arraySize) elementType identifier[arraySize]
-    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
-            {a0,a1,a2,a3,a4,a5,a6,a7}
-    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
-            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
-
-#elif defined(OSD_PATCH_BASIS_CUDA)
-
-    #define OSD_FUNCTION_STORAGE_CLASS __device__
-    #define OSD_DATA_STORAGE_CLASS
-    #define OSD_OPTIONAL(a) true
-    #define OSD_OPTIONAL_INIT(a,b) b
-    #define OSD_OUT
-    #define OSD_INOUT
-    #define OSD_TYPE_ARRAY(elementType, identifier, arraySize) elementType identifier[arraySize]
-    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
-            {a0,a1,a2,a3,a4,a5,a6,a7}
-    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
-            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
-
-#elif defined(OSD_PATCH_BASIS_OPENCL)
-
-    #define OSD_FUNCTION_STORAGE_CLASS static
-    #define OSD_DATA_STORAGE_CLASS
-    #define OSD_OPTIONAL(a) true
-    #define OSD_OPTIONAL_INIT(a,b) b
-    #define OSD_OUT
-    #define OSD_INOUT
-    #define OSD_TYPE_ARRAY(elementType, identifier, arraySize) elementType identifier[arraySize]
-    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
-            {a0,a1,a2,a3,a4,a5,a6,a7}
-    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
-            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
-
-#elif defined(OSD_PATCH_BASIS_METAL)
-
-    #define OSD_FUNCTION_STORAGE_CLASS
-    #define OSD_DATA_STORAGE_CLASS
-    #define OSD_OPTIONAL(a) true
-    #define OSD_OPTIONAL_INIT(a,b) b
-    #define OSD_OUT
-    #define OSD_INOUT
-    #define OSD_TYPE_ARRAY(elementType, identifier, arraySize) thread elementType* identifier
-    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
-            {a0,a1,a2,a3,a4,a5,a6,a7}
-    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
-            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
-
-#else
-
-    #define OSD_FUNCTION_STORAGE_CLASS static inline
-    #define OSD_DATA_STORAGE_CLASS static
-    #define OSD_OPTIONAL(a) (a)
-    #define OSD_OPTIONAL_INIT(a,b) (a ? b : 0)
-    #define OSD_OUT
-    #define OSD_INOUT
-    #define OSD_TYPE_ARRAY(elementType, identifier, arraySize) elementType identifier[arraySize]
-    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
-            {a0,a1,a2,a3,a4,a5,a6,a7}
-    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
-            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
-
-#endif
-
 OSD_FUNCTION_STORAGE_CLASS
-void
-OsdGetBezierWeights(
-    float t, OSD_TYPE_ARRAY(OSD_OUT float, wP, 4), OSD_TYPE_ARRAY(OSD_OUT float, wDP, 4), OSD_TYPE_ARRAY(OSD_OUT float, wDP2, 4)) {
+// template <typename REAL>
+int
+Osd_EvalBasisLinear(OSD_REAL s, OSD_REAL t,
+        OSD_OUT_ARRAY(OSD_REAL, wP, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDs, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDt, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDss, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDst, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDtt, 4)) {
 
-    // The four uniform cubic Bezier basis functions (in terms of t and its
-    // complement tC) evaluated at t:
-    float t2 = t*t;
-    float tC = 1.0f - t;
-    float tC2 = tC * tC;
-
-    wP[0] = tC2 * tC;
-    wP[1] = tC2 * t * 3.0f;
-    wP[2] = t2 * tC * 3.0f;
-    wP[3] = t2 * t;
-
-    // Derivatives of the above four basis functions at t:
-    if (OSD_OPTIONAL(wDP)) {
-       wDP[0] = -3.0f * tC2;
-       wDP[1] =  9.0f * t2 - 12.0f * t + 3.0f;
-       wDP[2] = -9.0f * t2 +  6.0f * t;
-       wDP[3] =  3.0f * t2;
-    }
-
-    // Second derivatives of the basis functions at t:
-    if (OSD_OPTIONAL(wDP2)) {
-        wDP2[0] =   6.0f * tC;
-        wDP2[1] =  18.0f * t - 12.0f;
-        wDP2[2] = -18.0f * t +  6.0f;
-        wDP2[3] =   6.0f * t;
-    }
-}
-
-OSD_FUNCTION_STORAGE_CLASS
-void
-OsdGetBSplineWeights(
-    float t, OSD_TYPE_ARRAY(OSD_OUT float, wP, 4), OSD_TYPE_ARRAY(OSD_OUT float, wDP, 4), OSD_TYPE_ARRAY(OSD_OUT float, wDP2, 4)) {
-
-    // The four uniform cubic B-Spline basis functions evaluated at t:
-    const float one6th = 1.0f / 6.0f;
-
-    float t2 = t * t;
-    float t3 = t * t2;
-
-    wP[0] = one6th * (1.0f - 3.0f*(t -      t2) -      t3);
-    wP[1] = one6th * (4.0f           - 6.0f*t2  + 3.0f*t3);
-    wP[2] = one6th * (1.0f + 3.0f*(t +      t2  -      t3));
-    wP[3] = one6th * (                                 t3);
-
-    // Derivatives of the above four basis functions at t:
-    if (OSD_OPTIONAL(wDP)) {
-        wDP[0] = -0.5f*t2 +      t - 0.5f;
-        wDP[1] =  1.5f*t2 - 2.0f*t;
-        wDP[2] = -1.5f*t2 +      t + 0.5f;
-        wDP[3] =  0.5f*t2;
-    }
-
-    // Second derivatives of the basis functions at t:
-    if (OSD_OPTIONAL(wDP2)) {
-        wDP2[0] = -       t + 1.0f;
-        wDP2[1] =  3.0f * t - 2.0f;
-        wDP2[2] = -3.0f * t + 1.0f;
-        wDP2[3] =         t;
-    }
-}
-
-OSD_FUNCTION_STORAGE_CLASS
-void
-OsdGetBoxSplineWeights(float v, float w, OSD_TYPE_ARRAY(OSD_OUT float, wP, 12)) {
-
-    float u = 1.0f - v - w;
-
-    //
-    //  The 12 basis functions of the quartic box spline (unscaled by their common
-    //  factor of 1/12 until later, and formatted to make it easy to spot any
-    //  typing errors):
-    //
-    //      15 terms for the 3 points above the triangle corners
-    //       9 terms for the 3 points on faces opposite the triangle edges
-    //       2 terms for the 6 points on faces opposite the triangle corners
-    //
-    //  Powers of each variable for notational convenience:
-    float u2 = u*u;
-    float u3 = u*u2;
-    float u4 = u*u3;
-    float v2 = v*v;
-    float v3 = v*v2;
-    float v4 = v*v3;
-    float w2 = w*w;
-    float w3 = w*w2;
-    float w4 = w*w3;
-
-    //  And now the basis functions:
-    wP[ 0] = u4 + 2.0f*u3*v;
-    wP[ 1] = u4 + 2.0f*u3*w;
-    wP[ 8] = w4 + 2.0f*w3*u;
-    wP[11] = w4 + 2.0f*w3*v;
-    wP[ 9] = v4 + 2.0f*v3*w;
-    wP[ 5] = v4 + 2.0f*v3*u;
-
-    wP[ 2] = u4 + 2.0f*u3*w + 6.0f*u3*v + 6.0f*u2*v*w + 12.0f*u2*v2 +
-                v4 + 2.0f*v3*w + 6.0f*v3*u + 6.0f*v2*u*w;
-    wP[ 4] = w4 + 2.0f*w3*v + 6.0f*w3*u + 6.0f*w2*u*v + 12.0f*w2*u2 +
-                u4 + 2.0f*u3*v + 6.0f*u3*w + 6.0f*u2*v*w;
-    wP[10] = v4 + 2.0f*v3*u + 6.0f*v3*w + 6.0f*v2*w*u + 12.0f*v2*w2 +
-                w4 + 2.0f*w3*u + 6.0f*w3*v + 6.0f*w3*u*v;
-
-    wP[ 3] = v4 + 6*v3*w + 8*v3*u + 36*v2*w*u + 24*v2*u2 + 24*v*u3 +
-                w4 + 6*w3*v + 8*w3*u + 36*w2*v*u + 24*w2*u2 + 24*w*u3 + 6*u4 + 60*u2*v*w + 12*v2*w2;
-    wP[ 6] = w4 + 6*w3*u + 8*w3*v + 36*w2*u*v + 24*w2*v2 + 24*w*v3 +
-                u4 + 6*u3*w + 8*u3*v + 36*u2*v*w + 24*u2*v2 + 24*u*v3 + 6*v4 + 60*v2*w*u + 12*w2*u2;
-    wP[ 7] = u4 + 6*u3*v + 8*u3*w + 36*u2*v*w + 24*u2*w2 + 24*u*w3 +
-                v4 + 6*v3*u + 8*v3*w + 36*v2*u*w + 24*v2*w2 + 24*v*w3 + 6*w4 + 60*w2*u*v + 12*u2*v2;
-
-    for (int i = 0; i < 12; ++i) {
-        wP[i] *= 1.0f / 12.0f;
-    }
-}
-
-OSD_FUNCTION_STORAGE_CLASS
-void
-OsdGetBilinearPatchWeights(
-        float s, float t, float dScale,
-        OSD_TYPE_ARRAY(OSD_OUT float, wP, 4), OSD_TYPE_ARRAY(OSD_OUT float, wDs, 4), OSD_TYPE_ARRAY(OSD_OUT float, wDt, 4),
-        OSD_TYPE_ARRAY(OSD_OUT float, wDss, 4), OSD_TYPE_ARRAY(OSD_OUT float, wDst, 4), OSD_TYPE_ARRAY(OSD_OUT float, wDtt, 4)) {
-
-    float sC = 1.0f - s,
-          tC = 1.0f - t;
+    OSD_REAL sC = 1.0f - s;
+    OSD_REAL tC = 1.0f - t;
 
     if (OSD_OPTIONAL(wP)) {
         wP[0] = sC * tC;
@@ -247,75 +46,153 @@ OsdGetBilinearPatchWeights(
         wP[3] = sC * t;
     }
 
-    if (OSD_OPTIONAL(derivS && derivT)) {
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        wDs[0] = -tC;
+        wDs[1] =  tC;
+        wDs[2] =   t;
+        wDs[3] =  -t;
 
-        wDs[0] = -tC * dScale;
-        wDs[1] =  tC * dScale;
-        wDs[2] =   t * dScale;
-        wDs[3] =  -t * dScale;
+        wDt[0] = -sC;
+        wDt[1] =  -s;
+        wDt[2] =   s;
+        wDt[3] =  sC;
 
-        wDt[0] = -sC * dScale;
-        wDt[1] =  -s * dScale;
-        wDt[2] =   s * dScale;
-        wDt[3] =  sC * dScale;
-
-        if (OSD_OPTIONAL(derivSS && derivST && derivTT)) {
-            float d2Scale = dScale * dScale;
-
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
             for(int i=0;i<4;i++) {
-                wDss[i] = 0;
-                wDtt[i] = 0;
+                wDss[i] = 0.0f;
+                wDtt[i] = 0.0f;
             }
 
-            wDst[0] =  d2Scale;
-            wDst[1] = -d2Scale;
-            wDst[2] = -d2Scale;
-            wDst[3] =  d2Scale;
+            wDst[0] =  1.0f;
+            wDst[1] = -1.0f;
+            wDst[2] = -1.0f;
+            wDst[3] =  1.0f;
         }
     }
+    return 4;
 }
 
-OSD_FUNCTION_STORAGE_CLASS
-void OsdAdjustBoundaryWeights(
-        int boundary,
-        OSD_TYPE_ARRAY(OSD_INOUT float, sWeights, 4), OSD_TYPE_ARRAY(OSD_INOUT float, tWeights, 4)) {
+// namespace {
+    //
+    //  Cubic BSpline curve basis evaluation:
+    //
+    OSD_FUNCTION_STORAGE_CLASS
+    // template <typename REAL>
+    void
+    Osd_evalBSplineCurve(OSD_REAL t,
+        OSD_OUT_ARRAY(OSD_REAL, wP, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDP, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDP2, 4)) {
 
-    if ((boundary & 1) != 0) {
-        tWeights[2] -= tWeights[0];
-        tWeights[1] += 2*tWeights[0];
-        tWeights[0] = 0;
+        const OSD_REAL one6th = OSD_REAL_CAST(1.0f / 6.0f);
+
+        OSD_REAL t2 = t * t;
+        OSD_REAL t3 = t * t2;
+
+        wP[0] = one6th * (1.0f - 3.0f*(t -      t2) -      t3);
+        wP[1] = one6th * (4.0f           - 6.0f*t2  + 3.0f*t3);
+        wP[2] = one6th * (1.0f + 3.0f*(t +      t2  -      t3));
+        wP[3] = one6th * (                                 t3);
+
+        if (OSD_OPTIONAL(wDP)) {
+            wDP[0] = -0.5f*t2 +      t - 0.5f;
+            wDP[1] =  1.5f*t2 - 2.0f*t;
+            wDP[2] = -1.5f*t2 +      t + 0.5f;
+            wDP[3] =  0.5f*t2;
+        }
+        if (OSD_OPTIONAL(wDP2)) {
+            wDP2[0] = -       t + 1.0f;
+            wDP2[1] =  3.0f * t - 2.0f;
+            wDP2[2] = -3.0f * t + 1.0f;
+            wDP2[3] =         t;
+        }
     }
-    if ((boundary & 2) != 0) {
-        sWeights[1] -= sWeights[3];
-        sWeights[2] += 2*sWeights[3];
-        sWeights[3] = 0;
+
+    //
+    //  Weight adjustments to account for phantom end points:
+    //
+    OSD_FUNCTION_STORAGE_CLASS
+    // template <typename REAL>
+    void
+    Osd_adjustBSplineBoundaryWeights(
+            int boundary,
+            OSD_INOUT_ARRAY(OSD_REAL, w, 16)) {
+
+        if ((boundary & 1) != 0) {
+            for (int i = 0; i < 4; ++i) {
+                w[i + 8] -= w[i + 0];
+                w[i + 4] += w[i + 0] * 2.0f;
+                w[i + 0]  = 0.0f;
+            }
+        }
+        if ((boundary & 2) != 0) {
+            for (int i = 0; i < 16; i += 4) {
+                w[i + 1] -= w[i + 3];
+                w[i + 2] += w[i + 3] * 2.0f;
+                w[i + 3]  = 0.0f;
+            }
+        }
+        if ((boundary & 4) != 0) {
+            for (int i = 0; i < 4; ++i) {
+                w[i +  4] -= w[i + 12];
+                w[i +  8] += w[i + 12] * 2.0f;
+                w[i + 12]  = 0.0f;
+            }
+        }
+        if ((boundary & 8) != 0) {
+            for (int i = 0; i < 16; i += 4) {
+                w[i + 2] -= w[i + 0];
+                w[i + 1] += w[i + 0] * 2.0f;
+                w[i + 0]  = 0.0f;
+            }
+        }
     }
-    if ((boundary & 4) != 0) {
-        tWeights[1] -= tWeights[3];
-        tWeights[2] += 2*tWeights[3];
-        tWeights[3] = 0;
+
+    OSD_FUNCTION_STORAGE_CLASS
+    // template <typename REAL>
+    void
+    Osd_boundBasisBSpline(
+            int boundary,
+            OSD_INOUT_ARRAY(OSD_REAL, wP, 16),
+            OSD_INOUT_ARRAY(OSD_REAL, wDs, 16),
+            OSD_INOUT_ARRAY(OSD_REAL, wDt, 16),
+            OSD_INOUT_ARRAY(OSD_REAL, wDss, 16),
+            OSD_INOUT_ARRAY(OSD_REAL, wDst, 16),
+            OSD_INOUT_ARRAY(OSD_REAL, wDtt, 16)) {
+
+        if (OSD_OPTIONAL(wP)) {
+            Osd_adjustBSplineBoundaryWeights(boundary, wP);
+        }
+        if (OSD_OPTIONAL(wDs && wDt)) {
+            Osd_adjustBSplineBoundaryWeights(boundary, wDs);
+            Osd_adjustBSplineBoundaryWeights(boundary, wDt);
+
+            if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+                Osd_adjustBSplineBoundaryWeights(boundary, wDss);
+                Osd_adjustBSplineBoundaryWeights(boundary, wDst);
+                Osd_adjustBSplineBoundaryWeights(boundary, wDtt);
+            }
+        }
     }
-    if ((boundary & 8) != 0) {
-        sWeights[2] -= sWeights[0];
-        sWeights[1] += 2*sWeights[0];
-        sWeights[0] = 0;
-    }
-}
+
+// } // end namespace
 
 OSD_FUNCTION_STORAGE_CLASS
-void OsdComputeTensorProductPatchWeights(float dScale, int boundary,
-    OSD_TYPE_ARRAY(float, sWeights, 4), OSD_TYPE_ARRAY(float, tWeights, 4),
-    OSD_TYPE_ARRAY(float, dsWeights, 4), OSD_TYPE_ARRAY(float, dtWeights, 4),
-    OSD_TYPE_ARRAY(float, dssWeights, 4), OSD_TYPE_ARRAY(float, dttWeights, 4),
-    OSD_TYPE_ARRAY(OSD_OUT float, wP, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDs, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDt, 16),
-    OSD_TYPE_ARRAY(OSD_OUT float, wDss, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDst, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDtt, 16)) {
+int
+Osd_EvalBasisBSpline(OSD_REAL s, OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 16)) {
+
+    OSD_REAL sWeights[4], tWeights[4], dsWeights[4], dtWeights[4], dssWeights[4], dttWeights[4];
+
+    Osd_evalBSplineCurve(s, sWeights, OSD_OPTIONAL_INIT(wDs, dsWeights), OSD_OPTIONAL_INIT(wDss, dssWeights));
+    Osd_evalBSplineCurve(t, tWeights, OSD_OPTIONAL_INIT(wDt, dtWeights), OSD_OPTIONAL_INIT(wDtt, dttWeights));
 
     if (OSD_OPTIONAL(wP)) {
-        // Compute the tensor product weight of the (s,t) basis function
-        // corresponding to each control vertex:
-
-        OsdAdjustBoundaryWeights(boundary, sWeights, tWeights);
-
         for (int i = 0; i < 4; ++i) {
             for (int j = 0; j < 4; ++j) {
                 wP[4*i+j] = sWeights[j] * tWeights[i];
@@ -323,91 +200,122 @@ void OsdComputeTensorProductPatchWeights(float dScale, int boundary,
         }
     }
 
-    if (OSD_OPTIONAL(derivS && derivT)) {
-        // Compute the tensor product weight of the differentiated (s,t) basis
-        // function corresponding to each control vertex (scaled accordingly):
-
-        OsdAdjustBoundaryWeights(boundary, dsWeights, dtWeights);
-
+    if (OSD_OPTIONAL(wDs && wDt)) {
         for (int i = 0; i < 4; ++i) {
             for (int j = 0; j < 4; ++j) {
-                wDs[4*i+j] = dsWeights[j] * tWeights[i] * dScale;
-                wDt[4*i+j] = sWeights[j] * dtWeights[i] * dScale;
+                wDs[4*i+j] = dsWeights[j] * tWeights[i];
+                wDt[4*i+j] = sWeights[j] * dtWeights[i];
             }
         }
 
-        if (OSD_OPTIONAL(derivSS && derivST && derivTT)) {
-            // Compute the tensor product weight of appropriate differentiated
-            // (s,t) basis functions for each control vertex (scaled accordingly):
-            float d2Scale = dScale * dScale;
-
-            OsdAdjustBoundaryWeights(boundary, dssWeights, dttWeights);
-
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
             for (int i = 0; i < 4; ++i) {
                 for (int j = 0; j < 4; ++j) {
-                    wDss[4*i+j] = dssWeights[j] * tWeights[i] * d2Scale;
-                    wDst[4*i+j] = dsWeights[j] * dtWeights[i] * d2Scale;
-                    wDtt[4*i+j] = sWeights[j] * dttWeights[i] * d2Scale;
+                    wDss[4*i+j] = dssWeights[j] * tWeights[i];
+                    wDst[4*i+j] = dsWeights[j] * dtWeights[i];
+                    wDtt[4*i+j] = sWeights[j] * dttWeights[i];
                 }
             }
         }
     }
+    return 16;
 }
 
-OSD_FUNCTION_STORAGE_CLASS
-void OsdGetBezierPatchWeights(
-    float s, float t, float dScale,
-    OSD_TYPE_ARRAY(OSD_OUT float, wP, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDS, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDT, 16),
-    OSD_TYPE_ARRAY(OSD_OUT float, wDSS, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDST, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDTT, 16)) {
-
-    float sWeights[4], tWeights[4], dsWeights[4], dtWeights[4], dssWeights[4], dttWeights[4];
-
-    OsdGetBezierWeights(s, OSD_OPTIONAL_INIT(wP, sWeights), OSD_OPTIONAL_INIT(wDS, dsWeights), OSD_OPTIONAL_INIT(wDSS, dssWeights));
-    OsdGetBezierWeights(t, OSD_OPTIONAL_INIT(wP, tWeights), OSD_OPTIONAL_INIT(wDT, dtWeights), OSD_OPTIONAL_INIT(wDTT, dttWeights));
-
-    OsdComputeTensorProductPatchWeights(dScale, /*boundary=*/0, sWeights, tWeights, dsWeights, dtWeights, dssWeights, dttWeights, wP, wDS, wDT, wDSS, wDST, wDTT);
-}
-
-OSD_FUNCTION_STORAGE_CLASS
-void OsdGetBSplinePatchWeights(
-    float s, float t, float dScale, int boundary,
-    OSD_TYPE_ARRAY(OSD_OUT float, wP, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDs, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDt, 16),
-    OSD_TYPE_ARRAY(OSD_OUT float, wDss, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDst, 16), OSD_TYPE_ARRAY(OSD_OUT float, wDtt, 16)) {
-
-    float sWeights[4], tWeights[4], dsWeights[4], dtWeights[4], dssWeights[4], dttWeights[4];
-
-    OsdGetBSplineWeights(s, sWeights, OSD_OPTIONAL_INIT(wDS, dsWeights), OSD_OPTIONAL_INIT(wDSS, dssWeights));
-    OsdGetBSplineWeights(t, tWeights, OSD_OPTIONAL_INIT(wDT, dtWeights), OSD_OPTIONAL_INIT(wDTT, dttWeights));
-
-    OsdComputeTensorProductPatchWeights(dScale, boundary, sWeights, tWeights, dsWeights, dtWeights, dssWeights, dttWeights, wP, wDs, wDt, wDss, wDst, wDtt);
-}
-
-OSD_FUNCTION_STORAGE_CLASS
-void OsdGetGregoryPatchWeights(
-    float s, float t, float dScale,
-    OSD_TYPE_ARRAY(OSD_OUT float, wP, 20), OSD_TYPE_ARRAY(OSD_OUT float, wDs, 20), OSD_TYPE_ARRAY(OSD_OUT float, wDt, 20),
-    OSD_TYPE_ARRAY(OSD_OUT float, wDss, 20), OSD_TYPE_ARRAY(OSD_OUT float, wDst, 20), OSD_TYPE_ARRAY(OSD_OUT float, wDtt, 20)) {
-
+// namespace {
     //
-    //  P3         e3-      e2+         P2
-    //     15------17-------11--------10
-    //     |        |        |        |
-    //     |        |        |        |
-    //     |        | f3-    | f2+    |
-    //     |       19       13        |
-    // e3+ 16-----18           14-----12 e2-
-    //     |     f3+          f2-     |
-    //     |                          |
-    //     |                          |
-    //     |      f0-         f1+     |
-    // e0- 2------4            8------6 e1+
-    //     |        3        9        |
-    //     |        | f0+    | f1-    |
-    //     |        |        |        |
-    //     |        |        |        |
-    //     O--------1--------7--------5
-    //  P0         e0+      e1-         P1
+    //  Cubic Bezier curve basis evaluation:
     //
+    OSD_FUNCTION_STORAGE_CLASS
+    // template <typename REAL>
+    void
+    Osd_evalBezierCurve(
+        OSD_REAL t,
+        OSD_OUT_ARRAY(OSD_REAL, wP, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDP, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDP2, 4)) {
+
+        // The four uniform cubic Bezier basis functions (in terms of t and its
+        // complement tC) evaluated at t:
+        OSD_REAL t2 = t*t;
+        OSD_REAL tC = 1.0f - t;
+        OSD_REAL tC2 = tC * tC;
+
+        wP[0] = tC2 * tC;
+        wP[1] = tC2 * t * 3.0f;
+        wP[2] = t2 * tC * 3.0f;
+        wP[3] = t2 * t;
+
+        // Derivatives of the above four basis functions at t:
+        if (OSD_OPTIONAL(wDP)) {
+           wDP[0] = -3.0f * tC2;
+           wDP[1] =  9.0f * t2 - 12.0f * t + 3.0f;
+           wDP[2] = -9.0f * t2 +  6.0f * t;
+           wDP[3] =  3.0f * t2;
+        }
+
+        // Second derivatives of the basis functions at t:
+        if (OSD_OPTIONAL(wDP2)) {
+            wDP2[0] =   6.0f * tC;
+            wDP2[1] =  18.0f * t - 12.0f;
+            wDP2[2] = -18.0f * t +  6.0f;
+            wDP2[3] =   6.0f * t;
+        }
+    }
+// } // end namespace
+
+OSD_FUNCTION_STORAGE_CLASS
+int
+Osd_EvalBasisBezier(OSD_REAL s, OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 16)) {
+
+    OSD_REAL sWeights[4], tWeights[4], dsWeights[4], dtWeights[4], dssWeights[4], dttWeights[4];
+
+    Osd_evalBezierCurve(s, OSD_OPTIONAL_INIT(wP, sWeights), OSD_OPTIONAL_INIT(wDs, dsWeights), OSD_OPTIONAL_INIT(wDss, dssWeights));
+    Osd_evalBezierCurve(t, OSD_OPTIONAL_INIT(wP, tWeights), OSD_OPTIONAL_INIT(wDt, dtWeights), OSD_OPTIONAL_INIT(wDtt, dttWeights));
+
+    if (OSD_OPTIONAL(wP)) {
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                wP[4*i+j] = sWeights[j] * tWeights[i];
+            }
+        }
+    }
+
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                wDs[4*i+j] = dsWeights[j] * tWeights[i];
+                wDt[4*i+j] = sWeights[j] * dtWeights[i];
+            }
+        }
+
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            for (int i = 0; i < 4; ++i) {
+                for (int j = 0; j < 4; ++j) {
+                    wDss[4*i+j] = dssWeights[j] * tWeights[i];
+                    wDst[4*i+j] = dsWeights[j] * dtWeights[i];
+                    wDtt[4*i+j] = sWeights[j] * dttWeights[i];
+                }
+            }
+        }
+    }
+    return 16;
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+int
+Osd_EvalBasisGregory(OSD_REAL s, OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 20)) {
 
     //  Indices of boundary and interior points and their corresponding Bezier points
     //  (this can be reduced with more direct indexing and unrolling of loops):
@@ -425,30 +333,30 @@ void OsdGetGregoryPatchWeights(
     //  interior points will be denoted G -- so we have B(s), B(t) and G(s,t):
     //
     //  Directional Bezier basis functions B at s and t:
-    float Bs[4], Bds[4], Bdss[4];
-    float Bt[4], Bdt[4], Bdtt[4];
+    OSD_REAL Bs[4], Bds[4], Bdss[4];
+    OSD_REAL Bt[4], Bdt[4], Bdtt[4];
 
-    OsdGetBezierWeights(s, Bs, OSD_OPTIONAL_INIT(wDs, Bds), OSD_OPTIONAL_INIT(wDss, Bdss));
-    OsdGetBezierWeights(t, Bt, OSD_OPTIONAL_INIT(wDt, Bdt), OSD_OPTIONAL_INIT(wDtt, Bdtt));
+    Osd_evalBezierCurve(s, Bs, OSD_OPTIONAL_INIT(wDs, Bds), OSD_OPTIONAL_INIT(wDss, Bdss));
+    Osd_evalBezierCurve(t, Bt, OSD_OPTIONAL_INIT(wDt, Bdt), OSD_OPTIONAL_INIT(wDtt, Bdtt));
 
     //  Rational multipliers G at s and t:
-    float sC = 1.0f - s;
-    float tC = 1.0f - t;
+    OSD_REAL sC = 1.0f - s;
+    OSD_REAL tC = 1.0f - t;
 
     //  Use <= here to avoid compiler warnings -- the sums should always be non-negative:
-    float df0 = s  + t;   df0 = (df0 <= 0.0f) ? 1.0f : (1.0f / df0);
-    float df1 = sC + t;   df1 = (df1 <= 0.0f) ? 1.0f : (1.0f / df1);
-    float df2 = sC + tC;  df2 = (df2 <= 0.0f) ? 1.0f : (1.0f / df2);
-    float df3 = s  + tC;  df3 = (df3 <= 0.0f) ? 1.0f : (1.0f / df3);
+    OSD_REAL df0 = s  + t;   df0 = (df0 <= 0.0f) ? 1.0f : (1.0f / df0);
+    OSD_REAL df1 = sC + t;   df1 = (df1 <= 0.0f) ? 1.0f : (1.0f / df1);
+    OSD_REAL df2 = sC + tC;  df2 = (df2 <= 0.0f) ? 1.0f : (1.0f / df2);
+    OSD_REAL df3 = s  + tC;  df3 = (df3 <= 0.0f) ? 1.0f : (1.0f / df3);
 
-    float G[8] = OSD_ARRAY_8(float, s*df0, t*df0,  t*df1, sC*df1,  sC*df2, tC*df2,  tC*df3, s*df3 );
+    OSD_REAL G[8] = OSD_ARRAY_8(OSD_REAL, s*df0, t*df0,  t*df1, sC*df1,  sC*df2, tC*df2,  tC*df3, s*df3 );
 
     //  Combined weights for boundary and interior points:
     for (int i = 0; i < 12; ++i) {
         wP[boundaryGregory[i]] = Bs[boundaryBezSCol[i]] * Bt[boundaryBezTRow[i]];
     }
-    for (int i = 0; i < 8; ++i) {
-        wP[interiorGregory[i]] = Bs[interiorBezSCol[i]] * Bt[interiorBezTRow[i]] * G[i];
+    for (int j = 0; j < 8; ++j) {
+        wP[interiorGregory[j]] = Bs[interiorBezSCol[j]] * Bt[interiorBezTRow[j]] * G[j];
     }
 
     //
@@ -458,51 +366,50 @@ void OsdGetGregoryPatchWeights(
     //  though, the approximation using the 16 Bezier points arising from the G(s,t) has
     //  proved adequate (and is what the GPU shaders use) so we continue to use that here.
     //
-    //  An implementation of the true derivatives is provided for future reference -- it is
-    //  unclear if the approximations will hold up under surface analysis involving higher
-    //  order differentiation.
+    //  An implementation of the true derivatives is provided and conditionally compiled for
+    //  those that require it, e.g.:
+    //
+    //    dclyde's note: skipping half of the product rule like this does seem to change the
+    //    result a lot in my tests.  This is not a runtime bottleneck for cloth sims anyway
+    //    so I'm just using the accurate version.
     //
     if (OSD_OPTIONAL(wDs && wDt)) {
         bool find_second_partials = OSD_OPTIONAL(wDs && wDst && wDtt);
-        //  Remember to include derivative scaling in all assignments below:
-        float d2Scale = dScale * dScale;
 
-        //  Combined weights for boundary points -- simple (scaled) tensor products:
+        //  Combined weights for boundary points -- simple tensor products:
         for (int i = 0; i < 12; ++i) {
             int iDst = boundaryGregory[i];
             int tRow = boundaryBezTRow[i];
             int sCol = boundaryBezSCol[i];
 
-            wDs[iDst] = Bds[sCol] * Bt[tRow] * dScale;
-            wDt[iDst] = Bdt[tRow] * Bs[sCol] * dScale;
+            wDs[iDst] = Bds[sCol] * Bt[tRow];
+            wDt[iDst] = Bdt[tRow] * Bs[sCol];
 
             if (find_second_partials) {
-                wDss[iDst] = Bdss[sCol] * Bt[tRow] * d2Scale;
-                wDst[iDst] = Bds[sCol] * Bdt[tRow] * d2Scale;
-                wDtt[iDst] = Bs[sCol] * Bdtt[tRow] * d2Scale;
+                wDss[iDst] = Bdss[sCol] * Bt[tRow];
+                wDst[iDst] = Bds[sCol] * Bdt[tRow];
+                wDtt[iDst] = Bs[sCol] * Bdtt[tRow];
             }
         }
 
-        // dclyde's note: skipping half of the product rule like this does seem to change the result a lot in my tests.
-        // This is not a runtime bottleneck for cloth sims anyway so I'm just using the accurate version.
 #ifndef OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES
         //  Approximation to the true Gregory derivatives by differentiating the Bezier patch
         //  unique to the given (s,t), i.e. having F = (g^+ * f^+) + (g^- * f^-) as its four
         //  interior points:
         //
-        //  Combined weights for interior points -- (scaled) tensor products with G+ or G-:
-        for (int i = 0; i < 8; ++i) {
-            int iDst = interiorGregory[i];
-            int tRow = interiorBezTRow[i];
-            int sCol = interiorBezSCol[i];
+        //  Combined weights for interior points -- tensor products with G+ or G-:
+        for (int j = 0; j < 8; ++j) {
+            int iDst = interiorGregory[j];
+            int tRow = interiorBezTRow[j];
+            int sCol = interiorBezSCol[j];
 
-            wDs[iDst] = Bds[sCol] * Bt[tRow] * G[i] * dScale;
-            wDt[iDst] = Bdt[tRow] * Bs[sCol] * G[i] * dScale;
+            wDs[iDst] = Bds[sCol] * Bt[tRow] * G[j];
+            wDt[iDst] = Bdt[tRow] * Bs[sCol] * G[j];
 
             if (find_second_partials) {
-                wDss[iDst] = Bdss[sCol] * Bt[tRow] * G[i] * d2Scale;
-                wDst[iDst] = Bds[sCol] * Bdt[tRow] * G[i] * d2Scale;
-                wDtt[iDst] = Bs[sCol] * Bdtt[tRow] * G[i] * d2Scale;
+                wDss[iDst] = Bdss[sCol] * Bt[tRow] * G[j];
+                wDst[iDst] = Bds[sCol] * Bdt[tRow] * G[j];
+                wDtt[iDst] = Bs[sCol] * Bdtt[tRow] * G[j];
             }
         }
 #else
@@ -517,42 +424,924 @@ void OsdGetGregoryPatchWeights(
         //  friendly...) but for now we treat all 8 independently for simplicity.
         //
         //float N[8] = OSD_ARRAY_8(float,    s,     t,      t,     sC,      sC,     tC,      tC,     s );
-        float D[8] = OSD_ARRAY_8(float,  df0,   df0,    df1,    df1,     df2,    df2,     df3,   df3 );
+        OSD_REAL D[8] = OSD_ARRAY_8(OSD_REAL,  df0,   df0,    df1,    df1,     df2,    df2,     df3,   df3 );
 
-        OSD_DATA_STORAGE_CLASS const float Nds[8] = OSD_ARRAY_8(float, 1.0f, 0.0f,  0.0f, -1.0f, -1.0f,  0.0f,  0.0f,  1.0f );
-        OSD_DATA_STORAGE_CLASS const float Ndt[8] = OSD_ARRAY_8(float, 0.0f, 1.0f,  1.0f,  0.0f,  0.0f, -1.0f, -1.0f,  0.0f );
+        OSD_DATA_STORAGE_CLASS const OSD_REAL Nds[8] = OSD_ARRAY_8(OSD_REAL, 1.0f, 0.0f,  0.0f, -1.0f, -1.0f,  0.0f,  0.0f,  1.0f );
+        OSD_DATA_STORAGE_CLASS const OSD_REAL Ndt[8] = OSD_ARRAY_8(OSD_REAL, 0.0f, 1.0f,  1.0f,  0.0f,  0.0f, -1.0f, -1.0f,  0.0f );
 
-        OSD_DATA_STORAGE_CLASS const float Dds[8] = OSD_ARRAY_8(float, 1.0f, 1.0f, -1.0f, -1.0f, -1.0f, -1.0f,  1.0f,  1.0f );
-        OSD_DATA_STORAGE_CLASS const float Ddt[8] = OSD_ARRAY_8(float, 1.0f, 1.0f,  1.0f,  1.0f, -1.0f, -1.0f, -1.0f, -1.0f );
-
+        OSD_DATA_STORAGE_CLASS const OSD_REAL Dds[8] = OSD_ARRAY_8(OSD_REAL, 1.0f, 1.0f, -1.0f, -1.0f, -1.0f, -1.0f,  1.0f,  1.0f );
+        OSD_DATA_STORAGE_CLASS const OSD_REAL Ddt[8] = OSD_ARRAY_8(OSD_REAL, 1.0f, 1.0f,  1.0f,  1.0f, -1.0f, -1.0f, -1.0f, -1.0f );
         //  Combined weights for interior points -- (scaled) combinations of B, B', G and G':
-        for (int i = 0; i < 8; ++i) {
-            int iDst = interiorGregory[i];
-            int tRow = interiorBezTRow[i];
-            int sCol = interiorBezSCol[i];
+        for (int k = 0; k < 8; ++k) {
+            int iDst = interiorGregory[k];
+            int tRow = interiorBezTRow[k];
+            int sCol = interiorBezSCol[k];
 
             //  Quotient rule for G' (re-expressed in terms of G to simplify (and D = 1/D)):
-            float Gds = (Nds[i] - Dds[i] * G[i]) * D[i];
-            float Gdt = (Ndt[i] - Ddt[i] * G[i]) * D[i];
+            OSD_REAL Gds = (Nds[k] - Dds[k] * G[k]) * D[k];
+            OSD_REAL Gdt = (Ndt[k] - Ddt[k] * G[k]) * D[k];
 
-            //  Product rule combining B and B' with G and G' (and scaled):
-            wDs[iDst] = (Bds[sCol] * G[i] + Bs[sCol] * Gds) * Bt[tRow] * dScale;
-            wDt[iDst] = (Bdt[tRow] * G[i] + Bt[tRow] * Gdt) * Bs[sCol] * dScale;
+            //  Product rule combining B and B' with G and G':
+            wDs[iDst] = (Bds[sCol] * G[k] + Bs[sCol] * Gds) * Bt[tRow];
+            wDt[iDst] = (Bdt[tRow] * G[k] + Bt[tRow] * Gdt) * Bs[sCol];
 
             if (find_second_partials) {
-                float Dsqr_inv = D[i]*D[i];
+                OSD_REAL Dsqr_inv = D[k]*D[k];
 
-                float Gdss = 2.0f * Dds[i] * Dsqr_inv * (G[i] * Dds[i] - Nds[i]);
-                float Gdst = Dsqr_inv * (2.0f * G[i] * Dds[i] * Ddt[i] - Nds[i] * Ddt[i] - Ndt[i] * Dds[i]);
-                float Gdtt = 2.0f * Ddt[i] * Dsqr_inv * (G[i] * Ddt[i] - Ndt[i]);
+                OSD_REAL Gdss = 2.0f * Dds[k] * Dsqr_inv * (G[k] * Dds[k] - Nds[k]);
+                OSD_REAL Gdst = Dsqr_inv * (2.0f * G[k] * Dds[k] * Ddt[k] - Nds[k] * Ddt[k] - Ndt[k] * Dds[k]);
+                OSD_REAL Gdtt = 2.0f * Ddt[k] * Dsqr_inv * (G[k] * Ddt[k] - Ndt[k]);
 
-                wDss[iDst] = (Bdss[sCol] * G[i] + 2.0f * Bds[sCol] * Gds + Bs[sCol] * Gdss) * Bt[tRow] * d2Scale;
-                wDst[iDst] = (Bt[tRow] * (Bs[sCol] * Gdst + Bds[sCol] * Gdt) + Bdt[tRow] * (Bds[sCol] * G[i] + Bs[sCol] * Gds)) * d2Scale;
-                wDtt[iDst] = (Bdtt[tRow] * G[i] + 2.0f * Bdt[tRow] * Gdt + Bt[tRow] * Gdtt) * Bs[sCol] * d2Scale;
+                wDss[iDst] = (Bdss[sCol] * G[k] + 2.0f * Bds[sCol] * Gds + Bs[sCol] * Gdss) * Bt[tRow];
+                wDst[iDst] =  Bt[tRow] * (Bs[sCol] * Gdst + Bds[sCol] * Gdt) +
+                             Bdt[tRow] * (Bds[sCol] * G[k] + Bs[sCol] * Gds);
+                wDtt[iDst] = (Bdtt[tRow] * G[k] + 2.0f * Bdt[tRow] * Gdt + Bt[tRow] * Gdtt) * Bs[sCol];
             }
         }
 #endif
     }
+    return 20;
 }
 
-#endif /* OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_H */
+
+OSD_FUNCTION_STORAGE_CLASS
+// template <typename REAL>
+int
+Osd_EvalBasisLinearTri(OSD_REAL s, OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 3),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 3),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 3),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 3),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 3),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 3)) {
+
+    if (OSD_OPTIONAL(wP)) {
+        wP[0] = 1.0f - s - t;
+        wP[1] = s;
+        wP[2] = t;
+    }
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        wDs[0] = -1.0f;
+        wDs[1] =  1.0f;
+        wDs[2] =  0.0f;
+
+        wDt[0] = -1.0f;
+        wDt[1] =  0.0f;
+        wDt[2] =  1.0f;
+
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            wDss[0] = wDss[1] = wDss[2] = 0.0f;
+            wDst[0] = wDst[1] = wDst[2] = 0.0f;
+            wDtt[0] = wDtt[1] = wDtt[2] = 0.0f;
+        }
+    }
+    return 3;
+}
+
+
+// namespace {
+    OSD_FUNCTION_STORAGE_CLASS
+    // template <typename REAL>
+    void
+    Osd_evalBivariateMonomialsQuartic(
+        OSD_REAL s, OSD_REAL t,
+        OSD_OUT_ARRAY(OSD_REAL, M, 15)) {
+
+        M[0] = 1.0;
+
+        M[1] = s;
+        M[2] = t;
+
+        M[3] = s * s;
+        M[4] = s * t;
+        M[5] = t * t;
+
+        M[6] = M[3] * s;
+        M[7] = M[4] * s;
+        M[8] = M[4] * t;
+        M[9] = M[5] * t;
+
+        M[10] = M[6] * s;
+        M[11] = M[7] * s;
+        M[12] = M[3] * M[5];
+        M[13] = M[8] * t;
+        M[14] = M[9] * t;
+    }
+
+    OSD_FUNCTION_STORAGE_CLASS
+    // template <typename REAL>
+    void
+    Osd_evalBoxSplineTriDerivWeights(
+        OSD_INOUT_ARRAY(OSD_REAL, /*stMonomials*/M, 15),
+        int ds, int dt,
+        OSD_OUT_ARRAY(OSD_REAL, w, 12)) {
+
+        // const OSD_REAL M[15] = stMonomials;
+
+        OSD_REAL S = 1.0f;
+
+        int totalOrder = ds + dt;
+        if (totalOrder == 0) {
+            S *= OSD_REAL_CAST(1.0 / 12.0);
+
+            w[0]  = S * (1 - 2*M[1] - 4*M[2]          + 6*M[4] + 6*M[5] + 2*M[6]          - 6*M[8] - 4*M[9] -   M[10] - 2*M[11] + 2*M[13] +   M[14]);
+            w[1]  = S * (1 + 2*M[1] - 2*M[2]          - 6*M[4]          - 4*M[6]          + 6*M[8] + 2*M[9] + 2*M[10] + 4*M[11] - 2*M[13] -   M[14]);
+            w[2]  = S * (                                                 2*M[6]                            -   M[10] - 2*M[11]                    );
+            w[3]  = S * (1 - 4*M[1] - 2*M[2] + 6*M[3] + 6*M[4]          - 4*M[6] - 6*M[7]          + 2*M[9] +   M[10] + 2*M[11] - 2*M[13] -   M[14]);
+            w[4]  = S * (6                   -12*M[3] -12*M[4] -12*M[5] + 8*M[6] +12*M[7] +12*M[8] + 8*M[9] -   M[10] - 2*M[11] - 2*M[13] -   M[14]);
+            w[5]  = S * (1 + 4*M[1] + 2*M[2] + 6*M[3] + 6*M[4]          - 4*M[6] - 6*M[7] -12*M[8] - 4*M[9] -   M[10] - 2*M[11] + 4*M[13] + 2*M[14]);
+            w[6]  = S * (                                                                                       M[10] + 2*M[11]                    );
+            w[7]  = S * (1 - 2*M[1] + 2*M[2]          - 6*M[4]          + 2*M[6] + 6*M[7]          - 4*M[9] -   M[10] - 2*M[11] + 4*M[13] + 2*M[14]);
+            w[8]  = S * (1 + 2*M[1] + 4*M[2]          + 6*M[4] + 6*M[5] - 4*M[6] -12*M[7] - 6*M[8] - 4*M[9] + 2*M[10] + 4*M[11] - 2*M[13] -   M[14]);
+            w[9]  = S * (                                                 2*M[6] + 6*M[7] + 6*M[8] + 2*M[9] -   M[10] - 2*M[11] - 2*M[13] -   M[14]);
+            w[10] = S * (                                                                            2*M[9]                     - 2*M[13] -   M[14]);
+            w[11] = S * (                                                                                                         2*M[13] +   M[14]);
+        } else if (totalOrder == 1) {
+            S *= OSD_REAL_CAST(1.0 / 6.0);
+
+            if (ds != 0) {
+                w[0]  = S * (-1          + 3*M[2] + 3*M[3]          - 3*M[5] - 2*M[6] - 3*M[7] +   M[9]);
+                w[1]  = S * ( 1          - 3*M[2] - 6*M[3]          + 3*M[5] + 4*M[6] + 6*M[7] -   M[9]);
+                w[2]  = S * (                       3*M[3]                   - 2*M[6] - 3*M[7]         );
+                w[3]  = S * (-2 + 6*M[1] + 3*M[2] - 6*M[3] - 6*M[4]          + 2*M[6] + 3*M[7] -   M[9]);
+                w[4]  = S * (   -12*M[1] - 6*M[2] +12*M[3] +12*M[4] + 6*M[5] - 2*M[6] - 3*M[7] -   M[9]);
+                w[5]  = S * ( 2 + 6*M[1] + 3*M[2] - 6*M[3] - 6*M[4] - 6*M[5] - 2*M[6] - 3*M[7] + 2*M[9]);
+                w[6]  = S * (                                                  2*M[6] + 3*M[7]         );
+                w[7]  = S * (-1          - 3*M[2] + 3*M[3] + 6*M[4]          - 2*M[6] - 3*M[7] + 2*M[9]);
+                w[8]  = S * ( 1          + 3*M[2] - 6*M[3] -12*M[4] - 3*M[5] + 4*M[6] + 6*M[7] -   M[9]);
+                w[9]  = S * (                       3*M[3] + 6*M[4] + 3*M[5] - 2*M[6] - 3*M[7] -   M[9]);
+                w[10] = S * (                                                                  -   M[9]);
+                w[11] = S * (                                                                      M[9]);
+            } else {
+                w[0]  = S * (-2 + 3*M[1] + 6*M[2]          - 6*M[4] - 6*M[5]  -   M[6] + 3*M[8] + 2*M[9]);
+                w[1]  = S * (-1 - 3*M[1]                   + 6*M[4] + 3*M[5]  + 2*M[6] - 3*M[8] - 2*M[9]);
+                w[2]  = S * (                                                 -   M[6]                  );
+                w[3]  = S * (-1 + 3*M[1]          - 3*M[3]          + 3*M[5]  +   M[6] - 3*M[8] - 2*M[9]);
+                w[4]  = S * (   - 6*M[1] -12*M[2] + 6*M[3] +12*M[4] +12*M[5]  -   M[6] - 3*M[8] - 2*M[9]);
+                w[5]  = S * ( 1 + 3*M[1]          - 3*M[3] -12*M[4] - 6*M[5]  -   M[6] + 6*M[8] + 4*M[9]);
+                w[6]  = S * (                                                 +   M[6]                  );
+                w[7]  = S * ( 1 - 3*M[1]          + 3*M[3]          - 6*M[5]  -   M[6] + 6*M[8] + 4*M[9]);
+                w[8]  = S * ( 2 + 3*M[1] + 6*M[2] - 6*M[3] - 6*M[4] - 6*M[5]  + 2*M[6] - 3*M[8] - 2*M[9]);
+                w[9]  = S * (                     + 3*M[3] + 6*M[4] + 3*M[5]  -   M[6] - 3*M[8] - 2*M[9]);
+                w[10] = S * (                                         3*M[5]           - 3*M[8] - 2*M[9]);
+                w[11] = S * (                                                            3*M[8] + 2*M[9]);
+            }
+        } else if (totalOrder == 2) {
+            if (ds == 2) {
+                w[0]  = S * (   +   M[1]          -   M[3] -   M[4]);
+                w[1]  = S * (   - 2*M[1]          + 2*M[3] + 2*M[4]);
+                w[2]  = S * (       M[1]          -   M[3] -   M[4]);
+                w[3]  = S * ( 1 - 2*M[1] -   M[2] +   M[3] +   M[4]);
+                w[4]  = S * (-2 + 4*M[1] + 2*M[2] -   M[3] -   M[4]);
+                w[5]  = S * ( 1 - 2*M[1] -   M[2] -   M[3] -   M[4]);
+                w[6]  = S * (                         M[3] +   M[4]);
+                w[7]  = S * (   +   M[1] +   M[2] -   M[3] -   M[4]);
+                w[8]  = S * (   - 2*M[1] - 2*M[2] + 2*M[3] + 2*M[4]);
+                w[9]  = S * (       M[1] +   M[2] -   M[3] -   M[4]);
+                w[10] =     0;
+                w[11] =     0;
+            } else if (dt == 2) {
+                w[0]  = S * ( 1 -   M[1] - 2*M[2] +   M[4] +   M[5]);
+                w[1]  = S * (   +   M[1] +   M[2] -   M[4] -   M[5]);
+                w[2]  =     0;
+                w[3]  = S * (            +   M[2] -   M[4] -   M[5]);
+                w[4]  = S * (-2 + 2*M[1] + 4*M[2] -   M[4] -   M[5]);
+                w[5]  = S * (   - 2*M[1] - 2*M[2] + 2*M[4] + 2*M[5]);
+                w[6]  =     0;
+                w[7]  = S * (            - 2*M[2] + 2*M[4] + 2*M[5]);
+                w[8]  = S * ( 1 -   M[1] - 2*M[2] -   M[4] -   M[5]);
+                w[9]  = S * (   +   M[1] +   M[2] -   M[4] -   M[5]);
+                w[10] = S * (                M[2] -   M[4] -   M[5]);
+                w[11] = S * (                         M[4] +   M[5]);
+            } else {
+                S *= OSD_REAL_CAST(1.0 / 2.0);
+
+                w[0]  = S * ( 1          - 2*M[2] -   M[3] +   M[5]);
+                w[1]  = S * (-1          + 2*M[2] + 2*M[3] -   M[5]);
+                w[2]  = S * (                     -   M[3]         );
+                w[3]  = S * ( 1 - 2*M[1]          +   M[3] -   M[5]);
+                w[4]  = S * (-2 + 4*M[1] + 4*M[2] -   M[3] -   M[5]);
+                w[5]  = S * ( 1 - 2*M[1] - 4*M[2] -   M[3] + 2*M[5]);
+                w[6]  = S * (                     +   M[3]         );
+                w[7]  = S * (-1 + 2*M[1]          -   M[3] + 2*M[5]);
+                w[8]  = S * ( 1 - 4*M[1] - 2*M[2] + 2*M[3] -   M[5]);
+                w[9]  = S * (   + 2*M[1] + 2*M[2] -   M[3] -   M[5]);
+                w[10] = S * (                              -   M[5]);
+                w[11] = S * (                                  M[5]);
+            }
+        } else {
+            // assert(totalOrder <= 2);
+        }
+    }
+
+    OSD_FUNCTION_STORAGE_CLASS
+    // template <typename REAL>
+    void
+    Osd_adjustBoxSplineTriBoundaryWeights(
+        int boundaryMask,
+        OSD_INOUT_ARRAY(OSD_REAL, weights, 12)) {
+
+        if (boundaryMask == 0) return;
+
+        //
+        //  Determine boundary edges and vertices from the lower 3 and upper
+        //  2 bits of the 5-bit mask:
+        //
+        bool edgeIsBoundary[3 + 2];  // +2 filled in to avoid +1 and +2 mod 3
+        bool vertexIsBoundary[3];
+
+        bool lowerBits[3];
+        lowerBits[0] = (boundaryMask & 0x1) != 0;
+        lowerBits[1] = (boundaryMask & 0x2) != 0;
+        lowerBits[2] = (boundaryMask & 0x4) != 0;
+
+        int upperBits = (boundaryMask >> 3) & 0x3;
+        if (upperBits == 0) {
+            //  Boundary edges only:
+            for (int i = 0; i < 3; ++i) {
+                edgeIsBoundary[i] = lowerBits[i];
+                vertexIsBoundary[i] = false;
+            }
+        } else if (upperBits == 1) {
+            //  Boundary vertices only:
+            for (int i = 0; i < 3; ++i) {
+                vertexIsBoundary[i] = lowerBits[i];
+                edgeIsBoundary[i] = false;
+            }
+        } else if (upperBits == 2) {
+            //  Boundary edge and opposite boundary vertex:
+            edgeIsBoundary[0] = vertexIsBoundary[2] = lowerBits[0];
+            edgeIsBoundary[1] = vertexIsBoundary[0] = lowerBits[1];
+            edgeIsBoundary[2] = vertexIsBoundary[1] = lowerBits[2];
+        }
+        //  Wrap the 2 additional values to avoid modulo 3 in the edge tests:
+        edgeIsBoundary[3] = edgeIsBoundary[0];
+        edgeIsBoundary[4] = edgeIsBoundary[1];
+
+        //
+        //  Adjust weights for the 4 boundary points (eB) and 3 interior points
+        //  (eI) to account for the 3 phantom points (eP) adjacent to each
+        //  boundary edge:
+        //
+        OSD_DATA_STORAGE_CLASS const int eP[3*3] = OSD_ARRAY_9(int,     0, 1, 2 ,    6, 9, 11 ,   10, 7, 3  );
+        OSD_DATA_STORAGE_CLASS const int eB[3*4] = OSD_ARRAY_12(int,  3, 4, 5, 6,  2, 5, 8, 10, 11, 8, 4, 0 );
+        OSD_DATA_STORAGE_CLASS const int eI[3*3] = OSD_ARRAY_9(int,     7, 8, 9 ,    1, 4, 7  ,    9, 5, 1  );
+
+        for (int i = 0; i < 3; ++i) {
+            if (edgeIsBoundary[i]) {
+                int iPhantom  = i*3;
+                int iBoundary = i*4;
+                int iInterior = i*3;
+
+                //  Adjust weights for points contributing to phantom point
+                //  P0 -- extrapolated according to the presence of adj edge:
+                OSD_REAL w0 = weights[eP[iPhantom+0]];
+                if (edgeIsBoundary[i + 2]) {
+                    //  P0 = B1 + (B1 - I1)
+                    weights[eB[iBoundary+1]] += w0;
+                    weights[eB[iBoundary+1]] += w0;
+                    weights[eI[iInterior+1]] -= w0;
+                } else {
+                    //  P0 = B1 + (B0 - I0)
+                    weights[eB[iBoundary+1]] += w0;
+                    weights[eB[iBoundary+0]] += w0;
+                    weights[eI[iInterior+0]] -= w0;
+                }
+
+                //  Adjust weights for points contributing to phantom point
+                //  P1 = B1 + (B2 - I1)
+                OSD_REAL w1 = weights[eP[iPhantom+1]];
+                weights[eB[iBoundary+1]] += w1;
+                weights[eB[iBoundary+2]] += w1;
+                weights[eI[iInterior+1]] -= w1;
+
+                //  Adjust weights for points contributing to phantom point
+                //  P2 -- extrapolated according to the presence of adj edge:
+                OSD_REAL w2 = weights[eP[iPhantom+2]];
+                if (edgeIsBoundary[i + 1]) {
+                    //  P2 = B2 + (B2 - I1)
+                    weights[eB[iBoundary+2]] += w2;
+                    weights[eB[iBoundary+2]] += w2;
+                    weights[eI[iInterior+1]] -= w2;
+                } else {
+                    //  P2 = B2 + (B3 - I2)
+                    weights[eB[iBoundary+2]] += w2;
+                    weights[eB[iBoundary+3]] += w2;
+                    weights[eI[iInterior+2]] -= w2;
+                }
+
+                //  Clear weights for the phantom points:
+                weights[eP[iPhantom+0]] = 0.0f;
+                weights[eP[iPhantom+1]] = 0.0f;
+                weights[eP[iPhantom+2]] = 0.0f;
+            }
+        }
+
+        //
+        //  Adjust weights for the 3 boundary points (vB) and the 2 interior
+        //  points (vI) to account for the 2 phantom points (vP) adjacent to
+        //  each boundary vertex:
+        //
+        OSD_DATA_STORAGE_CLASS const int vP[3*2] = OSD_ARRAY_6(int,   3, 0 ,    2, 6 ,   11, 10  );
+        OSD_DATA_STORAGE_CLASS const int vB[3*3] = OSD_ARRAY_9(int, 7, 4, 1,  1, 5, 9,  9,  8, 7 );
+        OSD_DATA_STORAGE_CLASS const int vI[3*2] = OSD_ARRAY_6(int,   8, 5 ,    4, 8 ,    5,  4  );
+
+        for (int j = 0; j < 3; ++j) {
+            if (vertexIsBoundary[j]) {
+                int iPhantom  = j*2;
+                int iBoundary = j*3;
+                int iInterior = j*2;
+
+                //  Adjust weights for points contributing to phantom point
+                //  P0 = B1 + (B0 - I0)
+                OSD_REAL w0 = weights[vP[iPhantom+0]];
+                weights[vB[iBoundary+1]] += w0;
+                weights[vB[iBoundary+0]] += w0;
+                weights[vI[iInterior+0]] -= w0;
+
+                //  Adjust weights for points contributing to phantom point
+                //  P1 = B1 + (B2 - I1)
+                OSD_REAL w1 = weights[vP[iPhantom+1]];
+                weights[vB[iBoundary+1]] += w1;
+                weights[vB[iBoundary+2]] += w1;
+                weights[vI[iInterior+1]] -= w1;
+
+                //  Clear weights for the phantom points:
+                weights[vP[iPhantom+0]] = 0.0f;
+                weights[vP[iPhantom+1]] = 0.0f;
+            }
+        }
+    }
+
+    OSD_FUNCTION_STORAGE_CLASS
+    // template <typename REAL>
+    void
+    Osd_boundBasisBoxSplineTri(
+            int boundary,
+            OSD_INOUT_ARRAY(OSD_REAL, wP, 12),
+            OSD_INOUT_ARRAY(OSD_REAL, wDs, 12),
+            OSD_INOUT_ARRAY(OSD_REAL, wDt, 12),
+            OSD_INOUT_ARRAY(OSD_REAL, wDss, 12),
+            OSD_INOUT_ARRAY(OSD_REAL, wDst, 12),
+            OSD_INOUT_ARRAY(OSD_REAL, wDtt, 12)) {
+
+        if (OSD_OPTIONAL(wP)) {
+            Osd_adjustBoxSplineTriBoundaryWeights(boundary, wP);
+        }
+        if (OSD_OPTIONAL(wDs && wDt)) {
+            Osd_adjustBoxSplineTriBoundaryWeights(boundary, wDs);
+            Osd_adjustBoxSplineTriBoundaryWeights(boundary, wDt);
+
+            if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+                Osd_adjustBoxSplineTriBoundaryWeights(boundary, wDss);
+                Osd_adjustBoxSplineTriBoundaryWeights(boundary, wDst);
+                Osd_adjustBoxSplineTriBoundaryWeights(boundary, wDtt);
+            }
+        }
+    }
+// }  // namespace
+
+OSD_FUNCTION_STORAGE_CLASS
+// template <typename REAL>
+int
+Osd_EvalBasisBoxSplineTri(OSD_REAL s, OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 12),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 12),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 12),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 12),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 12),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 12)) {
+
+    OSD_REAL stMonomials[15];
+    Osd_evalBivariateMonomialsQuartic(s, t, stMonomials);
+
+    if (OSD_OPTIONAL(wP)) {
+        Osd_evalBoxSplineTriDerivWeights(stMonomials, 0, 0, wP);
+    }
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        Osd_evalBoxSplineTriDerivWeights(stMonomials, 1, 0, wDs);
+        Osd_evalBoxSplineTriDerivWeights(stMonomials, 0, 1, wDt);
+
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            Osd_evalBoxSplineTriDerivWeights(stMonomials, 2, 0, wDss);
+            Osd_evalBoxSplineTriDerivWeights(stMonomials, 1, 1, wDst);
+            Osd_evalBoxSplineTriDerivWeights(stMonomials, 0, 2, wDtt);
+        }
+    }
+    return 12;
+}
+
+
+// namespace {
+    OSD_FUNCTION_STORAGE_CLASS
+    // template <typename REAL>
+    void
+    Osd_evalBezierTriDerivWeights(
+        OSD_REAL s, OSD_REAL t, int ds, int dt,
+        OSD_OUT_ARRAY(OSD_REAL, wB, 12)) {
+
+        OSD_REAL u  = s;
+        OSD_REAL v  = t;
+        OSD_REAL w  = 1 - u - v;
+
+        OSD_REAL u2 = u * u;
+        OSD_REAL v2 = v * v;
+        OSD_REAL w2 = w * w;
+
+        OSD_REAL uv = u * v;
+        OSD_REAL vw = v * w;
+        OSD_REAL uw = u * w;
+
+        int totalOrder = ds + dt;
+        if (totalOrder == 0) {
+            wB[0]  = w*w2;
+            wB[3]  = u*u2;
+            wB[11] = v*v2;
+
+            wB[1]  =  3 * uw * (uw + w2);
+            wB[2]  =  3 * uw * (uw + u2);
+
+            wB[7]  =  3 * uv * (uv + u2);
+            wB[10] =  3 * uv * (uv + v2);
+
+            wB[8]  =  3 * vw * (vw + v2);
+            wB[4]  =  3 * vw * (vw + w2);
+
+            wB[5]  = 12 * w2 * uv;
+            wB[6]  = 12 * u2 * vw;
+            wB[9]  = 12 * v2 * uw;
+        } else if (totalOrder == 1) {
+            if (ds != 0) {
+                wB[0]  = -3 * w2;
+                wB[3]  =  3 * u2;
+                wB[11] =  0;
+
+                wB[1]  =  3 * w * (w2 - uw - 2*u2);
+                wB[2]  = -3 * u * (u2 - uw - 2*w2);
+
+                wB[7]  =  9 * u2*v + 6 * u*v2;
+                wB[10] =  3 * v*v2 + 6 * u*v2;
+
+                wB[8]  = -3 * v*v2 - 6 * v2*w;
+                wB[4]  = -9 * v*w2 - 6 * v2*w;
+
+                wB[5]  = 12 * vw * (w - 2*u);
+                wB[6]  = 12 * uv * (2*w - u);
+                wB[9]  = 12 * v2 * (w - u);
+            } else {
+                wB[0]  = -3 * w2;
+                wB[3]  =  0;
+                wB[11] =  3 * v2;
+
+                wB[1]  = -9 * u*w2 - 6 * u2*w;
+                wB[2]  = -3 * u*u2 - 6 * u2*w;
+
+                wB[7]  =  3 * u*u2 + 6 * u2*v;
+                wB[10] =  9 * u*v2 + 6 * u2*v;
+
+                wB[8]  = -3 * v * (v2 - vw - 2*w2);
+                wB[4]  =  3 * w * (w2 - vw - 2*v2);
+
+                wB[5]  = 12 * uw * (w - 2*v);
+                wB[6]  = 12 * u2 * (w - v);
+                wB[9]  = 12 * uv * (2*w - v);
+            }
+        } else if (totalOrder == 2) {
+            if (ds == 2) {
+                wB[0]  =  6 * w;
+                wB[3]  =  6 * u;
+                wB[11] =  0;
+
+                wB[1]  =  6 * (u2 - uw - 2*w2);
+                wB[2]  =  6 * (w2 - uw - 2*u2);
+
+                wB[7]  =  6 * v2 + 18 * uv;
+                wB[10] =  6 * v2;
+
+                wB[8]  =  6 * v2;
+                wB[4]  =  6 * v2 + 18 * vw;
+
+                wB[5]  =  24 * (uv - 2*vw);
+                wB[6]  =  24 * (vw - 2*uv);
+                wB[9]  = -24 *  v2;
+            } else if (dt == 2) {
+                wB[0]  =  6 * w;
+                wB[3]  =  0;
+                wB[11] =  6 * v;
+
+                wB[1]  =  6 * u2 + 18 * uw;
+                wB[2]  =  6 * u2;
+
+                wB[7]  =  6 * u2;
+                wB[10] =  6 * u2 + 18 * uv;
+
+                wB[8]  =  6 * (w2 - vw - 2*v2);
+                wB[4]  =  6 * (v2 - vw - 2*w2);
+
+                wB[5]  =  24 * (uv - 2*uw);
+                wB[6]  = -24 *  u2;
+                wB[9]  =  24 * (uw - 2*uv);
+            } else {
+                wB[0]  =  6 * w;
+                wB[3]  =  0;
+                wB[11] =  0;
+
+                wB[1]  =  6 * (u2 +   uw - 1.5f*w2);
+                wB[2]  = -3 * (u2 + 4*uw);
+
+                wB[7]  =  9 * u2 + 12 * uv;
+                wB[10] =  9 * v2 + 12 * uv;
+
+                wB[8]  = -3 * (v2 + 4*vw);
+                wB[4]  =  6 * (v2 +   vw - 1.5f*w2);
+
+                wB[5]  =  24 * (uv - vw - uw + 0.5f*w2);
+                wB[6]  = -24 * (uv - uw      + 0.5f*u2);
+                wB[9]  = -24 * (uv - vw      + 0.5f*v2);
+            }
+        } else {
+            // assert(totalOrder <= 2);
+        }
+    }
+// } // end namespace
+
+OSD_FUNCTION_STORAGE_CLASS
+// template <typename REAL>
+int
+Osd_EvalBasisBezierTri(OSD_REAL s, OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 12),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 12),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 12),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 12),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 12),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 12)) {
+
+    if (OSD_OPTIONAL(wP)) {
+        Osd_evalBezierTriDerivWeights(s, t, 0, 0, wP);
+    }
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        Osd_evalBezierTriDerivWeights(s, t, 1, 0, wDs);
+        Osd_evalBezierTriDerivWeights(s, t, 0, 1, wDt);
+
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            Osd_evalBezierTriDerivWeights(s, t, 2, 0, wDss);
+            Osd_evalBezierTriDerivWeights(s, t, 1, 1, wDst);
+            Osd_evalBezierTriDerivWeights(s, t, 0, 2, wDtt);
+        }
+    }
+    return 12;
+}
+
+
+// namespace {
+    //
+    //  Expanding a set of 12 Bezier basis functions for the 6 (3 pairs) of
+    //  rational weights for the 15 Gregory basis functions:
+    //
+    OSD_FUNCTION_STORAGE_CLASS
+    // template <typename REAL>
+    void
+    Osd_convertBezierWeightsToGregory(
+        OSD_INOUT_ARRAY(OSD_REAL, wB, 12),
+        OSD_INOUT_ARRAY(OSD_REAL, rG,  6),
+        OSD_OUT_ARRAY(OSD_REAL, wG, 15)) {
+
+        wG[0]  = wB[0];
+        wG[1]  = wB[1];
+        wG[2]  = wB[4];
+        wG[3]  = wB[5] * rG[0];
+        wG[4]  = wB[5] * rG[1];
+
+        wG[5]  = wB[3];
+        wG[6]  = wB[7];
+        wG[7]  = wB[2];
+        wG[8]  = wB[6] * rG[2];
+        wG[9]  = wB[6] * rG[3];
+
+        wG[10] = wB[11];
+        wG[11] = wB[8];
+        wG[12] = wB[10];
+        wG[13] = wB[9] * rG[4];
+        wG[14] = wB[9] * rG[5];
+    }
+// } // end namespace
+
+OSD_FUNCTION_STORAGE_CLASS
+// template <typename REAL>
+int
+Osd_EvalBasisGregoryTri(OSD_REAL s, OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 15),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 15),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 15),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 15),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 15),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 15)) {
+
+    //
+    //  Bezier basis functions are denoted with B while the rational multipliers for the
+    //  interior points will be denoted G -- so we have B(s,t) and G(s,t) (though we
+    //  switch to barycentric (u,v,w) briefly to compute G)
+    //
+    OSD_REAL BP[12], BDs[12], BDt[12], BDss[12], BDst[12], BDtt[12];
+
+    OSD_REAL G[6] = OSD_ARRAY_6(OSD_REAL, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f );
+    OSD_REAL u = s;
+    OSD_REAL v = t;
+    OSD_REAL w = 1 - u - v;
+
+    if ((u + v) > 0) {
+        G[0]  = u / (u + v);
+        G[1]  = v / (u + v);
+    }
+    if ((v + w) > 0) {
+        G[2] = v / (v + w);
+        G[3] = w / (v + w);
+    }
+    if ((w + u) > 0) {
+        G[4] = w / (w + u);
+        G[5] = u / (w + u);
+    }
+
+    //
+    //  Compute Bezier basis functions and convert, adjusting interior points:
+    //
+    if (OSD_OPTIONAL(wP)) {
+        Osd_evalBezierTriDerivWeights(s, t, 0, 0, BP);
+        Osd_convertBezierWeightsToGregory(BP, G, wP);
+    }
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        //  TBD -- ifdef OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES
+
+        Osd_evalBezierTriDerivWeights(s, t, 1, 0, BDs);
+        Osd_evalBezierTriDerivWeights(s, t, 0, 1, BDt);
+
+        Osd_convertBezierWeightsToGregory(BDs, G, wDs);
+        Osd_convertBezierWeightsToGregory(BDt, G, wDt);
+
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            Osd_evalBezierTriDerivWeights(s, t, 2, 0, BDss);
+            Osd_evalBezierTriDerivWeights(s, t, 1, 1, BDst);
+            Osd_evalBezierTriDerivWeights(s, t, 0, 2, BDtt);
+
+            Osd_convertBezierWeightsToGregory(BDss, G, wDss);
+            Osd_convertBezierWeightsToGregory(BDst, G, wDst);
+            Osd_convertBezierWeightsToGregory(BDtt, G, wDtt);
+        }
+    }
+    return 15;
+}
+
+#define OSD_PATCH_BASIS_COMPATIBILITY
+#if defined(OSD_PATCH_BASIS_COMPATIBILITY)
+
+// The following functions are low-level internal methods which
+// were exposed in earlier releases, but were never intended to
+// be part of the supported public API.
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetBezierWeights(
+    OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 4),
+    OSD_OUT_ARRAY(OSD_REAL, wDP, 4),
+    OSD_OUT_ARRAY(OSD_REAL, wDP2, 4)) {
+
+    Osd_evalBezierCurve(t, wP, wDP, wDP2);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetBSplineWeights(
+    OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 4),
+    OSD_OUT_ARRAY(OSD_REAL, wDP, 4),
+    OSD_OUT_ARRAY(OSD_REAL, wDP2, 4)) {
+
+    Osd_evalBSplineCurve(t, wP, wDP, wDP2);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetBoxSplineWeights(
+    float s, float t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 12)) {
+
+    OSD_REAL stMonomials[15];
+    Osd_evalBivariateMonomialsQuartic(s, t, stMonomials);
+
+    if (OSD_OPTIONAL(wP)) {
+        Osd_evalBoxSplineTriDerivWeights(stMonomials, 0, 0, wP);
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdAdjustBoundaryWeights(
+        int boundary,
+        OSD_INOUT_ARRAY(OSD_REAL, sWeights, 4),
+        OSD_INOUT_ARRAY(OSD_REAL, tWeights, 4)) {
+
+    if ((boundary & 1) != 0) {
+        tWeights[2] -= tWeights[0];
+        tWeights[1] += tWeights[0] * 2.0f;
+        tWeights[0]  = 0.0f;
+    }
+    if ((boundary & 2) != 0) {
+        sWeights[1] -= sWeights[3];
+        sWeights[2] += sWeights[3] * 2.0f;
+        sWeights[3]  = 0.0f;
+    }
+    if ((boundary & 4) != 0) {
+        tWeights[1] -= tWeights[3];
+        tWeights[2] += tWeights[3] * 2.0f;
+        tWeights[3]  = 0.0f;
+    }
+    if ((boundary & 8) != 0) {
+        sWeights[2] -= sWeights[0];
+        sWeights[1] += sWeights[0] * 2.0f;
+        sWeights[0]  = 0.0f;
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdComputeTensorProductPatchWeights(
+    float dScale, int boundary,
+    OSD_IN_ARRAY(float, sWeights, 4),
+    OSD_IN_ARRAY(float, tWeights, 4),
+    OSD_IN_ARRAY(float, dsWeights, 4),
+    OSD_IN_ARRAY(float, dtWeights, 4),
+    OSD_IN_ARRAY(float, dssWeights, 4),
+    OSD_IN_ARRAY(float, dttWeights, 4),
+    OSD_OUT_ARRAY(float, wP, 16),
+    OSD_OUT_ARRAY(float, wDs, 16),
+    OSD_OUT_ARRAY(float, wDt, 16),
+    OSD_OUT_ARRAY(float, wDss, 16),
+    OSD_OUT_ARRAY(float, wDst, 16),
+    OSD_OUT_ARRAY(float, wDtt, 16)) {
+
+    if (OSD_OPTIONAL(wP)) {
+        // Compute the tensor product weight of the (s,t) basis function
+        // corresponding to each control vertex:
+
+        OsdAdjustBoundaryWeights(boundary, sWeights, tWeights);
+
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                wP[4*i+j] = sWeights[j] * tWeights[i];
+            }
+        }
+    }
+
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        // Compute the tensor product weight of the differentiated (s,t) basis
+        // function corresponding to each control vertex (scaled accordingly):
+
+        OsdAdjustBoundaryWeights(boundary, dsWeights, dtWeights);
+
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                wDs[4*i+j] = dsWeights[j] * tWeights[i] * dScale;
+                wDt[4*i+j] = sWeights[j] * dtWeights[i] * dScale;
+            }
+        }
+
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            // Compute the tensor product weight of appropriate differentiated
+            // (s,t) basis functions for each control vertex (scaled accordingly):
+            float d2Scale = dScale * dScale;
+
+            OsdAdjustBoundaryWeights(boundary, dssWeights, dttWeights);
+
+            for (int i = 0; i < 4; ++i) {
+                for (int j = 0; j < 4; ++j) {
+                    wDss[4*i+j] = dssWeights[j] * tWeights[i] * d2Scale;
+                    wDst[4*i+j] = dsWeights[j] * dtWeights[i] * d2Scale;
+                    wDtt[4*i+j] = sWeights[j] * dttWeights[i] * d2Scale;
+                }
+            }
+        }
+    }
+}
+
+// The following functions were exposed in earlier versions but have
+// been superceded by the public functions OsdEvaluatePatchBasis()
+// and OsdEvaluatePatchBasisNormalized().
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetBilinearPatchWeights(
+        OSD_REAL s, OSD_REAL t, OSD_REAL d1Scale,
+        OSD_OUT_ARRAY(OSD_REAL, wP, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDs, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDt, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDss, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDst, 4),
+        OSD_OUT_ARRAY(OSD_REAL, wDtt, 4)) {
+
+    int nPoints = Osd_EvalBasisLinear(s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        for (int i = 0; i < nPoints; ++i) {
+            wDs[i] *= d1Scale;
+            wDt[i] *= d1Scale;
+        }
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            OSD_REAL d2Scale = d1Scale * d1Scale;
+
+            for (int i = 0; i < nPoints; ++i) {
+                wDss[i] *= d2Scale;
+                wDst[i] *= d2Scale;
+                wDtt[i] *= d2Scale;
+            }
+        }
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetBSplinePatchWeights(
+    OSD_REAL s, OSD_REAL t, OSD_REAL d1Scale, int boundary,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 16)) {
+
+    int nPoints = Osd_EvalBasisBSpline(s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+    Osd_boundBasisBSpline(boundary, wP, wDs, wDt, wDss, wDst, wDtt);
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        for (int i = 0; i < nPoints; ++i) {
+            wDs[i] *= d1Scale;
+            wDt[i] *= d1Scale;
+        }
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            OSD_REAL d2Scale = d1Scale * d1Scale;
+
+            for (int i = 0; i < nPoints; ++i) {
+                wDss[i] *= d2Scale;
+                wDst[i] *= d2Scale;
+                wDtt[i] *= d2Scale;
+            }
+        }
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetBezierPatchWeights(
+    OSD_REAL s, OSD_REAL t, OSD_REAL d1Scale,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 16),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 16)) {
+    int nPoints = Osd_EvalBasisBezier(s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        for (int i = 0; i < nPoints; ++i) {
+            wDs[i] *= d1Scale;
+            wDt[i] *= d1Scale;
+        }
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            OSD_REAL d2Scale = d1Scale * d1Scale;
+
+            for (int i = 0; i < nPoints; ++i) {
+                wDss[i] *= d2Scale;
+                wDst[i] *= d2Scale;
+                wDtt[i] *= d2Scale;
+            }
+        }
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdGetGregoryPatchWeights(
+    OSD_REAL s, OSD_REAL t, OSD_REAL d1Scale,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 20)) {
+    int nPoints = Osd_EvalBasisGregory(s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        for (int i = 0; i < nPoints; ++i) {
+            wDs[i] *= d1Scale;
+            wDt[i] *= d1Scale;
+        }
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            OSD_REAL d2Scale = d1Scale * d1Scale;
+
+            for (int i = 0; i < nPoints; ++i) {
+                wDss[i] *= d2Scale;
+                wDst[i] *= d2Scale;
+                wDtt[i] *= d2Scale;
+            }
+        }
+    }
+}
+#endif // OSD_PATCH_BASIS_COMPATIBILITY
+
+#endif /* OPENSUBDIV3_OSD_PATCH_BASIS_H */

--- a/opensubdiv/osd/patchBasisCommonEval.h
+++ b/opensubdiv/osd/patchBasisCommonEval.h
@@ -1,0 +1,196 @@
+//
+//   Copyright 2018 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_EVAL_H
+#define OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_EVAL_H
+
+OSD_FUNCTION_STORAGE_CLASS
+// template <typename REAL>
+int
+OsdEvaluatePatchBasisNormalized(
+    int patchType, OsdPatchParam param,
+    OSD_REAL s, OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 20)) {
+
+    int boundaryMask = OsdPatchParamGetBoundary(param);
+
+    int nPoints = 0;
+    if (patchType == OSD_PATCH_DESCRIPTOR_REGULAR) {
+#if OSD_ARRAY_ARG_BOUND_OPTIONAL
+        nPoints = Osd_EvalBasisBSpline(s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+        if (boundaryMask != 0) {
+            Osd_boundBasisBSpline(
+                boundaryMask, wP, wDs, wDt, wDss, wDst, wDtt);
+        }
+#else
+        OSD_REAL wP16[16], wDs16[16], wDt16[16],
+                 wDss16[16], wDst16[16], wDtt16[16];
+        nPoints = Osd_EvalBasisBSpline(
+                s, t, wP16, wDs16, wDt16, wDss16, wDst16, wDtt16);
+        if (boundaryMask != 0) {
+            Osd_boundBasisBSpline(
+                boundaryMask, wP16, wDs16, wDt16, wDss16, wDst16, wDtt16);
+        }
+        for (int i=0; i<nPoints; ++i) {
+            wP[i] = wP16[i];
+            wDs[i] = wDs16[i]; wDt[i] = wDt16[i];
+            wDss[i] = wDss16[i]; wDst[i] = wDst16[i]; wDtt[i] = wDtt16[i];
+        }
+#endif
+    } else if (patchType == OSD_PATCH_DESCRIPTOR_LOOP) {
+#if OSD_ARRAY_ARG_BOUND_OPTIONAL
+        nPoints = Osd_EvalBasisBoxSplineTri(
+                s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+        if (boundaryMask != 0) {
+            Osd_boundBasisBoxSplineTri(
+                boundaryMask, wP, wDs, wDt, wDss, wDst, wDtt);
+        }
+#else
+        OSD_REAL wP12[12], wDs12[12], wDt12[12],
+                 wDss12[12], wDst12[12], wDtt12[12];
+        nPoints = Osd_EvalBasisBoxSplineTri(
+                s, t, wP12, wDs12, wDt12, wDss12, wDst12, wDtt12);
+        if (boundaryMask != 0) {
+            Osd_boundBasisBoxSplineTri(
+                boundaryMask, wP12, wDs12, wDt12, wDss12, wDst12, wDtt12);
+        }
+        for (int i=0; i<nPoints; ++i) {
+            wP[i] = wP12[i];
+            wDs[i] = wDs12[i]; wDt[i] = wDt12[i];
+            wDss[i] = wDss12[i]; wDst[i] = wDst12[i]; wDtt[i] = wDtt12[i];
+        }
+#endif
+    } else if (patchType == OSD_PATCH_DESCRIPTOR_GREGORY_BASIS) {
+        nPoints = Osd_EvalBasisGregory(s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+    } else if (patchType == OSD_PATCH_DESCRIPTOR_GREGORY_TRIANGLE) {
+#if OSD_ARRAY_ARG_BOUND_OPTIONAL
+        nPoints = Osd_EvalBasisGregoryTri(s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+#else
+        OSD_REAL wP15[15], wDs15[15], wDt15[15],
+                 wDss15[15], wDst15[15], wDtt15[15];
+        nPoints = Osd_EvalBasisGregoryTri(
+                s, t, wP15, wDs15, wDt15, wDss15, wDst15, wDtt15);
+        for (int i=0; i<nPoints; ++i) {
+            wP[i] = wP15[i];
+            wDs[i] = wDs15[i]; wDt[i] = wDt15[i];
+            wDss[i] = wDss15[i]; wDst[i] = wDst15[i]; wDtt[i] = wDtt15[i];
+        }
+#endif
+    } else if (patchType == OSD_PATCH_DESCRIPTOR_QUADS) {
+#if OSD_ARRAY_ARG_BOUND_OPTIONAL
+        nPoints = Osd_EvalBasisLinear(s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+#else
+        OSD_REAL wP4[4], wDs4[4], wDt4[4],
+                 wDss4[4], wDst4[4], wDtt4[4];
+        nPoints = Osd_EvalBasisLinear(
+                s, t, wP4, wDs4, wDt4, wDss4, wDst4, wDtt4);
+        for (int i=0; i<nPoints; ++i) {
+            wP[i] = wP4[i];
+            wDs[i] = wDs4[i]; wDt[i] = wDt4[i];
+            wDss[i] = wDss4[i]; wDst[i] = wDst4[i]; wDtt[i] = wDtt4[i];
+        }
+#endif
+    } else if (patchType == OSD_PATCH_DESCRIPTOR_TRIANGLES) {
+#if OSD_ARRAY_ARG_BOUND_OPTIONAL
+        nPoints = Osd_EvalBasisLinearTri(s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+#else
+        OSD_REAL wP3[3], wDs3[3], wDt3[3],
+                 wDss3[3], wDst3[3], wDtt3[3];
+        nPoints = Osd_EvalBasisLinearTri(
+                s, t, wP3, wDs3, wDt3, wDss3, wDst3, wDtt3);
+        for (int i=0; i<nPoints; ++i) {
+            wP[i] = wP3[i];
+            wDs[i] = wDs3[i]; wDt[i] = wDt3[i];
+            wDss[i] = wDss3[i]; wDst[i] = wDst3[i]; wDtt[i] = wDtt3[i];
+        }
+#endif
+    } else {
+        // assert(0);
+    }
+    return nPoints;
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+// template <typename REAL>
+int
+OsdEvaluatePatchBasis(
+    int patchType, OsdPatchParam param,
+    OSD_REAL s, OSD_REAL t,
+    OSD_OUT_ARRAY(OSD_REAL, wP, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 20),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 20)) {
+
+    OSD_REAL derivSign = 1.0f;
+
+    if ((patchType == OSD_PATCH_DESCRIPTOR_LOOP) ||
+        (patchType == OSD_PATCH_DESCRIPTOR_GREGORY_TRIANGLE) ||
+        (patchType == OSD_PATCH_DESCRIPTOR_TRIANGLES)) {
+        OSD_REAL uv[2] = OSD_ARRAY_2(OSD_REAL, s, t);
+        OsdPatchParamNormalizeTriangle(param, uv);
+        s = uv[0];
+        t = uv[1];
+        if (OsdPatchParamIsTriangleRotated(param)) {
+            derivSign = -1.0f;
+        }
+    } else {
+        OSD_REAL uv[2] = OSD_ARRAY_2(OSD_REAL, s, t);
+        OsdPatchParamNormalize(param, uv);
+        s = uv[0];
+        t = uv[1];
+    }
+
+    int nPoints = OsdEvaluatePatchBasisNormalized(
+        patchType, param, s, t, wP, wDs, wDt, wDss, wDst, wDtt);
+
+    if (OSD_OPTIONAL(wDs && wDt)) {
+        OSD_REAL d1Scale =
+                derivSign * OSD_REAL_CAST(1 << OsdPatchParamGetDepth(param));
+
+        for (int i = 0; i < nPoints; ++i) {
+            wDs[i] *= d1Scale;
+            wDt[i] *= d1Scale;
+        }
+
+        if (OSD_OPTIONAL(wDss && wDst && wDtt)) {
+            OSD_REAL d2Scale = derivSign * d1Scale * d1Scale;
+
+            for (int i = 0; i < nPoints; ++i) {
+                wDss[i] *= d2Scale;
+                wDst[i] *= d2Scale;
+                wDtt[i] *= d2Scale;
+            }
+        }
+    }
+    return nPoints;
+}
+
+#endif /* OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_EVAL_H */

--- a/opensubdiv/osd/patchBasisCommonTypes.h
+++ b/opensubdiv/osd/patchBasisCommonTypes.h
@@ -1,0 +1,422 @@
+//
+//   Copyright 2018 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#ifndef OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_TYPES_H
+#define OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_TYPES_H
+
+#if defined(OSD_PATCH_BASIS_GLSL)
+
+    #define OSD_FUNCTION_STORAGE_CLASS
+    #define OSD_DATA_STORAGE_CLASS
+    #define OSD_REAL float
+    #define OSD_REAL_CAST float
+    #define OSD_ARG_ARRAY_BOUND_OPTIONAL false
+    #define OSD_OPTIONAL(a) true
+    #define OSD_OPTIONAL_INIT(a,b) b
+    #define OSD_IN_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_OUT_ARRAY(elementType, identifier, arraySize) \
+            out elementType identifier[arraySize]
+    #define OSD_INOUT_ARRAY(elementType, identifier, arraySize) \
+            inout elementType identifier[arraySize]
+    #define OSD_ARRAY_2(elementType,a0,a1) \
+            elementType[](a0,a1)
+    #define OSD_ARRAY_3(elementType,a0,a1,a2) \
+            elementType[](a0,a1,a2)
+    #define OSD_ARRAY_4(elementType,a0,a1,a2,a3) \
+            elementType[](a0,a1,a2,a3)
+    #define OSD_ARRAY_6(elementType,a0,a1,a2,a3,a4,a5) \
+            elementType[](a0,a1,a2,a3,a4,a5)
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            elementType[](a0,a1,a2,a3,a4,a5,a6,a7)
+    #define OSD_ARRAY_9(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8) \
+            elementType[](a0,a1,a2,a3,a4,a5,a6,a7,a8)
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            elementType[](a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11)
+
+#elif defined(OSD_PATCH_BASIS_HLSL)
+
+    #define OSD_FUNCTION_STORAGE_CLASS
+    #define OSD_DATA_STORAGE_CLASS
+    #define OSD_REAL float
+    #define OSD_REAL_CAST float
+    #define OSD_ARG_ARRAY_BOUND_OPTIONAL false
+    #define OSD_OPTIONAL(a) true
+    #define OSD_OPTIONAL_INIT(a,b) b
+    #define OSD_IN_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_OUT_ARRAY(elementType, identifier, arraySize) \
+            out elementType identifier[arraySize]
+    #define OSD_INOUT_ARRAY(elementType, identifier, arraySize) \
+            inout elementType identifier[arraySize]
+    #define OSD_ARRAY_2(elementType,a0,a1) \
+            {a0,a1}
+    #define OSD_ARRAY_3(elementType,a0,a1,a2) \
+            {a0,a1,a2}
+    #define OSD_ARRAY_4(elementType,a0,a1,a2,a3) \
+            {a0,a1,a2,a3}
+    #define OSD_ARRAY_6(elementType,a0,a1,a2,a3,a4,a5) \
+            {a0,a1,a2,a3,a4,a5}
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            {a0,a1,a2,a3,a4,a5,a6,a7}
+    #define OSD_ARRAY_9(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8}
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
+
+#elif defined(OSD_PATCH_BASIS_CUDA)
+
+    #define OSD_FUNCTION_STORAGE_CLASS __device__
+    #define OSD_DATA_STORAGE_CLASS
+    #define OSD_REAL float
+    #define OSD_REAL_CAST float
+    #define OSD_OPTIONAL(a) true
+    #define OSD_OPTIONAL_INIT(a,b) b
+    #define OSD_ARRAY_ARG_BOUND_OPTIONAL false
+    #define OSD_IN_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_OUT_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_INOUT_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_ARRAY_2(elementType,a0,a1) \
+            {a0,a1}
+    #define OSD_ARRAY_3(elementType,a0,a1,a2) \
+            {a0,a1,a2}
+    #define OSD_ARRAY_4(elementType,a0,a1,a2,a3) \
+            {a0,a1,a2,a3}
+    #define OSD_ARRAY_6(elementType,a0,a1,a2,a3,a4,a5) \
+            {a0,a1,a2,a3,a4,a5}
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            {a0,a1,a2,a3,a4,a5,a6,a7}
+    #define OSD_ARRAY_9(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8}
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
+
+#elif defined(OSD_PATCH_BASIS_OPENCL)
+
+    #define OSD_FUNCTION_STORAGE_CLASS static
+    #define OSD_DATA_STORAGE_CLASS
+    #define OSD_REAL float
+    #define OSD_REAL_CAST convert_float
+    #define OSD_OPTIONAL(a) true
+    #define OSD_OPTIONAL_INIT(a,b) b
+    #define OSD_ARRAY_ARG_BOUND_OPTIONAL false
+    #define OSD_IN_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_OUT_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_INOUT_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_ARRAY_2(elementType,a0,a1) \
+            {a0,a1}
+    #define OSD_ARRAY_3(elementType,a0,a1,a2) \
+            {a0,a1,a2}
+    #define OSD_ARRAY_4(elementType,a0,a1,a2,a3) \
+            {a0,a1,a2,a3}
+    #define OSD_ARRAY_6(elementType,a0,a1,a2,a3,a4,a5) \
+            {a0,a1,a2,a3,a4,a5}
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            {a0,a1,a2,a3,a4,a5,a6,a7}
+    #define OSD_ARRAY_9(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8}
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
+
+#elif defined(OSD_PATCH_BASIS_METAL)
+
+    #define OSD_FUNCTION_STORAGE_CLASS
+    #define OSD_DATA_STORAGE_CLASS
+    #define OSD_REAL float
+    #define OSD_REAL_CAST float
+    #define OSD_OPTIONAL(a) true
+    #define OSD_OPTIONAL_INIT(a,b) b
+    #define OSD_ARRAY_ARG_BOUND_OPTIONAL false
+    #define OSD_IN_ARRAY(elementType, identifier, arraySize) \
+            thread elementType* identifier
+    #define OSD_OUT_ARRAY(elementType, identifier, arraySize) \
+            thread elementType* identifier
+    #define OSD_INOUT_ARRAY(elementType, identifier, arraySize) \
+            thread elementType* identifier
+    #define OSD_ARRAY_2(elementType,a0,a1) \
+            {a0,a1}
+    #define OSD_ARRAY_3(elementType,a0,a1,a2) \
+            {a0,a1,a2}
+    #define OSD_ARRAY_4(elementType,a0,a1,a2,a3) \
+            {a0,a1,a2,a3}
+    #define OSD_ARRAY_6(elementType,a0,a1,a2,a3,a4,a5) \
+            {a0,a1,a2,a3,a4,a5}
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            {a0,a1,a2,a3,a4,a5,a6,a7}
+    #define OSD_ARRAY_9(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8}
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
+
+#else
+
+    #define OSD_FUNCTION_STORAGE_CLASS static inline
+    #define OSD_DATA_STORAGE_CLASS static
+    #define OSD_REAL float
+    #define OSD_REAL_CAST float
+    #define OSD_OPTIONAL(a) (a)
+    #define OSD_OPTIONAL_INIT(a,b) (a ? b : 0)
+    #define OSD_ARRAY_ARG_BOUND_OPTIONAL true
+    #define OSD_IN_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_OUT_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_INOUT_ARRAY(elementType, identifier, arraySize) \
+            elementType identifier[arraySize]
+    #define OSD_ARRAY_2(elementType,a0,a1) \
+            {a0,a1}
+    #define OSD_ARRAY_3(elementType,a0,a1,a2) \
+            {a0,a1,a2}
+    #define OSD_ARRAY_4(elementType,a0,a1,a2,a3) \
+            {a0,a1,a2,a3}
+    #define OSD_ARRAY_6(elementType,a0,a1,a2,a3,a4,a5) \
+            {a0,a1,a2,a3,a4,a5}
+    #define OSD_ARRAY_8(elementType,a0,a1,a2,a3,a4,a5,a6,a7) \
+            {a0,a1,a2,a3,a4,a5,a6,a7}
+    #define OSD_ARRAY_9(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8}
+    #define OSD_ARRAY_12(elementType,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) \
+            {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11}
+
+#endif
+
+#if defined(OSD_PATCH_BASIS_OPENCL)
+// OpenCL binding uses typedef to provide the required "struct" type specifier.
+typedef struct OsdPatchParam OsdPatchParam;
+typedef struct OsdPatchArray OsdPatchArray;
+typedef struct OsdPatchCoord OsdPatchCoord;
+#endif
+
+// Osd reflection of Far::PatchDescriptor
+#define OSD_PATCH_DESCRIPTOR_QUADS            3
+#define OSD_PATCH_DESCRIPTOR_TRIANGLES        4
+#define OSD_PATCH_DESCRIPTOR_LOOP             5
+#define OSD_PATCH_DESCRIPTOR_REGULAR          6
+#define OSD_PATCH_DESCRIPTOR_GREGORY_BASIS    9
+#define OSD_PATCH_DESCRIPTOR_GREGORY_TRIANGLE 10
+
+// Osd reflection of Osd::PatchCoord
+struct OsdPatchCoord {
+   int arrayIndex;
+   int patchIndex;
+   int vertIndex;
+   float s;
+   float t;
+};
+
+OSD_FUNCTION_STORAGE_CLASS
+OsdPatchCoord
+OsdPatchCoordInit(
+    int arrayIndex, int patchIndex, int vertIndex, float s, float t)
+{
+    OsdPatchCoord coord;
+    coord.arrayIndex = arrayIndex;
+    coord.patchIndex = patchIndex;
+    coord.vertIndex = vertIndex;
+    coord.s = s;
+    coord.t = t;
+    return coord;
+}
+
+// Osd reflection of Osd::PatchArray
+struct OsdPatchArray {
+    int regDesc;
+    int desc;
+    int numPatches;
+    int indexBase;
+    int stride;
+    int primitiveIdBase;
+};
+
+OSD_FUNCTION_STORAGE_CLASS
+OsdPatchArray
+OsdPatchArrayInit(
+    int regDesc, int desc,
+    int numPatches, int indexBase, int stride, int primitiveIdBase)
+{
+    OsdPatchArray array;
+    array.regDesc = regDesc;
+    array.desc = desc;
+    array.numPatches = numPatches;
+    array.indexBase = indexBase;
+    array.stride = stride;
+    array.primitiveIdBase = primitiveIdBase;
+    return array;
+}
+
+// Osd reflection of Osd::PatchParam
+struct OsdPatchParam {
+    int field0;
+    int field1;
+    float sharpness;
+};
+
+OSD_FUNCTION_STORAGE_CLASS
+OsdPatchParam
+OsdPatchParamInit(int field0, int field1, float sharpness)
+{
+    OsdPatchParam param;
+    param.field0 = field0;
+    param.field1 = field1;
+    param.sharpness = sharpness;
+    return param;
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+int
+OsdPatchParamGetFaceId(OsdPatchParam param)
+{
+    return (param.field0 & 0xfffffff);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+int
+OsdPatchParamGetU(OsdPatchParam param)
+{
+    return ((param.field1 >> 22) & 0x3ff);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+int
+OsdPatchParamGetV(OsdPatchParam param)
+{
+    return ((param.field1 >> 12) & 0x3ff);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+int
+OsdPatchParamGetTransition(OsdPatchParam param)
+{
+    return ((param.field0 >> 28) & 0xf);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+int
+OsdPatchParamGetBoundary(OsdPatchParam param)
+{
+    return ((param.field1 >> 7) & 0x1f);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+int
+OsdPatchParamGetNonQuadRoot(OsdPatchParam param)
+{
+    return ((param.field1 >> 4) & 0x1);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+int
+OsdPatchParamGetDepth(OsdPatchParam param)
+{
+    return (param.field1 & 0xf);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+OSD_REAL
+OsdPatchParamGetParamFraction(OsdPatchParam param)
+{
+    return 1.0f / OSD_REAL_CAST(1 <<
+        (OsdPatchParamGetDepth(param) - OsdPatchParamGetNonQuadRoot(param)));
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+bool
+OsdPatchParamIsRegular(OsdPatchParam param)
+{
+    return (((param.field1 >> 5) & 0x1) != 0);
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+bool
+OsdPatchParamIsTriangleRotated(OsdPatchParam param)
+{
+    return ((OsdPatchParamGetU(param) + OsdPatchParamGetV(param)) >=
+            (1 << OsdPatchParamGetDepth(param)));
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdPatchParamNormalize(
+        OsdPatchParam param,
+        OSD_INOUT_ARRAY(OSD_REAL, uv, 2))
+{
+    OSD_REAL fracInv = 1.0f / OsdPatchParamGetParamFraction(param);
+
+    uv[0] = uv[0] * fracInv - OSD_REAL_CAST(OsdPatchParamGetU(param));
+    uv[1] = uv[1] * fracInv - OSD_REAL_CAST(OsdPatchParamGetV(param));
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdPatchParamUnnormalize(
+        OsdPatchParam param,
+        OSD_INOUT_ARRAY(OSD_REAL, uv, 2))
+{
+    OSD_REAL frac = OsdPatchParamGetParamFraction(param);
+
+    uv[0] = (uv[0] + OSD_REAL_CAST(OsdPatchParamGetU(param))) * frac;
+    uv[1] = (uv[1] + OSD_REAL_CAST(OsdPatchParamGetV(param))) * frac;
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdPatchParamNormalizeTriangle(
+        OsdPatchParam param,
+        OSD_INOUT_ARRAY(OSD_REAL, uv, 2))
+{
+    if (OsdPatchParamIsTriangleRotated(param)) {
+        OSD_REAL fracInv = 1.0f / OsdPatchParamGetParamFraction(param);
+
+        int depthFactor = 1 << OsdPatchParamGetDepth(param);
+        uv[0] = OSD_REAL_CAST(depthFactor - OsdPatchParamGetU(param)) - (uv[0] * fracInv);
+        uv[1] = OSD_REAL_CAST(depthFactor - OsdPatchParamGetV(param)) - (uv[1] * fracInv);
+    } else {
+        OsdPatchParamNormalize(param, uv);
+    }
+}
+
+OSD_FUNCTION_STORAGE_CLASS
+void
+OsdPatchParamUnnormalizeTriangle(
+        OsdPatchParam param,
+        OSD_INOUT_ARRAY(OSD_REAL, uv, 2))
+{
+    if (OsdPatchParamIsTriangleRotated(param)) {
+        OSD_REAL frac = OsdPatchParamGetParamFraction(param);
+
+        int depthFactor = 1 << OsdPatchParamGetDepth(param);
+        uv[0] = (OSD_REAL_CAST(depthFactor - OsdPatchParamGetU(param)) - uv[0]) * frac;
+        uv[1] = (OSD_REAL_CAST(depthFactor - OsdPatchParamGetV(param)) - uv[1]) * frac;
+    } else {
+        OsdPatchParamUnnormalize(param, uv);
+    }
+}
+
+#endif /* OPENSUBDIV3_OSD_PATCH_BASIS_COMMON_TYPES_H */


### PR DESCRIPTION
This updates the patch basis evaluation functions in Osd
to match recent changes to far/patchBasis.

This also exposes a common facility for dealing with PatchCoord,
PatchArray, and PatchParam. These are exposed as global functions
operating on struct data, since C++ style class methods are not
supported by all of the Osd shader and kernel execution envirionments.

Changes:
    - Merged far/patchBasis.cpp to osd/patchBasisCommon{,Types,Eval}.h
    - Exposed PatchCoord, PatchArray, and PatchParam to Osd kernels
    - exposed OsdEvaluatePatchBasis and OsdEvaluatePatchBasisNormalized
    - Updated CPU, TBB, Omp, CUDA, OpenCL, GLSL, HLSL, and Metal evaluators
    - Updated glFVarViewer