### PR TITLE
Fixed patch construction bug with sharp corner patches

### DIFF
--- a/opensubdiv/far/catmarkPatchBuilder.cpp
+++ b/opensubdiv/far/catmarkPatchBuilder.cpp
@@ -1251,6 +1251,8 @@ GregoryConverter<REAL>::getIrregularFacePointSize(
     CornerTopology const & corner    = _corners[cIndexNear];
     CornerTopology const & adjCorner = _corners[cIndexFar];
 
+    if (corner.isSharp && adjCorner.isSharp) return 2;
+
     int thisSize = corner.isSharp
                  ? 6
                  : (1 + corner.ringPoints.GetSize());

--- a/opensubdiv/far/loopPatchBuilder.cpp
+++ b/opensubdiv/far/loopPatchBuilder.cpp
@@ -1281,6 +1281,8 @@ GregoryTriConverter<REAL>::getIrregularFacePointSize(
     CornerTopology const & nearCorner = _corners[cIndexNear];
     CornerTopology const & farCorner  = _corners[cIndexFar];
 
+    if (nearCorner.isSharp && farCorner.isSharp) return 2;
+
     int nearSize = nearCorner.ringPoints.GetSize() - 3;
     int farSize  = farCorner.ringPoints.GetSize() - 3;
 


### PR DESCRIPTION
This change fixes an uncommon bug that occurs when building a patch from a face when both ends of an interior edge are infinitely sharp.  In this case, the stencil size of the interior face-points was not correctly estimated and triggers an assertion.

This can show up when vertices are implicitly made inf-sharp, e.g. when vertices are non-manifold or when boundary vertices in face-varying space are sharpened according to the interpolation choice.