### PR TITLE
Fixed static library linking on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,7 @@ if(GLEW_FOUND AND GLEW_INCLUDE_DIR)
         ${GLEW_INCLUDE_DIR}
         ${PROJECT_SOURCE_DIR}/glLoader)
     set(OPENGL_LOADER_LIBRARIES
-        glLoader
+        $<TARGET_OBJECTS:glLoader_obj>
         ${GLEW_LIBRARY}
         ${OPENGL_gl_LIBRARY})
 
@@ -478,7 +478,7 @@ elseif(OPENGL_FOUND)
         ${OPENGL_INCLUDE_DIR}
         ${PROJECT_SOURCE_DIR}/glLoader)
     set(OPENGL_LOADER_LIBRARIES
-        glLoader
+        $<TARGET_OBJECTS:glLoader_obj>
         ${OPENGL_gl_LIBRARY})
 
 endif()

--- a/glLoader/CMakeLists.txt
+++ b/glLoader/CMakeLists.txt
@@ -45,8 +45,8 @@ list(APPEND PLATFORM_LIBRARIES
     "${OPENGL_LOADER_LIBRARIES}"
 )
 
-add_library(glLoader
-    STATIC
+add_library(glLoader_obj
+    OBJECT
         ${GLLOADER_SOURCE_FILES}
         ${GLLOADER_HEADER_FILES}
 )

--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -64,6 +64,7 @@ if (NOT NO_LIB)
         list(APPEND PLATFORM_GPU_LIBRARIES
             ${OPENGL_LOADER_LIBRARIES}
         )
+        set(OPENGL_LOADER_OBJS $<TARGET_OBJECTS:glLoader_obj>)
     elseif( OPENGLES_FOUND )
         include_directories("${OPENGLES_INCLUDE_DIR}")
         list(APPEND PLATFORM_GPU_LIBRARIES
@@ -153,6 +154,7 @@ if (NOT NO_LIB)
                 STATIC
                 version.cpp
                 $<TARGET_OBJECTS:osd_gpu_obj>
+                ${OPENGL_LOADER_OBJS}
                 ${CUDA_KERNEL_FILES}
         )
         set_target_properties(osd_static_gpu PROPERTIES OUTPUT_NAME osdGPU CLEAN_DIRECT_OUTPUT 1)


### PR DESCRIPTION
Changed the glLoader library to an object library
instead of a static library to improve generating
opensubdiv static libraries.