### PR TITLE
Fixed warnings in examples and regression/common

### DIFF
--- a/examples/dxPtexViewer/sky.cpp
+++ b/examples/dxPtexViewer/sky.cpp
@@ -164,9 +164,9 @@ Sky::initialize(ID3D11Device * device) {
         for (int v = 0; v < V_DIV; ++v) {
             float s = float(2*M_PI*float(u)/U_DIV);
             float t = float(M_PI*float(v)/(V_DIV-1));
-            vbo.push_back(-sin(t)*sin(s));
-            vbo.push_back(cos(t));
-            vbo.push_back(-sin(t)*cos(s));
+            vbo.push_back(-sinf(t)*sinf(s));
+            vbo.push_back(cosf(t));
+            vbo.push_back(-sinf(t)*cosf(s));
             vbo.push_back(u/float(U_DIV));
             vbo.push_back(v/float(V_DIV));
 

--- a/regression/common/arg_utils.cpp
+++ b/regression/common/arg_utils.cpp
@@ -102,7 +102,7 @@ ArgOptions::PrintUnrecognizedArgsWarnings() const
     }
 }
 
-int
+size_t
 ArgOptions::AppendObjShapes(std::vector<ShapeDesc>& shapes, bool warn) const
 {
     size_t originalShapesSize = shapes.size();

--- a/regression/common/arg_utils.h
+++ b/regression/common/arg_utils.h
@@ -72,7 +72,8 @@ public:
     // Operations on parsed arguments
     //
 
-    int AppendObjShapes(std::vector<ShapeDesc>& shapes, bool warn = true) const;
+    size_t AppendObjShapes(std::vector<ShapeDesc>& shapes,
+                           bool warn = true) const;
 
 private:
 


### PR DESCRIPTION
This fixes some warnings raised by recent Visual Studio versions.