### PR TITLE
Removed linking with unnecessary TBB libraries

### DIFF
--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -106,11 +106,7 @@ else()
 endif()
 
 # List library files
-foreach(TBB_LIB tbb             tbb_debug
-                tbbmalloc       tbbmalloc_debug
-                tbbmalloc_proxy tbbmalloc_proxy_debug
-                tbb_preview     tbb_preview_debug)
-
+foreach(TBB_LIB tbb             tbb_debug)
 
     find_library(TBB_${TBB_LIB}_LIBRARY
         NAMES


### PR DESCRIPTION
We no longer search for or link with several TBB libraries
which are not used by this code base. Specifically, we no
longer link with tbbmalloc, tbbmalloc_debug, tbbmalloc_proxy
tbbmalloc_proxy_debug, tbb_preview, and tbb_preview_debug.

Fixes #1064 