### PR TITLE
Fixed references to recently renamed tutorials in tutorial source

### DIFF
--- a/tutorials/far/tutorial_1_1/far_tutorial_1_1.cpp
+++ b/tutorials/far/tutorial_1_1/far_tutorial_1_1.cpp
@@ -118,7 +118,7 @@ int main(int, char **) {
     desc.vertIndicesPerFace  = g_vertIndices;
 
 
-    // Instantiate a FarTopologyRefiner from the descriptor
+    // Instantiate a Far::TopologyRefiner from the descriptor
     Far::TopologyRefiner * refiner = Far::TopologyRefinerFactory<Descriptor>::Create(desc,
                                             Far::TopologyRefinerFactory<Descriptor>::Options(type, options));
 

--- a/tutorials/far/tutorial_1_2/far_tutorial_1_2.cpp
+++ b/tutorials/far/tutorial_1_2/far_tutorial_1_2.cpp
@@ -141,7 +141,7 @@ static float g_verts[8][3] = {{  0.0f,  0.0f,  1.0f },
                               {  1.0f,  0.0f,  0.0f }};
 
 //
-//  Creates Far::TopologyRefiner from raw geometry above (see tutorial_0 for
+//  Creates Far::TopologyRefiner from raw geometry above (see tutorial_1_1 for
 //  more details)
 //
 static Far::TopologyRefiner *
@@ -182,7 +182,7 @@ createFarTopologyRefiner() {
 
 int main(int, char **) {
 
-    //  Instantiate a FarTopologyRefiner from the global geometry:
+    //  Instantiate a Far::TopologyRefiner from the global geometry:
     Far::TopologyRefiner * refiner = createFarTopologyRefiner();
 
     //  Uniformly refine the topology up to 'maxlevel'

--- a/tutorials/far/tutorial_2_1/far_tutorial_2_1.cpp
+++ b/tutorials/far/tutorial_2_1/far_tutorial_2_1.cpp
@@ -212,7 +212,7 @@ int main(int, char **) {
 //------------------------------------------------------------------------------
 // Creates Far::TopologyRefiner from raw geometry
 //
-// see far_tutorial_0 for more details
+// see tutorial_1_1 for more details
 //
 static Far::TopologyRefiner *
 createFarTopologyRefiner() {

--- a/tutorials/far/tutorial_2_2/far_tutorial_2_2.cpp
+++ b/tutorials/far/tutorial_2_2/far_tutorial_2_2.cpp
@@ -243,7 +243,7 @@ int main(int, char **) {
     desc.numFVarChannels = 2;
     desc.fvarChannels = channels;
 
-    // Instantiate a FarTopologyRefiner from the descriptor
+    // Instantiate a Far::TopologyRefiner from the descriptor
     Far::TopologyRefiner * refiner =
         Far::TopologyRefinerFactory<Descriptor>::Create(desc,
             Far::TopologyRefinerFactory<Descriptor>::Options(type, options));

--- a/tutorials/far/tutorial_2_3/far_tutorial_2_3.cpp
+++ b/tutorials/far/tutorial_2_3/far_tutorial_2_3.cpp
@@ -319,7 +319,7 @@ int main(int argc, char ** argv) {
     desc.numFVarChannels = numChannels;
     desc.fvarChannels = channels;
 
-    // Instantiate a FarTopologyRefiner from the descriptor
+    // Instantiate a Far::TopologyRefiner from the descriptor
     Far::TopologyRefiner * refiner =
         Far::TopologyRefinerFactory<Descriptor>::Create(desc,
             Far::TopologyRefinerFactory<Descriptor>::Options(type, options));

--- a/tutorials/far/tutorial_4_1/far_tutorial_4_1.cpp
+++ b/tutorials/far/tutorial_4_1/far_tutorial_4_1.cpp
@@ -26,8 +26,8 @@
 //------------------------------------------------------------------------------
 // Tutorial description:
 //
-// This tutorial shows how to create and manipulate FarStencilTable. We use the
-// factorized stencils to interpolate vertex primvar data buffers.
+// This tutorial shows how to create and manipulate Far::StencilTable. We use
+// the factorized stencils to interpolate vertex primvar data buffers.
 //
 
 #include <opensubdiv/far/topologyDescriptor.h>
@@ -107,7 +107,7 @@ static Far::TopologyRefiner * createTopologyRefiner();
 //------------------------------------------------------------------------------
 int main(int, char **) {
 
-    // Generate some FarTopologyRefiner (see far_tutorial_0 for details).
+    // Generate a Far::TopologyRefiner (see tutorial_1_1 for details).
     Far::TopologyRefiner * refiner = createTopologyRefiner();
 
 
@@ -116,7 +116,7 @@ int main(int, char **) {
     refiner->RefineUniform(Far::TopologyRefiner::UniformOptions(maxlevel));
 
 
-    // Use the FarStencilTable factory to create discrete stencil table
+    // Use the Far::StencilTable factory to create discrete stencil table
     // note: we only want stencils for the highest refinement level.
     Far::StencilTableFactory::Options options;
     options.generateIntermediateLevels=false;
@@ -175,7 +175,7 @@ createTopologyRefiner() {
     desc.numVertsPerFace = g_vertsperface;
     desc.vertIndicesPerFace = g_vertIndices;
 
-    // Instantiate a FarTopologyRefiner from the descriptor.
+    // Instantiate a Far::TopologyRefiner from the descriptor.
     return Far::TopologyRefinerFactory<Descriptor>::Create(desc,
                 Far::TopologyRefinerFactory<Descriptor>::Options(type, options));
 

--- a/tutorials/far/tutorial_4_2/far_tutorial_4_2.cpp
+++ b/tutorials/far/tutorial_4_2/far_tutorial_4_2.cpp
@@ -113,7 +113,7 @@ static Far::TopologyRefiner * createTopologyRefiner();
 //------------------------------------------------------------------------------
 int main(int, char **) {
 
-    // Generate a FarTopologyRefiner (see far_tutorial_0 for details).
+    // Generate a Far::TopologyRefiner (see tutorial_1_1 for details).
     Far::TopologyRefiner * refiner = createTopologyRefiner();
 
 
@@ -227,7 +227,7 @@ createTopologyRefiner() {
     desc.numVertsPerFace = g_vertsperface;
     desc.vertIndicesPerFace = g_vertIndices;
 
-    // Instantiate a FarTopologyRefiner from the descriptor.
+    // Instantiate a Far::TopologyRefiner from the descriptor.
     Far::TopologyRefiner * refiner =
         Far::TopologyRefinerFactory<Descriptor>::Create(desc,
             Far::TopologyRefinerFactory<Descriptor>::Options(type, options));

--- a/tutorials/far/tutorial_4_3/far_tutorial_4_3.cpp
+++ b/tutorials/far/tutorial_4_3/far_tutorial_4_3.cpp
@@ -122,14 +122,14 @@ static Far::TopologyRefiner * createTopologyRefiner();
 //------------------------------------------------------------------------------
 int main(int, char **) {
 
-    // Generate a FarTopologyRefiner (see far_tutorial_0 for details).
+    // Generate a Far::TopologyRefiner (see tutorial_1_1 for details).
     Far::TopologyRefiner * refiner = createTopologyRefiner();
 
     // Uniformly refine the topology up to 'maxlevel'.
     int maxlevel = 4;
     refiner->RefineUniform(Far::TopologyRefiner::UniformOptions(maxlevel));
 
-    // Use the FarStencilTable factory to create cascading stencil table
+    // Use the Far::StencilTable factory to create cascading stencil table
     // note: we want stencils for each refinement level
     //       "cascade" mode is achieved by setting "factorizeIntermediateLevels"
     //       to false
@@ -229,7 +229,7 @@ createTopologyRefiner() {
     desc.numVertsPerFace = g_vertsperface;
     desc.vertIndicesPerFace = g_vertIndices;
 
-    // Instantiate a FarTopologyRefiner from the descriptor.
+    // Instantiate a Far::TopologyRefiner from the descriptor.
     return Far::TopologyRefinerFactory<Descriptor>::Create(desc,
             Far::TopologyRefinerFactory<Descriptor>::Options(type, options));
 

--- a/tutorials/far/tutorial_5_1/far_tutorial_5_1.cpp
+++ b/tutorials/far/tutorial_5_1/far_tutorial_5_1.cpp
@@ -137,7 +137,7 @@ struct LimitFrame {
 //------------------------------------------------------------------------------
 int main(int, char **) {
 
-    // Generate a FarTopologyRefiner (see far_tutorial_0 for details).
+    // Generate a Far::TopologyRefiner (see tutorial_1_1 for details).
     Far::TopologyRefiner * refiner = createTopologyRefiner();
 
     // Patches are constructed from adaptively refined faces, but the processes
@@ -198,7 +198,7 @@ int main(int, char **) {
     int nRefinedLevels = refiner->GetNumLevels();
 
     // Interpolate vertex primvar data : they are the control vertices
-    // of the limit patches (see far_tutorial_0 for details)
+    // of the limit patches (see tutorial_1_1 for details)
     Far::PrimvarRefinerReal<Real> primvarRefiner(*refiner);
 
     Vertex * src = &verts[0];
@@ -325,7 +325,7 @@ createTopologyRefiner() {
     desc.creaseVertexIndexPairs = g_creaseverts;
     desc.creaseWeights = g_creaseweights;
 
-    // Instantiate a FarTopologyRefiner from the descriptor.
+    // Instantiate a Far::TopologyRefiner from the descriptor.
     Far::TopologyRefiner * refiner =
         Far::TopologyRefinerFactory<Descriptor>::Create(desc,
             Far::TopologyRefinerFactory<Descriptor>::Options(type, options));

--- a/tutorials/far/tutorial_5_2/far_tutorial_5_2.cpp
+++ b/tutorials/far/tutorial_5_2/far_tutorial_5_2.cpp
@@ -29,7 +29,7 @@
 //      This tutorial shows how to manage the limit surface of a potentially
 //      large mesh by creating groups of patches for selected faces of the
 //      mesh.  Familiarity with construction and evaluation of a PatchTable
-//      is assumed (see far/tutorial_6).
+//      is assumed (see tutorial_5_1).
 //
 //      When the patches for a mesh do not need to be retained for further
 //      use, e.g. when simply computing points for a tessellation, the time
@@ -204,7 +204,7 @@ namespace {
         desc.numVertsPerFace = &topVertsPerFace[0];
         desc.vertIndicesPerFace = &topFaceVerts[0];
 
-        //  Instantiate a FarTopologyRefiner from the descriptor.
+        //  Instantiate a Far::TopologyRefiner from the descriptor.
         Far::TopologyRefiner * refiner =
             Far::TopologyRefinerFactory<Descriptor>::Create(desc,
                 Far::TopologyRefinerFactory<Descriptor>::Options(type, options));
@@ -349,7 +349,7 @@ PatchGroup::PatchGroup(Far::PatchTableFactory::Options patchOptions,
     patchFaceSize = Sdc::SchemeTypeTraits::GetRegularFaceSize(baseRefiner.GetSchemeType());
 
     //  Compute the number of refined and local points needed to evaluate the
-    //  patches, allocate and interpolate.  This varies from far/tutorial_6 in
+    //  patches, allocate and interpolate.  This varies from tutorial_5_1 in
     //  that the primvar buffer for the base vertices is separate from the
     //  refined vertices and local patch points (which must also be accounted
     //  for when evaluating the patches).


### PR DESCRIPTION
The recent reorganization and renaming of Far tutorials (#1083) neglected to update references to the tutorials from within the source for the tutorials.  These changes correct that oversight.

While making these changes, comments using the old 2.x style class naming (e.g. FarClassName vs Far::ClassName) were also encountered and the class names updated.