### PR TITLE
Fixed examples link dependency on GLFW

### DIFF
--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -44,56 +44,10 @@ set(EXAMPLES_COMMON_HEADER_FILES
     viewerArgsUtils.h
 )
 
-if( OPENGL_FOUND AND (GLEW_FOUND AND GLFW_FOUND) OR (APPLE AND GLFW_FOUND))
-
-    list(APPEND EXAMPLES_COMMON_SOURCE_FILES
-        glControlMeshDisplay.cpp
-        glHud.cpp
-        glUtils.cpp
-        glShaderCache.cpp
-    )
-
-    list(APPEND EXAMPLES_COMMON_HEADER_FILES
-        glControlMeshDisplay.h
-        glHud.h
-        glUtils.h
-        glShaderCache.h
-    )
-
-    if (NOT "${OPENGL_INCLUDE_DIR}" STREQUAL "")
-        include_directories("${OPENGL_INCLUDE_DIR}")
-    endif()
-
-    if (GLEW_FOUND)
-        include_directories("${GLEW_INCLUDE_DIR}")
-    endif()
-
-    if (GLFW_FOUND)
-        include_directories("${GLFW_INCLUDE_DIR}")
-    endif()
-
-endif()
-
-
-if(DXSDK_FOUND)
-
-    list(APPEND EXAMPLES_COMMON_SOURCE_FILES
-        d3d11ControlMeshDisplay.cpp
-        d3d11Hud.cpp
-        d3d11Utils.cpp
-        d3d11ShaderCache.cpp
-    )
-
-    list(APPEND EXAMPLES_COMMON_HEADER_FILES
-        d3d11ControlMeshDisplay.h
-        d3d11Hud.h
-        d3d11Utils.h
-        d3d11ShaderCache.h
-    )
-
-    include_directories("${DXSDK_INCLUDE_DIR}")
-
-endif()
+include_directories(
+    "${OPENSUBDIV_INCLUDE_DIR}"
+    "${CMAKE_CURRENT_BINARY_DIR}"
+)
 
 if(OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
@@ -117,19 +71,111 @@ if(CUDA_FOUND)
     )
 endif()
 
+if( OPENGL_FOUND AND (GLEW_FOUND AND GLFW_FOUND) OR (APPLE AND GLFW_FOUND))
+
+    list(APPEND EXAMPLES_COMMON_GL_SOURCE_FILES
+        glControlMeshDisplay.cpp
+        glHud.cpp
+        glUtils.cpp
+        glShaderCache.cpp
+    )
+
+    list(APPEND EXAMPLES_COMMON_GL_HEADER_FILES
+        glControlMeshDisplay.h
+        glHud.h
+        glUtils.h
+        glShaderCache.h
+    )
+
+    if (NOT "${OPENGL_INCLUDE_DIR}" STREQUAL "")
+        include_directories("${OPENGL_INCLUDE_DIR}")
+    endif()
+
+    if (GLEW_FOUND)
+        include_directories("${GLEW_INCLUDE_DIR}")
+    endif()
+
+    if (GLFW_FOUND)
+        include_directories("${GLFW_INCLUDE_DIR}")
+    endif()
+
+    add_library(examples_common_gl_obj
+        OBJECT
+            ${EXAMPLES_COMMON_SOURCE_FILES}
+            ${EXAMPLES_COMMON_HEADER_FILES}
+            ${EXAMPLES_COMMON_GL_SOURCE_FILES}
+            ${EXAMPLES_COMMON_GL_HEADER_FILES}
+    )
+
+    set_target_properties(examples_common_gl_obj
+        PROPERTIES
+            FOLDER "examples"
+    )
+
+endif()
+
+
+if(DXSDK_FOUND)
+
+    list(APPEND EXAMPLES_COMMON_DX11_SOURCE_FILES
+        d3d11ControlMeshDisplay.cpp
+        d3d11Hud.cpp
+        d3d11Utils.cpp
+        d3d11ShaderCache.cpp
+    )
+
+    list(APPEND EXAMPLES_COMMON_DX11_HEADER_FILES
+        d3d11ControlMeshDisplay.h
+        d3d11Hud.h
+        d3d11Utils.h
+        d3d11ShaderCache.h
+    )
+
+    include_directories("${DXSDK_INCLUDE_DIR}")
+
+    add_library(examples_common_dx11_obj
+        OBJECT
+            ${EXAMPLES_COMMON_SOURCE_FILES}
+            ${EXAMPLES_COMMON_HEADER_FILES}
+            ${EXAMPLES_COMMON_DX11_SOURCE_FILES}
+            ${EXAMPLES_COMMON_DX11_HEADER_FILES}
+    )
+
+    set_target_properties(examples_common_dx11_obj
+        PROPERTIES
+            FOLDER "examples"
+    )
+
+endif()
+
 if(METAL_FOUND)
     include_directories("${METAL_INCLUDE_DIR}")
