### PR TITLE
Minor improvements to examples for Loop

### DIFF
--- a/examples/dxPtexViewer/shader.hlsl
+++ b/examples/dxPtexViewer/shader.hlsl
@@ -465,13 +465,7 @@ getAdaptivePatchColor(int3 patchParam, float sharpness)
     };
 
     int patchType = 0;
-#if defined OSD_PATCH_ENABLE_SINGLE_CREASE
-    if (sharpness > 0) {
-        pattern = 1;
-    }
-#endif
 
-    int pattern = countbits(OsdGetPatchTransitionMask(patchParam));
     int edgeCount = countbits(OsdGetPatchBoundaryMask(patchParam));
     if (edgeCount == 1) {
         patchType = 2; // BOUNDARY
@@ -480,15 +474,19 @@ getAdaptivePatchColor(int3 patchParam, float sharpness)
         patchType = 3; // CORNER
     }
 
-    // XXX: it looks like edgeCount != 0 for some gregory boundary patches.
-    //      there might be a bug somewhere...
-#if defined OSD_PATCH_GREGORY
+#if defined OSD_PATCH_ENABLE_SINGLE_CREASE
+    if (sharpness > 0) {
+        patchType = 1;
+    }
+#elif defined OSD_PATCH_GREGORY
     patchType = 4;
 #elif defined OSD_PATCH_GREGORY_BOUNDARY
     patchType = 5;
 #elif defined OSD_PATCH_GREGORY_BASIS
     patchType = 6;
 #endif
+
+    int pattern = countbits(OsdGetPatchTransitionMask(patchParam));
 
     return patchColors[6*patchType + pattern];
 }

--- a/examples/dxViewer/shader.hlsl
+++ b/examples/dxViewer/shader.hlsl
@@ -416,11 +416,7 @@ getAdaptivePatchColor(int3 patchParam, float2 vSegments)
     if (vSegments.y > 0) {
         patchType = 1;
     }
-#endif
-
-    // XXX: it looks like edgeCount != 0 for gregory_boundary.
-    //      there might be a bug somewhere.
-#if defined OSD_PATCH_GREGORY
+#elif defined OSD_PATCH_GREGORY
     patchType = 4;
 #elif defined OSD_PATCH_GREGORY_BOUNDARY
     patchType = 5;

--- a/examples/glFVarViewer/shader.glsl
+++ b/examples/glFVarViewer/shader.glsl
@@ -167,7 +167,7 @@ out block {
 } outpt;
 
 uniform isamplerBuffer OsdFVarParamBuffer;
-layout(std140) uniform FVarArrayData {
+layout(std140) uniform OsdFVarArrayData {
     OsdPatchArray fvarPatchArray[2];
 };
 
@@ -211,25 +211,22 @@ void emit(int index, vec3 normal)
     outpt.v.normal = normal;
 #endif
 
-#ifdef LOOP  // ----- scheme : LOOP
+#ifdef SHADING_FACEVARYING_UNIFORM_SUBDIVISION
+    // interpolate fvar data at refined tri or quad vertex locations
+#ifdef PRIM_TRI
     vec2 trist[3] = vec2[](vec2(0,0), vec2(1,0), vec2(0,1));
-#ifdef SHADING_FACEVARYING_UNIFORM_SUBDIVISION
     vec2 st = trist[index];
-#else
-    vec2 st = inpt[index].v.tessCoord;
 #endif
-    vec2 uv = interpolateFaceVarying(st, /*fvarOffset*/0);
-
-#else        // ----- scheme : CATMARK / BILINEAR
-
-#ifdef SHADING_FACEVARYING_UNIFORM_SUBDIVISION
+#ifdef PRIM_QUAD
     vec2 quadst[4] = vec2[](vec2(0,0), vec2(1,0), vec2(1,1), vec2(0,1));
     vec2 st = quadst[index];
+#endif
 #else
+    // interpolate fvar data at tessellated vertex locations
     vec2 st = inpt[index].v.tessCoord;
 #endif
+
     vec2 uv = interpolateFaceVarying(st, /*fvarOffset*/0);
-#endif      // ------ scheme
 
     outpt.color = vec3(uv.s, uv.t, 0);
 

--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -117,11 +117,6 @@ public:
         } else if (type == Far::PatchDescriptor::GREGORY_TRIANGLE) {
             ss << "#define OSD_PATCH_GREGORY_TRIANGLE\n";
         }
