### PR TITLE
Additional fixes for dynamic and static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,6 @@ if(GLEW_FOUND AND GLEW_INCLUDE_DIR)
         ${GLEW_INCLUDE_DIR}
         ${PROJECT_SOURCE_DIR}/glLoader)
     set(OPENGL_LOADER_LIBRARIES
-        $<TARGET_OBJECTS:glLoader_obj>
         ${GLEW_LIBRARY}
         ${OPENGL_gl_LIBRARY})
 
@@ -478,7 +477,6 @@ elseif(OPENGL_FOUND)
         ${OPENGL_INCLUDE_DIR}
         ${PROJECT_SOURCE_DIR}/glLoader)
     set(OPENGL_LOADER_LIBRARIES
-        $<TARGET_OBJECTS:glLoader_obj>
         ${OPENGL_gl_LIBRARY})
 
 endif()

--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -209,6 +209,7 @@ if (NOT NO_LIB)
                 SHARED
                 version.cpp
                 $<TARGET_OBJECTS:osd_gpu_obj>
+                ${OPENGL_LOADER_OBJS}
                 ${CUDA_KERNEL_FILES}
             )
 
@@ -277,6 +278,7 @@ if (NOT NO_LIB)
             $<TARGET_OBJECTS:far_obj>
             $<TARGET_OBJECTS:osd_cpu_obj>
             $<TARGET_OBJECTS:osd_gpu_obj>
+            ${OPENGL_LOADER_OBJS}
         )
 
         set_target_properties(
@@ -310,6 +312,7 @@ if (NOT NO_LIB)
                 $<TARGET_OBJECTS:far_obj>
                 $<TARGET_OBJECTS:osd_cpu_obj>
                 $<TARGET_OBJECTS:osd_gpu_obj>
+                ${OPENGL_LOADER_OBJS}
             )
 
             set_target_properties(


### PR DESCRIPTION
Updated to link the GL loader objects directly
along with the osd GPU objects for both static
and dynamic libraries.