### PR TITLE
Turn off CUDA deprecation warnings until addressed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,7 @@ endif()
 if(CUDA_FOUND)
     add_definitions(
         -DOPENSUBDIV_HAS_CUDA
+        -DCUDA_ENABLE_DEPRECATED=0
     )
     set(OSD_GPU TRUE)
 


### PR DESCRIPTION
As mentioned in issue #997, OpenSubdiv still uses CUDA functionality that is being deprecated.  When warnings are treated as errors, this can make OpenSubdiv fail to compile.  For now, we turn off these
deprecation warnings until we can address them.