### PR TITLE
Prefix OpenSubdiv CMake macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,7 +610,7 @@ endif()
 
 add_custom_target( public_headers )
 
-macro(_add_doxy_headers headers)
+macro(osd_add_doxy_headers headers)
     if (NOT NO_DOC AND DOXYGEN_FOUND)
         file(RELATIVE_PATH path "${OpenSubdiv_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" )
 
@@ -649,7 +649,7 @@ endmacro()
 # characters we would need raw string literals from C++11 to do this directly.
 # To avoid depending on C++11 we instead use a small tool called "line_quote"
 # to generate source files that are suitable for direct inclusion.
-function(_stringify src_files varname)
+function(osd_stringify src_files varname)
 
     set(inc_files "")
 
@@ -674,7 +674,7 @@ function(_stringify src_files varname)
 endfunction()
 
 # Macro wrapper for adding a non-cuda dependent executable
-macro(_add_executable target folder)
+macro(osd_add_executable target folder)
 
     add_executable(${target} ${ARGN})
 
@@ -693,7 +693,7 @@ endmacro()
 
 # Macro for adding a cuda executable if cuda is found and a regular
 # executable otherwise.
-macro(_add_possibly_cuda_executable target folder)
+macro(osd_add_possibly_cuda_executable target folder)
     if(CUDA_FOUND)
         cuda_add_executable(${target} ${ARGN})
     else()
@@ -715,7 +715,7 @@ endmacro()
 
 # Macro for adding a cuda library if cuda is found and a regular
 # library otherwise.
-macro(_add_possibly_cuda_library target folder)
+macro(osd_add_possibly_cuda_library target folder)
     if(CUDA_FOUND)
         cuda_add_library(${target} ${ARGN})
     else()
@@ -731,31 +731,9 @@ endmacro()
 
 
 # Macro for adding a (potentially cuda) GLFW executable.
-macro(_add_glfw_executable target folder)
+macro(osd_add_glfw_executable target folder)
 
