### PR TITLE
Clean up the CMakeLists.txt in the far tutorials

### DIFF
--- a/tutorials/far/CMakeLists.txt
+++ b/tutorials/far/CMakeLists.txt
@@ -21,6 +21,19 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
+macro(_add_far_tutorial NAME)
+
+     _add_executable(${NAME} "tutorials/far"
+        ${ARGN}
+        $<TARGET_OBJECTS:sdc_obj>
+        $<TARGET_OBJECTS:vtr_obj>
+        $<TARGET_OBJECTS:far_obj>
+     )
+
+     install(TARGETS ${NAME} DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
+
+endmacro()
+
 
 set(TUTORIALS
     tutorial_0

--- a/tutorials/far/tutorial_0/CMakeLists.txt
+++ b/tutorials/far/tutorial_0/CMakeLists.txt
@@ -21,17 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_0
     far_tutorial_0.cpp
 )
-
-_add_executable(far_tutorial_0 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-)
-
-install(TARGETS far_tutorial_0 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/far/tutorial_1/CMakeLists.txt
+++ b/tutorials/far/tutorial_1/CMakeLists.txt
@@ -21,17 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_1
     far_tutorial_1.cpp
 )
-
-_add_executable(far_tutorial_1 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-)
-
-install(TARGETS far_tutorial_1 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/far/tutorial_10/CMakeLists.txt
+++ b/tutorials/far/tutorial_10/CMakeLists.txt
@@ -21,17 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_10
     far_tutorial_10.cpp
 )
-
-_add_executable(far_tutorial_10 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-)
-
-install(TARGETS far_tutorial_10 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/far/tutorial_2/CMakeLists.txt
+++ b/tutorials/far/tutorial_2/CMakeLists.txt
@@ -21,17 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_2
     far_tutorial_2.cpp
 )
-
-_add_executable(far_tutorial_2 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-)
-
-install(TARGETS far_tutorial_2 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/far/tutorial_3/CMakeLists.txt
+++ b/tutorials/far/tutorial_3/CMakeLists.txt
@@ -21,17 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_3
     far_tutorial_3.cpp
 )
-
-_add_executable(far_tutorial_3 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-)
-
-install(TARGETS far_tutorial_3 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/far/tutorial_4/CMakeLists.txt
+++ b/tutorials/far/tutorial_4/CMakeLists.txt
@@ -21,17 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_4
     far_tutorial_4.cpp
 )
-
-_add_executable(far_tutorial_4 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-)
-
-install(TARGETS far_tutorial_4 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/far/tutorial_5/CMakeLists.txt
+++ b/tutorials/far/tutorial_5/CMakeLists.txt
@@ -21,17 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_5
     far_tutorial_5.cpp
 )
-
-_add_executable(far_tutorial_5 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-)
-
-install(TARGETS far_tutorial_5 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/far/tutorial_6/CMakeLists.txt
+++ b/tutorials/far/tutorial_6/CMakeLists.txt
@@ -21,17 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_6
     far_tutorial_6.cpp
 )
-
-_add_executable(far_tutorial_6 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-)
-
-install(TARGETS far_tutorial_6 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/far/tutorial_7/CMakeLists.txt
+++ b/tutorials/far/tutorial_7/CMakeLists.txt
@@ -21,17 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_7
     far_tutorial_7.cpp
 )
-
-_add_executable(far_tutorial_7 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-)
-
-install(TARGETS far_tutorial_7 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/far/tutorial_8/CMakeLists.txt
+++ b/tutorials/far/tutorial_8/CMakeLists.txt
@@ -21,17 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_8
     far_tutorial_8.cpp
 )
-
-_add_executable(far_tutorial_8 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-)
-
-install(TARGETS far_tutorial_8 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/far/tutorial_9/CMakeLists.txt
+++ b/tutorials/far/tutorial_9/CMakeLists.txt
@@ -21,18 +21,8 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-
-set(SOURCE_FILES
+_add_far_tutorial(
+    far_tutorial_9
     far_tutorial_9.cpp
-)
-
-_add_executable(far_tutorial_9 "tutorials/far"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
     $<TARGET_OBJECTS:regression_common_obj>
 )
-
-install(TARGETS far_tutorial_9 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-


### PR DESCRIPTION
Most of the tutorials are built and installed the same way so provide a common _add_far_tutorial macro.