-    list(APPEND EXAMPLES_COMMON_SOURCE_FILES
+    list(APPEND EXAMPLES_COMMON_MTL_SOURCE_FILES
         mtlControlMeshDisplay.mm
         mtlUtils.mm
         mtlHud.mm
     )
-    list(APPEND EXAMPLES_COMMON_HEADER_FILES
+    list(APPEND EXAMPLES_COMMON_MTL_HEADER_FILES
         mtlControlMeshDisplay.h
         mtlUtils.h
         mtlHud.h
     )
+
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+
+    add_library(examples_common_mtl_obj
+        OBJECT
+            ${EXAMPLES_COMMON_SOURCE_FILES}
+            ${EXAMPLES_COMMON_HEADER_FILES}
+            ${EXAMPLES_COMMON_MTL_SOURCE_FILES}
+            ${EXAMPLES_COMMON_MTL_HEADER_FILES}
+    )
+
+    set_target_properties(examples_common_mtl_obj
+        PROPERTIES
+            FOLDER "examples"
+    )
+
 endif()
 
 #-------------------------------------------------------------------------------
@@ -195,21 +241,3 @@ set(EXAMPLES_COMMON_PTEX_INC_FILES )
     )
 
 endif()
-#-------------------------------------------------------------------------------
-
-include_directories(
-    "${OPENSUBDIV_INCLUDE_DIR}"
-    "${CMAKE_CURRENT_BINARY_DIR}"
-)
-
-add_library(examples_common_obj
-    OBJECT
-        ${EXAMPLES_COMMON_SOURCE_FILES}
-        ${EXAMPLES_COMMON_HEADER_FILES}
-)
-
-set_target_properties(examples_common_obj
-    PROPERTIES
-        FOLDER "examples"
-)
-

--- a/examples/dxPtexViewer/CMakeLists.txt
+++ b/examples/dxPtexViewer/CMakeLists.txt
@@ -46,15 +46,6 @@ if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
 endif()
 
-# XXX: This is unfortunate, we should probably refactor examples_common_obj
-# to separate out the GL from the DX dependencies so that we don't end up
-# in the situation where we have to link in GLFW for dxPtexViewer.
-if (GLFW_FOUND)
-    list(APPEND PLATFORM_LIBRARIES
-        "${GLFW_LIBRARIES}"
-    )
-endif()
-
 set(SOURCE_FILES
     dxPtexViewer.cpp
     sky.cpp
@@ -69,7 +60,7 @@ osd_add_possibly_cuda_executable(dxPtexViewer "examples" WIN32
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:regression_far_utils_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_dx11_obj>
     $<TARGET_OBJECTS:examples_common_ptex_obj>
 )
 

--- a/examples/dxViewer/CMakeLists.txt
+++ b/examples/dxViewer/CMakeLists.txt
@@ -42,15 +42,6 @@ if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
 endif()
 
-# XXX: This is unfortunate, we should probably refactor examples_common_obj
-# to separate out the GL from the DX dependencies so that we don't end up
-# in the situation where we have to link in GLFW for dxViewer.
-if (GLFW_FOUND)
-    list(APPEND PLATFORM_LIBRARIES
-        "${GLFW_LIBRARIES}"
-    )
-endif()
-
 set(SOURCE_FILES
     dxViewer.cpp
 )
@@ -64,7 +55,7 @@ osd_add_possibly_cuda_executable(dxViewer "examples" WIN32
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:regression_far_utils_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_dx11_obj>
 )
 
 target_link_libraries(dxViewer

--- a/examples/farViewer/CMakeLists.txt
+++ b/examples/farViewer/CMakeLists.txt
@@ -65,7 +65,7 @@ osd_add_glfw_executable(farViewer "examples"
     $<TARGET_OBJECTS:vtr_obj>
     $<TARGET_OBJECTS:far_obj>
     $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_gl_obj>
 )
 target_link_libraries(farViewer
     ${PLATFORM_LIBRARIES}

--- a/examples/glEvalLimit/CMakeLists.txt
+++ b/examples/glEvalLimit/CMakeLists.txt
@@ -57,7 +57,7 @@ osd_add_glfw_executable(glEvalLimit "examples"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:regression_far_utils_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_gl_obj>
 )
 
 target_link_libraries(glEvalLimit

--- a/examples/glFVarViewer/CMakeLists.txt
+++ b/examples/glFVarViewer/CMakeLists.txt
@@ -22,7 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-# *** uvViewer ***
+# *** glFVarViewer ***
 
 set(SHADER_FILES
      shader.glsl
@@ -60,7 +60,7 @@ osd_add_glfw_executable(glFVarViewer "examples"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:regression_far_utils_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_gl_obj>
 )
 
 target_link_libraries(glFVarViewer

--- a/examples/glImaging/CMakeLists.txt
+++ b/examples/glImaging/CMakeLists.txt
@@ -22,6 +22,8 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
+# *** glImaging ***
+
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
     "${GLFW_INCLUDE_DIR}"
@@ -62,7 +64,7 @@ osd_add_glfw_executable(glImaging "examples"
     "${SHADER_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_gl_obj>
 )
 
 target_link_libraries(glImaging

--- a/examples/glPaintTest/CMakeLists.txt
+++ b/examples/glPaintTest/CMakeLists.txt
@@ -22,7 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-# *** paintTest ***
+# *** glPaintTest ***
 
 set(SHADER_FILES
      shader.glsl
@@ -55,7 +55,7 @@ osd_add_glfw_executable(glPaintTest "examples"
     "${SHADER_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_gl_obj>
 )
 
 target_link_libraries(glPaintTest

--- a/examples/glPtexViewer/CMakeLists.txt
+++ b/examples/glPtexViewer/CMakeLists.txt
@@ -22,7 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-# *** ptexViewer ***
+# *** glPtexViewer ***
 
 set(SHADER_FILES
      shader.glsl
@@ -65,7 +65,7 @@ osd_add_glfw_executable(glPtexViewer "examples"
     "${SHADER_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_gl_obj>
     $<TARGET_OBJECTS:examples_common_ptex_obj>
 )
 

--- a/examples/glShareTopology/CMakeLists.txt
+++ b/examples/glShareTopology/CMakeLists.txt
@@ -22,7 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-# *** topologySharing ***
+# *** glShareTopology ***
 
 set(SHADER_FILES
      shader.glsl
@@ -60,7 +60,7 @@ osd_add_glfw_executable(glShareTopology "examples"
     "${SHADER_FILES}"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_gl_obj>
 )
 
 target_link_libraries(glShareTopology

--- a/examples/glStencilViewer/CMakeLists.txt
+++ b/examples/glStencilViewer/CMakeLists.txt
@@ -48,7 +48,7 @@ osd_add_glfw_executable(glStencilViewer "examples"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:regression_far_utils_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_gl_obj>
 )
 
 target_link_libraries(glStencilViewer

--- a/examples/glViewer/CMakeLists.txt
+++ b/examples/glViewer/CMakeLists.txt
@@ -59,7 +59,7 @@ osd_add_glfw_executable(glViewer "examples"
     "${INC_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:regression_far_utils_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_gl_obj>
 )
 
 target_link_libraries(glViewer

--- a/examples/mtlPtexViewer/CMakeLists.txt
+++ b/examples/mtlPtexViewer/CMakeLists.txt
@@ -61,13 +61,6 @@ else()
     set_source_files_properties("${BUNDLE_FILES}" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 endif()
 
-# XXX: This is unfortunate, we should probably refactor examples_common_obj
-# to separate out the GL from the Metal dependencies so that we don't end up
-# in the situation where we have to link in GLFW for mtlViewer.
-if (GLFW_FOUND)
-    list(APPEND PLATFORM_LIBRARIES "${GLFW_LIBRARIES}")
-endif()
-
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
     "${METAL_INCLUDE_DIR}"
@@ -98,7 +91,7 @@ osd_add_executable(mtlPtexViewer "examples/mtlPtexViewer"
     "${BUNDLE_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:regression_far_utils_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_mtl_obj>
     $<TARGET_OBJECTS:examples_common_ptex_obj>
 )
 

--- a/examples/mtlViewer/CMakeLists.txt
+++ b/examples/mtlViewer/CMakeLists.txt
@@ -60,13 +60,6 @@ else()
     set_source_files_properties("${BUNDLE_FILES}" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 endif()
 
-# XXX: This is unfortunate, we should probably refactor examples_common_obj
-# to separate out the GL from the Metal dependencies so that we don't end up
-# in the situation where we have to link in GLFW for mtlViewer.
-if (GLFW_FOUND)
-    list(APPEND PLATFORM_LIBRARIES "${GLFW_LIBRARIES}")
-endif()
-
 include_directories(
     "${OPENSUBDIV_INCLUDE_DIR}"
     "${METAL_INCLUDE_DIR}"
@@ -95,7 +88,7 @@ osd_add_executable(mtlViewer "examples/mtlViewer"
     "${BUNDLE_FILES}"
     $<TARGET_OBJECTS:regression_common_obj>
     $<TARGET_OBJECTS:regression_far_utils_obj>
-    $<TARGET_OBJECTS:examples_common_obj>
+    $<TARGET_OBJECTS:examples_common_mtl_obj>
 )
 
 


### PR DESCRIPTION
Split the examples/common objects into graphics API dependent object
libraries (following the pattern used for cemmon Ptex dependencies)
so that DX11 and Metal examples are no longer forced to link with GLFW.