### PR TITLE
Updates to GL and DX PtexViewers

### DIFF
--- a/cmake/FindDXSDK.cmake
+++ b/cmake/FindDXSDK.cmake
@@ -42,7 +42,7 @@ if (WIN32)
             "$ENV{DXSDK_LOCATION}/Include"
             "${DXSDK_ROOT}/Include"
             "$ENV{DXSDK_ROOT}/Include"
-            "C:/Program Files (x86)/Windows Kits/10/Include/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um"`
+            "C:/Program Files (x86)/Windows Kits/10/Include/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um"
             "C:/Program Files (x86)/Windows Kits/8.1/Include/um"
             "C:/Program Files (x86)/Microsoft DirectX SDK*/Include"
             "C:/Program Files/Microsoft DirectX SDK*/Include"

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -351,7 +351,7 @@ updateGeom() {
     if (g_moveScale && g_adaptive && g_objAnim) {
 
         std::vector<float> vertex;
-        vertex.reserve(nverts*3);
+        vertex.resize(nverts*3);
 
         g_objAnim->InterpolatePositions(g_animTime, &vertex[0], 3);
 


### PR DESCRIPTION
Fixed a few issues discovered while testing:

- updated dxPtexViewer to use regression/arg_utils and examples/objAnim
- fixed a memory allocation bug in glPtexViewer that was crashing on debug builds
- fixed a recently introduced typo in FindDXSDK.cmake