### PR TITLE
Prefix remaining OpenSubdiv CMake macros

### DIFF
--- a/tutorials/far/CMakeLists.txt
+++ b/tutorials/far/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-macro(_add_far_tutorial NAME)
+macro(osd_add_far_tutorial NAME)
 
      osd_add_executable(${NAME} "tutorials/far"
         ${ARGN}

--- a/tutorials/far/tutorial_1_1/CMakeLists.txt
+++ b/tutorials/far/tutorial_1_1/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_1_1
     far_tutorial_1_1.cpp
 )

--- a/tutorials/far/tutorial_1_2/CMakeLists.txt
+++ b/tutorials/far/tutorial_1_2/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_1_2
     far_tutorial_1_2.cpp
 )

--- a/tutorials/far/tutorial_2_1/CMakeLists.txt
+++ b/tutorials/far/tutorial_2_1/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_2_1
     far_tutorial_2_1.cpp
 )

--- a/tutorials/far/tutorial_2_2/CMakeLists.txt
+++ b/tutorials/far/tutorial_2_2/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_2_2
     far_tutorial_2_2.cpp
 )

--- a/tutorials/far/tutorial_2_3/CMakeLists.txt
+++ b/tutorials/far/tutorial_2_3/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_2_3
     far_tutorial_2_3.cpp
 )

--- a/tutorials/far/tutorial_3_1/CMakeLists.txt
+++ b/tutorials/far/tutorial_3_1/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_3_1
     far_tutorial_3_1.cpp
 )

--- a/tutorials/far/tutorial_4_1/CMakeLists.txt
+++ b/tutorials/far/tutorial_4_1/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_4_1
     far_tutorial_4_1.cpp
 )

--- a/tutorials/far/tutorial_4_2/CMakeLists.txt
+++ b/tutorials/far/tutorial_4_2/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_4_2
     far_tutorial_4_2.cpp
 )

--- a/tutorials/far/tutorial_4_3/CMakeLists.txt
+++ b/tutorials/far/tutorial_4_3/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_4_3
     far_tutorial_4_3.cpp
 )

--- a/tutorials/far/tutorial_5_1/CMakeLists.txt
+++ b/tutorials/far/tutorial_5_1/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_5_1
     far_tutorial_5_1.cpp
 )

--- a/tutorials/far/tutorial_5_2/CMakeLists.txt
+++ b/tutorials/far/tutorial_5_2/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_5_2
     far_tutorial_5_2.cpp
     $<TARGET_OBJECTS:regression_common_obj>

--- a/tutorials/far/tutorial_5_3/CMakeLists.txt
+++ b/tutorials/far/tutorial_5_3/CMakeLists.txt
@@ -21,7 +21,7 @@
 #   KIND, either express or implied. See the Apache License for the specific
 #   language governing permissions and limitations under the Apache License.
 #
-_add_far_tutorial(
+osd_add_far_tutorial(
     far_tutorial_5_3
     far_tutorial_5_3.cpp
     $<TARGET_OBJECTS:regression_common_obj>


### PR DESCRIPTION
This adds an "osd" prefix to the macros used
to install far tutorials.

Fixes #1157 