### PR TITLE
Fixed cracks in face-varying Loop patches for lineaar-boundaries option

### DIFF
--- a/opensubdiv/far/patchBuilder.cpp
+++ b/opensubdiv/far/patchBuilder.cpp
@@ -833,7 +833,12 @@ PatchBuilder::GetIrregularPatchCornerSpans(int levelIndex, Index faceIndex,
 
         //  Sharpen the span if a corner or subject to inf-sharp features:
         if (vTag._corner) {
-            cornerSpans[i]._sharp = true;
+            //  Corners tagged in FVar space need additional qualification:
+            if (isFVarMisMatch) {
+                cornerSpans[i]._sharp = (cornerSpans[i]._numFaces == 1) || isNonManifold;
+            } else {
+                cornerSpans[i]._sharp = true;
+            }
         } else if (isNonManifold) {
             cornerSpans[i]._sharp = vTag._infSharp;
         } else if (testInfSharpFeatures) {


### PR DESCRIPTION
This change addresses discontinuities that appear between face-varying patches for Loop when using the LINEAR_BOUNDARIES option.  The change works around a deeper issue in the way that face-varying topology is tagged for this option -- the boundary vertices are tagged as corners for ease of refinement and interpolation, but need to be re-assessed when considered as part of a patch.