### PR TITLE
Patch construction and more regression shapes for Bilinear scheme

### DIFF
--- a/regression/shapes/all.h
+++ b/regression/shapes/all.h
@@ -99,6 +99,9 @@
 #include "catmark_torus_creases1.h"
 
 #include "bilinear_cube.h"
+#include "bilinear_nonplanar.h"
+#include "bilinear_nonquads0.h"
+#include "bilinear_nonquads1.h"
 
 #include "loop_cube_creases0.h"
 #include "loop_cube_creases1.h"

--- a/regression/shapes/bilinear_nonplanar.h
+++ b/regression/shapes/bilinear_nonplanar.h
@@ -1,0 +1,45 @@
+//
+//   Copyright 2018 DreamWorks Animation LLC.
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+static const std::string bilinear_nonplanar = 
+"\n"
+"v -0.6 -0.5 -0.4\n"
+"v -0.1  0.0  0.4\n"
+"v -0.6  0.5 -0.4\n"
+"v -1.1  0.0  0.4\n"
+"v  0.6 -0.5 -0.4\n"
+"v  1.1  0.0  0.4\n"
+"v  0.6  0.5 -0.4\n"
+"v  0.1  0.0  0.4\n"
+"\n"
+"vt 0 0\n"
+"vt 1 0\n"
+"vt 1 1\n"
+"vt 0 1\n"
+"\n"
+"f 1/1 2/2 3/3 4/4\n"
+"f 6/2 7/3 8/4 5/1\n"
+"\n"
+"t interpolateboundary 1/0/0 1\n"
+;

--- a/regression/shapes/bilinear_nonquads0.h
+++ b/regression/shapes/bilinear_nonquads0.h
@@ -1,0 +1,49 @@
+//
+//   Copyright 2018 DreamWorks Animation LLC.
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+static const std::string bilinear_nonquads0 = 
+"\n"
+"v -2.05  0 -0.88\n"
+"v -0.05  0 -0.88\n"
+"v -1.05  0  0.85\n"
+"v  0.41  0 -0.91\n"
+"v  1.59  0 -0.91\n"
+"v  1.95  0  0.21\n"
+"v  1.00  0  0.90\n"
+"v  0.05  0  0.21\n"
+"\n"
+"vt 0.0  0.0\n"
+"vt 1.0  0.0\n"
+"vt 0.5  1.0\n"
+"vt 0.20 0.05\n"
+"vt 0.74 0.05\n"
+"vt 0.98 0.58\n"
+"vt 0.50 0.95\n"
+"vt 0.02 0.58\n"
+"\n"
+"f 1/1 2/2 3/3\n"
+"f 4/4 5/5 6/6 7/7 8/8\n"
+"\n"
+"t interpolateboundary 1/0/0 1\n"
+;

--- a/regression/shapes/bilinear_nonquads1.h
+++ b/regression/shapes/bilinear_nonquads1.h
@@ -1,0 +1,82 @@
+//
+//   Copyright 2018 DreamWorks Animation LLC.
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+static const std::string bilinear_nonquads1 = 
+"\n"
+"v  0.80  0.0  -0.9\n"
+"v  0.0   0.0  -0.9\n"
+"v  0.40  0.0  -1.2\n"
+"v  0.80  0.35 -0.5\n"
+"v  0.80  0.0   0.9\n"
+"v -0.50  0.0  -0.9\n"
+"v -0.50  0.0  -0.5\n"
+"v  0.0   0.0  -0.5\n"
+"v  0.0   0.35 -0.2\n"
+"v -0.50  0.35 -0.2\n"
+"v -0.0   0.0   0.5\n"
+"v -0.50  0.0   0.5\n"
+"v  0.40  0.35 -0.2\n"
+"v -0.0   0.0   0.9\n"
+"v -0.50  0.0   0.9\n"
+"v  0.40  0.0   1.2\n"
+"v -0.0   0.35  0.2\n"
+"v  0.80  0.35  0.5\n"
+"v  0.40  0.35  0.2\n"
+"v -0.50  0.35  0.2\n"
+"\n"
+"vt 0.80 0.2\n"
+"vt 0.40 0.2\n"
+"vt 0.60 0.1\n"
+"vt 0.80 0.33\n"
+"vt 0.80 0.8\n"
+"vt 0.15 0.2\n"
+"vt 0.15 0.33\n"
+"vt 0.40 0.33\n"
+"vt 0.40 0.43\n"
+"vt 0.15 0.43\n"
+"vt 0.40 0.67\n"
+"vt 0.15 0.67\n"
+"vt 0.60 0.43\n"
+"vt 0.40 0.8\n"
+"vt 0.15 0.8\n"
+"vt 0.60 0.9\n"
+"vt 0.40 0.57\n"
+"vt 0.80 0.67\n"
+"vt 0.60 0.57\n"
+"vt 0.15 0.57\n"
+"\n"
+"f 13/13 9/9 8/8\n"
+"f 11/11 17/17 19/19\n"
+"f 11/11 12/12 20/20 17/17\n"
+"f 7/7 6/6 2/2 8/8\n"
+"f 9/9 10/10 7/7 8/8\n"
+"f 14/14 15/15 12/12 11/11\n"
+"f 18/18 5/5 16/16 14/14 11/11 19/19\n"
+"f 2/2 3/3 1/1 4/4 13/13 8/8\n"
+"f 4/4 18/18 19/19 13/13\n"
+"f 17/17 20/20 10/10 9/9\n"
+"f 19/19 17/17 9/9 13/13\n"
+"\n"
+"t interpolateboundary 1/0/0 1\n"
+;


### PR DESCRIPTION
This change completes adaptive generation of patches for the Bilinear scheme and includes new regression/shapes.

For non-quad faces the patch generation needed adjustment to exclude incomplete faces that are generated at level 1 from the adaptive refinement -- that made it easier to consider Bilinear with other schemes and simplify patch inspection in terms of base and refined faces.

The new regression shapes include two exhibiting non-quads and one with highly non-planar quads.  These will be included in some of the example programs in conjunction with other work on those examples.