-        if (type == Far::PatchDescriptor::TRIANGLES ||
-            type == Far::PatchDescriptor::LOOP ||
-            type == Far::PatchDescriptor::GREGORY_TRIANGLE) {
-            ss << "#define LOOP\n";
-        }
         
         if (desc.IsAdaptive()) {
             ss << "#define SMOOTH_NORMALS\n";

--- a/examples/glImaging/shader.glsl
+++ b/examples/glImaging/shader.glsl
@@ -44,6 +44,13 @@
         mix(mix(inpt[a].color, inpt[b].color, UV.x), \
             mix(inpt[c].color, inpt[d].color, UV.x), UV.y)
 
+#undef OSD_USER_VARYING_PER_EVAL_POINT_TRIANGLE
+#define OSD_USER_VARYING_PER_EVAL_POINT_TRIANGLE(UV, a, b, c) \
+    outpt.color = \
+        inpt[a].color * (1.0f - UV.x - UV.y) + \
+        inpt[b].color * UV.x + \
+        inpt[c].color * UV.y;
+
 //--------------------------------------------------------------
 // Uniforms / Uniform Blocks
 //--------------------------------------------------------------
@@ -358,7 +365,7 @@ getAdaptivePatchColor(ivec3 patchParam)
         patchType = 3; // CORNER (not correct for patches that are not isolated)
     }
 
-#if defined(OSD_PATCH_ENABLE_SINGLE_CREASE) && !defined(LOOP)
+#if defined OSD_PATCH_ENABLE_SINGLE_CREASE
     // check this after boundary/corner since single crease patch also has edgeCount.
     if (inpt.vSegments.y > 0) {
         patchType = 1;

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -704,11 +704,6 @@ public:
         } else if (type == Far::PatchDescriptor::GREGORY_TRIANGLE) {
             ss << "#define OSD_PATCH_GREGORY_TRIANGLE\n";
         }
-        if (type == Far::PatchDescriptor::TRIANGLES ||
-            type == Far::PatchDescriptor::LOOP ||
-            type == Far::PatchDescriptor::GREGORY_TRIANGLE) {
-            ss << "#define LOOP\n";
-        }
 
         // include osd PatchCommon
         ss << Osd::GLSLPatchShaderSource::GetCommonShaderSource();

--- a/examples/glPtexViewer/shader.glsl
+++ b/examples/glPtexViewer/shader.glsl
@@ -475,7 +475,7 @@ GetOverrideColor(ivec3 patchParam)
         patchType = 3; // CORNER (not correct for patches that are not isolated)
     }
 
-#if defined(OSD_PATCH_ENABLE_SINGLE_CREASE) && !defined(LOOP)
+#if defined OSD_PATCH_ENABLE_SINGLE_CREASE
     // check this after boundary/corner since single crease patch also has edgeCount.
     if (inpt.vSegments.y > 0) {
         patchType = 1;

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -378,11 +378,6 @@ public:
         } else if (type == Far::PatchDescriptor::GREGORY_TRIANGLE) {
             ss << "#define OSD_PATCH_GREGORY_TRIANGLE\n";
         }
-        if (type == Far::PatchDescriptor::TRIANGLES ||
-            type == Far::PatchDescriptor::LOOP ||
-            type == Far::PatchDescriptor::GREGORY_TRIANGLE) {
-            ss << "#define LOOP\n";
-        }
 
         // for legacy gregory
         ss << "#define OSD_MAX_VALENCE " << effectDesc.maxValence << "\n";

--- a/examples/glShareTopology/shader.glsl
+++ b/examples/glShareTopology/shader.glsl
@@ -424,7 +424,7 @@ getAdaptivePatchColor(ivec3 patchParam)
         patchType = 3; // CORNER (not correct for patches that are not isolated)
     }
 
