### PR TITLE
Guard against failed DirectX shader compilation

### DIFF
--- a/examples/common/d3d11ShaderCache.cpp
+++ b/examples/common/d3d11ShaderCache.cpp
@@ -82,6 +82,9 @@ D3D11DrawConfig::CompileVertexShader(const std::string &target,
     ID3DBlob * pBlob = NULL;
     pBlob = _CompileShader(target, entry, source);
 
+    if (!pBlob)
+        return false;
+
     HRESULT hr = pd3dDevice->CreateVertexShader(pBlob->GetBufferPointer(),
                                                 pBlob->GetBufferSize(),
                                                 NULL,
@@ -112,6 +115,9 @@ D3D11DrawConfig::CompileHullShader(const std::string &target,
     ID3DBlob * pBlob = NULL;
     pBlob = _CompileShader(target, entry, source);
 
+    if (!pBlob)
+        return false;
+
     HRESULT hr = pd3dDevice->CreateHullShader(pBlob->GetBufferPointer(),
                                               pBlob->GetBufferSize(),
                                               NULL,
@@ -131,6 +137,9 @@ D3D11DrawConfig::CompileDomainShader(const std::string &target,
                                      ID3D11Device * pd3dDevice) {
     ID3DBlob * pBlob = NULL;
     pBlob = _CompileShader(target, entry, source);
+
+    if (!pBlob)
+        return false;
 
     HRESULT hr = pd3dDevice->CreateDomainShader(pBlob->GetBufferPointer(),
                                                 pBlob->GetBufferSize(),
@@ -152,6 +161,9 @@ D3D11DrawConfig::CompileGeometryShader(const std::string &target,
     ID3DBlob * pBlob = NULL;
     pBlob = _CompileShader(target, entry, source);
 
+    if (!pBlob)
+        return false;
+
     HRESULT hr = pd3dDevice->CreateGeometryShader(pBlob->GetBufferPointer(),
                                                   pBlob->GetBufferSize(),
                                                   NULL,
@@ -171,6 +183,9 @@ D3D11DrawConfig::CompilePixelShader(const std::string &target,
                                     ID3D11Device * pd3dDevice) {
     ID3DBlob * pBlob = NULL;
     pBlob = _CompileShader(target, entry, source);
+
+    if (!pBlob)
+        return false;
 
     HRESULT hr = pd3dDevice->CreatePixelShader(pBlob->GetBufferPointer(),
                                                pBlob->GetBufferSize(),

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -1467,10 +1467,7 @@ updateRenderTarget(HWND hWnd) {
 static void
 callbackError(OpenSubdiv::Far::ErrorType err, const char *message) {
 
-    std::ostringstream s;
-    s << "Error: " << err << "\n";
-    s << message;
-    OutputDebugString(s.str().c_str());
+    MessageBox(NULL, message, "Error", MB_ICONERROR);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Guard against cases where we can fail to compile various shaders in DirectX which can lead to crash.

- Make error reporting a little more prominent in dxViewer with a model message box.  It's easy enough to add a breakpoint to this code if debugging is desired, and this is more obvious when debugging is not desired.