### PR TITLE
Fixed PatchTableFactory internal option for uniform tables

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -440,7 +440,7 @@ PatchTableBuilder::PatchTableBuilder(
                                   _options.generateVaryingLocalPoints;
 
     //  Option to be made public in future:
-    bool options_generateNonLinearUniformPatches = true;
+    bool options_generateNonLinearUniformPatches = false;
 
     _buildUniformLinear = _refiner.IsUniform() && !options_generateNonLinearUniformPatches;
 


### PR DESCRIPTION
The internal setting for linear PatchTables was incorrectly initialized in #1024, producing non-linear tables by default.  This has been corrected.