### PR TITLE
Fixed triangular patches at interior infinitely sharp edges

### DIFF
--- a/opensubdiv/far/patchBuilder.cpp
+++ b/opensubdiv/far/patchBuilder.cpp
@@ -766,9 +766,9 @@ PatchBuilder::GetRegularPatchBoundaryMask(int levelIndex, Index faceIndex,
     //  the encoded result of the two sets of 3 bits:
     //
     Level::VTag vFeatureTag(0);
-    vFeatureTag._boundary    = true;
-    vFeatureTag._infSharp    = testInfSharpFeatures;
-    vFeatureTag._nonManifold = true;
+    vFeatureTag._boundary      = true;
+    vFeatureTag._infSharpEdges = testInfSharpFeatures;
+    vFeatureTag._nonManifold   = true;
 
     int vFeatureMask = vFeatureTag.getBits();
 


### PR DESCRIPTION
This change fixes a regression for triangular patches that cropped up when simplifying the topological analysis of patches.  When determining the boundary mask of a triangular patch whose apex lies on an interior infinitely sharp edge, the bit indicating the vertex has incident inf-sharp edges should be used rather than the bit indicating the vertex itself is inf-sharp.