### PR TITLE
Enforced consistent header file inclusion in source for examples

### DIFF
--- a/examples/dxPtexViewer/CMakeLists.txt
+++ b/examples/dxPtexViewer/CMakeLists.txt
@@ -38,7 +38,6 @@ set(PLATFORM_LIBRARIES
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${DXSDK_INCLUDE_DIR}"
     "${PTEX_INCLUDE_DIR}"
 )

--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -25,37 +25,37 @@
 #include <D3D11.h>
 #include <D3Dcompiler.h>
 
-#include <far/error.h>
+#include <opensubdiv/far/error.h>
 
-#include <osd/cpuD3D11VertexBuffer.h>
-#include <osd/cpuEvaluator.h>
+#include <opensubdiv/osd/cpuD3D11VertexBuffer.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
 
 #ifdef OPENSUBDIV_HAS_OPENMP
-    #include <osd/ompEvaluator.h>
+    #include <opensubdiv/osd/ompEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_TBB
-    #include <osd/tbbEvaluator.h>
+    #include <opensubdiv/osd/tbbEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL
-    #include <osd/clD3D11VertexBuffer.h>
-    #include <osd/clEvaluator.h>
+    #include <opensubdiv/osd/clD3D11VertexBuffer.h>
+    #include <opensubdiv/osd/clEvaluator.h>
     #include "../common/clDeviceContext.h"
     CLD3D11DeviceContext g_clDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_CUDA
-    #include <osd/cudaD3D11VertexBuffer.h>
-    #include <osd/cudaEvaluator.h>
+    #include <opensubdiv/osd/cudaD3D11VertexBuffer.h>
+    #include <opensubdiv/osd/cudaEvaluator.h>
     #include "../common/cudaDeviceContext.h"
     CudaDeviceContext g_cudaDeviceContext;
 #endif
 
-#include <osd/d3d11VertexBuffer.h>
-#include <osd/d3d11ComputeEvaluator.h>
+#include <opensubdiv/osd/d3d11VertexBuffer.h>
+#include <opensubdiv/osd/d3d11ComputeEvaluator.h>
 
-#include <osd/d3d11Mesh.h>
+#include <opensubdiv/osd/d3d11Mesh.h>
 OpenSubdiv::Osd::D3D11MeshInterface *g_mesh;
 
 #include "./sky.h"
@@ -71,7 +71,7 @@ OpenSubdiv::Osd::D3D11MeshInterface *g_mesh;
 #include "../common/d3d11ShaderCache.h"
 #include "../common/hdr_reader.h"
 
-#include <osd/hlslPatchShaderSource.h>
+#include <opensubdiv/osd/hlslPatchShaderSource.h>
 static const char *g_shaderSource =
 #include "shader.gen.h"
 ;

--- a/examples/dxViewer/CMakeLists.txt
+++ b/examples/dxViewer/CMakeLists.txt
@@ -35,7 +35,6 @@ set(PLATFORM_LIBRARIES
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${DXSDK_INCLUDE_DIR}"
 )
 

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -25,38 +25,38 @@
 #include <D3D11.h>
 #include <D3Dcompiler.h>
 
-#include <far/error.h>
+#include <opensubdiv/far/error.h>
 
-#include <osd/cpuD3D11VertexBuffer.h>
-#include <osd/cpuEvaluator.h>
+#include <opensubdiv/osd/cpuD3D11VertexBuffer.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
 
 #ifdef OPENSUBDIV_HAS_OPENMP
-    #include <osd/ompEvaluator.h>
+    #include <opensubdiv/osd/ompEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_TBB
-    #include <osd/tbbEvaluator.h>
+    #include <opensubdiv/osd/tbbEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL_DX_INTEROP
-    #include <osd/clD3D11VertexBuffer.h>
-    #include <osd/clEvaluator.h>
+    #include <opensubdiv/osd/clD3D11VertexBuffer.h>
+    #include <opensubdiv/osd/clEvaluator.h>
     #include "../common/clDeviceContext.h"
     CLD3D11DeviceContext g_clDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_CUDA
-    #include <osd/cudaD3D11VertexBuffer.h>
-    #include <osd/cudaEvaluator.h>
+    #include <opensubdiv/osd/cudaD3D11VertexBuffer.h>
+    #include <opensubdiv/osd/cudaEvaluator.h>
     #include "../common/cudaDeviceContext.h"
     CudaDeviceContext g_cudaDeviceContext;
 #endif
 
