### PR TITLE
New method to determine adaptive refinement options from choices for patches

### DIFF
--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -27,15 +27,13 @@
 
 #include "../version.h"
 
+#include "../far/topologyRefiner.h"
 #include "../far/patchTable.h"
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Far {
-
-//  Forward declarations (for internal implementation purposes):
-class TopologyRefiner;
 
 /// \brief Factory for constructing a PatchTable from a TopologyRefiner
 ///
@@ -86,6 +84,17 @@ public:
 
         /// \brief Set precision of face-varying patches
         template <typename REAL> void SetFVarPatchPrecision();
+
+        /// \brief Determine adaptive refinement options to match assigned patch options
+        TopologyRefiner::AdaptiveOptions GetRefineAdaptiveOptions() const {
+            TopologyRefiner::AdaptiveOptions adaptiveOptions(maxIsolationLevel);
+
+            adaptiveOptions.useInfSharpPatch     = useInfSharpPatch;
+            adaptiveOptions.useSingleCreasePatch = useSingleCreasePatch;
+            adaptiveOptions.considerFVarChannels = generateFVarTables &&
+                                                  !generateFVarLegacyLinearPatches;
+            return adaptiveOptions;
+        }
 
         unsigned int generateAllLevels           : 1, ///< Generate levels from 'firstLevel' to 'maxLevel' (Uniform mode only)
                      includeBaseLevelIndices     : 1, ///< Include base level in patch point indices (Uniform mode only)

--- a/tutorials/far/tutorial_9/far_tutorial_9.cpp
+++ b/tutorials/far/tutorial_9/far_tutorial_9.cpp
@@ -328,14 +328,6 @@ PatchGroup::PatchGroup(Far::PatchTableFactory::Options patchOptions,
         basePositions(basePositionsArg), 
         baseFaces(baseFacesArg) {
 
-    //  Derive adaptive refinement options from the given patch options:
-    //
-    Far::TopologyRefiner::AdaptiveOptions adaptiveOptions(0);
-    adaptiveOptions.isolationLevel       = patchOptions.maxIsolationLevel;
-    adaptiveOptions.useInfSharpPatch     = patchOptions.useInfSharpPatch;
-    adaptiveOptions.useSingleCreasePatch = patchOptions.useSingleCreasePatch;
-    adaptiveOptions.considerFVarChannels = patchOptions.generateFVarTables;
-
     //  Create a local refiner (sharing the base level), apply adaptive refinement
     //  to the given subset of base faces, and construct a patch table (and its
     //  associated map) for the same set of faces:
@@ -345,7 +337,7 @@ PatchGroup::PatchGroup(Far::PatchTableFactory::Options patchOptions,
     Far::TopologyRefiner *localRefiner =
         Far::TopologyRefinerFactory<Far::TopologyDescriptor>::Create(baseRefiner);
 
-    localRefiner->RefineAdaptive(adaptiveOptions, groupFaces);
+    localRefiner->RefineAdaptive(patchOptions.GetRefineAdaptiveOptions(), groupFaces);
 
     patchTable = Far::PatchTableFactory::Create(*localRefiner, patchOptions,
                     groupFaces);


### PR DESCRIPTION
This change provides a new public method for Far::PatchTableFactory::Options that determines the set of adaptive refinement options corresponding to a defined set of options for PatchTable construction.

Adaptive refinement exists solely to support the creation of patches for the limit surface, but the two processes have historically been separate.  The list of options for each process has grown with releases as missing functionality and improvements to legacy short cuts have been added -- each with a new option to be explicitly enabled rather than changing existing behavior, making errors more likely when options are required in both places.

In most common cases, the adaptive refinement options can be completely determined from the set of PatchTableFactory::Options -- which the new method provides.  In other cases, it may be desirable to modify additional settings, but even in such cases the new method can be used to first ensure that appropriate settings for key features are enabled.

The two far/tutorials that create a PatchTable were also updated to illustrate the use of the new method.