### PR TITLE
Fix build of Metal examples when also building GL

### DIFF
--- a/examples/mtlPtexViewer/CMakeLists.txt
+++ b/examples/mtlPtexViewer/CMakeLists.txt
@@ -61,6 +61,13 @@ else()
     set_source_files_properties("${BUNDLE_FILES}" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 endif()
 
+# XXX: This is unfortunate, we should probably refactor examples_common_obj
+# to separate out the GL from the Metal dependencies so that we don't end up
+# in the situation where we have to link in GLFW for mtlViewer.
+if (GLFW_FOUND)
+    list(APPEND PLATFORM_LIBRARIES "${GLFW_LIBRARIES}")
+endif()
+
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
     "${METAL_INCLUDE_DIR}"

--- a/examples/mtlViewer/CMakeLists.txt
+++ b/examples/mtlViewer/CMakeLists.txt
@@ -60,6 +60,13 @@ else()
     set_source_files_properties("${BUNDLE_FILES}" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 endif()
 
+# XXX: This is unfortunate, we should probably refactor examples_common_obj
+# to separate out the GL from the Metal dependencies so that we don't end up
+# in the situation where we have to link in GLFW for mtlViewer.
+if (GLFW_FOUND)
+    list(APPEND PLATFORM_LIBRARIES "${GLFW_LIBRARIES}")
+endif()
+
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
     "${METAL_INCLUDE_DIR}"


### PR DESCRIPTION
This fixes the build when trying to build both the Metal examples and the GL examples in the same build. The change is an unfortunate consequence of how dependencies are bundled together in examples/common and a future task is needed to split up these dependencies.  The same workaround exists in the DirectX examples as well and would also benefit from splitting up the dependencies.