### PR TITLE
Added simple tetrahedron to set of Loop test shapes

### DIFF
--- a/examples/dxViewer/init_shapes.h
+++ b/examples/dxViewer/init_shapes.h
@@ -72,6 +72,7 @@ static void initShapes() {
     g_defaultShapes.push_back(ShapeDesc("catmark_car",              catmark_car,              kCatmark));
 
     g_defaultShapes.push_back(ShapeDesc("loop_toroidal_tet",        loop_toroidal_tet,        kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_tetrahedron",         loop_tetrahedron,         kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cube",                loop_cube,                kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop));

--- a/examples/glFVarViewer/init_shapes.h
+++ b/examples/glFVarViewer/init_shapes.h
@@ -60,6 +60,7 @@ static void initShapes() {
     g_defaultShapes.push_back(ShapeDesc("catmark_hole_test2",       catmark_hole_test2,       kCatmark));
 
     g_defaultShapes.push_back(ShapeDesc("loop_toroidal_tet",        loop_toroidal_tet,        kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_tetrahedron",         loop_tetrahedron,         kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cube",                loop_cube,                kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop));

--- a/examples/glViewer/init_shapes.h
+++ b/examples/glViewer/init_shapes.h
@@ -72,6 +72,7 @@ static void initShapes() {
     g_defaultShapes.push_back(ShapeDesc("catmark_car",              catmark_car,              kCatmark));
 
     g_defaultShapes.push_back(ShapeDesc("loop_toroidal_tet",        loop_toroidal_tet,        kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_tetrahedron",         loop_tetrahedron,         kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cube",                loop_cube,                kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop));

--- a/examples/mtlViewer/init_shapes.h
+++ b/examples/mtlViewer/init_shapes.h
@@ -72,6 +72,7 @@ static void initShapes() {
     g_defaultShapes.push_back(ShapeDesc("catmark_car",              catmark_car,              kCatmark));
 
     g_defaultShapes.push_back(ShapeDesc("loop_toroidal_tet",        loop_toroidal_tet,        kLoop));
+    g_defaultShapes.push_back(ShapeDesc("loop_tetrahedron",         loop_tetrahedron,         kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cube",                loop_cube,                kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cubes_semisharp",     loop_cubes_semisharp,     kLoop));
     g_defaultShapes.push_back(ShapeDesc("loop_cubes_infsharp",      loop_cubes_infsharp,      kLoop));

--- a/regression/shapes/all.h
+++ b/regression/shapes/all.h
@@ -136,6 +136,7 @@
 #include "loop_pole360.h"
 #include "loop_saddle_edgecorner.h"
 #include "loop_saddle_edgeonly.h"
+#include "loop_tetrahedron.h"
 #include "loop_toroidal_tet.h"
 #include "loop_triangle_edgecorner.h"
 #include "loop_triangle_edgeonly.h"

--- a/regression/shapes/loop_tetrahedron.h
+++ b/regression/shapes/loop_tetrahedron.h
@@ -1,0 +1,47 @@
+//
+//   Copyright 2019 DreamWorks Animation LLC.
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+static const std::string loop_tetrahedron =
+"#\n"
+"#  Tetrahedron oriented within an axially aligned cube:\n"
+"#\n"
+"v -1 -1  1\n"
+"v  1 -1 -1\n"
+"v  1  1  1\n"
+"v -1  1 -1\n"
+"\n"
+"vt 0.375 0.217\n"
+"vt 0.75  0.0\n"
+"vt 0.375 0.65\n"
+"vt 0.0   0.0\n"
+"vt 0.25  1.0\n"
+"vt 0.625 0.35\n"
+"vt 1.0   1.0\n"
+"\n"
+"f 1/1 2/2 3/3\n"
+"f 1/1 3/3 4/4\n"
+"f 1/1 4/4 2/2\n"
+"f 4/5 3/6 2/7\n"
+"\n"
+;


### PR DESCRIPTION
A tetrahedron is added here to the set of test shapes for Loop.  An open tet (one face missing) and a tet with holes (the toroidal_tet) are already present, but a simple tetrahedron has been absent.

A second commit includes the new shape in the viewer examples for the main back-ends, along with the glFVarViewer for inspecting its assigned UVs.