### PR TITLE
Fixed initialization oversight in far/tutorial_5_1

### DIFF
--- a/tutorials/far/tutorial_5_1/far_tutorial_5_1.cpp
+++ b/tutorials/far/tutorial_5_1/far_tutorial_5_1.cpp
@@ -157,7 +157,7 @@ int main(int, char **) {
     //
     int maxPatchLevel = 3;
 
-    Far::PatchTableFactory::Options patchOptions;
+    Far::PatchTableFactory::Options patchOptions(maxPatchLevel);
     patchOptions.SetPatchPrecision<Real>();
     patchOptions.useInfSharpPatch = true;
     patchOptions.generateVaryingTables = false;
@@ -171,6 +171,7 @@ int main(int, char **) {
     if (assignAdaptiveOptionsExplicitly) {
         adaptiveOptions.useInfSharpPatch = true;
     } else {
+        // Be sure patch options were intialized with the desired max level
         adaptiveOptions = patchOptions.GetRefineAdaptiveOptions();
     }
     assert(adaptiveOptions.useInfSharpPatch == patchOptions.useInfSharpPatch);


### PR DESCRIPTION
Prior to the release of 3.4, the newly added Far::PatchTableFactory method to derive adaptive refinement options from patch table options was illustrated in far/tutorial_5_1.  But the desired refinement level was not being used to initialize the patch options.  As a result, the default value of 10 was being used to initialize adaptive refinement options.

The changes here initialize the patch options with the desired level and include a comment to warn about this kind of oversight in future.