### PR TITLE
Updated GL examples for common command line arguments

### DIFF
--- a/documentation/glevallimit.rst
+++ b/documentation/glevallimit.rst
@@ -35,7 +35,7 @@ SYNOPSIS
 .. parsed-literal::
    :class: codefhead
 
-   **glEvalLimit** [**-f**] [**-u**] [**-a**] [**-l** *refinement level*]
+   **glEvalLimit** [**-f**] [**-yup**] [**-u**] [**-a**] [**-l** *refinement level*]
        *objfile(s)* [**-catmark**] [**-loop**] [**-bilinear**]
 
 DESCRIPTION

--- a/documentation/glpainttest.rst
+++ b/documentation/glpainttest.rst
@@ -35,7 +35,7 @@ SYNOPSIS
 .. parsed-literal:: 
    :class: codefhead
 
-   **glPaintTest** [**-f**] [**-l** *adaptive refinement level*] 
+   **glPaintTest** [**-f**] [**-yup**] [**-l** *adaptive refinement level*] 
        *objfile(s)* [**-catmark**] [**-loop**]
 
    

--- a/documentation/glptexviewer.rst
+++ b/documentation/glptexviewer.rst
@@ -35,7 +35,7 @@ SYNOPSIS
 .. parsed-literal:: 
    :class: codefhead
 
-   **glPtexViewer** [**-f**] [**-u**] [**-a**] [**-l** *isolation level*] [**-c** *animation loops*] [**-y**]
+   **glPtexViewer** [**-f**] [**-yup**] [**-u**] [**-a**] [**-l** *isolation level*] [**-c** *animation loops*]
        [**-e** *environment map*] [**-d** *HDR diffuse map*] [**-s** *HDR specular map*]
        [**--disp** *displacement scale*] [**--bump** *bump scale*]
        *ptex color file*
@@ -62,9 +62,6 @@ OPTIONS
 See the description of the
 `common comand line options <code_examples.html#common-command-line-options>`__
 for the subset of common options supported here.
-
-**-y**
-  Swap Z-up geometry to Y-UP.
 
 **-e** *environment map*
   A low dynamic range spherical environment map used as a background. Ideally,

--- a/documentation/glstencilviewer.rst
+++ b/documentation/glstencilviewer.rst
@@ -35,7 +35,7 @@ SYNOPSIS
 .. parsed-literal::
    :class: codefhead
 
-   **glStencilViewer** [**-f**] [**-u**] [**-a**] [**-l** *refinement level*]
+   **glStencilViewer** [**-f**] [**-yup**] [**-u**] [**-a**] [**-l** *refinement level*]
        *objfile(s)* [**-catmark**] [**-loop**] [**-bilinear**]
 
 DESCRIPTION

