### PR TITLE
Minor revisions to a few precision related methods of Far classes

### DIFF
--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -167,9 +167,9 @@ public:
     template <typename REAL>
     StencilTableReal<REAL> const *GetLocalPointStencilTable() const;
 
-    /// \brief Tests the precision of the stencil table to compute local point
-    /// vertex values
-    template <typename REAL> bool IsLocalPointStencilPrecision() const;
+    /// \brief Tests if the precision of the stencil table to compute local point
+    /// vertex values matches the given floating point type <REAL>.
+    template <typename REAL> bool LocalPointStencilPrecisionMatchesType() const;
 
     /// \brief Updates local point vertex values.
     ///
@@ -197,9 +197,9 @@ public:
     template <typename REAL>
     StencilTableReal<REAL> const *GetLocalPointVaryingStencilTable() const;
 
-    /// \brief Tests the precision of the stencil table to compute local point
-    /// varying values
-    template <typename REAL> bool IsLocalPointVaryingStencilPrecision() const;
+    /// \brief Tests if the precision of the stencil table to compute local point
+    /// varying values matches the given floating point type <REAL>.
+    template <typename REAL> bool LocalPointVaryingStencilPrecisionMatchesType() const;
 
     /// \brief Updates local point varying values.
     ///
@@ -227,9 +227,9 @@ public:
     template <typename REAL>
     StencilTableReal<REAL> const * GetLocalPointFaceVaryingStencilTable(int channel = 0) const;
 
-    /// \brief Tests the precision of the stencil table to compute local point
-    /// face-varying values
-    template <typename REAL> bool IsLocalPointFaceVaryingStencilPrecision() const;
+    /// \brief Tests if the precision of the stencil table to compute local point
+    /// face-varying values matches the given floating point type <REAL>.
+    template <typename REAL> bool LocalPointFaceVaryingStencilPrecisionMatchesType() const;
 
     /// \brief Updates local point face-varying values.
     ///
@@ -698,28 +698,28 @@ template <> inline StencilTableReal<double> *
 PatchTable::StencilTablePtr::Get<double>() const { return _dPtr; }
 
 template <> inline bool
