### PR TITLE
Fixed bug in Far::PatchMap for rotated triangular patches

### DIFF
--- a/opensubdiv/far/patchMap.h
+++ b/opensubdiv/far/patchMap.h
@@ -181,7 +181,7 @@ PatchMap::transformUVToTriQuadrant(T const & median, T & u, T & v, bool & rotate
         u -= median;
         v -= median;
         if ((u + v) < median) {
-            rotated = true;
+            rotated = false;
             return 3;
         }
         return 0;


### PR DESCRIPTION
This change corrects a bug in the construction of a Far::PatchMap for triangular patches that occurs when building a PatchMap for a uniform PatchTable at level 3 or greater.