### PR TITLE
Added options to glFVarViewer example consistent with glViewer

### DIFF
--- a/examples/glFVarViewer/init_shapes.h
+++ b/examples/glFVarViewer/init_shapes.h
@@ -52,6 +52,7 @@ static void initShapes() {
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_corner4",     catmark_cube_corner4,     kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases0",    catmark_cube_creases0,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases1",    catmark_cube_creases1,    kCatmark ) );
+    g_defaultShapes.push_back( ShapeDesc("catmark_cube_creases2",    catmark_cube_creases2,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgecorner",  catmark_dart_edgecorner,  kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_dart_edgeonly",    catmark_dart_edgeonly,    kCatmark ) );
     g_defaultShapes.push_back( ShapeDesc("catmark_edgecorner",       catmark_edgecorner,       kCatmark ) );


### PR DESCRIPTION
This change adds options for smooth corner, single crease and inf-sharp patches to the glFVarViewer in the same layout as they appear in the glViewer.  The inf-sharp patch option is particularly warranted as some of the face-varying interpolation modes really warrant inf-sharp patches to capture the desired boundary shape, and results at low-levels of refinement can be misleading without them (though the poor approximation is correct).