### PR TITLE
Updated Far::PatchDescriptor methods involving "adaptive" patch types

### DIFF
--- a/opensubdiv/far/patchDescriptor.cpp
+++ b/opensubdiv/far/patchDescriptor.cpp
@@ -37,12 +37,16 @@ namespace Far {
 //
 // Lists of valid patch Descriptors for each subdivision scheme
 //
+// Historically this has only included the non-linear patch types, though
+// it is possible for linear patches to represent irregularities for both
+// Catmark and Loop, and the Bilinear scheme is adaptively refined into
+// linear quads (e.g. a pentagon becoming five quads).
+//
 
 ConstPatchDescriptorArray
 PatchDescriptor::GetAdaptivePatchDescriptors(Sdc::SchemeType type) {
 
     static PatchDescriptor _loopDescriptors[] = {
-        // XXXX work in progress !
         PatchDescriptor(LOOP),
         PatchDescriptor(GREGORY_TRIANGLE),
     };

--- a/opensubdiv/far/patchDescriptor.h
+++ b/opensubdiv/far/patchDescriptor.h
@@ -41,12 +41,6 @@ namespace Far {
 ///
 /// Uniquely identifies all the different types of patches
 ///
-/// * Uniformly subdivided meshes contain bilinear patches of either QUADS
-///   or TRIANGLES
-///
-/// * Adaptively subdivided meshes contain bicubic patches of types REGULAR,
-///   GREGORY, GREGORY_BOUNDARY, GREGORY_BASIS.
-///
 class PatchDescriptor {
 
 public:
@@ -57,12 +51,12 @@ public:
         POINTS,            ///< points (useful for cage drawing)
         LINES,             ///< lines  (useful for cage drawing)
 
-        QUADS,             ///< bilinear quads-only patches
-        TRIANGLES,         ///< bilinear triangles-only mesh
+        QUADS,             ///< 4-sided quadrilateral (bilinear)
+        TRIANGLES,         ///< 3-sided triangle
 
-        LOOP,              ///< Loop patch
+        LOOP,              ///< regular triangular patch for the Loop scheme
 
-        REGULAR,           ///< feature-adaptive bicubic patches
+        REGULAR,           ///< regular B-Spline patch for the Catmark scheme
         GREGORY,
         GREGORY_BOUNDARY,
         GREGORY_BASIS,
@@ -88,9 +82,9 @@ public:
         return (Type)_type;
     }
 
-    /// \brief Returns true if the type is an adaptive patch
+    /// \brief Returns true if the type is an adaptive (non-linear) patch
     static inline bool IsAdaptive(Type type) {
-        return (type>=LOOP && type<=GREGORY_TRIANGLE);
+        return GetNumControlVertices( type ) > 4;
     }
 
     /// \brief Returns true if the type is an adaptive patch


### PR DESCRIPTION
This change updates a few obscure Far::PatchDescriptor methods to account for current support of patches for all subdivision schemes.  The reference to "adaptive" patch types makes less sense these days (linear patches can be used in an adaptive context, non-linear patches potentially in a uniform context) so we interpret an adaptive patch type as historically non-linear.