### PR TITLE
Minor fixes to PatchBuilders related to boundary isolation assumptions

### DIFF
--- a/opensubdiv/far/loopPatchBuilder.cpp
+++ b/opensubdiv/far/loopPatchBuilder.cpp
@@ -746,11 +746,11 @@ GregoryTriConverter<REAL>::Initialize(SourcePatch const & sourcePatch) {
             //  is discontinuous -- one is then copied from the other (unless
             //  regular)
             if (corner.numFaces > 1) {
-                if (corner.epOnBoundary || _corners[cNext].isDart) {
+                if (corner.epOnBoundary) {
                     corner.fpIsRegular = corner.fmIsRegular;
                     corner.fpIsCopied  = !corner.fpIsRegular;
                 }
-                if (corner.emOnBoundary || _corners[cPrev].isDart) {
+                if (corner.emOnBoundary) {
                     corner.fmIsRegular = corner.fpIsRegular;
                     corner.fmIsCopied  = !corner.fmIsRegular;
                 }
@@ -1201,7 +1201,7 @@ GregoryTriConverter<REAL>::getIrregularFacePointSize(
                  ?  4
                  : (1 + corner.ringPoints.GetSize());
 
-    int adjSize = (adjCorner.isSharp || (adjCorner.numFaces < 2))
+    int adjSize = (adjCorner.isSharp || (adjCorner.numFaces <= 3))
                 ? 0
                 : (1 + adjCorner.ringPoints.GetSize() - 4);
 

--- a/opensubdiv/far/patchBuilder.h
+++ b/opensubdiv/far/patchBuilder.h
@@ -117,13 +117,20 @@ public:
 //  PatchBuilder
 //
 //  This is the main class to assist the identification of limit surface
-//  patches for assembly into other, larger datatypes.  The PatchBuilder takes
-//  a const reference to a TopologyRefiner and is intended to support both
-//  adaptive and uniformly refined hierarchies.
+//  patches from faces in a TopologyRefiner for assembly into other, larger
+//  datatypes.
+//
+//  The PatchBuilder takes a const reference to a refiner and supports
+//  arbitrarily refined hierarchies, i.e. it is not restricted to uniform or
+//  adaptive refinement strategies and does not include any logic relating
+//  to the origin of the hierarchy.  It can associate a patch with any face
+//  in the hierarchy (subject to a few minimum requirements) -- leaving the
+//  decision as to which faces/patches are appropriate to its client.
 //
 //  PatchBuilder is an abstract base class with a subclass derived to support
-//  each subdivision scheme.  Only two (pure) virtual methods are required
-//  (other than the required destructor):
+//  each subdivision scheme -- as such, construction relies on a factory
+//  method to create an instance of the appropriate subclass.  Only two pure
+//  virtual methods are required (other than the required destructor):
 //
 //      - determine the patch type for a subdivision scheme given a more
 //        general basis specification (e.g. Bezier, Gregory, Linear, etc)
@@ -179,6 +186,9 @@ public:
     };
 
 public:
+    //
+    //  Public construction (via factory method) and destruction:
+    //
     static PatchBuilder* Create(TopologyRefiner const& refiner,
                                 Options const& options);
     virtual ~PatchBuilder();


### PR DESCRIPTION
These changes fix some rare bugs in the internal PatchBuilder subclasses that can occur when constructing patches from faces whose boundary features have not been isolated.

When boundary features are isolated (currently the norm), two adjacent corners of a patch that are tagged as boundaries are guaranteed to be on the same boundary edge.  This is not the case when not isolated, and more clearly tagging the boundary edges avoids misinterpeting the boundary features present.