### PR TITLE
Fix build script on Linux when not building ptex

### DIFF
--- a/build_scripts/build_osd.py
+++ b/build_scripts/build_osd.py
@@ -905,17 +905,17 @@ if extraPaths:
 requiredDependencies = [GLEW, GLFW]
 
 if context.buildPtex:
-    requiredDependencies += [ZLIB, PTEX]
+    # Assume zlib already exists on Linux platforms and don't build
+    # our own. This avoids potential issues where a host application
+    # loads an older version of zlib than the one we'd build and link
+    # our libraries against.
+    if not Linux():
+        requiredDependencies += [ZLIB]
+    requiredDependencies += [PTEX]
 
 if context.buildTBB:
     requiredDependencies += [TBB]
 
-# Assume zlib already exists on Linux platforms and don't build
-# our own. This avoids potential issues where a host application
-# loads an older version of zlib than the one we'd build and link
-# our libraries against.
-if Linux():
-    requiredDependencies.remove(ZLIB)
 
 
 dependenciesToBuild = []


### PR DESCRIPTION
The build script assumed that we always had ZLIB, but we only add it when we build ptex.  Instead of removing it on Linux, we now only add it when we need to on non-Linux platforms.