### PR TITLE
Fixed single-crease patch creation near unisolated boundaries

### DIFF
--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -318,6 +318,8 @@ namespace internal {
         int_type selectInfSharpIrregularCrease : 1;
         int_type selectInfSharpIrregularCorner : 1;
 
+        int_type selectUnisolatedInteriorEdge : 1;
+
         int_type selectNonManifold  : 1;
         int_type selectFVarFeatures : 1;
     };
@@ -354,6 +356,8 @@ namespace internal {
         selectInfSharpIrregularDart   = true;
         selectInfSharpIrregularCrease = true;
         selectInfSharpIrregularCorner = true;
+
+        selectUnisolatedInteriorEdge = useSingleCreasePatch && !options.useInfSharpPatch;
 
         selectNonManifold  = true;
         selectFVarFeatures = options.considerFVarChannels;
@@ -570,6 +574,13 @@ namespace {
                 return doesInfSharpVTagHaveFeatures(compVTag, featureMask);
             } else if (isolateQuadBoundaries) {
                 return true;
+            } else if (featureMask.selectUnisolatedInteriorEdge) {
+                //  Needed for single-crease approximation to inf-sharp interior edge:
+                for (int i = 0; i < 4; ++i) {
+                    if (vTags[i]._infSharpEdges && !vTags[i]._boundary) {
+                        return true;
+                    }
+                }
             }
         } else {
             if (atLeastOneSmoothCorner && !compVTag._boundary) {


### PR DESCRIPTION
This change adds newly required feature isolation for the single-crease patch that is now necessary in the absence of the previous boundary isolation for quads (removed in #1025).

When the single-crease patch option is used without the inf-sharp patch option, semi-sharp single-crease patches are intended to approximate interior inf-sharp edges.  When too many inf-sharp features (including boundaries) are present around a base face, despite the face being regular and easily and accurately represented with a single regular patch, isolation is required if any of the inf-sharp edges are interior edges to accommodate the single-crease patch approximation.