### PR TITLE
Fixed semi-sharp face-varying boundaries when creating inf-sharp patches

### DIFF
--- a/opensubdiv/vtr/fvarLevel.cpp
+++ b/opensubdiv/vtr/fvarLevel.cpp
@@ -552,6 +552,12 @@ FVarLevel::completeTopologyFromFaceValues(int regularBoundaryValence) {
                                    : (isInfSharp ? (vSpan._size > 1) : valueTag._xordinary);
 
             if (!isInfSharp) {
+                //
+                //  Remember that a semi-sharp value (or one dependent on one) needs to be
+                //  treated as a corner (at least three sharp edges or one sharp vertex)
+                //  until the sharpness has decayed, so don't tag them as creases here.
+                //  But do initialize and maintain the ends of the crease until needed.
+                //
                 if (vSpan._semiSharpEdgeCount || vTag._semiSharp) {
                     valueTag._semiSharp = true;
                 } else if (hasDependentValuesToSharpen) {

--- a/opensubdiv/vtr/fvarLevel.h
+++ b/opensubdiv/vtr/fvarLevel.h
@@ -387,16 +387,26 @@ inline Level::VTag
 FVarLevel::ValueTag::combineWithLevelVTag(Level::VTag levelTag) const
 {
     if (this->_mismatch) {
+        //
+        //  Semi-sharp FVar values are always tagged and treated as corners
+        //  (at least three sharp edges (two boundary edges and one interior
+        //  semi-sharp) and/or vertex is semi-sharp) until the sharpness has
+        //  decayed, but they ultimately lie on the inf-sharp crease of the
+        //  FVar boundary.  Consider this when tagging inf-sharp features.
+        //
         if (this->isCorner()) {
             levelTag._rule = (Level::VTag::VTagSize) Sdc::Crease::RULE_CORNER;
-            levelTag._infSharp = true;
-            levelTag._infSharpCrease = false;
-            levelTag._corner = !this->_infIrregular && !this->_infSharpEdges;
         } else {
             levelTag._rule = (Level::VTag::VTagSize) Sdc::Crease::RULE_CREASE;
+        }
+        if (this->isCrease() || this->isSemiSharp()) {
             levelTag._infSharp = false;
             levelTag._infSharpCrease = true;
             levelTag._corner = false;
+        } else {
+            levelTag._infSharp = true;
+            levelTag._infSharpCrease = false;
+            levelTag._corner = !this->_infIrregular && !this->_infSharpEdges;
         }
         levelTag._infSharpEdges = true;
         levelTag._infIrregular = this->_infIrregular;


### PR DESCRIPTION
This change fixes an obscure bug present since 3.1 when face-varying patches and the inf-sharp patch option were introduced.  Semi-sharp features on the seams of face-varying patches were mistakenly tagged as inf-sharp, which only took effect when the inf-sharp patch option was enabled.