### PR TITLE
Improvements to far_perf output and options

### DIFF
--- a/regression/far_perf/far_perf.cpp
+++ b/regression/far_perf/far_perf.cpp
@@ -34,8 +34,8 @@
 #include <opensubdiv/far/primvarRefiner.h>
 #include <opensubdiv/far/stencilTableFactory.h>
 #include <opensubdiv/far/patchTableFactory.h>
+
 #include "../../regression/common/far_utils.h"
-// XXX: revisit the directory structure for examples/tests
 #include "../../examples/common/stopwatch.h"
 
 #include "init_shapes.h"
@@ -44,8 +44,33 @@
 
 using namespace OpenSubdiv;
 
-struct Result {
+struct TestOptions {
+    TestOptions() :
+        refineLevel(2),
+        refineAdaptive(true),
+        createPatches(true),
+        createStencils(true),
+        endCapType(Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS) { }
+
+    int  refineLevel;
+    bool refineAdaptive;
+    bool createPatches;
+    bool createStencils;
+
+    Far::PatchTableFactory::Options::EndCapType endCapType;
+};
+
+struct TestResult {
+    TestResult() :
+        level(-1),
+        timeTotal(0),
+        timeRefine(0),
+        timePatchFactory(0),
+        timeStencilFactory(0),
+        timeAppendStencil(0) { }
+
     std::string name;
+    int level;
     double timeTotal;
     double timeRefine;
     double timePatchFactory;
@@ -54,74 +79,76 @@ struct Result {
 };
 
 template <typename REAL>
-static Result
-doPerf(std::string const & name,
-       Shape const * shape,
-       int level,
-       bool adaptive,
-       Far::PatchTableFactory::Options::EndCapType endCapType)
-{
+static TestResult
+RunPerfTest(Shape const & shape, TestOptions const & options) {
 
     typedef Far::StencilTableReal<REAL>        FarStencilTable;
     typedef Far::StencilTableFactoryReal<REAL> FarStencilTableFactory;
 
-    Sdc::SchemeType sdcType = GetSdcType(*shape);
-    Sdc::Options sdcOptions = GetSdcOptions(*shape);
+    Sdc::SchemeType sdcType = GetSdcType(shape);
+    Sdc::Options sdcOptions = GetSdcOptions(shape);
 
-    Result result;
-    result.name = name;
+    TestResult result;
+    result.level = options.refineLevel;
 
     Stopwatch s; 
 
     // ----------------------------------------------------------------------
     // Configure the patch table factory options
-    Far::PatchTableFactory::Options poptions(level);
-    poptions.SetEndCapType(endCapType);
+    Far::PatchTableFactory::Options poptions(options.refineLevel);
+    poptions.SetEndCapType(options.endCapType);
     poptions.SetPatchPrecision<REAL>();
 
     // ----------------------------------------------------------------------
     // Instantiate a FarTopologyRefiner from the descriptor and refine
-    s.Start();
     Far::TopologyRefiner * refiner = Far::TopologyRefinerFactory<Shape>::Create(
-        *shape, Far::TopologyRefinerFactory<Shape>::Options(sdcType, sdcOptions));
-    {
-        if (adaptive) {
-            Far::TopologyRefiner::AdaptiveOptions options =
-                poptions.GetRefineAdaptiveOptions();
-            refiner->RefineAdaptive(options);
-        } else {
-            Far::TopologyRefiner::UniformOptions options(level);
-            refiner->RefineUniform(options);
-        }
+        shape, Far::TopologyRefinerFactory<Shape>::Options(sdcType, sdcOptions));
+    assert(refiner);
+
+    s.Start();
+    if (options.refineAdaptive) {
+        Far::TopologyRefiner::AdaptiveOptions rOptions =
+            poptions.GetRefineAdaptiveOptions();
+        refiner->RefineAdaptive(rOptions);
+    } else {
+        Far::TopologyRefiner::UniformOptions rOptions(options.refineLevel);
+        refiner->RefineUniform(rOptions);
     }
     s.Stop();
     result.timeRefine = s.GetElapsed();
 
     // ----------------------------------------------------------------------
     // Create patch table
-    s.Start();
     Far::PatchTable const * patchTable = NULL;
-    {
+    if (options.createPatches) {
+        s.Start();
         patchTable = Far::PatchTableFactory::Create(*refiner, poptions);
+        s.Stop();
+        result.timePatchFactory = s.GetElapsed();
+    } else {
+        result.timePatchFactory = 0;
     }
-    s.Stop();
-    result.timePatchFactory = s.GetElapsed();
 
     // ----------------------------------------------------------------------
     // Create stencil table
-    s.Start();
     FarStencilTable const * vertexStencils = NULL;
-    {
+    if (options.createStencils) {
+        s.Start();
+
         typename FarStencilTableFactory::Options options;
         vertexStencils = FarStencilTableFactory::Create(*refiner, options);
+
+        s.Stop();
+        result.timeStencilFactory = s.GetElapsed();
+    } else {
+        result.timeStencilFactory = 0;
     }
-    s.Stop();
-    result.timeStencilFactory = s.GetElapsed();
 
     // ----------------------------------------------------------------------
     // append local points to stencils
-    s.Start();
-    {
+    if (options.createPatches && options.createStencils) {
+        s.Start();
+
         if (FarStencilTable const *vertexStencilsWithLocalPoints =
             FarStencilTableFactory::AppendLocalPointStencilTable(
                 *refiner, vertexStencils,
@@ -129,14 +156,116 @@ doPerf(std::string const & name,
             delete vertexStencils;
             vertexStencils = vertexStencilsWithLocalPoints;
         }
+
+        s.Stop();
+        result.timeAppendStencil = s.GetElapsed();
+    } else {
+        result.timeAppendStencil = 0;
     }
-    s.Stop();
-    result.timeAppendStencil = s.GetElapsed();
 
     // ---------------------------------------------------------------------
     result.timeTotal = s.GetTotalElapsed();
 
+    delete vertexStencils;
+    delete patchTable;
+    delete refiner;
+
     return result;
+}
+
+//------------------------------------------------------------------------------
+
+struct PrintOptions {
+    PrintOptions() :
+        csvFormat(false),
+        refineTime(true),
+        patchTime(true),
+        stencilTime(true),
+        appendTime(true),
+        totalTime(true) { }
+
+    bool csvFormat;
+    bool refineTime;
+    bool patchTime;
+    bool stencilTime;
+    bool appendTime;
+    bool totalTime;
+};
+
+static void
+PrintShape(ShapeDesc const & shapeDesc, PrintOptions const & ) {
+
+    static char const * g_schemeNames[3] = { "bilinear", "catmark", "loop" };
+
+    char const * shapeName   = shapeDesc.name.c_str();
+    Scheme       shapeScheme = shapeDesc.scheme;
+
+    printf("%s (%s):\n", shapeName, g_schemeNames[shapeScheme]);
+}
+
+static void
+PrintResult(TestResult const & result, PrintOptions const & options) {
+
+    //  If only printing the total, combine on same line as level:
+    if (!options.refineTime  && !options.patchTime &&
+        !options.stencilTime && !options.appendTime) {
+        printf("  level %d:  %f\n", result.level, result.timeTotal);
+        return;
+    }
+
+    printf("  level %d:\n", result.level);
+
+    if (options.refineTime) {
+        printf("    TopologyRefiner::Refine     %f %5.2f%%\n",
+               result.timeRefine,
+               result.timeRefine/result.timeTotal*100);
+    }
+    if (options.patchTime) {
+        printf("    PatchTableFactory::Create   %f %5.2f%%\n",
+               result.timePatchFactory,
+               result.timePatchFactory/result.timeTotal*100);
+    }
+    if (options.stencilTime) {
+        printf("    StencilTableFactory::Create %f %5.2f%%\n",
+               result.timeStencilFactory,
+               result.timeStencilFactory/result.timeTotal*100);
+    }
+    if (options.appendTime) {
+        printf("    StencilTableFactory::Append %f %5.2f%%\n",
+               result.timeAppendStencil,
+               result.timeAppendStencil/result.timeTotal*100);
+    }
+    if (options.totalTime) {
+        printf("    Total                       %f\n",
+               result.timeTotal);
+    }
+}
+
+static void
+PrintHeaderCSV(PrintOptions const & options) {
+
+    // spreadsheet header row
+    printf("shape");
+    printf(",level");
+    if (options.refineTime)  printf(",refine");
+    if (options.patchTime)   printf(",patch");
+    if (options.stencilTime) printf(",stencilFactory");
+    if (options.appendTime)  printf(",stencilAppend");
+    if (options.totalTime)   printf(",total");
+    printf("\n");
+}
+static void
+PrintResultCSV(TestResult const & result, PrintOptions const & options) {
+
+    // spreadsheet data row
+    printf("%s",  result.name.c_str());
+    printf(",%d", result.level);
+    if (options.refineTime)  printf(",%f", result.timeRefine);
+    if (options.patchTime)   printf(",%f", result.timePatchFactory);
+    if (options.stencilTime) printf(",%f", result.timeStencilFactory);
+    if (options.appendTime)  printf(",%f", result.timeAppendStencil);
+    if (options.totalTime)   printf(",%f", result.timeTotal);
+    printf("\n");
 }
 
 //------------------------------------------------------------------------------
@@ -146,8 +275,9 @@ parseIntArg(char const * argString, int dfltValue = 0) {
     char *argEndptr;
     int argValue = strtol(argString, &argEndptr, 10);
     if (*argEndptr != 0) {
-        printf("Warning: non-integer option parameter '%s' ignored\n",
-                           argString);
+        fprintf(stderr,
+                "Warning: non-integer option parameter '%s' ignored\n",
+                argString);
         argValue = dfltValue;
     }
     return argValue;
@@ -155,30 +285,23 @@ parseIntArg(char const * argString, int dfltValue = 0) {
 
 int main(int argc, char **argv)
 {
-    bool adaptive = true;
-    int level = 8;
+    TestOptions testOptions;
+    PrintOptions printOptions;
+    std::vector<std::string> objFiles;
     Scheme defaultScheme = kCatmark;
-    Far::PatchTableFactory::Options::EndCapType endCapType =
-        Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS;
+    int minLevel = 1;
+    int maxLevel = 2;
     bool runDouble = false;
-    bool spreadsheet = false;
 
     for (int i = 1; i < argc; ++i) {
         if (strstr(argv[i], ".obj")) {
-            std::ifstream ifs(argv[i]);
-            if (ifs) {
-                std::stringstream ss;
-                ss << ifs.rdbuf();
-                ifs.close();
-                g_shapes.push_back(
-                        ShapeDesc(argv[i], ss.str(), defaultScheme));
-            }
+            objFiles.push_back(std::string(argv[i]));
         } else if (!strcmp(argv[i], "-a")) {
-            adaptive = true;
+            testOptions.refineAdaptive = true;
         } else if (!strcmp(argv[i], "-u")) {
-            adaptive = false;
+            testOptions.refineAdaptive = false;
         } else if (!strcmp(argv[i], "-l")) {
-            if (++i < argc) level = parseIntArg(argv[i], 8);
+            if (++i < argc) maxLevel = parseIntArg(argv[i], maxLevel);
         } else if (!strcmp(argv[i], "-bilinear")) {
             defaultScheme = kBilinear;
         } else if (!strcmp(argv[i], "-catmark")) {
@@ -188,22 +311,57 @@ int main(int argc, char **argv)
         } else if (!strcmp(argv[i], "-e")) {
             char const * type = argv[++i];
             if (!strcmp(type, "linear")) {
-                endCapType =
+                testOptions.endCapType =
                         Far::PatchTableFactory::Options::ENDCAP_BILINEAR_BASIS;
             } else if (!strcmp(type, "regular")) {
-                endCapType =
+                testOptions.endCapType =
                         Far::PatchTableFactory::Options::ENDCAP_BSPLINE_BASIS;
             } else if (!strcmp(type, "gregory")) {
-                endCapType =
+                testOptions.endCapType =
                         Far::PatchTableFactory::Options::ENDCAP_GREGORY_BASIS;
             } else {
-                printf("Unknown endcap type %s\n", type);
+                fprintf(stderr, "Error: Unknown endcap type %s\n", type);
                 return 1;
             }
         } else if (!strcmp(argv[i], "-double")) {
             runDouble = true;
-        } else if (!strcmp(argv[i], "-spreadsheet")) {
-            spreadsheet = true;
+        } else if (!strcmp(argv[i], "-nopatches")) {
+            testOptions.createPatches = false;
+
+            printOptions.patchTime  = false;
+            printOptions.appendTime = false;
+        } else if (!strcmp(argv[i], "-nostencils")) {
+            testOptions.createStencils = false;
+
+            printOptions.stencilTime = false;
+            printOptions.appendTime  = false;
+        } else if (!strcmp(argv[i], "-total")) {
+            printOptions.refineTime  = false;
+            printOptions.patchTime   = false;
+            printOptions.stencilTime = false;
+            printOptions.appendTime  = false;
+        } else if (!strcmp(argv[i], "-csv")) {
+            printOptions.csvFormat = true;
+        } else {
+            fprintf(stderr,
+                "Warning: unrecognized argument '%s' ignored\n", argv[i]);
+        }
+    }
+    assert(minLevel <= maxLevel);
+
+    if (!objFiles.empty()) {
+        for (size_t i = 0; i < objFiles.size(); ++i) {
+            char const * objFile = objFiles[i].c_str();
+            std::ifstream ifs(objFile);
+            if (ifs) {
+                std::stringstream ss;
+                ss << ifs.rdbuf();
+                ifs.close();
+                g_shapes.push_back(ShapeDesc(objFile, ss.str(), defaultScheme));
+            } else {
+                fprintf(stderr,
+                    "Warning: cannot open shape file '%s'\n", objFile);
+            }
         }
     }
 
@@ -211,67 +369,38 @@ int main(int argc, char **argv)
         initShapes();
     }
 
-    std::vector< std::vector<Result> > resultsByLevel(level+1);
-
-    for (int i = 0; i < (int)g_shapes.size(); ++i) {
-        std::string const & name = g_shapes[i].name;
-        Shape const * shape = Shape::parseObj(g_shapes[i]);
-
-        for (int lv = 1; lv <= level; ++lv) {
-            Result result;
-            if (runDouble) {
-                result = doPerf<double>(name, shape, lv, adaptive, endCapType);
-            } else {
-                result = doPerf<float>(name, shape, lv, adaptive, endCapType);
-            }
-            printf("---- %s, level %d ----\n", result.name.c_str(), lv);
-            printf("TopologyRefiner::Refine     %f %5.2f%%\n",
-                   result.timeRefine,
-                   result.timeRefine/result.timeTotal*100);
-            printf("StencilTableFactory::Create %f %5.2f%%\n",
-                   result.timeStencilFactory,
-                   result.timeStencilFactory/result.timeTotal*100);
-            printf("PatchTableFactory::Create   %f %5.2f%%\n",
-                   result.timePatchFactory,
-                   result.timePatchFactory/result.timeTotal*100);
-            printf("StencilTableFactory::Append %f %5.2f%%\n",
-                   result.timeAppendStencil,
-                   result.timeAppendStencil/result.timeTotal*100);
-            printf("Total                       %f\n",
-                   result.timeTotal);
-            if (spreadsheet) {
-                resultsByLevel[lv].push_back(result);
-            }
-        }
+    //  For each shape, run tests for all specified levels -- printing the
+    //  results in the specified format:
+    //
+    if (printOptions.csvFormat) {
+        PrintHeaderCSV(printOptions);
     }
-    if (spreadsheet) {
-        for (int lv=1; lv<(int)resultsByLevel.size(); ++lv) {
-            std::vector<Result> const & results = resultsByLevel[lv];
-            if (lv == 1) {
-                // spreadsheet header row
-                printf("level,");
-                for (int s=0; s<(int)results.size(); ++s) {
-                    Result const & result = results[s];
-                    printf("%s total,", result.name.c_str());
-                    printf("%s refine,", result.name.c_str());
-                    printf("%s patchFactory,", result.name.c_str());
-                    printf("%s stencilFactory,", result.name.c_str());
-                    printf("%s stencilAppend,", result.name.c_str());
-                }
-                printf("\n");
-            }
-            // spreadsheet data row
-            printf("%d,", lv);
-            for (int s=0; s<(int)results.size(); ++s) {
-                Result const & result = results[s];
-                printf("%f,", result.timeTotal);
-                printf("%f,", result.timeRefine);
-                printf("%f,", result.timePatchFactory);
-                printf("%f,", result.timeStencilFactory);
-                printf("%f,", result.timeAppendStencil);
-            }
-            printf("\n");
+    for (size_t i = 0; i < g_shapes.size(); ++i) {
+        ShapeDesc const & shapeDesc = g_shapes[i];
+        Shape const * shape = Shape::parseObj(shapeDesc);
+
+        if (!printOptions.csvFormat) {
+            PrintShape(shapeDesc, printOptions);
         }
+
+        for (int levelIndex = minLevel; levelIndex <= maxLevel; ++levelIndex) {
+            testOptions.refineLevel = levelIndex;
+
+            TestResult result;
+            if (runDouble) {
+                result = RunPerfTest<double>(*shape, testOptions);
+            } else {
+                result = RunPerfTest<float>(*shape, testOptions);
+            }
+            result.name = shapeDesc.name;
+
+            if (printOptions.csvFormat) {
+                PrintResultCSV(result, printOptions);
+            } else {
+                PrintResult(result, printOptions);
+            }
+        }
+        delete shape;
     }
 }
 


### PR DESCRIPTION
These changes build on #1119 in providing more flexibility with regression/perf.  Changes include:

- fixing memory leaks and asserting or reporting bad input data
- re-organizing the CSV output and renaming the option to -cvs (from -spreadsheet)
- addition of the -nostencils and -nopatches options to reduce and focus execution and output
- addition of the -total flag to provide only a summary of each test

Several of the growing set of options are also factored into two groups -- those affecting execution of the tests and those affecting the output generated.