--- a/examples/common/viewerArgsUtils.cpp
+++ b/examples/common/viewerArgsUtils.cpp
@@ -35,17 +35,13 @@ const ObjAnim *
 PopulateAnimShapes(const ArgOptions &args, 
                    std::vector<ShapeDesc> *defaultShapes)
 {
-    if (!defaultShapes)
-        return NULL;
-
     if (args.GetObjFiles().empty())
         return NULL;
-
 
     const ObjAnim *objAnim = ObjAnim::Create(args.GetObjFiles(),
         args.GetDefaultScheme());
 
-    if (objAnim) {
+    if (objAnim && defaultShapes) {
         defaultShapes->push_back(ShapeDesc(args.GetObjFiles()[0], "", 
             args.GetDefaultScheme()));
     }

--- a/examples/common/viewerArgsUtils.h
+++ b/examples/common/viewerArgsUtils.h
@@ -39,7 +39,7 @@ namespace ViewerArgsUtils {
 // defaultShapes vector, treating the objs as an animated series, returning
 // an ObjAnim object.
 const ObjAnim *PopulateAnimShapes(const ArgOptions &args, 
-                                  std::vector<ShapeDesc> *defaultShapes);
+                                  std::vector<ShapeDesc> *defaultShapes = 0);
 
 // From the list of obj files in args, populates the
 // defaultShapes vector.

--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -69,6 +69,7 @@
 #include <opensubdiv/osd/glMesh.h>
 
 #include "../../regression/common/far_utils.h"
+#include "../common/argOptions.h"
 #include "../common/patchColors.h"
 #include "../common/stb_image_write.h"    // common.obj has an implementation.
 #include "../common/glShaderCache.h"
@@ -459,7 +460,7 @@ void runTest(ShapeDesc const &shapeDesc, std::string const &kernel,
 
 static void usage(const char *program) {
     std::cout
-        << "Usage %s : " << program << "\n"
+        << "Usage: " << program << "\n"
         << "   -a                      : adaptive refinement (default)\n"
         << "   -u                      : uniform refinement\n"
         << "   -l <isolation level>    : isolation level (default = 2)\n"
@@ -485,30 +486,34 @@ int main(int argc, char ** argv) {
     std::string displayMode = "PATCH_TYPE";
     std::vector<std::string> kernels;
 
-    for (int i = 1; i < argc; ++i) {
-        if (!strcmp(argv[i], "-a")) {
-            adaptive = true;
-        } else if (!strcmp(argv[i], "-u")) {
-            adaptive = false;
-        } else if (!strcmp(argv[i], "-l")) {
-            isolationLevel = atoi(argv[++i]);
-        } else if (!strcmp(argv[i], "-k")) {
-            std::stringstream ss(argv[++i]);
+    ArgOptions args;
+
+    args.Parse(argc, argv);
+
+    adaptive = args.GetAdaptive();
+    isolationLevel = args.GetLevel();
+
+    // Parse remaining args
+    const std::vector<const char *> &argvRem = args.GetRemainingArgs();
+    for (size_t i = 0; i < argvRem.size(); ++i) {
+        if (!strcmp(argvRem[i], "-k")) {
+            std::stringstream ss(argvRem[++i]);
             std::string kernel;
             while(std::getline(ss, kernel, ',')) {
                 kernels.push_back(kernel);
             }
-        } else if (!strcmp(argv[i], "-t")) {
-            tessLevel = atoi(argv[++i]);
-        } else if (!strcmp(argv[i], "-w")) {
+        } else if (!strcmp(argvRem[i], "-t")) {
+            tessLevel = atoi(argvRem[++i]);
+        } else if (!strcmp(argvRem[i], "-w")) {
             writeToFile = true;
-            prefix = argv[++i];
-        } else if (!strcmp(argv[i], "-s")) {
-            width = atoi(argv[++i]);
-            height = atoi(argv[++i]);
-        } else if (!strcmp(argv[i], "-d")) {
-            displayMode = argv[++i];
+            prefix = argvRem[++i];
+        } else if (!strcmp(argvRem[i], "-s")) {
+            width = atoi(argvRem[++i]);
+            height = atoi(argvRem[++i]);
+        } else if (!strcmp(argvRem[i], "-d")) {
+            displayMode = argvRem[++i];
         } else {
+            args.PrintUnrecognizedArgWarning(argvRem[i]);
             usage(argv[0]);
             return 1;
         }

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -71,6 +71,7 @@ GLFWmonitor* g_primary=0;
 #include "../../regression/common/far_utils.h"
 #include "init_shapes.h"
 
+#include "../common/argOptions.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"
@@ -1172,16 +1173,14 @@ callbackErrorGLFW(int error, const char* description) {
 
 int main(int argc, char ** argv) {
 
-    std::string str;
-    for (int i = 1; i < argc; ++i) {
-        if (!strcmp(argv[i], "-l")) {
-            g_level = atoi(argv[++i]);
-        } else if (!strcmp(argv[i], "-a")) {
-            g_options.adaptive = true;
-        } else if (!strcmp(argv[i], "-u")) {
-            g_options.adaptive = false;
-        }
-    }
+    ArgOptions args;
+
+    args.Parse(argc, argv);
+    args.PrintUnrecognizedArgsWarnings();
+
+    g_options.adaptive = args.GetAdaptive();
+    g_level = args.GetLevel();
+
     Far::SetErrorCallback(callbackError);
 
     glfwSetErrorCallback(callbackErrorGLFW);


### PR DESCRIPTION
These changes update the remaining GL examples to make use of the common command line argument parsing and utilities recently added in #1087.  All now make use of common argument parsing and loading of user specified geometry.  Viewers that accept user-specified geometry were also updated to implement the -yup option consistently.

A couple of examples received some extra work:  glEvalLimit had additional UI options added to make it more consistent with glViewer, and glPtexViewer was updated to make use of the common ObjAnim class to support loading and interpolation of animated sequences of Obj files. 