### PR TITLE
Gregory patch transitional edge tessellation

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1237,7 +1237,7 @@ PatchTableBuilder::populatePatches() {
         PatchParam patchParam =
             _patchBuilder->ComputePatchParam(patch.levelIndex, patch.faceIndex,
                   _ptexIndices, patchInfo.isRegular, patchInfo.paramBoundaryMask,
-                  patchInfo.isRegular /* condition to compute transition mask */);
+                  true/* condition to compute transition mask */);
         *arrayBuilder->pptr++ = patchParam;
 
         //

--- a/opensubdiv/osd/glslPatchBSpline.glsl
+++ b/opensubdiv/osd/glslPatchBSpline.glsl
@@ -88,12 +88,6 @@ void main()
 #if defined OSD_ENABLE_SCREENSPACE_TESSELLATION
         // Gather bezier control points to compute limit surface tess levels
         OsdPerPatchVertexBezier cpBezier[16];
-#if 0
-        // XXX: this doesn't work on nvidia driver 34x.
-        for (int i=0; i<16; ++i) {
-            cpBezier[i] = outpt[i].v;
-        }
-#else
         cpBezier[0] = outpt[0].v;
         cpBezier[1] = outpt[1].v;
         cpBezier[2] = outpt[2].v;
@@ -110,7 +104,7 @@ void main()
         cpBezier[13] = outpt[13].v;
         cpBezier[14] = outpt[14].v;
         cpBezier[15] = outpt[15].v;
-#endif
+
         OsdEvalPatchBezierTessLevels(cpBezier, patchParam,
                          tessLevelOuter, tessLevelInner,
                          tessOuterLo, tessOuterHi);

--- a/opensubdiv/osd/glslPatchBoxSplineTriangle.glsl
+++ b/opensubdiv/osd/glslPatchBoxSplineTriangle.glsl
@@ -143,7 +143,7 @@ void main()
         cv[i] = inpt[i].v;
     }
 
