### PR TITLE
Minor updates to release notes pages

### DIFF
--- a/documentation/release_34.rst
+++ b/documentation/release_34.rst
@@ -22,8 +22,8 @@
      language governing permissions and limitations under the Apache License.
 
 
-Overview of Release 3.4 (draft)
-===============================
+Overview of Release 3.4
+=======================
 
 .. contents::
    :local:
@@ -34,9 +34,8 @@ New Features
 
 Triangular Patches for Loop Subdivision
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Added support for drawing and evaluation of Loop subdivision meshes with
-triangular patches.  This includes the full set of Far and Osd interfaces
+Support for the drawing and evaluation of Loop subdivision meshes with
+triangular patches was added.  This includes the full set of Far and Osd interfaces
 for both evaluation and drawing.
 
 +-----------------------------------+-----------------------------------+
@@ -56,11 +55,18 @@ including creases, face-varying patches, non-manifold topology, etc.
 |    :target: images/loop_rel_3.png|    :target: images/loop_rel_4.png                              |
 +----------------------------------+----------------------------------------------------------------+
 
-Quartic triangular patches are used to exactly match the limit surface of
-Loop subdivision where the mesh is regular and approximated where irregular.
-As is the case with use of the Catmark scheme, application of Loop subdivision
-to dense, poorly modeled meshes may lead to unexpectedly poor performance or
-surface quality.
+The long standing requirement that Loop meshes be purely triangular remains, as
+Loop subdivision is not defined for non-triangular faces.  And as is the case with
+the use of the Catmark scheme, application of Loop subdivision to dense, poorly
+modeled meshes may lead to unexpectedly poor performance and/or surface quality.
+
+The patch representation used for Loop subdivision is intended to exactly match the
+underlying limit surface where regular, and so uses quartic triangular Box-splines.
+This is in contrast to approaches that use simpler patches to approximate the Loop
+limit surface everywhere.  As with Catmark, Gregory patches are used to approximate
+irregular areas.  Though other choices are available that compromise surface
+quality in favor of improved performance, they may be less effective with Loop than
+they are with Catmark.
 
 Major Improvements to Introductory Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -119,33 +125,17 @@ API Additions
 
 See associated `Doxygen <doxy_html/index.html>`__ for full details.
 
-Osd::MeshBits
-~~~~~~~~~~~~~
-    - enumeration MeshEndCapBilinearBasis
-
-Osd::PatchArray
-~~~~~~~~~~~~~~~
-    - GetDescriptorRegular()
-    - GetDescriptorIrregular()
-    - GetPatchTyperRegular()
-    - GetPatchTyperIrregular()
-    - GetStride()
-
-Osd extensions common to all shaders
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    - TBD
-
-Far construction and refinement of topology
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    - overloaded TopologyRefinerFactory::Create()
-    - extensions to TopologyRefiner::RefineAdaptive()
-
 Far extensions for triangular patches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     - enum PatchDescriptor::Type::GREGORY_TRIANGLE
     - PatchParam::NormalizeTriangle()
     - PatchParam::UnnormalizeTriangle()
     - PatchParam::IsTriangleRotated()
+
+Construction and refinement of topology
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    - overloaded TopologyRefinerFactory::Create()
+    - extensions to TopologyRefiner::RefineAdaptive()
 
 Construction and interface of Far::PatchTable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -189,6 +179,51 @@ Far member functions converted to templates for double precision
     - PatchTable::GetLocalPointVaryingStencilTable()
     - PatchTable::GetLocalPointFaceVaryingStencilTable()
     - PatchMap::FindPatch()
+
+Osd::MeshBits
+~~~~~~~~~~~~~
+    - enumeration MeshEndCapBilinearBasis
+
+Osd::PatchArray
+~~~~~~~~~~~~~~~
+    - GetDescriptorRegular()
+    - GetDescriptorIrregular()
+    - GetPatchTyperRegular()
+    - GetPatchTyperIrregular()
+    - GetStride()
+
+Osd extensions for patch evaluation common to all shaders
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    - struct OsdPatchArray and OsdPatchArrayInit()
+    - struct OsdPatchCoord and OsdPatchCoordInit()
+    - struct OsdPatchParam and OsdPatchParamInit()
+    - OsdPatchParamGetFaceId()
+    - OsdPatchParamGetU()
+    - OsdPatchParamGetV()
+    - OsdPatchParamGetTransition()
+    - OsdPatchParamGetBoundary()
+    - OsdPatchParamGetNonQuadRoot()
+    - OsdPatchParamGetDepth()
+    - OsdPatchParamGetParamFraction()
+    - OsdPatchParamIsRegular()
+    - OsdPatchParamIsTriangleRotated()
+    - OsdPatchParamNormalize()
+    - OsdPatchParamUnnormalize()
+    - OsdPatchParamNormalize(Triangle)
+    - OsdPatchParamUnnormalizeTriangle()
+    - OsdEvaluatePatchBasisNormalized()
+    - OsdEvaluatePatchBasis()
+
+Osd extensions for patch tessellation common to all shaders
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    - OsdInterpolatePatchCoordTriangle()
+    - OsdComputePerPatchVertexBoxSplineTriangle
+    - OsdEvalPatchBezierTriangle()
+    - OsdEvalPatchGregoryTriangle()
+    - OsdGetTessLevelsUniformTriangle()
+    - OsdEvalPatchBezierTessLevels()
+    - OsdEvalPatchBezierTriangleTessLevels()
+    - OsdGetTessParameterizationTriangle()
 
 Other Changes
 -------------

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -31,6 +31,9 @@
 
 ----
 
+Release 3.4
+~~~~~~~~~~~
+
 Release 3.4.0 - Jun 2019
 ========================
 
@@ -62,6 +65,9 @@ code and configuration improvements.  For more information on the following, ple
     - Fixed Far::PrimvarRefiner internal limitFVar() prototype (GitHub #979)
     - Fixed Far::StencilTable append when base StencilTable empty (GitHub #982)
     - Patches around non-manifold vertices now free of cracks (GitHub #1013)
+
+Release 3.3
+~~~~~~~~~~~
 
 Release 3.3.3 - Jul 2018
 ========================
@@ -116,6 +122,9 @@ Release 3.3.0 is significant release adding an Osd implementation for Apple's Me
     - Fixed several instances of local variable shadowing that could cause build warnings
     - Updated continuous-integration build scripts and added testing on macOS
 
+Release 3.2
+~~~~~~~~~~~
+
 Release 3.2.0 - Feb 2017
 ========================
 
@@ -133,6 +142,9 @@ Release 3.2.0 is a minor release containing API additions and bug fixes
 
 **Bug Fixes**
     - Fixed a double delete of GL program in Osd::GLComputeEvaluator
+
+Release 3.1
+~~~~~~~~~~~
 
 Release 3.1.1 - Jan 2017
 ========================
@@ -178,6 +190,9 @@ code and configuration improvements.  For more information on the following, ple
     - Fixed bug interpolating face-varying data with Bilinear scheme
     - Fixed bug with refinement using Chaikin creasing
     - Fixed bugs with HUD sliders in the example viewers
+
+Release 3.0
+~~~~~~~~~~~
 
 Release 3.0.5 - Mar 2016
 ========================
@@ -315,7 +330,8 @@ Release 3.0.0 RC1
       supported.
     - The Osd layer was largely refactored.
 
+
 Previous 2.x Release Notes
-==========================
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `Previous releases <release_notes_2x.html>`_


### PR DESCRIPTION
Changes here include an update to the 3.4 release notes page that includes a little more detail, and a change to the Release Notes summaries to organize them into sections for a more structured table of contents.