### PR TITLE
Fixed bug with sparse PatchTables and irregular face-varying seams

### DIFF
--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -731,6 +731,11 @@ namespace {
         }
         Level::VTag compVTag = Level::VTag::BitwiseOr(vTags, fVerts.size());
 
+        //  Incomplete faces (incomplete neighborhood) are unconditionally excluded:
+        if (compVTag._incomplete) {
+            return false;
+        }
+
         //  Select non-manifold features if specified, otherwise treat as inf-sharp:
         if (compVTag._nonManifold && featureMask.selectNonManifold) {
             return true;


### PR DESCRIPTION
This change fixes a bug in the use of sparse PatchTables (introduced in 3.4.0) with seams in a non-linear face-varying channel.  The PatchTable will be successfully created but initialization of control point values -- either by construction of a StencilTable or interpolation with a PrimvarRefiner -- will crash due to a bug introduced by the adaptive refinement.

In practical terms, the bug occurs when a vertex on a non-linear UV seam is irregular in UV space and ends up on the boundary of the region of faces selected for a sparse PatchTable.

There is no simple workaround here.  Depending on how the faces are partitioned, a mesh with such vertices may or may not trigger the bug.  When it does, changing that partitioning can avoid it.  The larger the groups of faces, the less likely it is to occur.  Only by ensuring that all faces around such a vertex are included in the same PatchTable can it be avoided.