### PR TITLE
Turn on C++11 in clang when building with Metal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,12 @@ endif()
 
 if( METAL_FOUND AND NOT NO_METAL)
     set(OSD_GPU TRUE)
+    if (CMAKE_COMPILER_IS_CLANGCC)
+        # When building with Metal support enabled, we need to explicitly
+        # request that the C++ code be compiled with C++11 since some example
+        # code for Metal relies on functionality only available in C++11.
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
 endif()
 
 if( OPENGL_FOUND AND NOT NO_OPENGL)


### PR DESCRIPTION
The example code that uses Metal forces C++11 features, therefore we have to turn it on clang so that we can enable the building of compatible code that can be used by Metal and GL at the same time.