### PR TITLE
Replaced -axis with -yup in example viewers and common args

### DIFF
--- a/documentation/code_examples.rst
+++ b/documentation/code_examples.rst
@@ -63,6 +63,7 @@ all -- in some cases, certain options are not applicable.
 ::
 
       -f         : launches the application in full-screen mode (if supported)
+      -yup       : set initial view with Y-axis up (Z-up is the default)
       -u         : apply uniform subdivision to all meshes
       -a         : apply adaptive subdivision to create patches for the limit surface
       -l depth   : level of uniform or adaptive refinement to apply

--- a/documentation/glviewer.rst
+++ b/documentation/glviewer.rst
@@ -35,7 +35,7 @@ SYNOPSIS
 .. parsed-literal:: 
    :class: codefhead
 
-   **glViewer** [**-f**] [**-u**] [**-a**] [**-l** *refinement level*] [**-axis**] [**-c** *animation loops*]
+   **glViewer** [**-f**] [**-yup**] [**-u**] [**-a**] [**-l** *refinement level*] [**-c** *animation loops*]
        *objfile(s)* [**-anim**] [**-catmark**] [**-loop**] [**-bilinear**]
 
 DESCRIPTION
@@ -56,8 +56,5 @@ OPTIONS
 See the description of the
 `common comand line options <code_examples.html#common-command-line-options>`__
 for the subset of common options supported here.
-
-**-axis**
-  Swap Y-up / Z-up axis when loading Obj files
 
 .. include:: examples_see_also.rst

