### PR TITLE
Fixed a typo in examples/common/glHud.cpp

### DIFF
--- a/examples/common/glHud.cpp
+++ b/examples/common/glHud.cpp
@@ -121,7 +121,7 @@ static const char *s_BG_FS =
     "varying vec2 uv;\n"
     "void main() {\n"
     "  gl_FragColor = vec4(mix(0.1, 0.5, sin((uv.y*0.5+0.5)*3.14159)));\n"
-    "  gl_FragColor.a = 1.0;\n";
+    "  gl_FragColor.a = 1.0;\n"
     "}\n";
 #endif
 


### PR DESCRIPTION
This typo was in code that was executed only on platforms
with older GL header versions, or without using a GL loader
like GLEW.