### PR TITLE
Minor documentation changes to preserve existing external links

### DIFF
--- a/documentation/compatibility.rst
+++ b/documentation/compatibility.rst
@@ -83,7 +83,7 @@ simply be changed -- and so an additional mode was added to avoid such behavior.
 
 All choices are now provided through a single "linear interpolation" enum,
 described and illustrated in more detail in the overview of
-`Face-Varying Interpolation <subdivision_surfaces.html#face-varying-interpolation>`__.
+`Face-Varying Interpolation <subdivision_surfaces.html#face-varying-interpolation-rules>`__.
 The use of "boundary" in the name of the enum was intentionally removed
 as the choice also affects interior interpolation.  The new use of "linear"
 is now intended to reflect the fact that interpolation is constrained to be

--- a/documentation/far_overview.rst
+++ b/documentation/far_overview.rst
@@ -51,7 +51,7 @@ not depend on the speciific values of any primvar data (point positions, etc).
 
 Topology refinement can be either uniform or adaptive, where extraordinary
 features are automatically isolated (see
-`feature adaptive subdivision <subdivision_surfaces.html#feature-adaptive>`__).
+`feature adaptive subdivision <subdivision_surfaces.html#feature-adaptive-subdivision>`__).
 
 The *Far* topology classes present a public interface for the refinement
 functionality provided in `Vtr <vtr_overview.html#Vtr>`__,

--- a/documentation/hbr_overview.rst
+++ b/documentation/hbr_overview.rst
@@ -110,9 +110,8 @@ Boundary Interpolation Rules
 | k_InterpolateBoundaryAlwaysSharp   |
 +------------------------------------+
 
-This enum is shared for both `vertex and face-varying interpolation
-<subdivision_surfaces.html#boundary-interpolation>`__, with the following
-distinctions:
+This enum is shared for both vertex and face-varying interpolation,
+with the following distinctions:
 
     - vertex boundaries:
         - the *BoundaryNone* rule skips all boundary vertices (results are ''undefined'')

--- a/documentation/osd_overview.rst
+++ b/documentation/osd_overview.rst
@@ -66,7 +66,7 @@ Refinement
 ==========
 
 **Osd** supports both uniform and
-`feature adaptive <subdivision_surfaces.html#feature-adaptive>`__ subdivision.
+`feature adaptive <subdivision_surfaces.html#feature-adaptive-subdivision>`__ subdivision.
 
 
 .. image:: images/osd_refinement.png

--- a/documentation/porting.rst
+++ b/documentation/porting.rst
@@ -130,7 +130,7 @@ options used to control its interpolation have changed.  The documentation on
 `Compatibility with OpenSubdiv 2.x <compatibility.html#compatibility-with-opensubdiv-2.x>`__
 details the equivalence of interpolation options between Hbr and the new
 *Sdc::Options::FVarLinearInterpolation* enum, while the section on
-`Face Varying Interpolation <subdivision_surfaces.html#face-varying-interpolation>`__
+`Face Varying Interpolation <subdivision_surfaces.html#face-varying-interpolation-rules>`__
 illustrates their effects.
 
 Face varying data is now specified by index rather than by value, or as often

--- a/documentation/release_31.rst
+++ b/documentation/release_31.rst
@@ -37,7 +37,7 @@ Bicubic Face-Varying Patches
 
 The motivation for this feature is to improve drawing and evaluation of face-varying
 primvar values for all
-`face-varying interpolation options <subdivision_surfaces.html#face-varying-interpolation>`__.
+`face-varying interpolation options <subdivision_surfaces.html#face-varying-interpolation-rules>`__.
 
 A common use of non-linear face-varying data is to capture a UV projection on
 the surface.  The following example shows a simple shape with the face-varying

--- a/documentation/subdivision_surfaces.rst
+++ b/documentation/subdivision_surfaces.rst
@@ -250,6 +250,9 @@ The presence of these irregular features makes the limit surface around them
 similarly irregular, i.e. it cannot be represented as simply as it can for regular
 regions.
 
+.. Explicit target to preserve external links:
+.. _feature-adaptive-subdivision:
+
 It's worth noting that irregular regions shrink in size and become more "isolated"
 as subdivision is applied.  A face with a lot of extra-ordinary vertices around it
 makes for a very complicated surface, and isolating these features is a way to
@@ -263,8 +266,6 @@ help deal with that complexity:
 |                                      |                                      |                                      |
 | Two valence-5 vertices nearby        | Isolation subdivided once            | Isolation subdivided twice           |
 +--------------------------------------+--------------------------------------+--------------------------------------+
-
-.. _feature-adaptive:
 
 It's generally necessary to perform some kind of local subdivision in these areas
 to break these pieces of surface into smaller, more manageable pieces, and the
@@ -812,8 +813,8 @@ prior to version 3.4.*
 
 ----
 
-Boundary Interpolation
-**********************
+Boundary Interpolation Rules
+****************************
 
 Boundary interpolation rules control how subdivision and the limit surface behave for faces
 adjacent to boundary edges and vertices.
@@ -854,8 +855,8 @@ by whether or not the surface at corner vertices is smooth or sharp.
 
 ----
 
-Face-varying Interpolation
-**************************
+Face-varying Interpolation Rules
+********************************
 
 Face-varying interpolation rules control how face-varying data is interpolated both in the
 interior of face-varying regions (smooth or linear) and at the boundaries where it is

--- a/documentation/using_osd_hbr.rst
+++ b/documentation/using_osd_hbr.rst
@@ -312,7 +312,6 @@ The rule-set can be selected using the following accessors:
 
 
 Additional information on boundary interpolation rules can be found
-`here <subdivision_surfaces.html#boundary-interpolation>`__ and
 `here <hbr_overview.html#boundary-interpolation-rules>`__
 
 .. container:: impnotip


### PR DESCRIPTION
Recent changes to the documentation have been made consistent in terms of internal links, but changes to subsections and their titles have broken pre-existing external links to those sections.  These changes restore some subsection titles and rename explicit internal targets to preserve those external links (which include several in the USD code base and examples).