-#include <osd/d3d11VertexBuffer.h>
-#include <osd/d3d11ComputeEvaluator.h>
+#include <opensubdiv/osd/d3d11VertexBuffer.h>
+#include <opensubdiv/osd/d3d11ComputeEvaluator.h>
 
-#include <osd/d3d11Mesh.h>
-#include <osd/d3d11LegacyGregoryPatchTable.h>
+#include <opensubdiv/osd/d3d11Mesh.h>
+#include <opensubdiv/osd/d3d11LegacyGregoryPatchTable.h>
 OpenSubdiv::Osd::D3D11MeshInterface *g_mesh = NULL;
 OpenSubdiv::Osd::D3D11LegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 
@@ -68,7 +68,7 @@ OpenSubdiv::Osd::D3D11LegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 #include "../common/d3d11Utils.h"
 #include "../common/d3d11ShaderCache.h"
 
-#include <osd/hlslPatchShaderSource.h>
+#include <opensubdiv/osd/hlslPatchShaderSource.h>
 static const char *shaderSource =
 #include "shader.gen.h"
 ;

--- a/examples/farViewer/CMakeLists.txt
+++ b/examples/farViewer/CMakeLists.txt
@@ -32,7 +32,6 @@ set(SHADER_FILES
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -42,12 +42,12 @@
 GLFWwindow* g_window=0;
 GLFWmonitor* g_primary=0;
 
-#include <osd/cpuGLVertexBuffer.h>
+#include <opensubdiv/osd/cpuGLVertexBuffer.h>
 
-#include <far/patchTableFactory.h>
-#include <far/stencilTable.h>
-#include <far/stencilTableFactory.h>
-#include <far/primvarRefiner.h>
+#include <opensubdiv/far/patchTableFactory.h>
+#include <opensubdiv/far/stencilTable.h>
+#include <opensubdiv/far/stencilTableFactory.h>
+#include <opensubdiv/far/primvarRefiner.h>
 
 #include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"

--- a/examples/farViewer/gl_mesh.h
+++ b/examples/farViewer/gl_mesh.h
@@ -27,7 +27,7 @@
 
 #include "../../regression/common/far_utils.h"
 #include "../../regression/common/hbr_utils.h"
-#include <far/patchTable.h>
+#include <opensubdiv/far/patchTable.h>
 
 #include "../common/glUtils.h"
 

--- a/examples/glEvalLimit/CMakeLists.txt
+++ b/examples/glEvalLimit/CMakeLists.txt
@@ -31,7 +31,6 @@ list(APPEND PLATFORM_LIBRARIES
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -28,56 +28,56 @@
 GLFWwindow* g_window=0;
 GLFWmonitor* g_primary=0;
 
-#include <osd/cpuEvaluator.h>
-#include <osd/cpuVertexBuffer.h>
-#include <osd/cpuPatchTable.h>
-#include <osd/cpuGLVertexBuffer.h>
-#include <osd/mesh.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
+#include <opensubdiv/osd/cpuVertexBuffer.h>
+#include <opensubdiv/osd/cpuPatchTable.h>
+#include <opensubdiv/osd/cpuGLVertexBuffer.h>
+#include <opensubdiv/osd/mesh.h>
 
 #ifdef OPENSUBDIV_HAS_TBB
-    #include <osd/tbbEvaluator.h>
+    #include <opensubdiv/osd/tbbEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENMP
-    #include <osd/ompEvaluator.h>
+    #include <opensubdiv/osd/ompEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_CUDA
-    #include <osd/cudaEvaluator.h>
-    #include <osd/cudaVertexBuffer.h>
-    #include <osd/cudaGLVertexBuffer.h>
-    #include <osd/cudaPatchTable.h>
+    #include <opensubdiv/osd/cudaEvaluator.h>
+    #include <opensubdiv/osd/cudaVertexBuffer.h>
+    #include <opensubdiv/osd/cudaGLVertexBuffer.h>
+    #include <opensubdiv/osd/cudaPatchTable.h>
     #include "../common/cudaDeviceContext.h"
 
     CudaDeviceContext g_cudaDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL
-    #include <osd/clVertexBuffer.h>
-    #include <osd/clGLVertexBuffer.h>
-    #include <osd/clEvaluator.h>
-    #include <osd/clPatchTable.h>
+    #include <opensubdiv/osd/clVertexBuffer.h>
+    #include <opensubdiv/osd/clGLVertexBuffer.h>
+    #include <opensubdiv/osd/clEvaluator.h>
+    #include <opensubdiv/osd/clPatchTable.h>
     #include "../common/clDeviceContext.h"
     CLDeviceContext g_clDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
-    #include <osd/glXFBEvaluator.h>
-    #include <osd/glVertexBuffer.h>
-    #include <osd/glPatchTable.h>
+    #include <opensubdiv/osd/glXFBEvaluator.h>
+    #include <opensubdiv/osd/glVertexBuffer.h>
+    #include <opensubdiv/osd/glPatchTable.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    #include <osd/glComputeEvaluator.h>
-    #include <osd/glVertexBuffer.h>
-    #include <osd/glPatchTable.h>
+    #include <opensubdiv/osd/glComputeEvaluator.h>
+    #include <opensubdiv/osd/glVertexBuffer.h>
+    #include <opensubdiv/osd/glPatchTable.h>
 #endif
 
-#include <far/topologyRefiner.h>
-#include <far/stencilTableFactory.h>
-#include <far/patchTableFactory.h>
+#include <opensubdiv/far/topologyRefiner.h>
+#include <opensubdiv/far/stencilTableFactory.h>
+#include <opensubdiv/far/patchTableFactory.h>
 
-#include <far/error.h>
+#include <opensubdiv/far/error.h>
 
 #include "../../regression/common/far_utils.h"
 #include "../common/stopwatch.h"

--- a/examples/glEvalLimit/particles.cpp
+++ b/examples/glEvalLimit/particles.cpp
@@ -24,9 +24,9 @@
 
 #include "particles.h"
 
-#include <far/ptexIndices.h>
-#include <far/patchMap.h>
-#include <sdc/types.h>
+#include <opensubdiv/far/ptexIndices.h>
+#include <opensubdiv/far/patchMap.h>
+#include <opensubdiv/sdc/types.h>
 
 #include <cassert>
 #include <cmath>

--- a/examples/glEvalLimit/particles.h
+++ b/examples/glEvalLimit/particles.h
@@ -25,9 +25,9 @@
 #ifndef ST_PARTICLES_H
 #define ST_PARTICLES_H
 
-#include <far/topologyRefiner.h>
-#include <far/patchMap.h>
-#include <osd/types.h>
+#include <opensubdiv/far/topologyRefiner.h>
+#include <opensubdiv/far/patchMap.h>
+#include <opensubdiv/osd/types.h>
 #include <iostream>
 
 //

--- a/examples/glFVarViewer/CMakeLists.txt
+++ b/examples/glFVarViewer/CMakeLists.txt
@@ -36,7 +36,6 @@ list(APPEND PLATFORM_LIBRARIES
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -28,11 +28,11 @@
 GLFWwindow* g_window = 0;
 GLFWmonitor* g_primary = 0;
 
-#include <far/error.h>
-#include <osd/cpuEvaluator.h>
-#include <osd/cpuVertexBuffer.h>
-#include <osd/cpuGLVertexBuffer.h>
-#include <osd/glMesh.h>
+#include <opensubdiv/far/error.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
+#include <opensubdiv/osd/cpuVertexBuffer.h>
+#include <opensubdiv/osd/cpuGLVertexBuffer.h>
+#include <opensubdiv/osd/glMesh.h>
 OpenSubdiv::Osd::GLMeshInterface *g_mesh = NULL;
 
 #include "../../regression/common/far_utils.h"
@@ -42,7 +42,7 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh = NULL;
 #include "../common/glHud.h"
 #include "../common/glShaderCache.h"
 
-#include <osd/glslPatchShaderSource.h>
+#include <opensubdiv/osd/glslPatchShaderSource.h>
 static const char *shaderSource =
 #if defined(GL_ARB_tessellation_shader) || defined(GL_VERSION_4_0)
     #include "shader.gen.h"

--- a/examples/glImaging/CMakeLists.txt
+++ b/examples/glImaging/CMakeLists.txt
@@ -24,7 +24,6 @@
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -30,43 +30,43 @@
 #include <limits>
 #include <GLFW/glfw3.h>
 
-#include <osd/cpuEvaluator.h>
-#include <osd/cpuGLVertexBuffer.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
+#include <opensubdiv/osd/cpuGLVertexBuffer.h>
 
 #ifdef OPENSUBDIV_HAS_OPENMP
-    #include <osd/ompEvaluator.h>
+    #include <opensubdiv/osd/ompEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_TBB
-    #include <osd/tbbEvaluator.h>
+    #include <opensubdiv/osd/tbbEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL
-    #include <osd/clEvaluator.h>
-    #include <osd/clGLVertexBuffer.h>
+    #include <opensubdiv/osd/clEvaluator.h>
+    #include <opensubdiv/osd/clGLVertexBuffer.h>
 
     #include "../common/clDeviceContext.h"
     CLDeviceContext g_clDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_CUDA
-    #include <osd/cudaEvaluator.h>
-    #include <osd/cudaGLVertexBuffer.h>
+    #include <opensubdiv/osd/cudaEvaluator.h>
+    #include <opensubdiv/osd/cudaGLVertexBuffer.h>
     #include "../common/cudaDeviceContext.h"
     CudaDeviceContext g_cudaDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
-    #include <osd/glXFBEvaluator.h>
-    #include <osd/glVertexBuffer.h>
+    #include <opensubdiv/osd/glXFBEvaluator.h>
+    #include <opensubdiv/osd/glVertexBuffer.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    #include <osd/glComputeEvaluator.h>
-    #include <osd/glVertexBuffer.h>
+    #include <opensubdiv/osd/glComputeEvaluator.h>
+    #include <opensubdiv/osd/glVertexBuffer.h>
 #endif
 
-#include <osd/glMesh.h>
+#include <opensubdiv/osd/glMesh.h>
 
 #include "../../regression/common/far_utils.h"
 #include "../common/patchColors.h"
@@ -76,7 +76,7 @@
 
 using namespace OpenSubdiv;
 
-#include <osd/glslPatchShaderSource.h>
+#include <opensubdiv/osd/glslPatchShaderSource.h>
 static const char *shaderSource =
 #include "shader.gen.h"
 ;

--- a/examples/glPaintTest/CMakeLists.txt
+++ b/examples/glPaintTest/CMakeLists.txt
@@ -38,7 +38,6 @@ list(APPEND PLATFORM_LIBRARIES
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${GLEW_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
 )

--- a/examples/glPaintTest/glPaintTest.cpp
+++ b/examples/glPaintTest/glPaintTest.cpp
@@ -29,11 +29,11 @@
 GLFWwindow* g_window=0;
 GLFWmonitor* g_primary=0;
 
-#include <far/error.h>
-#include <far/ptexIndices.h>
-#include <osd/cpuEvaluator.h>
-#include <osd/cpuGLVertexBuffer.h>
-#include <osd/glMesh.h>
+#include <opensubdiv/far/error.h>
+#include <opensubdiv/far/ptexIndices.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
+#include <opensubdiv/osd/cpuGLVertexBuffer.h>
+#include <opensubdiv/osd/glMesh.h>
 OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 
 #include "../../regression/common/far_utils.h"
@@ -44,7 +44,7 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 
 #include "init_shapes.h"
 
-#include <osd/glslPatchShaderSource.h>
+#include <opensubdiv/osd/glslPatchShaderSource.h>
 static const char *shaderSource =
 #include "shader.gen.h"
 ;

--- a/examples/glPtexViewer/CMakeLists.txt
+++ b/examples/glPtexViewer/CMakeLists.txt
@@ -40,7 +40,6 @@ list(APPEND PLATFORM_LIBRARIES
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${GLFW_INCLUDE_DIR}"
     "${PTEX_INCLUDE_DIR}"
 )

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -49,44 +49,44 @@ GLFWmonitor* g_primary = 0;
 #include <string>
 #include <utility>
 #include <algorithm>
-#include <far/error.h>
+#include <opensubdiv/far/error.h>
 
-#include <osd/cpuEvaluator.h>
-#include <osd/cpuGLVertexBuffer.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
+#include <opensubdiv/osd/cpuGLVertexBuffer.h>
 
 #ifdef OPENSUBDIV_HAS_OPENMP
-    #include <osd/ompEvaluator.h>
+    #include <opensubdiv/osd/ompEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_TBB
-    #include <osd/tbbEvaluator.h>
+    #include <opensubdiv/osd/tbbEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL
-    #include <osd/clEvaluator.h>
-    #include <osd/clGLVertexBuffer.h>
+    #include <opensubdiv/osd/clEvaluator.h>
+    #include <opensubdiv/osd/clGLVertexBuffer.h>
     #include "../common/clDeviceContext.h"
     CLDeviceContext g_clDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_CUDA
-    #include <osd/cudaEvaluator.h>
-    #include <osd/cudaGLVertexBuffer.h>
+    #include <opensubdiv/osd/cudaEvaluator.h>
+    #include <opensubdiv/osd/cudaGLVertexBuffer.h>
     #include "../common/cudaDeviceContext.h"
     CudaDeviceContext g_cudaDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
-    #include <osd/glXFBEvaluator.h>
-    #include <osd/glVertexBuffer.h>
+    #include <opensubdiv/osd/glXFBEvaluator.h>
+    #include <opensubdiv/osd/glVertexBuffer.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    #include <osd/glComputeEvaluator.h>
-    #include <osd/glVertexBuffer.h>
+    #include <opensubdiv/osd/glComputeEvaluator.h>
+    #include <opensubdiv/osd/glVertexBuffer.h>
 #endif
 
-#include <osd/glMesh.h>
+#include <opensubdiv/osd/glMesh.h>
 OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 
 #include "Ptexture.h"
@@ -102,7 +102,7 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 #include "../common/glPtexMipmapTexture.h"
 #include "../common/glShaderCache.h"
 
-#include <osd/glslPatchShaderSource.h>
+#include <opensubdiv/osd/glslPatchShaderSource.h>
 static const char *g_defaultShaderSource =
 #if defined(GL_ARB_tessellation_shader) || defined(GL_VERSION_4_0)
     #include "shader.gen.h"

--- a/examples/glShareTopology/CMakeLists.txt
+++ b/examples/glShareTopology/CMakeLists.txt
@@ -36,7 +36,6 @@ list(APPEND PLATFORM_LIBRARIES
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -28,43 +28,43 @@
 GLFWwindow* g_window=0;
 GLFWmonitor* g_primary=0;
 
-#include <far/error.h>
-#include <far/stencilTable.h>
-#include <far/ptexIndices.h>
+#include <opensubdiv/far/error.h>
+#include <opensubdiv/far/stencilTable.h>
+#include <opensubdiv/far/ptexIndices.h>
 
-#include <osd/mesh.h>
-#include <osd/glVertexBuffer.h>
-#include <osd/cpuGLVertexBuffer.h>
-#include <osd/cpuEvaluator.h>
+#include <opensubdiv/osd/mesh.h>
+#include <opensubdiv/osd/glVertexBuffer.h>
+#include <opensubdiv/osd/cpuGLVertexBuffer.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
 
 #ifdef OPENSUBDIV_HAS_OPENMP
-    #include <osd/ompEvaluator.h>
+    #include <opensubdiv/osd/ompEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_TBB
-    #include <osd/tbbEvaluator.h>
+    #include <opensubdiv/osd/tbbEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL
-    #include <osd/clGLVertexBuffer.h>
-    #include <osd/clEvaluator.h>
+    #include <opensubdiv/osd/clGLVertexBuffer.h>
+    #include <opensubdiv/osd/clEvaluator.h>
     #include "../common/clDeviceContext.h"
     CLDeviceContext g_clDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_CUDA
-    #include <osd/cudaGLVertexBuffer.h>
-    #include <osd/cudaEvaluator.h>
+    #include <opensubdiv/osd/cudaGLVertexBuffer.h>
+    #include <opensubdiv/osd/cudaEvaluator.h>
     #include "../common/cudaDeviceContext.h"
     CudaDeviceContext g_cudaDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
-    #include <osd/glXFBEvaluator.h>
+    #include <opensubdiv/osd/glXFBEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    #include <osd/glComputeEvaluator.h>
+    #include <opensubdiv/osd/glComputeEvaluator.h>
 #endif
 
 
@@ -76,7 +76,7 @@ GLFWmonitor* g_primary=0;
 #include "../common/glHud.h"
 #include "../common/glShaderCache.h"
 
-#include <osd/glslPatchShaderSource.h>
+#include <opensubdiv/osd/glslPatchShaderSource.h>
 static const char *shaderSource =
 #include "shader.gen.h"
 ;

--- a/examples/glShareTopology/meshRefiner.h
+++ b/examples/glShareTopology/meshRefiner.h
@@ -25,7 +25,7 @@
 #ifndef OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_MESH_REFINER_H
 #define OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_MESH_REFINER_H
 
-#include <osd/mesh.h>   // for evaluator cache
+#include <opensubdiv/osd/mesh.h>   // for evaluator cache
 
 template <class EVALUATOR,
           class VERTEX_BUFFER,

--- a/examples/glShareTopology/sceneBase.cpp
+++ b/examples/glShareTopology/sceneBase.cpp
@@ -25,8 +25,8 @@
 #include "sceneBase.h"
 #include <limits>
 #include "../../regression/common/far_utils.h"
-#include <far/patchTableFactory.h>
-#include <far/stencilTableFactory.h>
+#include <opensubdiv/far/patchTableFactory.h>
+#include <opensubdiv/far/stencilTableFactory.h>
 
 using namespace OpenSubdiv;
 

--- a/examples/glShareTopology/sceneBase.h
+++ b/examples/glShareTopology/sceneBase.h
@@ -25,10 +25,10 @@
 #ifndef OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_SCENE_BASE_H
 #define OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_SCENE_BASE_H
 
-#include <far/patchDescriptor.h>
-#include <far/patchTable.h>
-#include <osd/bufferDescriptor.h>
-#include <osd/opengl.h>
+#include <opensubdiv/far/patchDescriptor.h>
+#include <opensubdiv/far/patchTable.h>
+#include <opensubdiv/osd/bufferDescriptor.h>
+#include <opensubdiv/osd/opengl.h>
 
 struct Shape;
 

--- a/examples/glShareTopology/vbo.h
+++ b/examples/glShareTopology/vbo.h
@@ -26,8 +26,8 @@
 #define OPENSUBDIV_EXAMPLES_GL_SHARE_TOPOLOGY_VBO_H
 
 #include <vector>
-#include <osd/bufferDescriptor.h>
-#include <osd/opengl.h>
+#include <opensubdiv/osd/bufferDescriptor.h>
+#include <opensubdiv/osd/opengl.h>
 
 template <class VERTEX_BUFFER, class DEVICE_CONTEXT>
 class VBO {

--- a/examples/glStencilViewer/CMakeLists.txt
+++ b/examples/glStencilViewer/CMakeLists.txt
@@ -31,7 +31,6 @@ list(APPEND PLATFORM_LIBRARIES
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -34,51 +34,51 @@ GLFWmonitor* g_primary=0;
 #include "../common/glHud.h"
 #include "../common/glControlMeshDisplay.h"
 
-#include <far/patchTableFactory.h>
-#include <far/ptexIndices.h>
-#include <far/stencilTableFactory.h>
+#include <opensubdiv/far/patchTableFactory.h>
+#include <opensubdiv/far/ptexIndices.h>
+#include <opensubdiv/far/stencilTableFactory.h>
 
-#include <osd/cpuGLVertexBuffer.h>
-#include <osd/cpuVertexBuffer.h>
-#include <osd/cpuEvaluator.h>
+#include <opensubdiv/osd/cpuGLVertexBuffer.h>
+#include <opensubdiv/osd/cpuVertexBuffer.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
 
 #if defined(OPENSUBDIV_HAS_OPENMP)
-    #include <osd/ompEvaluator.h>
+    #include <opensubdiv/osd/ompEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_TBB
-    #include <osd/tbbEvaluator.h>
+    #include <opensubdiv/osd/tbbEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_CUDA
-    #include <osd/cudaVertexBuffer.h>
-    #include <osd/cudaGLVertexBuffer.h>
-    #include <osd/cudaEvaluator.h>
+    #include <opensubdiv/osd/cudaVertexBuffer.h>
+    #include <opensubdiv/osd/cudaGLVertexBuffer.h>
+    #include <opensubdiv/osd/cudaEvaluator.h>
     #include "../common/cudaDeviceContext.h"
 
     CudaDeviceContext g_cudaDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL
-    #include <osd/clVertexBuffer.h>
-    #include <osd/clGLVertexBuffer.h>
-    #include <osd/clEvaluator.h>
+    #include <opensubdiv/osd/clVertexBuffer.h>
+    #include <opensubdiv/osd/clGLVertexBuffer.h>
+    #include <opensubdiv/osd/clEvaluator.h>
     #include "../common/clDeviceContext.h"
 
     CLDeviceContext g_clDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
-    #include <osd/glXFBEvaluator.h>
-    #include <osd/glVertexBuffer.h>
+    #include <opensubdiv/osd/glXFBEvaluator.h>
+    #include <opensubdiv/osd/glVertexBuffer.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    #include <osd/glComputeEvaluator.h>
-    #include <osd/glVertexBuffer.h>
+    #include <opensubdiv/osd/glComputeEvaluator.h>
+    #include <opensubdiv/osd/glVertexBuffer.h>
 #endif
 
-#include <osd/mesh.h>
+#include <opensubdiv/osd/mesh.h>
 
 #include <cfloat>
 #include <list>

--- a/examples/glViewer/CMakeLists.txt
+++ b/examples/glViewer/CMakeLists.txt
@@ -31,7 +31,6 @@ set(SHADER_FILES
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${GLFW_INCLUDE_DIR}"
 )
 

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -28,47 +28,47 @@
 GLFWwindow* g_window=0;
 GLFWmonitor* g_primary=0;
 
-#include <far/error.h>
+#include <opensubdiv/far/error.h>
 
-#include <osd/cpuEvaluator.h>
-#include <osd/cpuGLVertexBuffer.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
+#include <opensubdiv/osd/cpuGLVertexBuffer.h>
 
 #ifdef OPENSUBDIV_HAS_OPENMP
-    #include <osd/ompEvaluator.h>
+    #include <opensubdiv/osd/ompEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_TBB
-    #include <osd/tbbEvaluator.h>
+    #include <opensubdiv/osd/tbbEvaluator.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_OPENCL
-    #include <osd/clGLVertexBuffer.h>
-    #include <osd/clEvaluator.h>
+    #include <opensubdiv/osd/clGLVertexBuffer.h>
+    #include <opensubdiv/osd/clEvaluator.h>
     #include "../common/clDeviceContext.h"
 
     CLDeviceContext g_clDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_CUDA
-    #include <osd/cudaGLVertexBuffer.h>
-    #include <osd/cudaEvaluator.h>
+    #include <opensubdiv/osd/cudaGLVertexBuffer.h>
+    #include <opensubdiv/osd/cudaEvaluator.h>
     #include "../common/cudaDeviceContext.h"
 
     CudaDeviceContext g_cudaDeviceContext;
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
-    #include <osd/glXFBEvaluator.h>
-    #include <osd/glVertexBuffer.h>
+    #include <opensubdiv/osd/glXFBEvaluator.h>
+    #include <opensubdiv/osd/glVertexBuffer.h>
 #endif
 
 #ifdef OPENSUBDIV_HAS_GLSL_COMPUTE
-    #include <osd/glComputeEvaluator.h>
-    #include <osd/glVertexBuffer.h>
+    #include <opensubdiv/osd/glComputeEvaluator.h>
+    #include <opensubdiv/osd/glVertexBuffer.h>
 #endif
 
-#include <osd/glMesh.h>
-#include <osd/glLegacyGregoryPatchTable.h>
+#include <opensubdiv/osd/glMesh.h>
+#include <opensubdiv/osd/glLegacyGregoryPatchTable.h>
 OpenSubdiv::Osd::GLMeshInterface *g_mesh = NULL;
 OpenSubdiv::Osd::GLLegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 
@@ -80,7 +80,7 @@ OpenSubdiv::Osd::GLLegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 #include "../common/objAnim.h"
 #include "../common/simple_math.h"
 #include "../common/stopwatch.h"
-#include <osd/glslPatchShaderSource.h>
+#include <opensubdiv/osd/glslPatchShaderSource.h>
 
 
 

--- a/examples/mtlPtexViewer/CMakeLists.txt
+++ b/examples/mtlPtexViewer/CMakeLists.txt
@@ -63,7 +63,6 @@ endif()
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${METAL_INCLUDE_DIR}"
     "${PTEX_INCLUDE_DIR}"
 )

--- a/examples/mtlPtexViewer/mtlPtexViewer.mm
+++ b/examples/mtlPtexViewer/mtlPtexViewer.mm
@@ -12,17 +12,17 @@
 #import <vector>
 #import <memory>
 
-#import <far/error.h>
-#import <osd/mesh.h>
-#import <osd/cpuVertexBuffer.h>
-#import <osd/cpuEvaluator.h>
-#import <osd/cpuPatchTable.h>
-#import <osd/mtlLegacyGregoryPatchTable.h>
-#import <osd/mtlVertexBuffer.h>
-#import <osd/mtlMesh.h>
-#import <osd/mtlPatchTable.h>
-#import <osd/mtlComputeEvaluator.h>
-#import <osd/mtlPatchShaderSource.h>
+#import <opensubdiv/far/error.h>
+#import <opensubdiv/osd/mesh.h>
+#import <opensubdiv/osd/cpuVertexBuffer.h>
+#import <opensubdiv/osd/cpuEvaluator.h>
+#import <opensubdiv/osd/cpuPatchTable.h>
+#import <opensubdiv/osd/mtlLegacyGregoryPatchTable.h>
+#import <opensubdiv/osd/mtlVertexBuffer.h>
+#import <opensubdiv/osd/mtlMesh.h>
+#import <opensubdiv/osd/mtlPatchTable.h>
+#import <opensubdiv/osd/mtlComputeEvaluator.h>
+#import <opensubdiv/osd/mtlPatchShaderSource.h>
 
 #import "../common/simple_math.h"
 #import "../../regression/common/far_utils.h"

--- a/examples/mtlViewer/CMakeLists.txt
+++ b/examples/mtlViewer/CMakeLists.txt
@@ -62,7 +62,6 @@ endif()
 
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
-    "${OPENSUBDIV_INCLUDE_DIR}/opensubdiv"
     "${METAL_INCLUDE_DIR}"
 )
 

--- a/examples/mtlViewer/OSX/ViewController.mm
+++ b/examples/mtlViewer/OSX/ViewController.mm
@@ -24,7 +24,7 @@
 
 
 #import "ViewController.h"
-#import <far/patchDescriptor.h>
+#import <opensubdiv/far/patchDescriptor.h>
 
 using namespace OpenSubdiv::OPENSUBDIV_VERSION;
 

--- a/examples/mtlViewer/mtlViewer.mm
+++ b/examples/mtlViewer/mtlViewer.mm
@@ -35,17 +35,17 @@
 #import <vector>
 #import <memory>
 
-#import <far/error.h>
-#import <osd/mesh.h>
-#import <osd/cpuVertexBuffer.h>
-#import <osd/cpuEvaluator.h>
-#import <osd/cpuPatchTable.h>
-#import <osd/mtlLegacyGregoryPatchTable.h>
-#import <osd/mtlVertexBuffer.h>
-#import <osd/mtlMesh.h>
-#import <osd/mtlPatchTable.h>
-#import <osd/mtlComputeEvaluator.h>
-#import <osd/mtlPatchShaderSource.h>
+#import <opensubdiv/far/error.h>
+#import <opensubdiv/osd/mesh.h>
+#import <opensubdiv/osd/cpuVertexBuffer.h>
+#import <opensubdiv/osd/cpuEvaluator.h>
+#import <opensubdiv/osd/cpuPatchTable.h>
+#import <opensubdiv/osd/mtlLegacyGregoryPatchTable.h>
+#import <opensubdiv/osd/mtlVertexBuffer.h>
+#import <opensubdiv/osd/mtlMesh.h>
+#import <opensubdiv/osd/mtlPatchTable.h>
+#import <opensubdiv/osd/mtlComputeEvaluator.h>
+#import <opensubdiv/osd/mtlPatchShaderSource.h>
 
 #import "../common/simple_math.h"
 #import "../../regression/common/far_utils.h"


### PR DESCRIPTION
This change completes work begun in #1005 to make all source outside the core library include OpenSubdiv header files consistent with external usage.  Extensions to the standard include path in the examples were removed and all header inclusions in their source were updated to use <opensubdiv/...>.