### PR TITLE
Fix construction of face-varying patches around non-manifold vertices

### DIFF
--- a/opensubdiv/vtr/fvarLevel.h
+++ b/opensubdiv/vtr/fvarLevel.h
@@ -403,7 +403,8 @@ FVarLevel::ValueTag::combineWithLevelVTag(Level::VTag levelTag) const
 
         levelTag._boundary = true;
         levelTag._xordinary = this->_xordinary;
-        levelTag._nonManifold = this->_nonManifold;
+
+        levelTag._nonManifold |= this->_nonManifold;
     }
     return levelTag;
 }


### PR DESCRIPTION
With the recent removal of the restriction that patches around non-manifold vertices be regular, face-varying patches whose topology does not match warrants a little more care.  Regardless of the face-varying topology, the fact that the vertex is non-manifold makes is necessary to perform a non-manifold search for the span containing the face of the patch.  So the initialization of the face-varying tags is updated here to ensure that the non-manifold bit of the vertex is always included to trigger the appropriate search.