### PR TITLE
Add support for newer DirectX SDKs

### DIFF
--- a/cmake/FindDXSDK.cmake
+++ b/cmake/FindDXSDK.cmake
@@ -43,6 +43,7 @@ if (WIN32)
             "${DXSDK_ROOT}/Include"
             "$ENV{DXSDK_ROOT}/Include"
             "C:/Program Files (x86)/Windows Kits/8.1/Include/um"
+            "C:/Program Files (x86)/Windows Kits/10/Include/*/um"
             "C:/Program Files (x86)/Microsoft DirectX SDK*/Include"
             "C:/Program Files/Microsoft DirectX SDK*/Include"
     )
@@ -61,6 +62,7 @@ if (WIN32)
             "${DXSDK_ROOT}/Lib/${ARCH}"
             "$ENV{DXSDK_ROOT}/Lib/${ARCH}"
             "C:/Program Files (x86)/Windows Kits/8.1/Lib/winv6.3/um/${ARCH}"
+            "C:/Program Files (x86)/Windows Kits/10/Lib/*/um/${ARCH}"
             "C:/Program Files (x86)/Microsoft DirectX SDK*/Lib/${ARCH}"
             "C:/Program Files/Microsoft DirectX SDK*/Lib/${ARCH}"
     )
@@ -74,9 +76,14 @@ if (WIN32)
                 ${DX_LIB}.lib
             PATHS
                 ${DXSDK_LIBRARY_DIR}
+            NO_DEFAULT_PATH
         )
 
-        list(APPEND DXSDK_LIBRARIES ${DXSDK_${DX_LIB}_LIBRARY})
+        if(NOT DXSDK_${DX_LIB}_LIBRARY)
+            message(FATAL_ERROR "Could not find required library ${DX_LIB}")
+        else()
+            list(APPEND DXSDK_LIBRARIES ${DXSDK_${DX_LIB}_LIBRARY})
+        endif()
 
 
     endforeach(DX_LIB)


### PR DESCRIPTION
- Add search path for Windows 10 support for DirectX SDK

- Turn off searching the default paths for the DirectX libraries and instead use the explicit paths provided.  On certain configurations, this fixes the case where cmake will pick up the librariees for the wrong architecture

- Be more explicit when a required DirectX library is not found instead of silent failure.