### PR TITLE
Fixed Microsoft Visual Studio warnings in examples

### DIFF
--- a/examples/common/hud.h
+++ b/examples/common/hud.h
@@ -143,7 +143,7 @@ protected:
             v = std::max(std::min(v, max), min);
             if (intStep) {
                 // MSVC 2010 does not have std::round() or roundf()
-                v = v>0.0f ? floor(v+0.5f) : ceil(v-0.5f);
+                v = v>0.0f ? floorf(v+0.5f) : ceilf(v-0.5f);
             }
             value = v;
         }

--- a/examples/glPaintTest/glPaintTest.cpp
+++ b/examples/glPaintTest/glPaintTest.cpp
@@ -988,7 +988,7 @@ initHUD() {
     g_hud.AddPullDownButton(shading_pulldown, "Shaded", 1, g_wire==1);
     g_hud.AddPullDownButton(shading_pulldown, "Wire+Shaded", 2, g_wire==2);
 
-    g_hud.AddSlider("Brush size", 10, 500, g_brushSize,
+    g_hud.AddSlider("Brush size", 10.0f, 500.0f, (float)g_brushSize,
                      350, -60, 40, true, callbackBrushSize, 0);
 
     for (int i = 1; i < 11; ++i) {


### PR DESCRIPTION
These changes fix warnings generated from MSVC in the OpenGL examples (noted in #1156) as well as new warnings arising from MSVC 2019.