### PR TITLE
Moved common command line parsing to regression/common

### DIFF
--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -29,7 +29,6 @@ set(EXAMPLES_COMMON_SHADER_FILES
 )
 
 set(EXAMPLES_COMMON_SOURCE_FILES
-    argOptions.cpp
     font_image.cpp
     hdr_reader.cpp
     hud.cpp
@@ -39,7 +38,6 @@ set(EXAMPLES_COMMON_SOURCE_FILES
 )
 
 set(EXAMPLES_COMMON_HEADER_FILES
-    argOptions.h
     font_image.h
     hdr_reader.h
     hud.h

--- a/examples/common/viewerArgsUtils.cpp
+++ b/examples/common/viewerArgsUtils.cpp
@@ -24,10 +24,11 @@
 
 #include "../common/viewerArgsUtils.h"
 
+#include "../../regression/common/arg_utils.h"
+#include "../../regression/common/shape_utils.h"
 #include "../common/objAnim.h"
 
-#include <fstream>
-#include <sstream>
+#include <stdio.h>
 
 namespace ViewerArgsUtils {
 
@@ -54,28 +55,9 @@ void
 PopulateShapes(const ArgOptions &args,
                std::vector<ShapeDesc> *defaultShapes)
 {
-    if (!defaultShapes)
-        return;
-
-    if (args.GetObjFiles().empty())
-        return;
-
-    for (size_t i = 0; i < args.GetObjFiles().size(); ++i) {
-        std::ifstream ifs(args.GetObjFiles()[i]);
-        if (ifs) {
-            std::stringstream ss;
-            ss << ifs.rdbuf();
-            ifs.close();
-            std::string str = ss.str();
-            defaultShapes->push_back(ShapeDesc(
-                        args.GetObjFiles()[i], str.c_str(), 
-                        args.GetDefaultScheme()));
-        } else {
-            printf("Warning: cannot open shape file '%s'\n", 
-                   args.GetObjFiles()[i]);
-        }
+    if (defaultShapes) {
+        args.AppendObjShapes(*defaultShapes, true /* print warnings */);
     }
-
 }
 
 void 

--- a/examples/common/viewerArgsUtils.h
+++ b/examples/common/viewerArgsUtils.h
@@ -25,13 +25,11 @@
 #ifndef VIEWER_ARGS_UTILS_H
 #define VIEWER_ARGS_UTILS_H
 
-#include "../../regression/common/shape_utils.h"
-
-#include "../common/argOptions.h"
-
-class ObjAnim;
-
 #include <vector>
+
+class ArgOptions;
+class ShapeDesc;
+class ObjAnim;
 
 namespace ViewerArgsUtils {
 

--- a/examples/common/viewerArgsUtils.h
+++ b/examples/common/viewerArgsUtils.h
@@ -28,7 +28,7 @@
 #include <vector>
 
 class ArgOptions;
-class ShapeDesc;
+struct ShapeDesc;
 class ObjAnim;
 
 namespace ViewerArgsUtils {

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -62,7 +62,7 @@ OpenSubdiv::Osd::D3D11LegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 bool g_legacyGregoryEnabled = false;
 
 #include "../../regression/common/far_utils.h"
-#include "../common/argOptions.h"
+#include "../../regression/common/arg_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/d3d11ControlMeshDisplay.h"

--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -80,7 +80,7 @@ GLFWmonitor* g_primary=0;
 #include <opensubdiv/far/error.h>
 
 #include "../../regression/common/far_utils.h"
-#include "../common/argOptions.h"
+#include "../../regression/common/arg_utils.h"
 #include "../common/viewerArgsUtils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -36,7 +36,7 @@ GLFWmonitor* g_primary = 0;
 OpenSubdiv::Osd::GLMeshInterface *g_mesh = NULL;
 
 #include "../../regression/common/far_utils.h"
-#include "../common/argOptions.h"
+#include "../../regression/common/arg_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glControlMeshDisplay.h"

--- a/examples/glImaging/glImaging.cpp
+++ b/examples/glImaging/glImaging.cpp
@@ -69,7 +69,7 @@
 #include <opensubdiv/osd/glMesh.h>
 
 #include "../../regression/common/far_utils.h"
-#include "../common/argOptions.h"
+#include "../../regression/common/arg_utils.h"
 #include "../common/patchColors.h"
 #include "../common/stb_image_write.h"    // common.obj has an implementation.
 #include "../common/glShaderCache.h"

--- a/examples/glPaintTest/glPaintTest.cpp
+++ b/examples/glPaintTest/glPaintTest.cpp
@@ -37,7 +37,7 @@ GLFWmonitor* g_primary=0;
 OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 
 #include "../../regression/common/far_utils.h"
-#include "../common/argOptions.h"
+#include "../../regression/common/arg_utils.h"
 #include "../common/viewerArgsUtils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -93,7 +93,7 @@ OpenSubdiv::Osd::GLMeshInterface *g_mesh;
 #include "PtexUtils.h"
 
 #include "../../regression/common/far_utils.h"
-#include "../common/argOptions.h"
+#include "../../regression/common/arg_utils.h"
 #include "../common/objAnim.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -71,7 +71,7 @@ GLFWmonitor* g_primary=0;
 #include "../../regression/common/far_utils.h"
 #include "init_shapes.h"
 
-#include "../common/argOptions.h"
+#include "../../regression/common/arg_utils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"
 #include "../common/glHud.h"

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -29,7 +29,7 @@ GLFWwindow* g_window=0;
 GLFWmonitor* g_primary=0;
 
 #include "../../regression/common/far_utils.h"
-#include "../common/argOptions.h"
+#include "../../regression/common/arg_utils.h"
 #include "../common/viewerArgsUtils.h"
 #include "../common/stopwatch.h"
 #include "../common/simple_math.h"

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -74,7 +74,7 @@ OpenSubdiv::Osd::GLLegacyGregoryPatchTable *g_legacyGregoryPatchTable = NULL;
 bool g_legacyGregoryEnabled = false;
 
 #include "../../regression/common/far_utils.h"
-#include "../common/argOptions.h"
+#include "../../regression/common/arg_utils.h"
 #include "../common/glHud.h"
 #include "../common/glUtils.h"
 #include "../common/glControlMeshDisplay.h"

--- a/examples/mtlPtexViewer/mtlPtexViewer.mm
+++ b/examples/mtlPtexViewer/mtlPtexViewer.mm
@@ -24,7 +24,7 @@
 #import <opensubdiv/osd/mtlPatchShaderSource.h>
 
 #import "../../regression/common/far_utils.h"
-#import "../common/argOptions.h"
+#import "../../regression/common/arg_utils.h"
 #import "../common/mtlUtils.h"
 #import "../common/mtlControlMeshDisplay.h"
 #import "../common/mtlPtexMipmapTexture.h"

--- a/examples/mtlViewer/mtlViewer.mm
+++ b/examples/mtlViewer/mtlViewer.mm
@@ -48,7 +48,7 @@
 #import <opensubdiv/osd/mtlPatchShaderSource.h>
 
 #import "../../regression/common/far_utils.h"
-#import "../common/argOptions.h"
+#import "../../regression/common/arg_utils.h"
 #import "../common/mtlUtils.h"
 #import "../common/mtlControlMeshDisplay.h"
 #import "../common/simple_math.h"

--- a/regression/common/CMakeLists.txt
+++ b/regression/common/CMakeLists.txt
@@ -23,10 +23,12 @@
 #
 
 set(REGRESSION_COMMON_SOURCE_FILES
+    arg_utils.cpp
     shape_utils.cpp
 )
 
 set(REGRESSION_COMMON_HEADER_FILES
+    arg_utils.h
     cmp_utils.h
     hbr_utils.h
     shape_utils.h

--- a/regression/common/arg_utils.cpp
+++ b/regression/common/arg_utils.cpp
@@ -22,8 +22,10 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#include "../common/argOptions.h"
+#include "arg_utils.h"
 
+#include <fstream>
+#include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -98,4 +100,27 @@ ArgOptions::PrintUnrecognizedArgsWarnings() const
     for(size_t i = 0; i < _remainingArgs.size(); ++i) {
         PrintUnrecognizedArgWarning(_remainingArgs[i]);
     }
+}
+
+int
+ArgOptions::AppendObjShapes(std::vector<ShapeDesc>& shapes, bool warn) const
+{
+    size_t originalShapesSize = shapes.size();
+
+    for (size_t i = 0; i < GetObjFiles().size(); ++i) {
+        std::ifstream ifs(GetObjFiles()[i]);
+        if (ifs) {
+            std::stringstream ss;
+            ss << ifs.rdbuf();
+            ifs.close();
+            std::string str = ss.str();
+            shapes.push_back(ShapeDesc(
+                        GetObjFiles()[i], str.c_str(),
+                        GetDefaultScheme()));
+        } else if (warn) {
+            printf("Warning: cannot open shape file '%s'\n",
+                   GetObjFiles()[i]);
+        }
+    }
+    return shapes.size() - originalShapesSize;
 }

--- a/regression/common/arg_utils.h
+++ b/regression/common/arg_utils.h
@@ -22,10 +22,10 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-#ifndef COMMON_ARGS_H
-#define COMMON_ARGS_H
+#ifndef ARG_UTILS_H
+#define ARG_UTILS_H
 
-#include "../../regression/common/shape_utils.h"
+#include "shape_utils.h"
 
 #include <vector>
 
@@ -67,7 +67,13 @@ public:
 
     const std::vector<const char *> GetRemainingArgs() const {
         return _remainingArgs; }
- 
+
+
+    // Operations on parsed arguments
+    //
+
+    int AppendObjShapes(std::vector<ShapeDesc>& shapes, bool warn = true) const;
+
 private:
 
     bool _adaptive;


### PR DESCRIPTION
These changes move the ArgOptions class for parsing common command line arguments from examples/common to regression/common.  This allows it to be used in regression tests and tutorials without creating the link dependencies that examples/common introduces (e.g. osdGPU, Ptex, etc.).