### PR TITLE
Added option to control building shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,13 @@ option(NO_GLFW_X11 "Disable GLFW components depending on X11" OFF)
 
 option(OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES "Enable true derivative evaluation for Gregory basis patches" OFF)
 
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+# Save the current value of BUILD_SHARED_LIBS and restore it after
+# processing Find* modules, since some of the Find* modules invoked
+# below may wind up stomping over this value.
+set(build_shared_libs "${BUILD_SHARED_LIBS}")
+
 set(OSD_GPU FALSE)
 
 # Check for dependencies
@@ -376,6 +383,8 @@ if (NOT NO_DOC)
 else()
     set(DOXYGEN_EXECUTABLE )
 endif()
+
+set(BUILD_SHARED_LIBS "${build_shared_libs}")
 
 # Warn about missing dependencies that will cause parts of OpenSubdiv to be
 # disabled.  Also, add preprocessor defines that can be used in the source
@@ -607,11 +616,19 @@ if( OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES )
     add_definitions(-DOPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES)
 endif()
 
-# Link examples & regressions dynamically against Osd
-if( OSD_GPU )
-    set( OSD_LINK_TARGET osd_dynamic_cpu osd_dynamic_gpu )
+# Link examples & regressions against Osd
+if( BUILD_SHARED_LIBS )
+    if( OSD_GPU )
+        set( OSD_LINK_TARGET osd_dynamic_gpu osd_dynamic_cpu )
+    else()
+        set( OSD_LINK_TARGET osd_dynamic_cpu )
+    endif()
 else()
-    set( OSD_LINK_TARGET osd_dynamic_cpu )
+    if( OSD_GPU )
+        set( OSD_LINK_TARGET osd_static_gpu osd_static_cpu )
+    else()
+        set( OSD_LINK_TARGET osd_static_cpu )
+    endif()
 endif()
 
 if (WIN32)

--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -133,9 +133,9 @@ if (NOT NO_LIB)
         $<TARGET_OBJECTS:osd_cpu_obj>
     )
 
-    set_target_properties(osd_static_cpu 
-        PROPERTIES 
-            OUTPUT_NAME osdCPU 
+    set_target_properties(osd_static_cpu
+        PROPERTIES
+            OUTPUT_NAME osdCPU
             CLEAN_DIRECT_OUTPUT 1
             FOLDER "opensubdiv"
     )
@@ -166,7 +166,7 @@ if (NOT NO_LIB)
 
 
     # Build dynamic libs  ----------------------------------
-    if (NOT WIN32 AND NOT IOS)
+    if (BUILD_SHARED_LIBS AND NOT WIN32 AND NOT IOS)
 
         # generate dynamic-link targets
 
@@ -298,48 +298,54 @@ if (NOT NO_LIB)
              ARCHIVE DESTINATION "${CMAKE_LIBDIR_BASE}")
 
 
-        #shared framework 
-        add_library(osd_dynamic_framework
-            SHARED
-            version.cpp
-            $<TARGET_OBJECTS:sdc_obj>
-            $<TARGET_OBJECTS:vtr_obj>
-            $<TARGET_OBJECTS:far_obj>
-            $<TARGET_OBJECTS:osd_cpu_obj>
-            $<TARGET_OBJECTS:osd_gpu_obj>
-        )
-
-        set_target_properties(
-            osd_dynamic_framework
-            PROPERTIES
-            RPATH true
-            FRAMEWORK true
-            INSTALL_NAME_DIR "@rpath/OpenSubdiv.framework/OpenSubdiv"
-            INSTALL_RPATH "@executable_path/Frameworks;@loader_path/Frameworks"
-            OUTPUT_NAME OpenSubdiv
-            CLEAN_DIRECT_OUTPUT true
-        )
-
-        target_link_libraries(osd_dynamic_framework
-            ${PLATFORM_CPU_LIBRARIES} ${PLATFORM_GPU_LIBRARIES}
-        )
-
-        install( TARGETS osd_dynamic_framework
-             FRAMEWORK DESTINATION "${CMAKE_LIBDIR_BASE}"
-             LIBRARY DESTINATION "${CMAKE_LIBDIR_BASE}"
-             PUBLIC_HEADER  DESTINATION "${CMAKE_INCDIR_BASE}"
-             PRIVATE_HEADER  DESTINATION "${CMAKE_INCDIR_BASE}"
-             )
-
-        foreach(file ${PUBLIC_HEADER_FILES})
-            add_custom_command(TARGET osd_dynamic_framework POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/opensubdiv/${file}" "$<TARGET_FILE_DIR:osd_dynamic_framework>/Headers/${file}"
+        #shared framework
+        if (BUILD_SHARED_LIBS)
+            add_library(osd_dynamic_framework
+                SHARED
+                version.cpp
+                $<TARGET_OBJECTS:sdc_obj>
+                $<TARGET_OBJECTS:vtr_obj>
+                $<TARGET_OBJECTS:far_obj>
+                $<TARGET_OBJECTS:osd_cpu_obj>
+                $<TARGET_OBJECTS:osd_gpu_obj>
             )
-        endforeach(file)
 
-        add_custom_command(TARGET osd_dynamic_framework POST_BUILD
-            COMMAND ln -sf "Versions/Current/Headers" "$<TARGET_FILE_DIR:osd_dynamic_framework>/../../Headers"
-        )
+            set_target_properties(
+                osd_dynamic_framework
+                PROPERTIES
+                RPATH true
+                FRAMEWORK true
+                INSTALL_NAME_DIR "@rpath/OpenSubdiv.framework/OpenSubdiv"
+                INSTALL_RPATH "@executable_path/Frameworks;@loader_path/Frameworks"
+                OUTPUT_NAME OpenSubdiv
+                CLEAN_DIRECT_OUTPUT true
+            )
+
+            target_link_libraries(osd_dynamic_framework
+                ${PLATFORM_CPU_LIBRARIES} ${PLATFORM_GPU_LIBRARIES}
+            )
+
+            install( TARGETS osd_dynamic_framework
+                 FRAMEWORK DESTINATION "${CMAKE_LIBDIR_BASE}"
+                 LIBRARY DESTINATION "${CMAKE_LIBDIR_BASE}"
+                 PUBLIC_HEADER  DESTINATION "${CMAKE_INCDIR_BASE}"
+                 PRIVATE_HEADER  DESTINATION "${CMAKE_INCDIR_BASE}"
+                 )
+
+            foreach(file ${PUBLIC_HEADER_FILES})
+                add_custom_command(TARGET osd_dynamic_framework POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy
+                    "${CMAKE_SOURCE_DIR}/opensubdiv/${file}"
+                    "$<TARGET_FILE_DIR:osd_dynamic_framework>/Headers/${file}"
+                )
+            endforeach(file)
+
+            add_custom_command(TARGET osd_dynamic_framework POST_BUILD
+                COMMAND ln -sf
+                "Versions/Current/Headers"
+                "$<TARGET_FILE_DIR:osd_dynamic_framework>/../../Headers"
+            )
+        endif()
 
     endif()
 endif()


### PR DESCRIPTION
This adds support for the standard global option
  BUILD_SHARED_LIBS
to select whether to build shared libraries.

Note that building shared DLL libraries is still
not yet supported on Windows.

Fixes #1169 