-    _add_possibly_cuda_executable(${target} ${folder} ${ARGN})
-
-#
-# manuelk : commenting this out as it seems to be causing more problems than 
-# it is worth. Moving glfw as a native git recursive dependency will make this
-# redundant anyway.
-#
-
-#    if(WIN32)
-#        # Windows needs some of its dependency dll's copied into the same
-#        # directory as the executable.
-#        set(LIBRARIES ${GLFW_LIBRARIES})
-#        foreach (LIB ${LIBRARIES} )
-#            string(REPLACE ".lib" ".dll" DLL ${LIB})
-#            string(REPLACE ".LIB" ".DLL" DLL ${DLL})
-#            add_custom_command(
-#                TARGET ${target} POST_BUILD
-#                COMMAND ${CMAKE_COMMAND} -E copy_if_different
-#                    ${DLL}
-#                    $<TARGET_FILE_DIR:${target}>
-#            )
-#        endforeach()
-#    endif()
+    osd_add_possibly_cuda_executable(${target} ${folder} ${ARGN})
 
     if(APPLE)
         set_property (TARGET ${target} APPEND_STRING PROPERTY

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -187,7 +187,7 @@ include_directories(
 set(INC_FILES )
 
 if(OPENGL_FOUND OR DXSDK_FOUND OR METAL_FOUND)
-_stringify("${EXAMPLES_COMMON_SHADER_FILES}" INC_FILES)
+osd_stringify("${EXAMPLES_COMMON_SHADER_FILES}" INC_FILES)
 
 source_group("Shaders" FILES ${EXAMPLES_COMMON_SHADER_FILES})
 source_group("Inc" FILES ${INC_FILES})

--- a/examples/dxPtexViewer/CMakeLists.txt
+++ b/examples/dxPtexViewer/CMakeLists.txt
@@ -60,11 +60,11 @@ set(SOURCE_FILES
     sky.cpp
 )
 
-_stringify("${SHADER_FILES}" INC_FILES)
+osd_stringify("${SHADER_FILES}" INC_FILES)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-_add_possibly_cuda_executable(dxPtexViewer "examples" WIN32
+osd_add_possibly_cuda_executable(dxPtexViewer "examples" WIN32
     "${SOURCE_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>

--- a/examples/dxViewer/CMakeLists.txt
+++ b/examples/dxViewer/CMakeLists.txt
@@ -55,11 +55,11 @@ set(SOURCE_FILES
     dxViewer.cpp
 )
 
-_stringify("${SHADER_FILES}" INC_FILES)
+osd_stringify("${SHADER_FILES}" INC_FILES)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-_add_possibly_cuda_executable(dxViewer "examples" WIN32
+osd_add_possibly_cuda_executable(dxViewer "examples" WIN32
     "${SOURCE_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>

--- a/examples/farViewer/CMakeLists.txt
+++ b/examples/farViewer/CMakeLists.txt
@@ -50,11 +50,11 @@ if( OPENCL_FOUND )
     include_directories("${OPENCL_INCLUDE_DIRS}")
 endif()
 
-_stringify("${SHADER_FILES}" INC_FILES)
+osd_stringify("${SHADER_FILES}" INC_FILES)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-_add_glfw_executable(farViewer "examples"
+osd_add_glfw_executable(farViewer "examples"
     farViewer.cpp
     gl_fontutils.cpp
     gl_mesh.cpp

--- a/examples/glEvalLimit/CMakeLists.txt
+++ b/examples/glEvalLimit/CMakeLists.txt
@@ -50,7 +50,7 @@ if( TBB_FOUND )
     )
 endif()
 
-_add_glfw_executable(glEvalLimit "examples"
+osd_add_glfw_executable(glEvalLimit "examples"
     glEvalLimit.cpp
     particles.cpp
     particles.h

--- a/examples/glFVarViewer/CMakeLists.txt
+++ b/examples/glFVarViewer/CMakeLists.txt
@@ -50,11 +50,11 @@ endif()
 
 #-------------------------------------------------------------------------------
 
-_stringify("${SHADER_FILES}" INC_FILES)
+osd_stringify("${SHADER_FILES}" INC_FILES)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-_add_glfw_executable(glFVarViewer "examples"
+osd_add_glfw_executable(glFVarViewer "examples"
     glFVarViewer.cpp
     "${SHADER_FILES}"
     "${INC_FILES}"

--- a/examples/glImaging/CMakeLists.txt
+++ b/examples/glImaging/CMakeLists.txt
@@ -53,11 +53,11 @@ if ( OPENCL_FOUND )
     include_directories( "${OPENCL_INCLUDE_DIRS}" )
 endif()
 
-_stringify("${SHADER_FILES}" INC_FILES)
+osd_stringify("${SHADER_FILES}" INC_FILES)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-_add_glfw_executable(glImaging "examples"
+osd_add_glfw_executable(glImaging "examples"
     "${SOURCE_FILES}"
     "${SHADER_FILES}"
     "${INC_FILES}"

--- a/examples/glPaintTest/CMakeLists.txt
+++ b/examples/glPaintTest/CMakeLists.txt
@@ -46,11 +46,11 @@ if( OPENCL_FOUND )
     include_directories("${OPENCL_INCLUDE_DIRS}")
 endif()
 
-_stringify("${SHADER_FILES}" INC_FILES)
+osd_stringify("${SHADER_FILES}" INC_FILES)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-_add_glfw_executable(glPaintTest "examples"
+osd_add_glfw_executable(glPaintTest "examples"
     glPaintTest.cpp
     "${SHADER_FILES}"
     "${INC_FILES}"

--- a/examples/glPtexViewer/CMakeLists.txt
+++ b/examples/glPtexViewer/CMakeLists.txt
@@ -55,12 +55,12 @@ endif()
 
 #-------------------------------------------------------------------------------
 
-_stringify("${SHADER_FILES}" INC_FILES)
+osd_stringify("${SHADER_FILES}" INC_FILES)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 #-------------------------------------------------------------------------------
-_add_glfw_executable(glPtexViewer "examples"
+osd_add_glfw_executable(glPtexViewer "examples"
     glPtexViewer.cpp
     "${SHADER_FILES}"
     "${INC_FILES}"

--- a/examples/glShareTopology/CMakeLists.txt
+++ b/examples/glShareTopology/CMakeLists.txt
@@ -50,11 +50,11 @@ endif()
 
 #-------------------------------------------------------------------------------
 
-_stringify("${SHADER_FILES}" INC_FILES)
+osd_stringify("${SHADER_FILES}" INC_FILES)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-_add_glfw_executable(glShareTopology "examples"
+osd_add_glfw_executable(glShareTopology "examples"
     glShareTopology.cpp
     sceneBase.cpp
     "${SHADER_FILES}"

--- a/examples/glStencilViewer/CMakeLists.txt
+++ b/examples/glStencilViewer/CMakeLists.txt
@@ -43,7 +43,7 @@ if( OPENCL_FOUND )
     include_directories("${OPENCL_INCLUDE_DIRS}")
 endif()
 
-_add_glfw_executable(glStencilViewer "examples"
+osd_add_glfw_executable(glStencilViewer "examples"
     glStencilViewer.cpp
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>

--- a/examples/glViewer/CMakeLists.txt
+++ b/examples/glViewer/CMakeLists.txt
@@ -49,11 +49,11 @@ if( OPENCL_FOUND )
     include_directories("${OPENCL_INCLUDE_DIRS}")
 endif()
 
-_stringify("${SHADER_FILES}" INC_FILES)
+osd_stringify("${SHADER_FILES}" INC_FILES)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-_add_glfw_executable(glViewer "examples"
+osd_add_glfw_executable(glViewer "examples"
     glViewer.cpp
     "${SHADER_FILES}"
     "${INC_FILES}"

--- a/examples/mtlPtexViewer/CMakeLists.txt
+++ b/examples/mtlPtexViewer/CMakeLists.txt
@@ -88,10 +88,10 @@ list(APPEND PLATFORM_LIBRARIES
     "${PTEX_LIBRARY}"
 )
 
-_stringify("mtlPtexViewer.metal" INC_FILES)
+osd_stringify("mtlPtexViewer.metal" INC_FILES)
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-_add_executable(mtlPtexViewer "examples/mtlPtexViewer"
+osd_add_executable(mtlPtexViewer "examples/mtlPtexViewer"
     MACOSX_BUNDLE
     "${PLATFORM_FILES}"
     "${INC_FILES}"

--- a/examples/mtlViewer/CMakeLists.txt
+++ b/examples/mtlViewer/CMakeLists.txt
@@ -85,10 +85,10 @@ list(APPEND PLATFORM_LIBRARIES
     "-framework QuartzCore"
 )
 
-_stringify("mtlViewer.metal" INC_FILES)
+osd_stringify("mtlViewer.metal" INC_FILES)
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-_add_executable(mtlViewer "examples/mtlViewer"
+osd_add_executable(mtlViewer "examples/mtlViewer"
     MACOSX_BUNDLE
     "${PLATFORM_FILES}"
     "${INC_FILES}"

--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -167,7 +167,7 @@ if (NOT NO_LIB)
     if( OSD_GPU )
         # this macro uses FindCUDA.cmake to compile .cu kernel files
         # the target then adds the other obj dependencies and include files
-        _add_possibly_cuda_library(osd_static_gpu "opensubdiv"
+        osd_add_possibly_cuda_library(osd_static_gpu "opensubdiv"
                 STATIC
                 version.cpp
                 $<TARGET_OBJECTS:osd_gpu_obj>
@@ -221,7 +221,7 @@ if (NOT NO_LIB)
 
         #---------------------------------------------------
         if( OSD_GPU )
-            _add_possibly_cuda_library(osd_dynamic_gpu "opensubdiv"
+            osd_add_possibly_cuda_library(osd_dynamic_gpu "opensubdiv"
                 SHARED
                 version.cpp
                 $<TARGET_OBJECTS:osd_gpu_obj>

--- a/opensubdiv/far/CMakeLists.txt
+++ b/opensubdiv/far/CMakeLists.txt
@@ -93,7 +93,7 @@ if (NOT NO_LIB)
 endif()
 
 #-------------------------------------------------------------------------------
-_add_doxy_headers( "${DOXY_HEADER_FILES}" )
+osd_add_doxy_headers( "${DOXY_HEADER_FILES}" )
 
 install(
     FILES

--- a/opensubdiv/hbr/CMakeLists.txt
+++ b/opensubdiv/hbr/CMakeLists.txt
@@ -44,7 +44,6 @@ set(PUBLIC_HEADER_FILES
 )
 
 #-------------------------------------------------------------------------------
-#_add_doxy_headers( "${PUBLIC_HEADER_FILES}" )
 
 install( 
     FILES

--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -362,7 +362,7 @@ list(APPEND DOXY_HEADER_FILES ${CUDA_PUBLIC_HEADERS})
 
 #-------------------------------------------------------------------------------
 
-_stringify("${KERNEL_FILES}" INC_FILES)
+osd_stringify("${KERNEL_FILES}" INC_FILES)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -398,7 +398,7 @@ if( GPU_SOURCE_FILES )
     )
 endif()
 
-_add_doxy_headers( "${DOXY_HEADER_FILES}" )
+osd_add_doxy_headers( "${DOXY_HEADER_FILES}" )
 
 install(
     FILES

--- a/opensubdiv/sdc/CMakeLists.txt
+++ b/opensubdiv/sdc/CMakeLists.txt
@@ -62,7 +62,7 @@ if (NOT NO_LIB)
 endif()
 
 #-------------------------------------------------------------------------------
-_add_doxy_headers( "${DOXY_HEADER_FILES}" )
+osd_add_doxy_headers( "${DOXY_HEADER_FILES}" )
 
 install(
     FILES

--- a/opensubdiv/tools/stringify/CMakeLists.txt
+++ b/opensubdiv/tools/stringify/CMakeLists.txt
@@ -29,7 +29,7 @@ if(CMAKE_CROSSCOMPILING)
 endif()
 
 if(NOT CMAKE_CROSSCOMPILING)
-	_add_executable(stringify "opensubdiv/tools"
+	osd_add_executable(stringify "opensubdiv/tools"
 	    main.cpp
 	)
 	install(TARGETS stringify DESTINATION ${CMAKE_BINDIR_BASE})

--- a/opensubdiv/vtr/CMakeLists.txt
+++ b/opensubdiv/vtr/CMakeLists.txt
@@ -75,7 +75,7 @@ if (NOT NO_LIB)
 endif()
 
 #-------------------------------------------------------------------------------
-_add_doxy_headers( "${DOXY_HEADER_FILES}" )
+osd_add_doxy_headers( "${DOXY_HEADER_FILES}" )
 
 install(
     FILES

--- a/regression/far_perf/CMakeLists.txt
+++ b/regression/far_perf/CMakeLists.txt
@@ -34,7 +34,7 @@ set(PLATFORM_LIBRARIES
     "${OSD_LINK_TARGET}"
 )
 
-_add_executable(far_perf "regression"
+osd_add_executable(far_perf "regression"
     ${SOURCE_FILES}
     $<TARGET_OBJECTS:sdc_obj>
     $<TARGET_OBJECTS:vtr_obj>

--- a/regression/far_regression/CMakeLists.txt
+++ b/regression/far_regression/CMakeLists.txt
@@ -32,7 +32,7 @@ set(PLATFORM_LIBRARIES
     "${OSD_LINK_TARGET}"
 )
 
-_add_executable(far_regression "regression"
+osd_add_executable(far_regression "regression"
     ${SOURCE_FILES}
     $<TARGET_OBJECTS:sdc_obj>
     $<TARGET_OBJECTS:vtr_obj>

--- a/regression/hbr_regression/CMakeLists.txt
+++ b/regression/hbr_regression/CMakeLists.txt
@@ -24,7 +24,7 @@
 
 include_directories("${OPENSUBDIV_INCLUDE_DIR}")
 
-_add_possibly_cuda_executable(hbr_regression "regression"
+osd_add_possibly_cuda_executable(hbr_regression "regression"
    main.cpp
     $<TARGET_OBJECTS:regression_common_obj>
 )
@@ -44,7 +44,7 @@ add_definitions(
 )
 
 
-_add_executable(hbr_baseline "regression"
+osd_add_executable(hbr_baseline "regression"
    baseline.cpp
     $<TARGET_OBJECTS:regression_common_obj>
 )

--- a/regression/osd_regression/CMakeLists.txt
+++ b/regression/osd_regression/CMakeLists.txt
@@ -42,7 +42,7 @@ if ( GLEW_FOUND )
     list(APPEND PLATFORM_LIBRARIES "${GLEW_LIBRARY}")
 endif()
 
-_add_executable(osd_regression "regression"
+osd_add_executable(osd_regression "regression"
     "${SOURCE_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
 )

--- a/tutorials/far/CMakeLists.txt
+++ b/tutorials/far/CMakeLists.txt
@@ -23,7 +23,7 @@
 #
 macro(_add_far_tutorial NAME)
 
-     _add_executable(${NAME} "tutorials/far"
+     osd_add_executable(${NAME} "tutorials/far"
         ${ARGN}
         $<TARGET_OBJECTS:sdc_obj>
         $<TARGET_OBJECTS:vtr_obj>

--- a/tutorials/hbr/tutorial_0/CMakeLists.txt
+++ b/tutorials/hbr/tutorial_0/CMakeLists.txt
@@ -26,7 +26,7 @@ set(SOURCE_FILES
     hbr_tutorial_0.cpp
 )
 
-_add_executable(hbr_tutorial_0 "tutorials/hbr"
+osd_add_executable(hbr_tutorial_0 "tutorials/hbr"
     ${SOURCE_FILES}
 )
 

--- a/tutorials/hbr/tutorial_1/CMakeLists.txt
+++ b/tutorials/hbr/tutorial_1/CMakeLists.txt
@@ -26,7 +26,7 @@ set(SOURCE_FILES
     hbr_tutorial_1.cpp
 )
 
-_add_executable(hbr_tutorial_1 "tutorials/hbr"
+osd_add_executable(hbr_tutorial_1 "tutorials/hbr"
     ${SOURCE_FILES}
 )
 

--- a/tutorials/hbr/tutorial_2/CMakeLists.txt
+++ b/tutorials/hbr/tutorial_2/CMakeLists.txt
@@ -26,7 +26,7 @@ set(SOURCE_FILES
     hbr_tutorial_2.cpp
 )
 
-_add_executable(hbr_tutorial_2 "tutorials/hbr"
+osd_add_executable(hbr_tutorial_2 "tutorials/hbr"
     ${SOURCE_FILES}
 )
 

--- a/tutorials/osd/tutorial_0/CMakeLists.txt
+++ b/tutorials/osd/tutorial_0/CMakeLists.txt
@@ -26,7 +26,7 @@ set(SOURCE_FILES
     osd_tutorial_0.cpp
 )
 
-_add_executable(osd_tutorial_0 "tutorials/osd"
+osd_add_executable(osd_tutorial_0 "tutorials/osd"
     ${SOURCE_FILES}
 )
 


### PR DESCRIPTION
This fixes issue #1157 by adding "osd" as a prefix to public macros.