-    vec2 UV = OsdGetTessParameterizationTriangle(gl_TessCoord.xy,
+    vec2 UV = OsdGetTessParameterizationTriangle(gl_TessCoord.xyz,
                                                  tessOuterLo,
                                                  tessOuterHi);
 

--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -993,17 +993,17 @@ OsdEvalPatchGregory(ivec3 patchParam, vec2 UV, vec3 cv[20],
 //  The equivalant quartic Bezier triangle (15 points):
 //
 //                              14
-//                              . . 
-//                             .   . 
+//                              . .
+//                             .   .
 //                           12 --- 13
-//                           . .   . . 
-//                          .   . .   . 
+//                           . .   . .
+//                          .   . .   .
 //                         9 -- 10 --- 11
-//                        . .   . .   . . 
-//                       .   . .   . .   . 
+//                        . .   . .   . .
+//                       .   . .   . .   .
 //                      5 --- 6 --- 7 --- 8
-//                     . .   . .   . .   . . 
-//                    .   . .   . .   . .   . 
+//                     . .   . .   . .   . .
+//                    .   . .   . .   . .   .
 //                   0 --- 1 --- 2 --- 3 --- 4
 //
 //  A hybrid cubic/quartic Bezier patch with cubic boundaries is a close

--- a/opensubdiv/osd/glslPatchCommonTess.glsl
+++ b/opensubdiv/osd/glslPatchCommonTess.glsl
@@ -507,7 +507,6 @@ OsdGetTessLevelsUniform(ivec3 patchParam,
                  out vec4 tessLevelOuter, out vec2 tessLevelInner,
                  out vec4 tessOuterLo, out vec4 tessOuterHi)
 {
-    // uniform tessellation
     OsdGetTessLevelsUniform(patchParam, tessOuterLo, tessOuterHi);
 
     OsdComputeTessLevels(tessOuterLo, tessOuterHi,
@@ -519,7 +518,6 @@ OsdGetTessLevelsUniformTriangle(ivec3 patchParam,
                  out vec4 tessLevelOuter, out vec2 tessLevelInner,
                  out vec4 tessOuterLo, out vec4 tessOuterHi)
 {
-    // uniform tessellation
     OsdGetTessLevelsUniformTriangle(patchParam, tessOuterLo, tessOuterHi);
 
     OsdComputeTessLevelsTriangle(tessOuterLo, tessOuterHi,
@@ -586,6 +584,7 @@ OsdGetTessLevelsAdaptiveLimitPoints(OsdPerPatchVertexBezier cpBezier[16],
                          tessLevelOuter, tessLevelInner);
 }
 
+//  Deprecated -- prefer use of newer Bezier patch equivalent:
 void
 OsdGetTessLevels(vec3 cp0, vec3 cp1, vec3 cp2, vec3 cp3,
                  ivec3 patchParam,
@@ -697,38 +696,37 @@ OsdGetTessTransitionSplit(float t, float lo, float hi)
 }
 
 vec2
-OsdGetTessParameterization(vec2 uv, vec4 tessOuterLo, vec4 tessOuterHi)
+OsdGetTessParameterization(vec2 p, vec4 tessOuterLo, vec4 tessOuterHi)
 {
-    vec2 UV = uv;
-    if (UV.x == 0 && tessOuterHi[0] > 0) {
+    vec2 UV = p;
+    if (p.x == 0 && tessOuterHi[0] > 0) {
         UV.y = OsdGetTessTransitionSplit(UV.y, tessOuterLo[0], tessOuterHi[0]);
     } else
-    if (UV.y == 0 && tessOuterHi[1] > 0) {
+    if (p.y == 0 && tessOuterHi[1] > 0) {
         UV.x = OsdGetTessTransitionSplit(UV.x, tessOuterLo[1], tessOuterHi[1]);
     } else
-    if (UV.x == 1 && tessOuterHi[2] > 0) {
+    if (p.x == 1 && tessOuterHi[2] > 0) {
         UV.y = OsdGetTessTransitionSplit(UV.y, tessOuterLo[2], tessOuterHi[2]);
     } else
-    if (UV.y == 1 && tessOuterHi[3] > 0) {
+    if (p.y == 1 && tessOuterHi[3] > 0) {
         UV.x = OsdGetTessTransitionSplit(UV.x, tessOuterLo[3], tessOuterHi[3]);
     }
     return UV;
 }
 
 vec2
-OsdGetTessParameterizationTriangle(vec2 uv, vec4 tessOuterLo, vec4 tessOuterHi)
+OsdGetTessParameterizationTriangle(vec3 p, vec4 tessOuterLo, vec4 tessOuterHi)
 {
-    vec2 UV = uv;
-    if (UV.x == 0 && tessOuterHi[0] > 0) {
+    vec2 UV = p.xy;
+    if (p.x == 0 && tessOuterHi[0] > 0) {
         UV.y = OsdGetTessTransitionSplit(UV.y, tessOuterLo[0], tessOuterHi[0]);
     } else
-    if (UV.y == 0 && tessOuterHi[1] > 0) {
+    if (p.y == 0 && tessOuterHi[1] > 0) {
         UV.x = OsdGetTessTransitionSplit(UV.x, tessOuterLo[1], tessOuterHi[1]);
     } else
-    if (UV.x+UV.y == 1 && tessOuterHi[2] > 0) {
+    if (p.z == 0 && tessOuterHi[2] > 0) {
         UV.x = OsdGetTessTransitionSplit(UV.x, tessOuterLo[2], tessOuterHi[2]);
         UV.y = 1.0 - UV.x;
     }
     return UV;
 }
-

--- a/opensubdiv/osd/hlslPatchBSpline.hlsl
+++ b/opensubdiv/osd/hlslPatchBSpline.hlsl
@@ -78,13 +78,7 @@ HSConstFunc(
     OSD_PATCH_CULL(16);
 
 #if defined OSD_ENABLE_SCREENSPACE_TESSELLATION
-#if 0
-    // XXX: this doesn't work on nvidia driver 34x.
-    OsdEvalPatchBezierTessLevels(bezierPatch, patchParam,
-                     tessLevelOuter, tessLevelInner,
-                     tessOuterLo, tessOuterHi);
-#else
-    // This is needed to coerce correct behavior on nvidia driver 34x
+    // Gather bezier control points to compute limit surface tess levels
     OsdPerPatchVertexBezier cpBezier[16];
     for (int i=0; i<16; ++i) {
         cpBezier[i] = bezierPatch[i];
@@ -93,7 +87,6 @@ HSConstFunc(
     OsdEvalPatchBezierTessLevels(cpBezier, patchParam,
                      tessLevelOuter, tessLevelInner,
                      tessOuterLo, tessOuterHi);
-#endif
 #else
     OsdGetTessLevelsUniform(patchParam, tessLevelOuter, tessLevelInner,
                      tessOuterLo, tessOuterHi);

--- a/opensubdiv/osd/hlslPatchBoxSplineTriangle.hlsl
+++ b/opensubdiv/osd/hlslPatchBoxSplineTriangle.hlsl
@@ -121,7 +121,7 @@ void ds_main_patches(
         cv[i] = patch[i];
     }
 
-    float2 UV = OsdGetTessParameterizationTriangle(domainCoord.xy,
+    float2 UV = OsdGetTessParameterizationTriangle(domainCoord,
                                                    input.tessOuterLo,
                                                    input.tessOuterHi);
 

--- a/opensubdiv/osd/hlslPatchCommon.hlsl
+++ b/opensubdiv/osd/hlslPatchCommon.hlsl
@@ -458,7 +458,7 @@ OsdComputeBoxSplineTriangleBoundaryPoints(inout float3 cpt[12], int3 patchParam)
     if (boundaryMask == 0) return;
 
     int upperBits = (boundaryMask >> 3) & 0x3;
-    int lowerBits = boundaryMask & 0x7;
+    int lowerBits = boundaryMask & 7;
 
     int eBits = lowerBits;
     int vBits = 0;
@@ -881,7 +881,7 @@ OsdEvalPatchBezier(int3 patchParam, float2 UV,
 }
 
 // ----------------------------------------------------------------------------
-// GregoryBasis
+// Gregory Basis
 // ----------------------------------------------------------------------------
 
 struct OsdPerPatchVertexGregoryBasis {

--- a/opensubdiv/osd/hlslPatchCommonTess.hlsl
+++ b/opensubdiv/osd/hlslPatchCommonTess.hlsl
@@ -602,6 +602,7 @@ OsdGetTessLevelsAdaptiveLimitPoints(OsdPerPatchVertexBezier cpBezier[16],
                          tessLevelOuter, tessLevelInner);
 }
 
+//  Deprecated -- prefer use of newer Bezier patch equivalent:
 void
 OsdGetTessLevels(float3 cp0, float3 cp1, float3 cp2, float3 cp3,
                  int3 patchParam,
@@ -713,38 +714,37 @@ OsdGetTessTransitionSplit(float t, float lo, float hi)
 }
 
 float2
-OsdGetTessParameterization(float2 uv, float4 tessOuterLo, float4 tessOuterHi)
+OsdGetTessParameterization(float2 p, float4 tessOuterLo, float4 tessOuterHi)
 {
-    float2 UV = uv;
-    if (UV.x == 0 && tessOuterHi[0] > 0) {
+    float2 UV = p;
+    if (p.x == 0 && tessOuterHi[0] > 0) {
         UV.y = OsdGetTessTransitionSplit(UV.y, tessOuterLo[0], tessOuterHi[0]);
     } else
-    if (UV.y == 0 && tessOuterHi[1] > 0) {
+    if (p.y == 0 && tessOuterHi[1] > 0) {
         UV.x = OsdGetTessTransitionSplit(UV.x, tessOuterLo[1], tessOuterHi[1]);
     } else
-    if (UV.x == 1 && tessOuterHi[2] > 0) {
+    if (p.x == 1 && tessOuterHi[2] > 0) {
         UV.y = OsdGetTessTransitionSplit(UV.y, tessOuterLo[2], tessOuterHi[2]);
     } else
-    if (UV.y == 1 && tessOuterHi[3] > 0) {
+    if (p.y == 1 && tessOuterHi[3] > 0) {
         UV.x = OsdGetTessTransitionSplit(UV.x, tessOuterLo[3], tessOuterHi[3]);
     }
     return UV;
 }
 
 float2
-OsdGetTessParameterizationTriangle(float2 uv, float4 tessOuterLo, float4 tessOuterHi)
+OsdGetTessParameterizationTriangle(float3 p, float4 tessOuterLo, float4 tessOuterHi)
 {
-    float2 UV = uv;
-    if (UV.x == 0 && tessOuterHi[0] > 0) {
+    float2 UV = p.xy;
+    if (p.x == 0 && tessOuterHi[0] > 0) {
         UV.y = OsdGetTessTransitionSplit(UV.y, tessOuterLo[0], tessOuterHi[0]);
     } else
-    if (UV.y == 0 && tessOuterHi[1] > 0) {
+    if (p.y == 0 && tessOuterHi[1] > 0) {
         UV.x = OsdGetTessTransitionSplit(UV.x, tessOuterLo[1], tessOuterHi[1]);
     } else
-    if (UV.x+UV.y == 1 && tessOuterHi[2] > 0) {
+    if (p.z == 0 && tessOuterHi[2] > 0) {
         UV.x = OsdGetTessTransitionSplit(UV.x, tessOuterLo[2], tessOuterHi[2]);
         UV.y = 1.0 - UV.x;
     }
     return UV;
 }
-

--- a/opensubdiv/osd/mtlPatchBSpline.metal
+++ b/opensubdiv/osd/mtlPatchBSpline.metal
@@ -65,10 +65,10 @@ void OsdComputePerPatchBSplineFactors(
         device MTLQuadTessellationFactorsHalf& quadFactors
         )
 {
-    float4 tessLevelOuter = float4(0,0,0,0);
-    float2 tessLevelInner = float2(0,0);
-    float4 tessOuterLo = float4(0,0,0,0);
-    float4 tessOuterHi = float4(0,0,0,0);
+    float4 tessLevelOuter = float4(0);
+    float2 tessLevelInner = float2(0);
+    float4 tessOuterLo = float4(0);
+    float4 tessOuterHi = float4(0);
 
 #if OSD_ENABLE_SCREENSPACE_TESSELLATION
     OsdEvalPatchBezierTessLevels(
@@ -121,7 +121,7 @@ void OsdComputePerPatchFactors(
         tessLevel,
         projectionMatrix,
         modelViewMatrix,
-        osdBuffer.perPatchVertexBuffer + patchID * CONTROL_POINTS_PER_PATCH,
+        osdBuffer.perPatchVertexBuffer + patchID * VERTEX_CONTROL_POINTS_PER_PATCH,
 #if !USE_PTVS_FACTORS
         osdBuffer.patchTessBuffer[patchID],
 #endif
@@ -167,15 +167,15 @@ OsdPatchVertex ds_regular_patches(
     OsdGetTessLevelsUniform(tessLevel, patchParam, tessOuterLo, tessOuterHi);
 #endif
 
-    float2 UV = OsdGetTessParameterization(domainCoord.xy,
+    float2 UV = OsdGetTessParameterization(domainCoord,
                                            tessOuterLo,
                                            tessOuterHi);
 
     OsdPatchVertex output;
 
-    float3 P, dPu, dPv;
-    float3 N, dNu, dNv;
-    float2 vSegments;
+    float3 P = float3(0), dPu = float3(0), dPv = float3(0);
+    float3 N = float3(0), dNu = float3(0), dNv = float3(0);
+    float2 vSegments = float2(0);
 
     OsdEvalPatchBezier(patchParam, UV, cv, P, dPu, dPv, N, dNu, dNv, vSegments);
 

--- a/opensubdiv/osd/mtlPatchBoxSplineTriangle.metal
+++ b/opensubdiv/osd/mtlPatchBoxSplineTriangle.metal
@@ -65,10 +65,10 @@ void OsdComputePerPatchBezierTriangleFactors(
         device MTLTriangleTessellationFactorsHalf& triFactors
         )
 {
-    float4 tessLevelOuter = float4(0,0,0,0);
-    float2 tessLevelInner = float2(0,0);
-    float4 tessOuterLo = float4(0,0,0,0);
-    float4 tessOuterHi = float4(0,0,0,0);
+    float4 tessLevelOuter = float4(0);
+    float2 tessLevelInner = float2(0);
+    float4 tessOuterLo = float4(0);
+    float4 tessOuterHi = float4(0);
 
 #if OSD_ENABLE_SCREENSPACE_TESSELLATION
     // Gather bezier control points to compute limit surface tess levels
@@ -76,6 +76,7 @@ void OsdComputePerPatchBezierTriangleFactors(
     for (int i=0; i<15; ++i) {
         bezcv[i] = patch[i].P;
     }
+
     OsdEvalPatchBezierTriangleTessLevels(
         tessLevel,
         projectionMatrix,
@@ -172,14 +173,15 @@ OsdPatchVertex ds_regular_patches(
         tessLevel, patchParam, tessOuterLo, tessOuterHi);
 #endif
 
-    float2 UV = OsdGetTessParameterizationTriangle(domainCoord.xy,
+    float2 UV = OsdGetTessParameterizationTriangle(domainCoord,
                                                    tessOuterLo,
                                                    tessOuterHi);
 
     OsdPatchVertex output;
 
-    float3 P, dPu, dPv;
-    float3 N, dNu, dNv;
+    float3 P = float3(0), dPu = float3(0), dPv = float3(0);
+    float3 N = float3(0), dNu = float3(0), dNv = float3(0);
+
     OsdEvalPatchBezierTriangle(patchParam, UV, cv, P, dPu, dPv, N, dNu, dNv);
 
     output.normal = N;

--- a/opensubdiv/osd/mtlPatchCommon.metal
+++ b/opensubdiv/osd/mtlPatchCommon.metal
@@ -860,7 +860,6 @@ OsdComputePerPatchVertexBSpline(
         P += Q[j][k]*Hi[k];
     }
 
-
     result.P  = P;
     result.P1 = P;
     result.P2 = P;
@@ -875,7 +874,6 @@ OsdComputePerPatchVertexBSpline(
             H[l] += Q[i][k] * (cv + l*4 + k)->GetPosition();
         }
     }
-
     {
         result.P = float3(0,0,0);
         for (int k=0; k<4; ++k){

--- a/opensubdiv/osd/mtlPatchGregory.metal
+++ b/opensubdiv/osd/mtlPatchGregory.metal
@@ -54,6 +54,77 @@ void OsdComputePerVertex(
 // Patches.Gregory.Factors
 //----------------------------------------------------------
 
+void OsdComputePerPatchGregoryFactors(
+        int3 patchParam,
+        float tessLevel,
+        float4x4 projectionMatrix,
+        float4x4 modelViewMatrix,
+        device OsdPerPatchVertexGregory* patchVertices,
+#if !USE_PTVS_FACTORS
+        device OsdPerPatchTessFactors& patchFactors,
+#endif
+        device MTLQuadTessellationFactorsHalf& quadFactors
+        )
+{
+    float4 tessLevelOuter = float4(0);
+    float2 tessLevelInner = float2(0);
+    float4 tessOuterLo = float4(0);
+    float4 tessOuterHi = float4(0);
+
+#if OSD_ENABLE_SCREENSPACE_TESSELLATION
+    // Gather bezier control points to compute limit surface tess levels
+    float3 bezcv[16];
+    bezcv[ 0] = patchVertices[0].P;
+    bezcv[ 1] = patchVertices[0].Ep;
+    bezcv[ 2] = patchVertices[1].Em;
+    bezcv[ 3] = patchVertices[1].P;
+    bezcv[ 4] = patchVertices[0].Em;
+    bezcv[ 5] = patchVertices[0].Fp;
+    bezcv[ 6] = patchVertices[1].Fm;
+    bezcv[ 7] = patchVertices[1].Ep;
+    bezcv[ 8] = patchVertices[3].Ep;
+    bezcv[ 9] = patchVertices[3].Fm;
+    bezcv[10] = patchVertices[2].Fp;
+    bezcv[11] = patchVertices[2].Em;
+    bezcv[12] = patchVertices[3].P;
+    bezcv[13] = patchVertices[3].Em;
+    bezcv[14] = patchVertices[2].Ep;
+    bezcv[15] = patchVertices[2].P;
+
+    OsdEvalPatchBezierTessLevels(
+        tessLevel,
+        projectionMatrix,
+        modelViewMatrix,
+        bezcv,
+        patchParam,
+        tessLevelOuter,
+        tessLevelInner,
+        tessOuterLo,
+        tessOuterHi
+        );
+#else
+    OsdGetTessLevelsUniform(
+        tessLevel,
+        patchParam,
+        tessLevelOuter,
+        tessLevelInner,
+        tessOuterLo,
+        tessOuterHi
+        );
+#endif
+
+    quadFactors.edgeTessellationFactor[0] = tessLevelOuter[0];
+    quadFactors.edgeTessellationFactor[1] = tessLevelOuter[1];
+    quadFactors.edgeTessellationFactor[2] = tessLevelOuter[2];
+    quadFactors.edgeTessellationFactor[3] = tessLevelOuter[3];
+    quadFactors.insideTessellationFactor[0] = tessLevelInner[0];
+    quadFactors.insideTessellationFactor[1] = tessLevelInner[1];
+#if !USE_PTVS_FACTORS
+    patchFactors.tessOuterLo = tessOuterLo;
+    patchFactors.tessOuterHi = tessOuterHi;
+#endif
+}
+
 void OsdComputePerPatchFactors(
         int3 patchParam,
         float tessLevel,
@@ -65,28 +136,17 @@ void OsdComputePerPatchFactors(
         device MTLQuadTessellationFactorsHalf& quadFactors
         )
 {
-    float4 tessLevelOuter = float4(0,0,0,0);
-    float2 tessLevelInner = float2(0,0);
-
-    OsdGetTessLevels(
-            tessLevel,
-            projectionMatrix,
-            modelViewMatrix,
-            patchVertices[0].P,
-            patchVertices[3].P,
-            patchVertices[2].P,
-            patchVertices[1].P,
-            patchParam,
-            tessLevelOuter,
-            tessLevelInner
-            );
-
-    quadFactors.edgeTessellationFactor[0] = tessLevelOuter[0];
-    quadFactors.edgeTessellationFactor[1] = tessLevelOuter[1];
-    quadFactors.edgeTessellationFactor[2] = tessLevelOuter[2];
-    quadFactors.edgeTessellationFactor[3] = tessLevelOuter[3];
-    quadFactors.insideTessellationFactor[0] = tessLevelInner[0];
-    quadFactors.insideTessellationFactor[1] = tessLevelInner[1];
+    OsdComputePerPatchGregoryFactors(
+        patchParam,
+        tessLevel,
+        projectionMatrix,
+        modelViewMatrix,
+        osdBuffer.perPatchVertexBuffer + patchID * VERTEX_CONTROL_POINTS_PER_PATCH,
+#if !USE_PTVS_FACTORS
+        osdBuffer.patchTessBuffer[patchID],
+#endif
+        quadFactors
+        );
 }
 
 //----------------------------------------------------------
@@ -117,42 +177,52 @@ void OsdComputePerPatchVertex(
 
 template<typename PerPatchVertexGregory>
 OsdPatchVertex ds_gregory_patches(
+        const float tessLevel,
+#if !USE_PTVS_FACTORS
+        float4 tessOuterLo,
+        float4 tessOuterHi,
+#endif
         PerPatchVertexGregory patch,
         int3 patchParam,
         float2 domainCoord
         )
 {
-    OsdPatchVertex output;
-
-    float3 P = float3(0,0,0), dPu = float3(0,0,0), dPv = float3(0,0,0);
-    float3 N = float3(0,0,0), dNu = float3(0,0,0), dNv = float3(0,0,0);
-
     float3 cv[20];
     cv[0] = patch[0].P;
     cv[1] = patch[0].Ep;
     cv[2] = patch[0].Em;
     cv[3] = patch[0].Fp;
     cv[4] = patch[0].Fm;
-
     cv[5] = patch[1].P;
     cv[6] = patch[1].Ep;
     cv[7] = patch[1].Em;
     cv[8] = patch[1].Fp;
     cv[9] = patch[1].Fm;
-
     cv[10] = patch[2].P;
     cv[11] = patch[2].Ep;
     cv[12] = patch[2].Em;
     cv[13] = patch[2].Fp;
     cv[14] = patch[2].Fm;
-
     cv[15] = patch[3].P;
     cv[16] = patch[3].Ep;
     cv[17] = patch[3].Em;
     cv[18] = patch[3].Fp;
     cv[19] = patch[3].Fm;
 
-    float2 UV = domainCoord.xy;
+#if USE_PTVS_FACTORS
+    float4 tessOuterLo(0), tessOuterHi(0);
+    OsdGetTessLevelsUniform(tessLevel, patchParam, tessOuterLo, tessOuterHi);
+#endif
+
+    float2 UV = OsdGetTessParameterization(domainCoord,
+                                           tessOuterLo,
+                                           tessOuterHi);
+
+    OsdPatchVertex output;
+
+    float3 P = float3(0), dPu = float3(0), dPv = float3(0);
+    float3 N = float3(0), dNu = float3(0), dNv = float3(0);
+
     OsdEvalPatchGregory(patchParam, UV, cv, P, dPu, dPv, N, dNu, dNv);
 
     // all code below here is client code
@@ -186,6 +256,16 @@ OsdPatchVertex OsdComputePatch(
         )
 {
     return ds_gregory_patches(
+            tessLevel,
+#if !USE_PTVS_FACTORS
+#if USE_STAGE_IN
+            osdPatch.tessOuterLo,
+            osdPatch.tessOuterHi,
+#else
+            osdBuffers.patchTessBuffer[patchID].tessOuterLo,
+            osdBuffers.patchTessBuffer[patchID].tessOuterHi,
+#endif
+#endif
 #if USE_STAGE_IN
             osdPatch.cv,
             osdPatch.patchParam,


### PR DESCRIPTION
Since 3.1 it has been possible to restrict the level of refinement around extraordinary vertices such that a resulting Gregory patch might have transitional edges, but the existing tessellation shaders for Gregory basis and Legacy Gregory patches had not been updated to account for this situation.

These changes make the handling of the tessellation of transitional edges more consistent across all of the back-end drawing implementations for all patch types along with improving some other minor discrepancies among the various shader implementations.

