### PR TITLE
Minor improvement to degenerate normals in GLSL Bezier triangle

### DIFF
--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -1172,10 +1172,17 @@ OsdEvalPatchBezierTriangle(ivec3 patchParam, vec2 UV,
     dNv = cross(dUV, dPv) + cross(dPu, dVV);
 
     if (nLength < nEpsilon) {
-        float DU = (UV.x == 1.0) ? -1.0 : 1.0;
-        float DV = (UV.y == 1.0) ? -1.0 : 1.0;
+        //  Use 1st order Taylor approximation of N(u,v) within patch interior:
+        if (w > 0.0) {
+            N =  dNu + dNv;
+        } else if (u >= 1.0) {
+            N = -dNu + dNv;
+        } else if (v >= 1.0) {
+            N =  dNu - dNv;
+        } else {
+            N = -dNu - dNv;
+        }
 
-        N = DU * dNu + DV * dNv;
         nLength = length(N);
         if (nLength < nEpsilon) {
             nLength = 1.0;


### PR DESCRIPTION
The 1st order Taylor approximation used to resolve degenerate normals in the GLSL Bezier triangle shader was copied from its use with quads.  It approximates in the direction of the patch interior, but detecting the upper U and V patch extremities of the unit square for quads is not sufficient for triangles -- the diagonal boundary (where u + v == 1) also needs to be considered and the derivative terms negated accordingly.