### PR TITLE
Fixed regression with legacy smooth corner patch approximation

### DIFF
--- a/opensubdiv/far/patchBuilder.cpp
+++ b/opensubdiv/far/patchBuilder.cpp
@@ -842,7 +842,8 @@ PatchBuilder::GetIrregularPatchCornerSpans(int levelIndex, Index faceIndex,
         }
 
         //  Legacy option -- reinterpret a smooth corner as sharp:
-        if (_options.approxSmoothCornerWithSharp && vTag._xordinary &&
+        bool smoothCorner = !cornerSpans[i]._sharp;
+        if (smoothCorner && _options.approxSmoothCornerWithSharp && vTag._xordinary &&
                 vTag._boundary && !vTag._infSharp && !vTag._nonManifold) {
             int nFaces = cornerSpans[i].isAssigned()
                 ? cornerSpans[i]._numFaces


### PR DESCRIPTION
This change fixes a regression that was introduced into the application of the legacy patch construction option that approximates a smooth corner patch with a regular sharp patch.  The condition of application had been rewritten and mistakenly considered all corners, rather than only those that had been determined as smooth.  So some sharp corners were being mistakenly re-assigned as smooth.

This tended to occur more frequently in face-varying patches, where the combination of inf-sharp and irregular features on boundaries is more prevalent along the UV seams.