--- a/examples/common/argOptions.cpp
+++ b/examples/common/argOptions.cpp
@@ -42,11 +42,11 @@ parseIntArg(const char* argString, int dfltValue = 0) {
 
 
 ArgOptions::ArgOptions() 
-    : _adaptive(false)
+    : _adaptive(true)
     , _fullscreen(false)
     , _level(2)
     , _objsAreAnim(false)
-    , _axis(true)
+    , _yup(false)
     , _repeatCount(0)
     , _defaultScheme(kCatmark)
 {
@@ -69,8 +69,8 @@ ArgOptions::Parse(int argc, char **argv)
             if (++i < argc) _repeatCount = parseIntArg(argv[i], 0);
         } else if (!strcmp(argv[i], "-f")) {
             _fullscreen = true;
-        } else if (!strcmp(argv[i], "-axis")) {
-            _axis = false;
+        } else if (!strcmp(argv[i], "-yup")) {
+            _yup = true;
         } else if (!strcmp(argv[i], "-anim")) {
             _objsAreAnim = true;
         } else if (!strcmp(argv[i], "-bilinear")) {

--- a/examples/common/argOptions.h
+++ b/examples/common/argOptions.h
@@ -57,7 +57,7 @@ public:
 
     bool GetObjsAreAnim() const { return _objsAreAnim; }
 
-    bool GetAxis() const { return _axis; }
+    bool GetYUp() const { return _yup; }
 
     int GetRepeatCount() const { return _repeatCount; }
     
@@ -78,7 +78,7 @@ private:
 
     bool _objsAreAnim;
 
-    bool _axis;
+    bool _yup;
 
     int _repeatCount;
 

--- a/examples/common/viewerArgsUtils.cpp
+++ b/examples/common/viewerArgsUtils.cpp
@@ -43,7 +43,7 @@ PopulateAnimShapes(const ArgOptions &args,
         return NULL;
 
 
-    const ObjAnim *objAnim = ObjAnim::Create(args.GetObjFiles(), args.GetAxis(),
+    const ObjAnim *objAnim = ObjAnim::Create(args.GetObjFiles(), true,
         args.GetDefaultScheme());
 
     if (objAnim) {

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -147,6 +147,8 @@ float g_rotate[2] = {0, 0},
       g_center[3] = {0, 0, 0},
       g_size = 0;
 
+bool  g_yup = false;
+
 int   g_width = 1024,
       g_height = 1024;
 
@@ -697,7 +699,9 @@ bindProgram(Effect effect, OpenSubdiv::Osd::PatchArray const & patch) {
         rotate(pData->ModelViewMatrix, g_rotate[1], 1, 0, 0);
         rotate(pData->ModelViewMatrix, g_rotate[0], 0, 1, 0);
         translate(pData->ModelViewMatrix, -g_center[0], -g_center[2], g_center[1]); // z-up model
-        rotate(pData->ModelViewMatrix, -90, 1, 0, 0); // z-up model
+        if (!g_yup) {
+            rotate(pData->ModelViewMatrix, -90, 1, 0, 0); // z-up model
+        }
         inverseMatrix(pData->ModelViewInverseMatrix, pData->ModelViewMatrix);
 
         identity(pData->ProjectionMatrix);
@@ -1556,8 +1560,13 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine,
     // Parse the command line arguments
     ArgOptions args;
     args.Parse(__argc, __argv);
+    args.PrintUnrecognizedArgsWarnings();
+
+    g_yup = args.GetYUp();
+    g_adaptive = args.GetAdaptive();
     g_level = args.GetLevel();
     g_repeatCount = args.GetRepeatCount();
+
     ViewerArgsUtils::PopulateShapes(args, &g_defaultShapes);
 
     initShapes();

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -98,6 +98,8 @@ float g_rotate[2] = {0, 0},
       g_uvPan[2] = {0, 0},
       g_uvScale = 1.0;
 
+bool  g_yup = false;
+
 int   g_prev_x = 0,
       g_prev_y = 0;
 
@@ -859,7 +861,9 @@ display() {
     translate(g_transformData.ModelViewMatrix, -g_pan[0], -g_pan[1], -g_dolly);
     rotate(g_transformData.ModelViewMatrix, g_rotate[1], 1, 0, 0);
     rotate(g_transformData.ModelViewMatrix, g_rotate[0], 0, 1, 0);
-    rotate(g_transformData.ModelViewMatrix, -90, 1, 0, 0);
+    if (!g_yup) {
+        rotate(g_transformData.ModelViewMatrix, -90, 1, 0, 0);
+    }
     translate(g_transformData.ModelViewMatrix,
               -g_center[0], -g_center[1], -g_center[2]);
     perspective(g_transformData.ProjectionMatrix,
@@ -1249,18 +1253,6 @@ callbackErrorGLFW(int error, const char* description) {
 }
 
 //------------------------------------------------------------------------------
-static int
-parseIntArg(const char* argString, int dfltValue = 0) {
-    char *argEndptr;
-    int argValue = strtol(argString, &argEndptr, 10);
-    if (*argEndptr != 0) {
-        printf("Warning: non-integer option parameter '%s' ignored\n", argString);
-        argValue = dfltValue;
-    }
-    return argValue;
-}
-
-//------------------------------------------------------------------------------
 int main(int argc, char ** argv) {
 
     ArgOptions args;
@@ -1268,6 +1260,7 @@ int main(int argc, char ** argv) {
     args.Parse(argc, argv);
     args.PrintUnrecognizedArgsWarnings();
 
+    g_yup = args.GetYUp();
     g_adaptive = args.GetAdaptive();
     g_level = args.GetLevel();
     g_repeatCount = args.GetRepeatCount();

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -201,6 +201,8 @@ float g_rotate[2] = {0, 0},
       g_center[3] = {0, 0, 0},
       g_size = 0;
 
+bool  g_yup = false;
+
 int   g_prev_x = 0,
       g_prev_y = 0;
 
@@ -1082,7 +1084,9 @@ display() {
     translate(g_transformData.ModelViewMatrix, -g_pan[0], -g_pan[1], -g_dolly);
     rotate(g_transformData.ModelViewMatrix, g_rotate[1], 1, 0, 0);
     rotate(g_transformData.ModelViewMatrix, g_rotate[0], 0, 1, 0);
-    rotate(g_transformData.ModelViewMatrix, -90, 1, 0, 0);
+    if (!g_yup) {
+        rotate(g_transformData.ModelViewMatrix, -90, 1, 0, 0);
+    }
     translate(g_transformData.ModelViewMatrix,
               -g_center[0], -g_center[1], -g_center[2]);
     perspective(g_transformData.ProjectionMatrix,
@@ -1654,6 +1658,7 @@ int main(int argc, char ** argv) {
         
     args.Parse(argc, argv);
 
+    g_yup = args.GetYUp();
     g_adaptive = args.GetAdaptive();
     g_level = args.GetLevel();
     g_repeatCount = args.GetRepeatCount();


### PR DESCRIPTION
These changes replace the poorly named -axis flag (used by the viewing applications and recently included in the set of common command line arguments) with -yup.  The default viewing orientation for all examples is Z-axis up and the -yup flag now modifies the viewing matrix -- not the shape coordinates -- to present the initial view with Y-axis up.