### PR TITLE
Fixed Far::PatchDescriptor::IsAdaptive() for legacy Gregory

### DIFF
--- a/opensubdiv/far/patchDescriptor.h
+++ b/opensubdiv/far/patchDescriptor.h
@@ -84,7 +84,7 @@ public:
 
     /// \brief Returns true if the type is an adaptive (non-linear) patch
     static inline bool IsAdaptive(Type type) {
-        return GetNumControlVertices( type ) > 4;
+        return type > TRIANGLES;
     }
 
     /// \brief Returns true if the type is an adaptive patch


### PR DESCRIPTION
The IsAdaptive() test was previously modified to use the number of control points to detect non-linear patches requiring tessellation, but legacy Gregory patches are of size 4.  So the patch type must ultimately be inspected (with or without the patch sizes).
