### PR TITLE
Fixed mtlViewer for iOS

### DIFF
--- a/examples/mtlViewer/iOS/ViewController.mm
+++ b/examples/mtlViewer/iOS/ViewController.mm
@@ -98,7 +98,7 @@
     _osdRenderer.displayControlMeshVertices = _controlMeshSwitch.isOn;
     _osdRenderer.displayControlMeshEdges = _controlMeshSwitch.isOn;
     _osdRenderer.usePatchClipCulling = _patchClipCullingSwitch.isOn;
-    _osdRenderer.useFractionalTessellation = _osdRenderer.useScreenspaceTessellation;
+    _osdRenderer.useFractionalTessellation = _osdRenderer.useFractionalTessellation;
     _osdRenderer.useAdaptive = true;
     _osdRenderer.freeze = true;
     _osdRenderer.animateVertices = false;
@@ -210,7 +210,7 @@
         _osdRenderer.displayControlMeshVertices = sender.isOn;
     } else if(sender == _screenspaceTessellationSwitch) {
         _osdRenderer.useScreenspaceTessellation = sender.isOn;
-        _osdRenderer.useFractionalTessellation = _osdRenderer.useScreenspaceTessellation;
+        _osdRenderer.useFractionalTessellation = _osdRenderer.useFractionalTessellation;
     }
 }
 

--- a/examples/mtlViewer/mtlViewer.h
+++ b/examples/mtlViewer/mtlViewer.h
@@ -30,8 +30,8 @@
 typedef enum {
     kEndCapBilinearBasis = 0,
     kEndCapBSplineBasis,
-    kEndCapLegacyGregory,
     kEndCapGregoryBasis,
+    kEndCapLegacyGregory,
 } EndCap;
 
 typedef enum {

--- a/examples/mtlViewer/mtlViewer.mm
+++ b/examples/mtlViewer/mtlViewer.mm
@@ -342,7 +342,7 @@ struct PipelineConfig {
         self.useSmoothCornerPatch = true;
         self.useSingleCreasePatch = true;
         self.useInfinitelySharpPatch = true;
-        self.useStageIn = !TARGET_OS_EMBEDDED;
+        self.useStageIn = true;
         self.endCapMode = kEndCapGregoryBasis;
         self.useScreenspaceTessellation = false;
         self.useFractionalTessellation = false;


### PR DESCRIPTION
-Fixed the iOS ViewController to set the correct irregular
 patch approximation mode.
-Fixed the setting of fractionalSpacing to be separate from
 screenspace tessellation.
-Fixed the configuration of the internal stage-in setting
 on embedded builds.