### PR TITLE
Fixed CMP0054 warnings in top-level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,9 +125,9 @@ if (CMAKE_COMPILER_IS_GNUCC)
 endif()
 
 # Detect Clang (until a cmake version provides built-in variables)
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     set(CMAKE_COMPILER_IS_CLANGCC 1)
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
+elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
     set(CMAKE_COMPILER_IS_ICC 1)
 endif()
 


### PR DESCRIPTION
Fixes warnings from CMake versions 3.1 and later. Tested back through CMake 2.8