### PR TITLE
Several minor updates to the GL examples

### DIFF
--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -131,9 +131,9 @@ std::vector<float> g_orgPositions,
 
 int g_currentShape = 0,
     g_adaptive = 1,
-    g_level = 3,
+    g_level = 2,
     g_kernel = kCPU,
-    g_endCap = kEndCapBSplineBasis,
+    g_endCap = kEndCapGregoryBasis,
     g_infSharpPatch = 0,
     g_numElements = 3;
 
@@ -1223,8 +1223,8 @@ keyboard(GLFWwindow *, int key, int /* scancode */, int event, int /* mods */) {
 //------------------------------------------------------------------------------
 static void
 callbackError(OpenSubdiv::Far::ErrorType err, const char *message) {
-    printf("Error: %d\n", err);
-    printf("%s", message);
+    printf("OpenSubdiv Error: %d\n", err);
+    printf("    %s\n", message);
 }
 
 //------------------------------------------------------------------------------
@@ -1382,10 +1382,10 @@ initHUD() {
 
     int endcap_pulldown = g_hud.AddPullDown("End cap (E)", 10, 150, 200,
                                             callbackEndCap, 'e');
-    g_hud.AddPullDownButton(endcap_pulldown, "BSpline",
+    g_hud.AddPullDownButton(endcap_pulldown, "Regular",
         kEndCapBSplineBasis,
         g_endCap == kEndCapBSplineBasis);
-    g_hud.AddPullDownButton(endcap_pulldown, "GregoryBasis",
+    g_hud.AddPullDownButton(endcap_pulldown, "Gregory",
         kEndCapGregoryBasis,
         g_endCap == kEndCapGregoryBasis);
 
@@ -1442,36 +1442,39 @@ int main(int argc, char **argv) {
 
     bool fullscreen = false;
     Scheme defaultScheme = kCatmark;
-    std::string str;
+    std::vector<char const *> objfiles;
 
     for (int i = 1; i < argc; ++i) {
-        if (!strcmp(argv[i], "-u")) {
+        if (strstr(argv[i], ".obj")) {
+            objfiles.push_back(argv[i]);
+        } else if (!strcmp(argv[i], "-a")) {
+            g_adaptive = true;
+        } else if (!strcmp(argv[i], "-u")) {
             g_adaptive = false;
-        }
-        else if (!strcmp(argv[i], "-d")) {
+        } else if (!strcmp(argv[i], "-l")) {
             if (++i < argc) g_level = atoi(argv[i]);
-        }
-        else if (!strcmp(argv[i], "-f")) {
+        } else if (!strcmp(argv[i], "-f")) {
             fullscreen = true;
-        }
-        else if (!strcmp(argv[i], "-bilinear")) {
+        } else if (!strcmp(argv[i], "-bilinear")) {
             defaultScheme = kBilinear;
-        }
-        else if (!strcmp(argv[i], "-catmark")) {
+        } else if (!strcmp(argv[i], "-catmark")) {
             defaultScheme = kCatmark;
-        }
-        else if (!strcmp(argv[i], "-loop")) {
+        } else if (!strcmp(argv[i], "-loop")) {
             defaultScheme = kLoop;
+        } else {
+            printf("Warning: unrecognized argument '%s' ignored\n", argv[i]);
         }
-        else {
-            std::ifstream ifs(argv[i]);
-            if (ifs) {
-                std::stringstream ss;
-                ss << ifs.rdbuf();
-                ifs.close();
-                str = ss.str();
-                g_defaultShapes.push_back(ShapeDesc(argv[i], str.c_str(), defaultScheme));
-            }
+    }
+    for (int i = 0; i < (int)objfiles.size(); ++i) {
+        std::ifstream ifs(objfiles[i]);
+        if (ifs) {
+            std::stringstream ss;
+            ss << ifs.rdbuf();
+            ifs.close();
+            std::string str = ss.str();
+            g_defaultShapes.push_back(ShapeDesc(objfiles[i], str.c_str(), defaultScheme));
+        } else {
+            printf("Warning: cannot open shape file '%s'\n", objfiles[i]);
         }
     }
 

--- a/examples/glEvalLimit/init_shapes.h
+++ b/examples/glEvalLimit/init_shapes.h
@@ -40,6 +40,7 @@ static std::vector<ShapeDesc> g_defaultShapes;
 
 //------------------------------------------------------------------------------
 static void initShapes() {
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner0",     catmark_cube_corner0,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner1",     catmark_cube_corner1,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner2",     catmark_cube_corner2,     kCatmark ) );
@@ -48,22 +49,14 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases2",    catmark_cube_creases2,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgecorner",       catmark_edgecorner,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgeonly",         catmark_edgeonly,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin0",         catmark_chaikin0,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin1",         catmark_chaikin1,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin2",         catmark_chaikin2,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_quadstrips",       catmark_quadstrips,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_single_crease",    catmark_single_crease,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_inf_crease0",      catmark_inf_crease0,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fan",              catmark_fan,              kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap",             catmark_flap,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap2",            catmark_flap2,            kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound0",      catmark_fvar_bound0,      kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound1",      catmark_fvar_bound1,      kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound2",      catmark_fvar_bound2,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test1",    catmark_gregory_test1,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test2",    catmark_gregory_test2,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test3",    catmark_gregory_test3,    kCatmark ) );
@@ -81,16 +74,29 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_tent",             catmark_tent,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_torus",            catmark_torus,            kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_torus_creases0",   catmark_torus_creases0,   kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit0",    catmark_square_hedit0,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit1",    catmark_square_hedit1,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit2",    catmark_square_hedit2,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit3",    catmark_square_hedit3,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_bishop",           catmark_bishop,           kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_car",              catmark_car,              kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_helmet",           catmark_helmet,           kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pawn",             catmark_pawn,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_rook",             catmark_rook,             kCatmark ) );
 
-    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cube",                loop_cube,                kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cube_asymmetric",     loop_cube_asymmetric,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_interior",       loop_xord_interior,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_boundary",       loop_xord_boundary,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_semisharp",      loop_icos_semisharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_infsharp",       loop_icos_infsharp,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_pole8",               loop_pole8,               kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_pole64",              loop_pole64,              kLoop ) );
+
+    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonplanar",       bilinear_nonplanar,       kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonquads0",       bilinear_nonquads0,       kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonquads1",       bilinear_nonquads1,       kBilinear ) );
 }
 //------------------------------------------------------------------------------

--- a/examples/glFVarViewer/init_shapes.h
+++ b/examples/glFVarViewer/init_shapes.h
@@ -44,6 +44,7 @@ static void initShapes() {
     //  Note that any shapes added here must have UVs -- loading a shape without UVs is a fatal
     //  error and will result in termination when it is selected.
     //
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner0",     catmark_cube_corner0,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner1",     catmark_cube_corner1,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner2",     catmark_cube_corner2,     kCatmark ) );
@@ -51,16 +52,12 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner4",     catmark_cube_corner4,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgecorner",       catmark_edgecorner,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgeonly",         catmark_edgeonly,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin0",         catmark_chaikin0,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin1",         catmark_chaikin1,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_quadstrips",       catmark_quadstrips,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fan",              catmark_fan,              kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap",             catmark_flap,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap2",            catmark_flap2,            kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound0",      catmark_fvar_bound0,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound1",      catmark_fvar_bound1,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound2",      catmark_fvar_bound2,      kCatmark ) );
@@ -84,27 +81,26 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_tent",             catmark_tent,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_torus",            catmark_torus,            kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_torus_creases0",   catmark_torus_creases0,   kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit0",    catmark_square_hedit0,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit1",    catmark_square_hedit1,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit2",    catmark_square_hedit2,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit3",    catmark_square_hedit3,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_bishop",           catmark_bishop,           kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_car",              catmark_car,              kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_helmet",           catmark_helmet,           kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_pawn",             catmark_pawn,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_rook",             catmark_rook,             kCatmark ) );
 
