### PR TITLE
Extended triangular Gregory patch to full quartic

### DIFF
--- a/opensubdiv/far/patchBasis.h
+++ b/opensubdiv/far/patchBasis.h
@@ -76,7 +76,7 @@ int EvalBasisLinearTri(REAL s, REAL t,
 
 template <typename REAL>
 int EvalBasisBezierTri(REAL s, REAL t,
-    REAL wP[12], REAL wDs[12] = 0, REAL wDt[12] = 0, REAL wDss[12] = 0, REAL wDst[12] = 0, REAL wDtt[12] = 0);
+    REAL wP[15], REAL wDs[15] = 0, REAL wDt[15] = 0, REAL wDss[15] = 0, REAL wDst[15] = 0, REAL wDtt[15] = 0);
 
 template <typename REAL>
 int EvalBasisBoxSplineTri(REAL s, REAL t,
@@ -84,7 +84,7 @@ int EvalBasisBoxSplineTri(REAL s, REAL t,
 
 template <typename REAL>
 int EvalBasisGregoryTri(REAL s, REAL t,
-    REAL wP[15], REAL wDs[15] = 0, REAL wDt[15] = 0, REAL wDss[15] = 0, REAL wDst[15] = 0, REAL wDtt[15] = 0);
+    REAL wP[18], REAL wDs[18] = 0, REAL wDt[18] = 0, REAL wDss[18] = 0, REAL wDst[18] = 0, REAL wDtt[18] = 0);
 
 
 //

--- a/opensubdiv/far/patchDescriptor.h
+++ b/opensubdiv/far/patchDescriptor.h
@@ -149,7 +149,7 @@ PatchDescriptor::GetNumControlVertices( Type type ) {
         case GREGORY           :
         case GREGORY_BOUNDARY  : return GetGregoryPatchSize();
         case GREGORY_BASIS     : return GetGregoryBasisPatchSize();
-        case GREGORY_TRIANGLE  : return 15;
+        case GREGORY_TRIANGLE  : return 18;
         case TRIANGLES         : return 3;
         case LINES             : return 2;
         case POINTS            : return 1;

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1644,11 +1644,13 @@ namespace {
                 { 0, 0, 1, 0, 0, 1, 1, 2, 2, 1, 2, 2 };
         static int const gregoryIndices[] =
                 { 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3 };
+        static int const gregoryTriIndices[] =
+                { 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 0, 1, 2 };
 
         if (type == PatchDescriptor::GREGORY_BASIS) {
             return gregoryIndices;
         } else if (type == PatchDescriptor::GREGORY_TRIANGLE) {
-            return gregoryIndices;
+            return gregoryTriIndices;
         } else if (type == PatchDescriptor::REGULAR) {
             return bsplineIndices;
         } else if (type == PatchDescriptor::LOOP) {

--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -1148,7 +1148,7 @@ OsdEvalPatchBezierTriangle(ivec3 patchParam, vec2 UV,
 }
 
 void
-OsdEvalPatchGregoryTriangle(ivec3 patchParam, vec2 UV, vec3 cv[15],
+OsdEvalPatchGregoryTriangle(ivec3 patchParam, vec2 UV, vec3 cv[18],
                             out vec3 P, out vec3 dPu, out vec3 dPv,
                             out vec3 N, out vec3 dNu, out vec3 dNv)
 {
@@ -1167,16 +1167,16 @@ OsdEvalPatchGregoryTriangle(ivec3 patchParam, vec2 UV, vec3 cv[15],
     bezcv[10].P = (dwu == 0.0) ? cv[13] : ((w*cv[13] + u*cv[14]) / dwu);
 
     bezcv[ 0].P = cv[ 0];
-    bezcv[ 1].P = 0.25*cv[ 0] + 0.75*cv[ 1];
-    bezcv[ 2].P = 0.5 *cv[ 1] + 0.5 *cv[ 7];
-    bezcv[ 3].P = 0.25*cv[ 5] + 0.75*cv[ 7];
+    bezcv[ 1].P = cv[ 1];
+    bezcv[ 2].P = cv[15];
+    bezcv[ 3].P = cv[ 7];
     bezcv[ 4].P = cv[ 5];
-    bezcv[ 5].P = 0.25*cv[ 0] + 0.75*cv[ 2];
-    bezcv[ 8].P = 0.25*cv[ 5] + 0.75*cv[ 6];
-    bezcv[ 9].P = 0.5 *cv[ 2] + 0.5 *cv[11];
-    bezcv[11].P = 0.5 *cv[ 6] + 0.5 *cv[12];
-    bezcv[12].P = 0.25*cv[10] + 0.75*cv[11];
-    bezcv[13].P = 0.25*cv[10] + 0.75*cv[12];
+    bezcv[ 5].P = cv[ 2];
+    bezcv[ 8].P = cv[ 6];
+    bezcv[ 9].P = cv[17];
+    bezcv[11].P = cv[16];
+    bezcv[12].P = cv[11];
+    bezcv[13].P = cv[12];
     bezcv[14].P = cv[10];
 
     OsdEvalPatchBezierTriangle(patchParam, UV, bezcv, P, dPu, dPv, N, dNu, dNv);

--- a/opensubdiv/osd/glslPatchCommonTess.glsl
+++ b/opensubdiv/osd/glslPatchCommonTess.glsl
@@ -368,46 +368,6 @@ OsdGetTessLevelsLimitPointsTriangle(vec3 cv[15],
     }
 }
 
-void
-OsdGetTessLevelsLimitPointsGregoryTriangle(vec3 cv[15],
-                 ivec3 patchParam, out vec4 tessOuterLo, out vec4 tessOuterHi)
-{
-    // Each edge of a transition patch is adjacent to one or two patches
-    // at the next refined level of subdivision. When the patch control
-    // points have been converted to the Bezier basis, the control points
-    // at the corners are on the limit surface (since a Bezier patch
-    // interpolates its corner control points). We can compute an adaptive
-    // tessellation level for transition edges on the limit surface by
-    // evaluating a limit position at the mid point of each transition edge.
-
-    tessOuterLo = vec4(0);
-    tessOuterHi = vec4(0);
-
-    int transitionMask = OsdGetPatchTransitionMask(patchParam);
-
-    if ((transitionMask & 4) != 0) {
-        vec3 P = Osd_EvalBezierCurveMidPoint(cv[0], cv[2], cv[11], cv[10]);
-        tessOuterLo[0] = OsdComputeTessLevel(cv[0], P);
-        tessOuterHi[0] = OsdComputeTessLevel(cv[10], P);
-    } else {
-        tessOuterLo[0] = OsdComputeTessLevel(cv[0], cv[10]);
-    }
-    if ((transitionMask & 1) != 0) {
-        vec3 P = Osd_EvalBezierCurveMidPoint(cv[0], cv[1], cv[7], cv[5]);
-        tessOuterLo[1] = OsdComputeTessLevel(cv[0], P);
-        tessOuterHi[1] = OsdComputeTessLevel(cv[5], P);
-    } else {
-        tessOuterLo[1] = OsdComputeTessLevel(cv[0], cv[5]);
-    }
-    if ((transitionMask & 2) != 0) {
-        vec3 P = Osd_EvalBezierCurveMidPoint(cv[5], cv[6], cv[12], cv[10]);
-        tessOuterLo[2] = OsdComputeTessLevel(cv[10], P);
-        tessOuterHi[2] = OsdComputeTessLevel(cv[5], P);
-    } else {
-        tessOuterLo[2] = OsdComputeTessLevel(cv[5], cv[10]);
-    }
-}
-
 // Round up to the nearest even integer
 float OsdRoundUpEven(float x) {
     return 2*ceil(x/2);
@@ -572,19 +532,6 @@ OsdGetTessLevelsAdaptiveLimitPointsTriangle(vec3 cv[15],
 
     OsdComputeTessLevelsTriangle(tessOuterLo, tessOuterHi,
                                  tessLevelOuter, tessLevelInner);
-}
-
-void
-OsdGetTessLevelsAdaptiveLimitPointsGregoryTriangle(vec3 cv[15],
-                 ivec3 patchParam,
-                 out vec4 tessLevelOuter, out vec2 tessLevelInner,
-                 out vec4 tessOuterLo, out vec4 tessOuterHi)
-{
-    OsdGetTessLevelsLimitPointsGregoryTriangle(cv, patchParam,
-                                tessOuterLo, tessOuterHi);
-
-    OsdComputeTessLevelsTriangle(tessOuterLo, tessOuterHi,
-                         tessLevelOuter, tessLevelInner);
 }
 
 void

--- a/opensubdiv/osd/glslPatchGregoryTriangle.glsl
+++ b/opensubdiv/osd/glslPatchGregoryTriangle.glsl
@@ -59,9 +59,9 @@ in block {
 out block {
     OsdPerPatchVertexBezier v;
     OSD_USER_VARYING_DECLARE
-} outpt[15];
+} outpt[18];
 
-layout(vertices = 15) out;
+layout(vertices = 18) out;
 
 void main()
 {
@@ -82,7 +82,7 @@ void main()
         vec4 tessLevelOuter = vec4(0);
         vec2 tessLevelInner = vec2(0);
 
-        OSD_PATCH_CULL(15);
+        OSD_PATCH_CULL(18);
 
         OsdGetTessLevelsUniformTriangle(patchParam,
                          tessLevelOuter, tessLevelInner,
@@ -91,10 +91,23 @@ void main()
 #if defined OSD_ENABLE_SCREENSPACE_TESSELLATION
         // Gather bezier control points to compute limit surface tess levels
         vec3 cv[15];
-        for (int i=0; i<15; ++i) {
-            cv[i] = outpt[i].v.P;
-        }
-        OsdGetTessLevelsAdaptiveLimitPointsGregoryTriangle(
+        cv[ 0] = outpt[ 0].v.P;
+        cv[ 1] = outpt[ 1].v.P;
+        cv[ 2] = outpt[15].v.P;
+        cv[ 3] = outpt[ 7].v.P;
+        cv[ 4] = outpt[ 5].v.P;
+        cv[ 5] = outpt[ 2].v.P;
+        cv[ 6] = outpt[ 3].v.P;
+        cv[ 7] = outpt[ 8].v.P;
+        cv[ 8] = outpt[ 6].v.P;
+        cv[ 9] = outpt[17].v.P;
+        cv[10] = outpt[13].v.P;
+        cv[11] = outpt[16].v.P;
+        cv[12] = outpt[11].v.P;
+        cv[13] = outpt[12].v.P;
+        cv[14] = outpt[10].v.P;
+
+        OsdGetTessLevelsAdaptiveLimitPointsTriangle(
 		         cv, patchParam,
                          tessLevelOuter, tessLevelInner,
                          tessOuterLo, tessOuterHi);
@@ -144,8 +157,8 @@ void main()
     vec3 P = vec3(0), dPu = vec3(0), dPv = vec3(0);
     vec3 N = vec3(0), dNu = vec3(0), dNv = vec3(0);
 
-    vec3 cv[15];
-    for (int i = 0; i < 15; ++i) {
+    vec3 cv[18];
+    for (int i = 0; i < 18; ++i) {
         cv[i] = inpt[i].v.P;
     }
 

--- a/opensubdiv/osd/patchBasisCommon.h
+++ b/opensubdiv/osd/patchBasisCommon.h
@@ -838,15 +838,15 @@ Osd_EvalBasisBoxSplineTri(OSD_REAL s, OSD_REAL t,
     void
     Osd_evalBezierTriDerivWeights(
         OSD_REAL s, OSD_REAL t, int ds, int dt,
-        OSD_OUT_ARRAY(OSD_REAL, wB, 12)) {
+        OSD_OUT_ARRAY(OSD_REAL, wB, 15)) {
 
         OSD_REAL u  = s;
         OSD_REAL v  = t;
         OSD_REAL w  = 1 - u - v;
 
-        OSD_REAL u2 = u * u;
-        OSD_REAL v2 = v * v;
-        OSD_REAL w2 = w * w;
+        OSD_REAL uu = u * u;
+        OSD_REAL vv = v * v;
+        OSD_REAL ww = w * w;
 
         OSD_REAL uv = u * v;
         OSD_REAL vw = v * w;
@@ -854,110 +854,104 @@ Osd_EvalBasisBoxSplineTri(OSD_REAL s, OSD_REAL t,
 
         int totalOrder = ds + dt;
         if (totalOrder == 0) {
-            wB[0]  = w*w2;
-            wB[3]  = u*u2;
-            wB[11] = v*v2;
-
-            wB[1]  =  3 * uw * (uw + w2);
-            wB[2]  =  3 * uw * (uw + u2);
-
-            wB[7]  =  3 * uv * (uv + u2);
-            wB[10] =  3 * uv * (uv + v2);
-
-            wB[8]  =  3 * vw * (vw + v2);
-            wB[4]  =  3 * vw * (vw + w2);
-
-            wB[5]  = 12 * w2 * uv;
-            wB[6]  = 12 * u2 * vw;
-            wB[9]  = 12 * v2 * uw;
+            wB[0]  =      ww * ww;
+            wB[1]  =  4 * uw * ww;
+            wB[2]  =  6 * uw * uw;
+            wB[3]  =  4 * uw * uu;
+            wB[4]  =      uu * uu;
+            wB[5]  =  4 * vw * ww;
+            wB[6]  = 12 * ww * uv;
+            wB[7]  = 12 * uu * vw;
+            wB[8]  =  4 * uv * uu;
+            wB[9]  =  6 * vw * vw;
+            wB[10] = 12 * vv * uw;
+            wB[11] =  6 * uv * uv;
+            wB[12] =  4 * vw * vv;
+            wB[13] =  4 * uv * vv;
+            wB[14] =      vv * vv;
         } else if (totalOrder == 1) {
-            if (ds != 0) {
-                wB[0]  = -3 * w2;
-                wB[3]  =  3 * u2;
-                wB[11] =  0;
-
-                wB[1]  =  3 * w * (w2 - uw - 2*u2);
-                wB[2]  = -3 * u * (u2 - uw - 2*w2);
-
-                wB[7]  =  9 * u2*v + 6 * u*v2;
-                wB[10] =  3 * v*v2 + 6 * u*v2;
-
-                wB[8]  = -3 * v*v2 - 6 * v2*w;
-                wB[4]  = -9 * v*w2 - 6 * v2*w;
-
-                wB[5]  = 12 * vw * (w - 2*u);
-                wB[6]  = 12 * uv * (2*w - u);
-                wB[9]  = 12 * v2 * (w - u);
+            if (ds == 1) {
+                wB[0]  =  -4 * ww * w;
+                wB[1]  =   4 * ww * (w - 3 * u);
+                wB[2]  =  12 * uw * (w - u);
+                wB[3]  =   4 * uu * (3 * w - u);
+                wB[4]  =   4 * uu * u;
+                wB[5]  = -12 * vw * w;
+                wB[6]  =  12 * vw * (w - 2 * u);
+                wB[7]  =  12 * uv * (2 * w - u);
+                wB[8]  =  12 * uv * u;
+                wB[9]  = -12 * vv * w;
+                wB[10] =  12 * vv * (w - u);
+                wB[11] =  12 * vv * u;
+                wB[12] =  -4 * vv * v;
+                wB[13] =   4 * vv * v;
+                wB[14] =   0;
             } else {
-                wB[0]  = -3 * w2;
-                wB[3]  =  0;
-                wB[11] =  3 * v2;
-
-                wB[1]  = -9 * u*w2 - 6 * u2*w;
-                wB[2]  = -3 * u*u2 - 6 * u2*w;
-
-                wB[7]  =  3 * u*u2 + 6 * u2*v;
-                wB[10] =  9 * u*v2 + 6 * u2*v;
-
-                wB[8]  = -3 * v * (v2 - vw - 2*w2);
-                wB[4]  =  3 * w * (w2 - vw - 2*v2);
-
-                wB[5]  = 12 * uw * (w - 2*v);
-                wB[6]  = 12 * u2 * (w - v);
-                wB[9]  = 12 * uv * (2*w - v);
+                wB[0]  =  -4 * ww * w;
+                wB[1]  = -12 * ww * u;
+                wB[2]  = -12 * uu * w;
+                wB[3]  =  -4 * uu * u;
+                wB[4]  =   0;
+                wB[5]  =   4 * ww * (w - 3 * v);
+                wB[6]  =  12 * uw * (w - 2 * v);
+                wB[7]  =  12 * uu * (w - v);
+                wB[8]  =   4 * uu * u;
+                wB[9]  =  12 * vw * (w - v);
+                wB[10] =  12 * uv * (2 * w - v);
+                wB[11] =  12 * uv * u;;
+                wB[12] =   4 * vv * (3 * w - v);
+                wB[13] =  12 * vv * u;
+                wB[14] =   4 * vv * v;
             }
         } else if (totalOrder == 2) {
             if (ds == 2) {
-                wB[0]  =  6 * w;
-                wB[3]  =  6 * u;
-                wB[11] =  0;
-
-                wB[1]  =  6 * (u2 - uw - 2*w2);
-                wB[2]  =  6 * (w2 - uw - 2*u2);
-
-                wB[7]  =  6 * v2 + 18 * uv;
-                wB[10] =  6 * v2;
-
-                wB[8]  =  6 * v2;
-                wB[4]  =  6 * v2 + 18 * vw;
-
-                wB[5]  =  24 * (uv - 2*vw);
-                wB[6]  =  24 * (vw - 2*uv);
-                wB[9]  = -24 *  v2;
+                wB[0]  =  12 * ww;
+                wB[1]  =  24 * (uw - ww);
+                wB[2]  =  12 * (uu - 4 * uw + ww);
+                wB[3]  =  24 * (uw - uu);
+                wB[4]  =  12 * uu;
+                wB[5]  =  24 * vw;
+                wB[6]  =  24 * (uv - 2 * vw);
+                wB[7]  =  24 * (vw - 2 * uv);
+                wB[8]  =  24 * uv;
+                wB[9]  =  12 * vv;
+                wB[10] = -24 * vv;
+                wB[11] =  12 * vv;
+                wB[12] =   0;
+                wB[13] =   0;
+                wB[14] =   0;
             } else if (dt == 2) {
-                wB[0]  =  6 * w;
-                wB[3]  =  0;
-                wB[11] =  6 * v;
-
-                wB[1]  =  6 * u2 + 18 * uw;
-                wB[2]  =  6 * u2;
-
-                wB[7]  =  6 * u2;
-                wB[10] =  6 * u2 + 18 * uv;
-
-                wB[8]  =  6 * (w2 - vw - 2*v2);
-                wB[4]  =  6 * (v2 - vw - 2*w2);
-
-                wB[5]  =  24 * (uv - 2*uw);
-                wB[6]  = -24 *  u2;
-                wB[9]  =  24 * (uw - 2*uv);
+                wB[0]  =  12 * ww;
+                wB[1]  =  24 * uw;
+                wB[2]  =  12 * uu;
+                wB[3]  =   0;
+                wB[4]  =   0;
+                wB[5]  =  24 * (vw - ww);
+                wB[6]  =  24 * (uv - 2 * uw);
+                wB[7]  = -24 * uu;
+                wB[8]  =   0;
+                wB[9]  =  12 * (vv - 4 * vw + ww);
+                wB[10] =  24 * (uw - 2 * uv);
+                wB[11] =  12 * uu;
+                wB[12] =  24 * (vw - vv);
+                wB[13] =  24 * uv;
+                wB[14] =  12 * vv;
             } else {
-                wB[0]  =  6 * w;
-                wB[3]  =  0;
-                wB[11] =  0;
-
-                wB[1]  =  6 * (u2 +   uw - 1.5f*w2);
-                wB[2]  = -3 * (u2 + 4*uw);
-
-                wB[7]  =  9 * u2 + 12 * uv;
-                wB[10] =  9 * v2 + 12 * uv;
-
-                wB[8]  = -3 * (v2 + 4*vw);
-                wB[4]  =  6 * (v2 +   vw - 1.5f*w2);
-
-                wB[5]  =  24 * (uv - vw - uw + 0.5f*w2);
-                wB[6]  = -24 * (uv - uw      + 0.5f*u2);
-                wB[9]  = -24 * (uv - vw      + 0.5f*v2);
+                wB[0]  =  12 * ww;
+                wB[3]  = -12 * uu;
+                wB[13] =  12 * vv;
+                wB[11] =  24 * uv;
+                wB[1]  =  24 * uw - wB[0];
+                wB[2]  = -24 * uw - wB[3];
+                wB[5]  =  24 * vw - wB[0];
+                wB[6]  = -24 * vw + wB[11] - wB[1];
+                wB[8]  = - wB[3];
+                wB[7]  = -(wB[11] + wB[2]);
+                wB[9]  =   wB[13] - wB[5] - wB[0];
+                wB[10] = -(wB[9] + wB[11]);
+                wB[12] = - wB[13];
+                wB[4]  =   0;
+                wB[14] =   0;
             }
         } else {
             // assert(totalOrder <= 2);
@@ -969,12 +963,12 @@ OSD_FUNCTION_STORAGE_CLASS
 // template <typename REAL>
 int
 Osd_EvalBasisBezierTri(OSD_REAL s, OSD_REAL t,
-    OSD_OUT_ARRAY(OSD_REAL, wP, 12),
-    OSD_OUT_ARRAY(OSD_REAL, wDs, 12),
-    OSD_OUT_ARRAY(OSD_REAL, wDt, 12),
-    OSD_OUT_ARRAY(OSD_REAL, wDss, 12),
-    OSD_OUT_ARRAY(OSD_REAL, wDst, 12),
-    OSD_OUT_ARRAY(OSD_REAL, wDtt, 12)) {
+    OSD_OUT_ARRAY(OSD_REAL, wP, 15),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 15),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 15),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 15),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 15),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 15)) {
 
     if (OSD_OPTIONAL(wP)) {
         Osd_evalBezierTriDerivWeights(s, t, 0, 0, wP);
@@ -989,40 +983,44 @@ Osd_EvalBasisBezierTri(OSD_REAL s, OSD_REAL t,
             Osd_evalBezierTriDerivWeights(s, t, 0, 2, wDtt);
         }
     }
-    return 12;
+    return 15;
 }
 
 
 // namespace {
     //
-    //  Expanding a set of 12 Bezier basis functions for the 6 (3 pairs) of
-    //  rational weights for the 15 Gregory basis functions:
+    //  Expanding a set of 15 Bezier basis functions for the 6 (3 pairs) of
+    //  rational weights for the 18 Gregory basis functions:
     //
     OSD_FUNCTION_STORAGE_CLASS
     // template <typename REAL>
     void
     Osd_convertBezierWeightsToGregory(
-        OSD_INOUT_ARRAY(OSD_REAL, wB, 12),
+        OSD_INOUT_ARRAY(OSD_REAL, wB, 15),
         OSD_INOUT_ARRAY(OSD_REAL, rG,  6),
-        OSD_OUT_ARRAY(OSD_REAL, wG, 15)) {
+        OSD_OUT_ARRAY(OSD_REAL, wG, 18)) {
 
         wG[0]  = wB[0];
         wG[1]  = wB[1];
-        wG[2]  = wB[4];
-        wG[3]  = wB[5] * rG[0];
-        wG[4]  = wB[5] * rG[1];
+        wG[2]  = wB[5];
+        wG[3]  = wB[6] * rG[0];
+        wG[4]  = wB[6] * rG[1];
 
-        wG[5]  = wB[3];
-        wG[6]  = wB[7];
-        wG[7]  = wB[2];
-        wG[8]  = wB[6] * rG[2];
-        wG[9]  = wB[6] * rG[3];
+        wG[5]  = wB[4];
+        wG[6]  = wB[8];
+        wG[7]  = wB[3];
+        wG[8]  = wB[7] * rG[2];
+        wG[9]  = wB[7] * rG[3];
 
-        wG[10] = wB[11];
-        wG[11] = wB[8];
-        wG[12] = wB[10];
-        wG[13] = wB[9] * rG[4];
-        wG[14] = wB[9] * rG[5];
+        wG[10] = wB[14];
+        wG[11] = wB[12];
+        wG[12] = wB[13];
+        wG[13] = wB[10] * rG[4];
+        wG[14] = wB[10] * rG[5];
+
+        wG[15] = wB[2];
+        wG[16] = wB[11];
+        wG[17] = wB[9];
     }
 // } // end namespace
 
@@ -1030,19 +1028,19 @@ OSD_FUNCTION_STORAGE_CLASS
 // template <typename REAL>
 int
 Osd_EvalBasisGregoryTri(OSD_REAL s, OSD_REAL t,
-    OSD_OUT_ARRAY(OSD_REAL, wP, 15),
-    OSD_OUT_ARRAY(OSD_REAL, wDs, 15),
-    OSD_OUT_ARRAY(OSD_REAL, wDt, 15),
-    OSD_OUT_ARRAY(OSD_REAL, wDss, 15),
-    OSD_OUT_ARRAY(OSD_REAL, wDst, 15),
-    OSD_OUT_ARRAY(OSD_REAL, wDtt, 15)) {
+    OSD_OUT_ARRAY(OSD_REAL, wP, 18),
+    OSD_OUT_ARRAY(OSD_REAL, wDs, 18),
+    OSD_OUT_ARRAY(OSD_REAL, wDt, 18),
+    OSD_OUT_ARRAY(OSD_REAL, wDss, 18),
+    OSD_OUT_ARRAY(OSD_REAL, wDst, 18),
+    OSD_OUT_ARRAY(OSD_REAL, wDtt, 18)) {
 
     //
     //  Bezier basis functions are denoted with B while the rational multipliers for the
     //  interior points will be denoted G -- so we have B(s,t) and G(s,t) (though we
     //  switch to barycentric (u,v,w) briefly to compute G)
     //
-    OSD_REAL BP[12], BDs[12], BDt[12], BDss[12], BDst[12], BDtt[12];
+    OSD_REAL BP[15], BDs[15], BDt[15], BDss[15], BDst[15], BDtt[15];
 
     OSD_REAL G[6] = OSD_ARRAY_6(OSD_REAL, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f );
     OSD_REAL u = s;
@@ -1088,7 +1086,7 @@ Osd_EvalBasisGregoryTri(OSD_REAL s, OSD_REAL t,
             Osd_convertBezierWeightsToGregory(BDtt, G, wDtt);
         }
     }
-    return 15;
+    return 18;
 }
 
 #define OSD_PATCH_BASIS_COMPATIBILITY

--- a/opensubdiv/osd/patchBasisCommonEval.h
+++ b/opensubdiv/osd/patchBasisCommonEval.h
@@ -92,14 +92,14 @@ OsdEvaluatePatchBasisNormalized(
 #if OSD_ARRAY_ARG_BOUND_OPTIONAL
         nPoints = Osd_EvalBasisGregoryTri(s, t, wP, wDs, wDt, wDss, wDst, wDtt);
 #else
-        OSD_REAL wP15[15], wDs15[15], wDt15[15],
-                 wDss15[15], wDst15[15], wDtt15[15];
+        OSD_REAL wP18[18], wDs18[18], wDt18[18],
+                 wDss18[18], wDst18[18], wDtt18[18];
         nPoints = Osd_EvalBasisGregoryTri(
-                s, t, wP15, wDs15, wDt15, wDss15, wDst15, wDtt15);
+                s, t, wP18, wDs18, wDt18, wDss18, wDst18, wDtt18);
         for (int i=0; i<nPoints; ++i) {
-            wP[i] = wP15[i];
-            wDs[i] = wDs15[i]; wDt[i] = wDt15[i];
-            wDss[i] = wDss15[i]; wDst[i] = wDst15[i]; wDtt[i] = wDtt15[i];
+            wP[i] = wP18[i];
+            wDs[i] = wDs18[i]; wDt[i] = wDt18[i];
+            wDss[i] = wDss18[i]; wDst[i] = wDst18[i]; wDtt[i] = wDtt18[i];
         }
 #endif
     } else if (patchType == OSD_PATCH_DESCRIPTOR_QUADS) {


### PR DESCRIPTION
These changes extend the triangular Gregory patch used to represent irregular areas of Loop subdivision from the cubic/quartic hybrid patch (cubic boundaries with quartic interior) to a full quartic.  This eliminates cracks between the Gregory and regular patches.

Construction of the Gregory triangle and basis evaluation for both the quartic Gregory triangle and its Bezier counterpart were updated in Far (and a long-standing tangent continuity bug near boundaries fixed in the process).  The Osd counterparts for basis evaluation were synchronized with the Far changes and the GLSL shaders for the Gregory triangle updated to quartic Bezier for both evaluation and adaptive tessellation.