### PR TITLE
Fixed strict-aliasing warnings

### DIFF
--- a/opensubdiv/vtr/fvarLevel.cpp
+++ b/opensubdiv/vtr/fvarLevel.cpp
@@ -1050,20 +1050,17 @@ FVarLevel::getFaceCompositeValueTag(Index faceIndex) const {
 
     typedef ValueTag::ValueTagSize ValueTagSize;
 
-    ValueTag       compTag;
-    ValueTagSize & compInt = *(reinterpret_cast<ValueTagSize *>(&compTag));
-
-    compInt = 0;
+    ValueTagSize compInt = 0;
     for (int i = 0; i < faceValues.size(); ++i) {
         Index srcValueIndex = findVertexValueIndex(faceVerts[i], faceValues[i]);
         assert(_vertValueIndices[srcValueIndex] == faceValues[i]);
 
-        ValueTag const &     srcTag = _vertValueTags[srcValueIndex];
-        ValueTagSize const & srcInt = *(reinterpret_cast<ValueTagSize const *>(&srcTag));
+        ValueTag const &   srcTag = _vertValueTags[srcValueIndex];
+        ValueTagSize const srcInt = srcTag.getBits();
 
         compInt |= srcInt;
     }
-    return compTag;
+    return ValueTag(compInt);
 }
 
 } // end namespace internal

--- a/opensubdiv/vtr/fvarLevel.h
+++ b/opensubdiv/vtr/fvarLevel.h
@@ -135,6 +135,16 @@ public:
         ValueTagSize _infIrregular  : 1;  // value span includes inf-sharp irregularity
 
         Level::VTag combineWithLevelVTag(Level::VTag) const;
+
+        //  Alternate constructor and accessor for dealing with integer bits directly:
+        explicit ValueTag(ValueTagSize bits) {
+            std::memcpy(this, &bits, sizeof(bits));
+        }
+        ValueTagSize getBits() const {
+            ValueTagSize bits;
+            std::memcpy(&bits, this, sizeof(bits));
+            return bits;
+        }
     };
 
     typedef Vtr::ConstArray<ValueTag> ConstValueTagArray;

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -126,8 +126,14 @@ public:
         VTagSize _infIrregular    : 1;  // fixed
 
         //  Alternate constructor and accessor for dealing with integer bits directly:
-        explicit VTag(VTagSize bits) { *this = *reinterpret_cast<VTag const *>(&bits); }
-        VTagSize getBits() const { return *reinterpret_cast<VTagSize const *>(this); }
+        explicit VTag(VTagSize bits) {
+            std::memcpy(this, &bits, sizeof(bits));
+        }
+        VTagSize getBits() const {
+            VTagSize bits;
+            std::memcpy(&bits, this, sizeof(bits));
+            return bits;
+        }
 
         static VTag BitwiseOr(VTag const vTags[], int size = 4);
     };
@@ -145,8 +151,14 @@ public:
         ETagSize _semiSharp    : 1;  // variable
 
         //  Alternate constructor and accessor for dealing with integer bits directly:
-        explicit ETag(ETagSize bits) { *this = *reinterpret_cast<ETag const *>(&bits); }
-        ETagSize getBits() const { return *reinterpret_cast<ETagSize const *>(this); }
+        explicit ETag(ETagSize bits) {
+            std::memcpy(this, &bits, sizeof(bits));
+        }
+        ETagSize getBits() const {
+            ETagSize bits;
+            std::memcpy(&bits, this, sizeof(bits));
+            return bits;
+        }
 
         static ETag BitwiseOr(ETag const eTags[], int size = 4);
     };


### PR DESCRIPTION
Minor update to the implementation of a few internal tagging
methods in Vtr to avoid violating strict-aliasing rules.
Specifically, switched to using std::memcpy instead of
reinterpret_cast to implement type punning.