### PR TITLE
Minor improvements to Doxygen comments in Far header files

### DIFF
--- a/opensubdiv/far/patchMap.h
+++ b/opensubdiv/far/patchMap.h
@@ -62,7 +62,7 @@ public:
     /// face indices and not the base face indices (see Far::PtexIndices for more
     /// details).
     ///
-    /// @param patchFaceId  The index of the face
+    /// @param patchFaceId  The index of the patch (Ptex) face
     ///
     /// @param u       Local u parameter
     ///

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -168,7 +168,7 @@ public:
     StencilTableReal<REAL> const *GetLocalPointStencilTable() const;
 
     /// \brief Tests if the precision of the stencil table to compute local point
-    /// vertex values matches the given floating point type <REAL>.
+    /// vertex values matches the given floating point type \<REAL\>.
     template <typename REAL> bool LocalPointStencilPrecisionMatchesType() const;
 
     /// \brief Updates local point vertex values.
@@ -198,7 +198,7 @@ public:
     StencilTableReal<REAL> const *GetLocalPointVaryingStencilTable() const;
 
     /// \brief Tests if the precision of the stencil table to compute local point
-    /// varying values matches the given floating point type <REAL>.
+    /// varying values matches the given floating point type \<REAL\>.
     template <typename REAL> bool LocalPointVaryingStencilPrecisionMatchesType() const;
 
     /// \brief Updates local point varying values.
@@ -228,7 +228,7 @@ public:
     StencilTableReal<REAL> const * GetLocalPointFaceVaryingStencilTable(int channel = 0) const;
 
     /// \brief Tests if the precision of the stencil table to compute local point
-    /// face-varying values matches the given floating point type <REAL>.
+    /// face-varying values matches the given floating point type \<REAL\>.
     template <typename REAL> bool LocalPointFaceVaryingStencilPrecisionMatchesType() const;
 
     /// \brief Updates local point face-varying values.

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -44,12 +44,20 @@ public:
     ///
     struct Options {
 
+        /// \brief Choice for approximating irregular patches (end-caps)
+        ///
+        /// This enum specifies how irregular patches (end-caps) are approximated.
+        /// A basis is chosen, rather than a specific patch type, and has a
+        /// corresponding patch type for each subdivision scheme, i.e. a quad and
+        /// triangular patch type exists for each basis.  These choices provide a
+        /// trade-off between surface quality and performance.
+        ///
         enum EndCapType {
-            ENDCAP_NONE = 0,             ///< no endcap
-            ENDCAP_BILINEAR_BASIS,       ///< use bilinear quads (4 cp) as end-caps
-            ENDCAP_BSPLINE_BASIS,        ///< use BSpline basis patches (16 cp) as end-caps
-            ENDCAP_GREGORY_BASIS,        ///< use Gregory basis patches (20 cp) as end-caps
-            ENDCAP_LEGACY_GREGORY        ///< use legacy (2.x) Gregory patches (4 cp + valence table) as end-caps
+            ENDCAP_NONE = 0,        ///< unspecified
+            ENDCAP_BILINEAR_BASIS,  ///< use linear patches (simple quads or tris)
+            ENDCAP_BSPLINE_BASIS,   ///< use BSpline-like patches (same patch type as regular)
+            ENDCAP_GREGORY_BASIS,   ///< use Gregory patches (highest quality, recommended default)
+            ENDCAP_LEGACY_GREGORY   ///< legacy option for 2.x style Gregory patches (Catmark only)
         };
 
         Options(unsigned int maxIsolation=10) :
@@ -73,10 +81,10 @@ public:
              fvarChannelIndices(0)
         { }
 
-        /// \brief Get endcap patch type
+        /// \brief Get endcap basis type
         EndCapType GetEndCapType() const { return (EndCapType)endCapType; }
 
-        /// \brief Set endcap patch type
+        /// \brief Set endcap basis type
         void SetEndCapType(EndCapType e) { endCapType = e; }
 
         /// \brief Set precision of vertex patches
@@ -175,7 +183,7 @@ public:
     //  It is no longer used internally and is being kept here to respect preservation
     //  of the public interface, but it will be deprecated at the earliest opportunity.
     //
-    /// \brief Obsolete internal struct accidentally exposed for public use -- due to
+    /// \brief Obsolete internal struct not intended for public use -- due to
     /// be deprecated.
     //
     struct PatchFaceTag {

--- a/opensubdiv/far/stencilTableFactory.h
+++ b/opensubdiv/far/stencilTableFactory.h
@@ -120,7 +120,7 @@ public:
     /// @param localPointStencilTable
     ///                             StencilTable for the change of basis patch points.
     ///
-    /// @param factorize            If factorize set to true, endcap stencils will be
+    /// @param factorize            If factorize is set to true, endcap stencils will be
     ///                             factorized with supporting vertices from baseStencil
     ///                             table so that the endcap points can be computed
     ///                             directly from control vertices.
@@ -140,7 +140,7 @@ public:
     /// @param localPointStencilTable
     ///                             StencilTable for the change of basis patch points.
     ///
-    /// @param factorize            If factorize set to true, endcap stencils will be
+    /// @param factorize            If factorize is set to true, endcap stencils will be
     ///                             factorized with supporting vertices from baseStencil
     ///                             table so that the endcap points can be computed
     ///                             directly from control vertices.
@@ -166,7 +166,7 @@ public:
     ///
     /// @param channel              face-varying channel
     ///
-    /// @param factorize            If factorize sets to true, endcap stencils will be
+    /// @param factorize            If factorize is set to true, endcap stencils will be
     ///                             factorized with supporting vertices from baseStencil
     ///                             table so that the endcap points can be computed
     ///                             directly from control vertices.


### PR DESCRIPTION
These are very minor changes to Doxygen comments in Far header files based on feedback.  It also includes a fix to Doxygen warnings generated by far/patchTable.h and its use of \<REAL\> in the comments.