-PatchTable::IsLocalPointStencilPrecision<float>() const {
+PatchTable::LocalPointStencilPrecisionMatchesType<float>() const {
     return !_vertexPrecisionIsDouble;
 }
 template <> inline bool
-PatchTable::IsLocalPointVaryingStencilPrecision<float>() const {
+PatchTable::LocalPointVaryingStencilPrecisionMatchesType<float>() const {
     return !_varyingPrecisionIsDouble;
 }
 template <> inline bool
-PatchTable::IsLocalPointFaceVaryingStencilPrecision<float>() const {
+PatchTable::LocalPointFaceVaryingStencilPrecisionMatchesType<float>() const {
     return !_faceVaryingPrecisionIsDouble;
 }
 
 template <> inline bool
-PatchTable::IsLocalPointStencilPrecision<double>() const {
+PatchTable::LocalPointStencilPrecisionMatchesType<double>() const {
     return _vertexPrecisionIsDouble;
 }
 template <> inline bool
-PatchTable::IsLocalPointVaryingStencilPrecision<double>() const {
+PatchTable::LocalPointVaryingStencilPrecisionMatchesType<double>() const {
     return _varyingPrecisionIsDouble;
 }
 template <> inline bool
-PatchTable::IsLocalPointFaceVaryingStencilPrecision<double>() const {
+PatchTable::LocalPointFaceVaryingStencilPrecisionMatchesType<double>() const {
     return _faceVaryingPrecisionIsDouble;
 }
 
@@ -728,18 +728,18 @@ PatchTable::IsLocalPointFaceVaryingStencilPrecision<double>() const {
 //
 inline StencilTable const *
 PatchTable::GetLocalPointStencilTable() const {
-    assert(IsLocalPointStencilPrecision<float>());
+    assert(LocalPointStencilPrecisionMatchesType<float>());
     return static_cast<StencilTable const *>(_localPointStencils.Get<float>());
 }
 inline StencilTable const *
 PatchTable::GetLocalPointVaryingStencilTable() const {
-    assert(IsLocalPointVaryingStencilPrecision<float>());
+    assert(LocalPointVaryingStencilPrecisionMatchesType<float>());
     return static_cast<StencilTable const *>(
             _localPointVaryingStencils.Get<float>());
 }
 inline StencilTable const *
 PatchTable::GetLocalPointFaceVaryingStencilTable(int channel) const {
-    assert(IsLocalPointFaceVaryingStencilPrecision<float>());
+    assert(LocalPointFaceVaryingStencilPrecisionMatchesType<float>());
     if (channel >= 0 && channel < (int)_localPointFaceVaryingStencils.size()) {
         return static_cast<StencilTable const *>(
                 _localPointFaceVaryingStencils[channel].Get<float>());
@@ -750,19 +750,19 @@ PatchTable::GetLocalPointFaceVaryingStencilTable(int channel) const {
 template <typename REAL>
 inline StencilTableReal<REAL> const *
 PatchTable::GetLocalPointStencilTable() const {
-    assert(IsLocalPointStencilPrecision<REAL>());
+    assert(LocalPointStencilPrecisionMatchesType<REAL>());
     return _localPointStencils.Get<REAL>();
 }
 template <typename REAL>
 inline StencilTableReal<REAL> const *
 PatchTable::GetLocalPointVaryingStencilTable() const {
-    assert(IsLocalPointVaryingStencilPrecision<REAL>());
+    assert(LocalPointVaryingStencilPrecisionMatchesType<REAL>());
     return _localPointVaryingStencils.Get<REAL>();
 }
 template <typename REAL>
 inline StencilTableReal<REAL> const *
 PatchTable::GetLocalPointFaceVaryingStencilTable(int channel) const {
-    assert(IsLocalPointFaceVaryingStencilPrecision<REAL>());
+    assert(LocalPointFaceVaryingStencilPrecisionMatchesType<REAL>());
     if (channel >= 0 && channel < (int)_localPointFaceVaryingStencils.size()) {
         return _localPointFaceVaryingStencils[channel].Get<REAL>();
     }
@@ -776,7 +776,7 @@ PatchTable::GetLocalPointFaceVaryingStencilTable(int channel) const {
 template <class T>
 inline void
 PatchTable::ComputeLocalPointValues(T const *src, T *dst) const {
-    assert(IsLocalPointStencilPrecision<float>());
+    assert(LocalPointStencilPrecisionMatchesType<float>());
     if (_localPointStencils) {
         _localPointStencils.Get<float>()->UpdateValues(src, dst);
     }
@@ -785,7 +785,7 @@ PatchTable::ComputeLocalPointValues(T const *src, T *dst) const {
 template <class T>
 inline void
 PatchTable::ComputeLocalPointValuesVarying(T const *src, T *dst) const {
-    assert(IsLocalPointVaryingStencilPrecision<float>());
+    assert(LocalPointVaryingStencilPrecisionMatchesType<float>());
     if (_localPointVaryingStencils) {
         _localPointVaryingStencils.Get<float>()->UpdateValues(src, dst);
     }
@@ -794,7 +794,7 @@ PatchTable::ComputeLocalPointValuesVarying(T const *src, T *dst) const {
 template <class T>
 inline void
 PatchTable::ComputeLocalPointValuesFaceVarying(T const *src, T *dst, int channel) const {
-    assert(IsLocalPointFaceVaryingStencilPrecision<float>());
+    assert(LocalPointFaceVaryingStencilPrecisionMatchesType<float>());
     if (channel >= 0 && channel < (int)_localPointFaceVaryingStencils.size()) {
         if (_localPointFaceVaryingStencils[channel]) {
             _localPointFaceVaryingStencils[channel].Get<float>()->UpdateValues(src, dst);

--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -459,9 +459,9 @@ PatchTableBuilder::PatchTableBuilder(
 
     _table->_numPtexFaces = _ptexIndices.GetNumFaces();
 
-    _table->_vertexPrecisionIsDouble = _options.setPatchPrecisionDouble;
-    _table->_varyingPrecisionIsDouble = _options.setPatchPrecisionDouble;
-    _table->_faceVaryingPrecisionIsDouble = _options.setFVarPatchPrecisionDouble;
+    _table->_vertexPrecisionIsDouble = _options.patchPrecisionDouble;
+    _table->_varyingPrecisionIsDouble = _options.patchPrecisionDouble;
+    _table->_faceVaryingPrecisionIsDouble = _options.fvarPatchPrecisionDouble;
 
     _table->_varyingDesc = PatchDescriptor(_patchBuilder->GetLinearPatchType());
 
@@ -495,8 +495,8 @@ PatchTableBuilder::identifyPatchTopology(PatchTuple const & patch,
         patchLevel, patchFace, fvarInTable);
 
     bool useDoubleMatrix = (fvarInRefiner < 0)
-                         ? _options.setPatchPrecisionDouble
-                         : _options.setFVarPatchPrecisionDouble;
+                         ? _options.patchPrecisionDouble
+                         : _options.fvarPatchPrecisionDouble;
 
     if (patchInfo.isRegular) {
         patchInfo.regBoundaryMask = _patchBuilder->GetRegularPatchBoundaryMask(
@@ -586,8 +586,8 @@ PatchTableBuilder::assignPatchPointsAndStencils(PatchTuple const & patch,
                           : _levelFVarValueOffsets[fvarInTable][patch.levelIndex];
 
     bool useDoubleMatrix = (fvarInTable < 0)
-                         ? _options.setPatchPrecisionDouble
-                         : _options.setFVarPatchPrecisionDouble;
+                         ? _options.patchPrecisionDouble
+                         : _options.fvarPatchPrecisionDouble;
 
     int numPatchPoints = 0;
     if (patchInfo.isRegular) {
@@ -1166,7 +1166,7 @@ PatchTableBuilder::populatePatches() {
         LocalPointHelper::Options opts;
         opts.createStencilTable = true;
         opts.createVaryingTable = _requiresVaryingLocalPoints;
-        opts.doubleStencilTable = _options.setPatchPrecisionDouble;
+        opts.doubleStencilTable = _options.patchPrecisionDouble;
         opts.shareLocalPoints   = _options.shareEndCapPatchPoints;
         opts.reuseSourcePoints  = (_patchBuilder->GetIrregularPatchType() ==
                                    _patchBuilder->GetNativePatchType() );
@@ -1177,7 +1177,7 @@ PatchTableBuilder::populatePatches() {
         if (_requiresFVarPatches) {
             opts.createStencilTable = true;
             opts.createVaryingTable = false;
-            opts.doubleStencilTable = _options.setFVarPatchPrecisionDouble;
+            opts.doubleStencilTable = _options.fvarPatchPrecisionDouble;
 
             fvarLocalPointHelpers.SetSize((int)_fvarChannelIndices.size());
 
@@ -1197,8 +1197,8 @@ PatchTableBuilder::populatePatches() {
     PatchInfo patchInfo;
     PatchInfo fvarPatchInfo;
 
-    bool fvarPrecisionMatches = (_options.setPatchPrecisionDouble ==
-                                 _options.setFVarPatchPrecisionDouble);
+    bool fvarPrecisionMatches = (_options.patchPrecisionDouble ==
+                                 _options.fvarPatchPrecisionDouble);
 
     for (int patchIndex = 0; patchIndex < (int)_patches.size(); ++patchIndex) {
 

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -65,8 +65,8 @@ public:
              generateVaryingTables(true),
              generateVaryingLocalPoints(true),
              generateFVarTables(false),
-             setPatchPrecisionDouble(false),
-             setFVarPatchPrecisionDouble(false),
+             patchPrecisionDouble(false),
+             fvarPatchPrecisionDouble(false),
              generateFVarLegacyLinearPatches(true),
              generateLegacySharpCornerPatches(true),
              numFVarChannels(-1),
@@ -118,8 +118,8 @@ public:
                      generateFVarTables  : 1, ///< Generate face-varying patch tables
 
                      // precision
-                     setPatchPrecisionDouble     : 1, ///< Generate double-precision stencils for vertex patches
-                     setFVarPatchPrecisionDouble : 1, ///< Generate double-precision stencils for face-varying patches
+                     patchPrecisionDouble     : 1, ///< Generate double-precision stencils for vertex patches
+                     fvarPatchPrecisionDouble : 1, ///< Generate double-precision stencils for face-varying patches
 
                      // legacy behaviors (default to true)
                      generateFVarLegacyLinearPatches  : 1, ///< Generate all linear face-varying patches (legacy)
@@ -199,17 +199,17 @@ public:
 
 
 template <> inline void PatchTableFactory::Options::SetPatchPrecision<float>() {
-    setPatchPrecisionDouble = false;
+    patchPrecisionDouble = false;
 }
 template <> inline void PatchTableFactory::Options::SetFVarPatchPrecision<float>() {
-    setFVarPatchPrecisionDouble = false;
+    fvarPatchPrecisionDouble = false;
 }
 
 template <> inline void PatchTableFactory::Options::SetPatchPrecision<double>() {
-    setPatchPrecisionDouble = true;
+    patchPrecisionDouble = true;
 }
 template <> inline void PatchTableFactory::Options::SetFVarPatchPrecision<double>() {
-    setFVarPatchPrecisionDouble = true;
+    fvarPatchPrecisionDouble = true;
 }
 
 


### PR DESCRIPTION
These changes modify a couple of public methods added to Far to support variable precision based on feedback.  Methods to query the precision of Far::PatchTable's internal StencilTables were renamed, along with the precision related members of Far::PatchTableFactory::Options.