-    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
-
-    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases0",       loop_cube_creases0,       kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases1",       loop_cube_creases1,       kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_cube",                loop_cube,                kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgecorner",   loop_saddle_edgecorner,   kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgeonly",     loop_saddle_edgeonly,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cube_asymmetric",     loop_cube_asymmetric,     kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_chaikin0",            loop_chaikin0,            kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_chaikin1",            loop_chaikin1,            kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_interior",       loop_xord_interior,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_boundary",       loop_xord_boundary,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_fvar_bound0",         loop_fvar_bound0,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_fvar_bound1",         loop_fvar_bound1,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_fvar_bound2",         loop_fvar_bound2,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_fvar_bound3",         loop_fvar_bound3,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_semisharp",      loop_icos_semisharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_infsharp",       loop_icos_infsharp,       kLoop ) );
+
+    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonplanar",       bilinear_nonplanar,       kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonquads0",       bilinear_nonquads0,       kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonquads1",       bilinear_nonquads1,       kBilinear ) );
 }
 //------------------------------------------------------------------------------

--- a/examples/glImaging/init_shapes.h
+++ b/examples/glImaging/init_shapes.h
@@ -40,6 +40,7 @@ static std::vector<ShapeDesc> g_shapes;
 //------------------------------------------------------------------------------
 static void initShapes() {
 
+    g_shapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_cube_corner0",     catmark_cube_corner0,     kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_cube_corner1",     catmark_cube_corner1,     kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_cube_corner2",     catmark_cube_corner2,     kCatmark ) );
@@ -48,17 +49,15 @@ static void initShapes() {
     g_shapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_cube_creases2",    catmark_cube_creases2,    kCatmark ) );
-    g_shapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_edgecorner",       catmark_edgecorner,       kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_edgeonly",         catmark_edgeonly,         kCatmark ) );
+    g_shapes.push_back( ShapeDesc("catmark_quadstrips",       catmark_quadstrips,       kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_chaikin0",         catmark_chaikin0,         kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_chaikin1",         catmark_chaikin1,         kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_chaikin2",         catmark_chaikin2,         kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_fan",              catmark_fan,              kCatmark ) );
-    g_shapes.push_back( ShapeDesc("catmark_flap",             catmark_flap,             kCatmark ) );
-    g_shapes.push_back( ShapeDesc("catmark_flap2",            catmark_flap2,            kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_fvar_bound0",      catmark_fvar_bound0,      kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_fvar_bound1",      catmark_fvar_bound1,      kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_fvar_bound2",      catmark_fvar_bound2,      kCatmark ) );
@@ -90,17 +89,29 @@ static void initShapes() {
     g_shapes.push_back( ShapeDesc("catmark_pawn",             catmark_pawn,             kCatmark ) );
     g_shapes.push_back( ShapeDesc("catmark_rook",             catmark_rook,             kCatmark ) );
 
-    g_shapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
-
-    g_shapes.push_back( ShapeDesc("loop_cube_creases0",       loop_cube_creases0,       kLoop ) );
-    g_shapes.push_back( ShapeDesc("loop_cube_creases1",       loop_cube_creases1,       kLoop ) );
     g_shapes.push_back( ShapeDesc("loop_cube",                loop_cube,                kLoop ) );
-    g_shapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
-    g_shapes.push_back( ShapeDesc("loop_saddle_edgecorner",   loop_saddle_edgecorner,   kLoop ) );
-    g_shapes.push_back( ShapeDesc("loop_saddle_edgeonly",     loop_saddle_edgeonly,     kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_cube_asymmetric",     loop_cube_asymmetric,     kLoop ) );
     g_shapes.push_back( ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop ) );
     g_shapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_xord_interior",       loop_xord_interior,       kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_xord_boundary",       loop_xord_boundary,       kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_icos_semisharp",      loop_icos_semisharp,      kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_icos_infsharp",       loop_icos_infsharp,       kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_fvar_bound0",         loop_fvar_bound0,         kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_fvar_bound1",         loop_fvar_bound1,         kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_fvar_bound2",         loop_fvar_bound2,         kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_fvar_bound3",         loop_fvar_bound3,         kLoop ) );
     g_shapes.push_back( ShapeDesc("loop_chaikin0",            loop_chaikin0,            kLoop ) );
     g_shapes.push_back( ShapeDesc("loop_chaikin1",            loop_chaikin1,            kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_pole8",               loop_pole8,               kLoop ) );
+    g_shapes.push_back( ShapeDesc("loop_pole64",              loop_pole64,              kLoop ) );
+
+    g_shapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
+    g_shapes.push_back( ShapeDesc("bilinear_nonplanar",       bilinear_nonplanar,       kBilinear ) );
+    g_shapes.push_back( ShapeDesc("bilinear_nonquads0",       bilinear_nonquads0,       kBilinear ) );
+    g_shapes.push_back( ShapeDesc("bilinear_nonquads1",       bilinear_nonquads1,       kBilinear ) );
 }
 //------------------------------------------------------------------------------

--- a/examples/glImaging/shader.glsl
+++ b/examples/glImaging/shader.glsl
@@ -320,11 +320,11 @@ getAdaptivePatchColor(ivec3 patchParam)
         vec4(0.0f,  0.8f,  0.75f, 1.0f),   // boundary pattern 4
 
         vec4(0.0f,  1.0f,  0.0f,  1.0f),   // corner
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 0
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 1
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 2
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 3
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 4
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 0
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 1
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 2
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 3
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 4
 
         vec4(1.0f,  1.0f,  0.0f,  1.0f),   // gregory
         vec4(1.0f,  1.0f,  0.0f,  1.0f),   // gregory
@@ -354,11 +354,11 @@ getAdaptivePatchColor(ivec3 patchParam)
     if (edgeCount == 1) {
         patchType = 2; // BOUNDARY
     }
-    if (edgeCount == 2) {
-        patchType = 3; // CORNER
+    if (edgeCount > 1) {
+        patchType = 3; // CORNER (not correct for patches that are not isolated)
     }
 
-#if defined OSD_PATCH_ENABLE_SINGLE_CREASE
+#if defined(OSD_PATCH_ENABLE_SINGLE_CREASE) && !defined(LOOP)
     // check this after boundary/corner since single crease patch also has edgeCount.
     if (inpt.vSegments.y > 0) {
         patchType = 1;
@@ -368,6 +368,8 @@ getAdaptivePatchColor(ivec3 patchParam)
 #elif defined OSD_PATCH_GREGORY_BOUNDARY
     patchType = 5;
 #elif defined OSD_PATCH_GREGORY_BASIS
+    patchType = 6;
+#elif defined OSD_PATCH_GREGORY_TRIANGLE
     patchType = 6;
 #endif
 

--- a/examples/glPaintTest/init_shapes.h
+++ b/examples/glPaintTest/init_shapes.h
@@ -39,6 +39,7 @@ static std::vector<ShapeDesc> g_defaultShapes;
 
 //------------------------------------------------------------------------------
 static void initShapes() {
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner0",     catmark_cube_corner0,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner1",     catmark_cube_corner1,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner2",     catmark_cube_corner2,     kCatmark ) );
@@ -46,17 +47,12 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner4",     catmark_cube_corner4,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgecorner",       catmark_edgecorner,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgeonly",         catmark_edgeonly,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin0",         catmark_chaikin0,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin1",         catmark_chaikin1,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin2",         catmark_chaikin2,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_quadstrips",       catmark_quadstrips,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fan",              catmark_fan,              kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap",             catmark_flap,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap2",            catmark_flap2,            kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test1",    catmark_gregory_test1,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test2",    catmark_gregory_test2,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test3",    catmark_gregory_test3,    kCatmark ) );
@@ -76,5 +72,19 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_helmet",           catmark_helmet,           kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pawn",             catmark_pawn,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_rook",             catmark_rook,             kCatmark ) );
+
+    g_defaultShapes.push_back( ShapeDesc("loop_cube",                loop_cube,                kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cube_asymmetric",     loop_cube_asymmetric,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_interior",       loop_xord_interior,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_boundary",       loop_xord_boundary,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_semisharp",      loop_icos_semisharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_infsharp",       loop_icos_infsharp,       kLoop ) );
+
+    //  REMEMBER:  no Bilinear shapes here -- application requires a tessellation shader
 }
 //------------------------------------------------------------------------------

--- a/examples/glPtexViewer/shader.glsl
+++ b/examples/glPtexViewer/shader.glsl
@@ -437,11 +437,11 @@ GetOverrideColor(ivec3 patchParam)
         vec4(0.0f,  0.8f,  0.75f, 1.0f),   // boundary pattern 4
 
         vec4(0.0f,  1.0f,  0.0f,  1.0f),   // corner
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 0
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 1
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 2
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 3
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 4
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 0
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 1
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 2
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 3
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 4
 
         vec4(1.0f,  1.0f,  0.0f,  1.0f),   // gregory
         vec4(1.0f,  1.0f,  0.0f,  1.0f),   // gregory
@@ -466,8 +466,18 @@ GetOverrideColor(ivec3 patchParam)
     );
 
     int patchType = 0;
-#if defined OSD_PATCH_SINGLE_CREASE
-    if (inpt.sharpness > 0) {
+
+    int edgeCount = bitCount(OsdGetPatchBoundaryMask(patchParam));
+    if (edgeCount == 1) {
+        patchType = 2; // BOUNDARY
+    }
+    if (edgeCount > 1) {
+        patchType = 3; // CORNER (not correct for patches that are not isolated)
+    }
+
+#if defined(OSD_PATCH_ENABLE_SINGLE_CREASE) && !defined(LOOP)
+    // check this after boundary/corner since single crease patch also has edgeCount.
+    if (inpt.vSegments.y > 0) {
         patchType = 1;
     }
 #elif defined OSD_PATCH_GREGORY
@@ -476,15 +486,9 @@ GetOverrideColor(ivec3 patchParam)
     patchType = 5;
 #elif defined OSD_PATCH_GREGORY_BASIS
     patchType = 6;
+#elif defined OSD_PATCH_GREGORY_TRIANGLE
+    patchType = 6;
 #endif
-
-    int edgeCount = bitCount(OsdGetPatchBoundaryMask(patchParam));
-    if (edgeCount == 1) {
-        patchType = 2; // BOUNDARY
-    }
-    if (edgeCount == 2) {
-        patchType = 3; // CORNER
-    }
 
     int pattern = bitCount(OsdGetPatchTransitionMask(patchParam));
 

--- a/examples/glShareTopology/init_shapes.h
+++ b/examples/glShareTopology/init_shapes.h
@@ -41,6 +41,7 @@ static std::vector<ShapeDesc> g_defaultShapes;
 
 //------------------------------------------------------------------------------
 static void initShapes() {
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner0",     catmark_cube_corner0,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner1",     catmark_cube_corner1,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner2",     catmark_cube_corner2,     kCatmark ) );
@@ -49,17 +50,15 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases2",    catmark_cube_creases2,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgecorner",       catmark_edgecorner,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgeonly",         catmark_edgeonly,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_quadstrips",       catmark_quadstrips,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_chaikin0",         catmark_chaikin0,         kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_chaikin1",         catmark_chaikin1,         kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_chaikin2",         catmark_chaikin2,         kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fan",              catmark_fan,              kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap",             catmark_flap,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap2",            catmark_flap2,            kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound0",      catmark_fvar_bound0,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound1",      catmark_fvar_bound1,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound2",      catmark_fvar_bound2,      kCatmark ) );
@@ -87,30 +86,31 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_torus_creases0",   catmark_torus_creases0,   kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_smoothtris0",      catmark_smoothtris0,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_smoothtris1",      catmark_smoothtris1,      kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit0",    catmark_square_hedit0,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit1",    catmark_square_hedit1,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit2",    catmark_square_hedit2,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit3",    catmark_square_hedit3,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_bishop",           catmark_bishop,           kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_car",              catmark_car,              kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_helmet",           catmark_helmet,           kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pawn",             catmark_pawn,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_rook",             catmark_rook,             kCatmark ) );
 
-#if 0
-    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
-
-
-    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases0",       loop_cube_creases0,       kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases1",       loop_cube_creases1,       kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_cube",                loop_cube,                kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgecorner",   loop_saddle_edgecorner,   kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgeonly",     loop_saddle_edgeonly,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cube_asymmetric",     loop_cube_asymmetric,     kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_interior",       loop_xord_interior,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_boundary",       loop_xord_boundary,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_semisharp",      loop_icos_semisharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_infsharp",       loop_icos_infsharp,       kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_chaikin0",            loop_chaikin0,            kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_chaikin1",            loop_chaikin1,            kLoop ) );
-#endif
+    g_defaultShapes.push_back( ShapeDesc("loop_pole8",               loop_pole8,               kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_pole64",              loop_pole64,              kLoop ) );
+
+    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonplanar",       bilinear_nonplanar,       kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonquads0",       bilinear_nonquads0,       kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonquads1",       bilinear_nonquads1,       kBilinear ) );
 }
 //------------------------------------------------------------------------------

--- a/examples/glShareTopology/sceneBase.h
+++ b/examples/glShareTopology/sceneBase.h
@@ -38,7 +38,7 @@ public:
                        kEndCapGregoryBasis };
 
     struct Options {
-        Options() : adaptive(true), endCap(kEndCapBSplineBasis) { }
+        Options() : adaptive(true), endCap(kEndCapGregoryBasis) { }
 
         bool adaptive;
         int endCap;

--- a/examples/glShareTopology/shader.glsl
+++ b/examples/glShareTopology/shader.glsl
@@ -386,11 +386,11 @@ getAdaptivePatchColor(ivec3 patchParam)
         vec4(0.0f,  0.8f,  0.75f, 1.0f),   // boundary pattern 4
 
         vec4(0.0f,  1.0f,  0.0f,  1.0f),   // corner
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 0
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 1
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 2
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 3
-        vec4(0.25f, 0.25f, 0.25f, 1.0f),   // corner pattern 4
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 0
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 1
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 2
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 3
+        vec4(0.5f,  1.0f,  0.5f,  1.0f),   // corner pattern 4
 
         vec4(1.0f,  1.0f,  0.0f,  1.0f),   // gregory
         vec4(1.0f,  1.0f,  0.0f,  1.0f),   // gregory
@@ -415,26 +415,31 @@ getAdaptivePatchColor(ivec3 patchParam)
     );
 
     int patchType = 0;
-#if defined OSD_PATCH_GREGORY
-    patchType = 4;
-#elif defined OSD_PATCH_GREGORY_BOUNDARY
-    patchType = 5;
-#elif defined OSD_PATCH_GREGORY_BASIS
-    patchType = 6;
-#endif
 
     int edgeCount = bitCount(OsdGetPatchBoundaryMask(patchParam));
     if (edgeCount == 1) {
         patchType = 2; // BOUNDARY
     }
-    if (edgeCount == 2) {
-        patchType = 3; // CORNER
+    if (edgeCount > 1) {
+        patchType = 3; // CORNER (not correct for patches that are not isolated)
     }
 
-    int pattern = bitCount(OsdGetPatchTransitionMask(patchParam));
-#ifdef OSD_PATCH_ENABLE_SINGLE_CREASE
-    if (inpt.sharpness > 0) pattern += 6;
+#if defined(OSD_PATCH_ENABLE_SINGLE_CREASE) && !defined(LOOP)
+    // check this after boundary/corner since single crease patch also has edgeCount.
+    if (inpt.vSegments.y > 0) {
+        patchType = 1;
+    }
+#elif defined OSD_PATCH_GREGORY
+    patchType = 4;
+#elif defined OSD_PATCH_GREGORY_BOUNDARY
+    patchType = 5;
+#elif defined OSD_PATCH_GREGORY_BASIS
+    patchType = 6;
+#elif defined OSD_PATCH_GREGORY_TRIANGLE
+    patchType = 6;
 #endif
+
+    int pattern = bitCount(OsdGetPatchTransitionMask(patchParam));
 
     return patchColors[6*patchType + pattern];
 }

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -106,7 +106,7 @@ enum HudCheckBox { kHUD_CB_DISPLAY_CONTROL_MESH_EDGES,
                    kHUD_CB_INF_SHARP_PATCH };
 
 int g_kernel = kCPU,
-    g_isolationLevel = 5; // max level of extraordinary feature isolation
+    g_isolationLevel = 2; // max level of extraordinary feature isolation
 
 int   g_running = 1,
       g_width = 1024,
@@ -1061,36 +1061,39 @@ int main(int argc, char **argv) {
 
     bool fullscreen = false;
     Scheme defaultScheme = kCatmark;
-    std::string str;
+    std::vector<char const *> objfiles;
 
     for (int i = 1; i < argc; ++i) {
-        if (!strcmp(argv[i], "-u")) {
+        if (strstr(argv[i], ".obj")) {
+            objfiles.push_back(argv[i]);
+        } else if (!strcmp(argv[i], "-a")) {
+            g_adaptive = true;
+        } else if (!strcmp(argv[i], "-u")) {
             g_adaptive = false;
-        }
-        if (!strcmp(argv[i], "-d")) {
+        } else if (!strcmp(argv[i], "-l")) {
             g_isolationLevel = atoi(argv[++i]);
-        }
-        else if (!strcmp(argv[i], "-f")) {
+        } else if (!strcmp(argv[i], "-f")) {
             fullscreen = true;
-        }
-        else if (!strcmp(argv[i], "-bilinear")) {
+        } else if (!strcmp(argv[i], "-bilinear")) {
             defaultScheme = kBilinear;
-        }
-        else if (!strcmp(argv[i], "-catmark")) {
+        } else if (!strcmp(argv[i], "-catmark")) {
             defaultScheme = kCatmark;
-        }
-        else if (!strcmp(argv[i], "-loop")) {
+        } else if (!strcmp(argv[i], "-loop")) {
             defaultScheme = kLoop;
+        } else {
+            printf("Warning: unrecognized argument '%s' ignored\n", argv[i]);
         }
-        else {
-            std::ifstream ifs(argv[i]);
-            if (ifs) {
-                std::stringstream ss;
-                ss << ifs.rdbuf();
-                ifs.close();
-                str = ss.str();
-                g_defaultShapes.push_back(ShapeDesc(argv[i], str.c_str(), defaultScheme));
-            }
+    }
+    for (int i = 0; i < (int)objfiles.size(); ++i) {
+        std::ifstream ifs(objfiles[i]);
+        if (ifs) {
+            std::stringstream ss;
+            ss << ifs.rdbuf();
+            ifs.close();
+            std::string str = ss.str();
+            g_defaultShapes.push_back(ShapeDesc(objfiles[i], str.c_str(), defaultScheme));
+        } else {
+            printf("Warning: cannot open shape file '%s'\n", objfiles[i]);
         }
     }
 

--- a/examples/glStencilViewer/init_shapes.h
+++ b/examples/glStencilViewer/init_shapes.h
@@ -39,8 +39,7 @@ static std::vector<ShapeDesc> g_defaultShapes;
 
 //------------------------------------------------------------------------------
 static void initShapes() {
-//    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear) );
-
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner0",     catmark_cube_corner0,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner1",     catmark_cube_corner1,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner2",     catmark_cube_corner2,     kCatmark ) );
@@ -48,17 +47,12 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner4",     catmark_cube_corner4,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgecorner",       catmark_edgecorner,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgeonly",         catmark_edgeonly,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin0",         catmark_chaikin0,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin1",         catmark_chaikin1,         kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_chaikin2",         catmark_chaikin2,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_quadstrips",       catmark_quadstrips,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fan",              catmark_fan,              kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap",             catmark_flap,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap2",            catmark_flap2,            kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test1",    catmark_gregory_test1,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test2",    catmark_gregory_test2,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test3",    catmark_gregory_test3,    kCatmark ) );
@@ -76,27 +70,29 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_tent",             catmark_tent,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_torus",            catmark_torus,            kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_torus_creases0",   catmark_torus_creases0,   kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit0",    catmark_square_hedit0,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit1",    catmark_square_hedit1,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit2",    catmark_square_hedit2,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit3",    catmark_square_hedit3,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_bishop",           catmark_bishop,           kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_car",              catmark_car,              kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_helmet",           catmark_helmet,           kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pawn",             catmark_pawn,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_rook",             catmark_rook,             kCatmark ) );
 
-//    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cube",                loop_cube,                kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cube_asymmetric",     loop_cube_asymmetric,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_interior",       loop_xord_interior,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_boundary",       loop_xord_boundary,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_semisharp",      loop_icos_semisharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_infsharp",       loop_icos_infsharp,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_pole8",               loop_pole8,               kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_pole64",              loop_pole64,              kLoop ) );
 
-//    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases0",       loop_cube_creases0,       kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases1",       loop_cube_creases1,       kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_cube",                loop_cube,                kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgecorner",   loop_saddle_edgecorner,   kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgeonly",     loop_saddle_edgeonly,     kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_chaikin0",            loop_chaikin0,            kLoop ) );
-//    g_defaultShapes.push_back( ShapeDesc("loop_chaikin1",            loop_chaikin1,            kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonplanar",       bilinear_nonplanar,       kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonquads0",       bilinear_nonquads0,       kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonquads1",       bilinear_nonquads1,       kBilinear ) );
 }
 //------------------------------------------------------------------------------

--- a/examples/glViewer/init_shapes.h
+++ b/examples/glViewer/init_shapes.h
@@ -41,6 +41,7 @@ static std::vector<ShapeDesc> g_defaultShapes;
 
 //------------------------------------------------------------------------------
 static void initShapes() {
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner0",     catmark_cube_corner0,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner1",     catmark_cube_corner1,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner2",     catmark_cube_corner2,     kCatmark ) );
@@ -49,11 +50,11 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases2",    catmark_cube_creases2,    kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_cube",             catmark_cube,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgecorner",       catmark_edgecorner,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgeonly",         catmark_edgeonly,         kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_quadstrips",       catmark_quadstrips,       kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_chaikin0",         catmark_chaikin0,         kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_chaikin1",         catmark_chaikin1,         kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_chaikin2",         catmark_chaikin2,         kCatmark ) );
@@ -61,11 +62,6 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_inf_crease0",      catmark_inf_crease0,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_inf_crease1",      catmark_inf_crease1,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_fan",              catmark_fan,              kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap",             catmark_flap,             kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_flap2",            catmark_flap2,            kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound0",      catmark_fvar_bound0,      kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound1",      catmark_fvar_bound1,      kCatmark ) );
-    g_defaultShapes.push_back( ShapeDesc("catmark_fvar_bound2",      catmark_fvar_bound2,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test0",    catmark_gregory_test0,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test1",    catmark_gregory_test1,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_gregory_test2",    catmark_gregory_test2,    kCatmark ) );
@@ -96,30 +92,31 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_torus_creases0",   catmark_torus_creases0,   kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_smoothtris0",      catmark_smoothtris0,      kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_smoothtris1",      catmark_smoothtris1,      kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit0",    catmark_square_hedit0,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit1",    catmark_square_hedit1,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit2",    catmark_square_hedit2,    kCatmark ) );
-//    g_defaultShapes.push_back( ShapeDesc("catmark_square_hedit3",    catmark_square_hedit3,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_bishop",           catmark_bishop,           kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_car",              catmark_car,              kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_helmet",           catmark_helmet,           kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_pawn",             catmark_pawn,             kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_rook",             catmark_rook,             kCatmark ) );
 
-    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
-
-    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases0",       loop_cube_creases0,       kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_cube_creases1",       loop_cube_creases1,       kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_cube",                loop_cube,                kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgecorner",   loop_saddle_edgecorner,   kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_saddle_edgeonly",     loop_saddle_edgeonly,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_cube_asymmetric",     loop_cube_asymmetric,     kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgecorner", loop_triangle_edgecorner, kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_triangle_edgeonly",   loop_triangle_edgeonly,   kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_interior",       loop_xord_interior,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_xord_boundary",       loop_xord_boundary,       kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icosahedron",         loop_icosahedron,         kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_semisharp",      loop_icos_semisharp,      kLoop ) );
+    g_defaultShapes.push_back( ShapeDesc("loop_icos_infsharp",       loop_icos_infsharp,       kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_chaikin0",            loop_chaikin0,            kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_chaikin1",            loop_chaikin1,            kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_pole8",               loop_pole8,               kLoop ) );
     g_defaultShapes.push_back( ShapeDesc("loop_pole64",              loop_pole64,              kLoop ) );
-    g_defaultShapes.push_back( ShapeDesc("loop_pole360",             loop_pole360,             kLoop ) );
+
+    g_defaultShapes.push_back( ShapeDesc("bilinear_cube",            bilinear_cube,            kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonplanar",       bilinear_nonplanar,       kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonquads0",       bilinear_nonquads0,       kBilinear ) );
+    g_defaultShapes.push_back( ShapeDesc("bilinear_nonquads1",       bilinear_nonquads1,       kBilinear ) );
 }
 //------------------------------------------------------------------------------


### PR DESCRIPTION
These changes include several minor updates to the examples under examples/gl*.

The primary purpose was to ensure all function correctly when patches are built (via adaptive refinement) for shapes of any subdivision scheme -- now that Loop and Bilinear are fully supported.  So any remaining Catmark-specific assumptions or restrictions were removed and remaining legitimate limitations (e.g. lack of support for Bilinear in glPaintTest or Loop in glPtexViewer) were emphasized with specific error messages and/or assertions.

Usage of all examples was also made more consistent -- particularly the loading of Obj files from the command line.  Conventions adopted from existing usage include:

    - Obj files specified on the command line require a .obj suffix
    - shapes from Obj files are assigned the specified scheme (or default to Catmark)
    - Obj files representing a single animated shape must be explicitly distinguished
    - consistent flags affecting refinement on start-up (adaptive vs uniform, level)

Additional behavioral changes include:

    - all examples start with adaptive refinement at level 2
    - all use of "Patch Type" color is now consistent with the glViewer
    - error reporting was improved to ensure messages are flushed before termination

The examples remain inconsistent in terms of the options they present in their UI -- which is appropriate in several cases.  No attempt was made to define consistent content or adjust the layout of any UI at this time.