-#if defined(OSD_PATCH_ENABLE_SINGLE_CREASE) && !defined(LOOP)
+#if defined OSD_PATCH_ENABLE_SINGLE_CREASE
     // check this after boundary/corner since single crease patch also has edgeCount.
     if (inpt.vSegments.y > 0) {
         patchType = 1;

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -233,7 +233,9 @@ GLuint g_transformUB = 0,
        g_tessellationUB = 0,
        g_tessellationBinding = 1,
        g_lightingUB = 0,
-       g_lightingBinding = 2;
+       g_lightingBinding = 2,
+       g_fvarArrayDataUB = 0,
+       g_fvarArrayDataBinding = 3;
 
 struct Transform {
     float ModelViewMatrix[16];
@@ -251,7 +253,7 @@ GLuint g_vao = 0;
 struct FVarData
 {
     FVarData() :
-        textureBuffer(0) {
+        textureBuffer(0), textureParamBuffer(0) {
     }
     ~FVarData() {
         Release();
@@ -260,11 +262,17 @@ struct FVarData
         if (textureBuffer)
             glDeleteTextures(1, &textureBuffer);
         textureBuffer = 0;
+        if (textureParamBuffer)
+            glDeleteTextures(1, &textureParamBuffer);
+        textureParamBuffer = 0;
     }
     void Create(OpenSubdiv::Far::PatchTable const *patchTable,
                 int fvarWidth, std::vector<float> const & fvarSrcData) {
+
+        using namespace OpenSubdiv;
+
         Release();
-        OpenSubdiv::Far::ConstIndexArray indices = patchTable->GetFVarValues();
+        Far::ConstIndexArray indices = patchTable->GetFVarValues();
 
         // expand fvardata to per-patch array
         std::vector<float> data;
@@ -289,8 +297,22 @@ struct FVarData
         glBindBuffer(GL_ARRAY_BUFFER, 0);
 
         glDeleteBuffers(1, &buffer);
+
+        Far::ConstPatchParamArray fvarParam = patchTable->GetFVarPatchParams();
+        glGenBuffers(1, &buffer);
+        glBindBuffer(GL_ARRAY_BUFFER, buffer);
+        glBufferData(GL_ARRAY_BUFFER, fvarParam.size()*sizeof(Far::PatchParam),
+                     &fvarParam[0], GL_STATIC_DRAW);
+
+        glGenTextures(1, &textureParamBuffer);
+        glBindTexture(GL_TEXTURE_BUFFER, textureParamBuffer);
+        glTexBuffer(GL_TEXTURE_BUFFER, GL_RG32I, buffer);
+        glBindTexture(GL_TEXTURE_BUFFER, 0);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+        glDeleteBuffers(1, &buffer);
     }
-    GLuint textureBuffer;
+    GLuint textureBuffer, textureParamBuffer;
 } g_fvarData;
 
 //------------------------------------------------------------------------------
@@ -780,11 +802,6 @@ public:
             break;
         }
 
-        if (type == Far::PatchDescriptor::TRIANGLES ||
-            type == Far::PatchDescriptor::LOOP ||
-            type == Far::PatchDescriptor::GREGORY_TRIANGLE) {
-            ss << "#define LOOP\n";
-        }
         if (type != Far::PatchDescriptor::TRIANGLES &&
             type != Far::PatchDescriptor::QUADS) {
             ss << "#define SMOOTH_NORMALS\n";
@@ -869,6 +886,10 @@ public:
         if (uboIndex != GL_INVALID_INDEX)
             glUniformBlockBinding(program, uboIndex, g_lightingBinding);
 
+        uboIndex = glGetUniformBlockIndex(program, "OsdFVarArrayData");
+        if (uboIndex != GL_INVALID_INDEX)
+            glUniformBlockBinding(program, uboIndex, g_fvarArrayDataBinding);
+
         // assign texture locations
         GLint loc;
         glUseProgram(program);
@@ -878,15 +899,18 @@ public:
         if ((loc = glGetUniformLocation(program, "OsdFVarDataBuffer")) != -1) {
             glUniform1i(loc, 1); // GL_TEXTURE1
         }
-        // for legacy gregory patches
-        if ((loc = glGetUniformLocation(program, "OsdVertexBuffer")) != -1) {
+        if ((loc = glGetUniformLocation(program, "OsdFVarParamBuffer")) != -1) {
             glUniform1i(loc, 2); // GL_TEXTURE2
         }
-        if ((loc = glGetUniformLocation(program, "OsdValenceBuffer")) != -1) {
+        // for legacy gregory patches
+        if ((loc = glGetUniformLocation(program, "OsdVertexBuffer")) != -1) {
             glUniform1i(loc, 3); // GL_TEXTURE3
         }
-        if ((loc = glGetUniformLocation(program, "OsdQuadOffsetBuffer")) != -1) {
+        if ((loc = glGetUniformLocation(program, "OsdValenceBuffer")) != -1) {
             glUniform1i(loc, 4); // GL_TEXTURE4
+        }
+        if ((loc = glGetUniformLocation(program, "OsdQuadOffsetBuffer")) != -1) {
+            glUniform1i(loc, 5); // GL_TEXTURE5
         }
         glUseProgram(0);
 
@@ -899,6 +923,9 @@ ShaderCache g_shaderCache;
 //------------------------------------------------------------------------------
 static void
 updateUniformBlocks() {
+
+    using namespace OpenSubdiv;
+
     if (! g_transformUB) {
         glGenBuffers(1, &g_transformUB);
         glBindBuffer(GL_UNIFORM_BUFFER, g_transformUB);
@@ -931,6 +958,29 @@ updateUniformBlocks() {
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
     glBindBufferBase(GL_UNIFORM_BUFFER, g_tessellationBinding, g_tessellationUB);
+
+    // Update and bind fvar patch array state
+    if (g_mesh->GetPatchTable()->GetNumFVarChannels() > 0) {
+        Osd::PatchArrayVector const &fvarPatchArrays =
+            g_mesh->GetPatchTable()->GetFVarPatchArrays();
+
+        // bind patch arrays UBO (std140 struct size padded to vec4 alignment)
+        int patchArraySize =
+            sizeof(GLint) * ((sizeof(Osd::PatchArray)/sizeof(GLint) + 3) & ~3);
+        if (!g_fvarArrayDataUB) {
+            glGenBuffers(1, &g_fvarArrayDataUB);
+        }
+        glBindBuffer(GL_UNIFORM_BUFFER, g_fvarArrayDataUB);
+        glBufferData(GL_UNIFORM_BUFFER,
+            fvarPatchArrays.size()*patchArraySize, NULL, GL_STATIC_DRAW);
+        for (int i=0; i<(int)fvarPatchArrays.size(); ++i) {
+            glBufferSubData(GL_UNIFORM_BUFFER,
+                i*patchArraySize, sizeof(Osd::PatchArray), &fvarPatchArrays[i]);
+        }
+
+        glBindBufferBase(GL_UNIFORM_BUFFER,
+                g_fvarArrayDataBinding, g_fvarArrayDataUB);
+    }
 
     // Update and bind lighting state
     struct Lighting {
@@ -978,17 +1028,20 @@ bindTextures() {
         glActiveTexture(GL_TEXTURE1);
         glBindTexture(GL_TEXTURE_BUFFER,
                       g_fvarData.textureBuffer);
+        glActiveTexture(GL_TEXTURE2);
+        glBindTexture(GL_TEXTURE_BUFFER,
+                      g_fvarData.textureParamBuffer);
     }
 
     // legacy gregory
     if (g_legacyGregoryPatchTable) {
-        glActiveTexture(GL_TEXTURE2);
-        glBindTexture(GL_TEXTURE_BUFFER,
-                      g_legacyGregoryPatchTable->GetVertexTextureBuffer());
         glActiveTexture(GL_TEXTURE3);
         glBindTexture(GL_TEXTURE_BUFFER,
-                      g_legacyGregoryPatchTable->GetVertexValenceTextureBuffer());
+                      g_legacyGregoryPatchTable->GetVertexTextureBuffer());
         glActiveTexture(GL_TEXTURE4);
+        glBindTexture(GL_TEXTURE_BUFFER,
+                      g_legacyGregoryPatchTable->GetVertexValenceTextureBuffer());
+        glActiveTexture(GL_TEXTURE5);
         glBindTexture(GL_TEXTURE_BUFFER,
                       g_legacyGregoryPatchTable->GetQuadOffsetsTextureBuffer());
     }

--- a/examples/glViewer/shader.glsl
+++ b/examples/glViewer/shader.glsl
@@ -324,8 +324,8 @@ void main()
 #endif // PRIM_QUAD
 
 #ifdef PRIM_TRI
-    vec3 A = (inpt[1].v.position - inpt[0].v.position).xyz;
-    vec3 B = (inpt[2].v.position - inpt[0].v.position).xyz;
+    vec3 A = (inpt[0].v.position - inpt[1].v.position).xyz;
+    vec3 B = (inpt[2].v.position - inpt[1].v.position).xyz;
     vec3 n0 = normalize(cross(B, A));
 
 #if defined(GEOMETRY_OUT_WIRE) || defined(GEOMETRY_OUT_LINE)


### PR DESCRIPTION
These improve some of the example shader code related to
adaptive refinement and tessellation of Loop meshes.

The main change is to update shader configuration so that it
depends only on the resulting patch type. Previously, there
were cases where a "LOOP" preprocessor symbol was passed
from the application to the shader code, but this is error prone
and confusing.

Also, fixed a few minor bugs discovered during testing.