### PR TITLE
Assign Far::PatchParam's regular bit consistent with Osd::PatchArray

### DIFF
--- a/opensubdiv/far/patchBuilder.cpp
+++ b/opensubdiv/far/patchBuilder.cpp
@@ -1239,7 +1239,7 @@ PatchBuilder::IsRegularSingleCreasePatch(int levelIndex, Index faceIndex,
 
 PatchParam
 PatchBuilder::ComputePatchParam(int levelIndex, Index faceIndex,
-        PtexIndices const& ptexIndices,
+        PtexIndices const& ptexIndices, bool isRegular,
         int boundaryMask, bool computeTransitionMask) const {
 
     // Move up the hierarchy accumulating u,v indices to the coarse level:
@@ -1348,7 +1348,8 @@ PatchBuilder::ComputePatchParam(int levelIndex, Index faceIndex,
 
     PatchParam param;
     param.Set(ptexIndex, (short)u, (short)v, (unsigned short) depth, irregBase,
-              (unsigned short) boundaryMask, (unsigned short) transitionMask);
+              (unsigned short) boundaryMask, (unsigned short) transitionMask,
+              (unsigned short) isRegular);
     return param;
 }
 

--- a/opensubdiv/far/patchBuilder.h
+++ b/opensubdiv/far/patchBuilder.h
@@ -268,7 +268,7 @@ public:
     //  data to accelerate these computations.
     //
     PatchParam ComputePatchParam(int level, Index face,
-            PtexIndices const& ptexIndices,
+            PtexIndices const& ptexIndices, bool isRegular = true,
             int boundaryMask = 0, bool computeTransitionMask = false) const;
 
 protected:

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1228,7 +1228,7 @@ PatchTableBuilder::populatePatches() {
         //
         PatchParam patchParam =
             _patchBuilder->ComputePatchParam(patch.levelIndex, patch.faceIndex,
-                  _ptexIndices, patchInfo.paramBoundaryMask,
+                  _ptexIndices, patchInfo.isRegular, patchInfo.paramBoundaryMask,
                   patchInfo.isRegular /* condition to compute transition mask */);
         *arrayBuilder->pptr++ = patchParam;
 


### PR DESCRIPTION
With patch evaluation in both Far and Osd relying more on the "IsRegular" bit of Far::PatchParam, the bits of the PatchParams for the regular and irregular arrays in a PatchTable have been updated to reflect that regular/irregular status.  The PatchBuilder method most often used to initialize the PatchParam of each patch was extended to optionally specify the value of the regular bit and its usage updated to do so.
