### PR TITLE
Adjustments to CMake config for use as a sub-project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,10 +53,17 @@ endif()
 
 #-------------------------------------------------------------------------------
 
-message(STATUS "Compiling ${CMAKE_PROJECT_NAME} version ${OpenSubdiv_VERSION}")
+message(STATUS "Compiling ${PROJECT_NAME} version ${OpenSubdiv_VERSION}")
 message(STATUS "Using cmake version ${CMAKE_VERSION}")
 
 #-------------------------------------------------------------------------------
+# Determine if the project is built as a subproject (using add_subdirectory)
+# or if it is the master project.
+set(MASTER_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(MASTER_PROJECT ON)
+endif()
+
 # Specify the default install path
 if (NOT DEFINED CMAKE_INSTALL_PREFIX)
     SET( CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/" )
@@ -97,19 +104,21 @@ if(LIBRARY_OUTPUT_PATH_ROOT)
     SET( CMAKE_INSTALL_PREFIX "${LIBRARY_OUTPUT_PATH_ROOT}/" )
 endif()
 
-# Set the directory where the executables will be stored.
-set(EXECUTABLE_OUTPUT_PATH
-    "${PROJECT_BINARY_DIR}/bin"
-    CACHE PATH
-    "Directory where executables will be stored"
-)
+if (MASTER_PROJECT)
+    # Set the directory where the executables will be stored.
+    set(EXECUTABLE_OUTPUT_PATH
+        "${PROJECT_BINARY_DIR}/bin"
+        CACHE PATH
+        "Directory where executables will be stored"
+    )
 
-# Set the directory where the libraries will be stored.
-set(LIBRARY_OUTPUT_PATH
-    "${PROJECT_BINARY_DIR}/lib"
-    CACHE PATH
-    "Directory where all libraries will be stored"
-)
+    # Set the directory where the libraries will be stored.
+    set(LIBRARY_OUTPUT_PATH
+        "${PROJECT_BINARY_DIR}/lib"
+        CACHE PATH
+        "Directory where all libraries will be stored"
+    )
+endif()
 
 # Specify the list of directories to search for cmake modules.
 set(CMAKE_MODULE_PATH
@@ -652,7 +661,7 @@ if (WIN32)
             "environment variable."
         )
     endif()
-    
+
     # Link examples & regressions statically against Osd for
     # Windows until all the kinks can be worked out.
     if( OSD_GPU )
@@ -660,7 +669,7 @@ if (WIN32)
     else()
         set( OSD_LINK_TARGET osd_static_cpu )
     endif()
-    
+
 endif()
 
 


### PR DESCRIPTION
I've been using OpenSubdiv in my project as a git submodule. Right now I'm in the process of converting my project to use CMake, so I absorbed OpenSubdiv into the build by using `add_subdirectory('ThirdParty/OpenSubdiv')`

While doing so I found that my build output for the whole project ended up under `ThirdParty/OpenSubdiv/bin` and `ThirdParty/OpenSubdiv/lib`.

After poking around I found that OpenSubdiv set two global properties that affect not only it's own dir and descendants, but also parent projects and directories - everything in the build.

This PR guard against setting these properties when the project is consumed as a sub-project.

While I was at it I also fixed a reference from `CMAKE_PROJECT_NAME` (which picked up the root project name) to `PROJECT_NAME` (Name of the last `project` call)

---

For reference, where is a fragment of CMake configuration output before my changes:
(I dump a few variables before I invoke `add_subdirectory` and then again after.

```
[cmake] -- ----------
[cmake] -- CMAKE_INSTALL_PREFIX: C:/Program Files (x86)/SUbD
[cmake] -- CMAKE_BINDIR_BASE:
[cmake] -- LIBRARY_OUTPUT_PATH_ROOT:
[cmake] -- EXECUTABLE_OUTPUT_PATH:
[cmake] -- LIBRARY_OUTPUT_PATH:
[cmake] -- ----------
[cmake] -- Compiling SUbD version v3_4_3
[cmake] -- Using cmake version 3.17.2
[cmake] -- Using static MSVC CRT
[cmake] -- ----------
[cmake] -- CMAKE_INSTALL_PREFIX: C:/Program Files (x86)/SUbD
[cmake] -- CMAKE_BINDIR_BASE:
[cmake] -- LIBRARY_OUTPUT_PATH_ROOT:
[cmake] -- EXECUTABLE_OUTPUT_PATH: C:/Users/Thomas/Source/SUbD/build/ThirdParty/OpenSubdiv/source/OpenSubdiv/bin
[cmake] -- LIBRARY_OUTPUT_PATH: C:/Users/Thomas/Source/SUbD/build/ThirdParty/OpenSubdiv/source/OpenSubdiv/lib
[cmake] -- ----------
```

After my changes:

```
[cmake] -- ----------
[cmake] -- CMAKE_INSTALL_PREFIX: C:/Program Files (x86)/SUbD
[cmake] -- CMAKE_BINDIR_BASE: 
[cmake] -- LIBRARY_OUTPUT_PATH_ROOT: 
[cmake] -- EXECUTABLE_OUTPUT_PATH: 
[cmake] -- LIBRARY_OUTPUT_PATH: 
[cmake] -- ----------
[cmake] -- Compiling OpenSubdiv version v3_4_3
[cmake] -- Using cmake version 3.17.2
[cmake] -- Using static MSVC CRT
[cmake] -- ----------
[cmake] -- CMAKE_INSTALL_PREFIX: C:/Program Files (x86)/SUbD
[cmake] -- CMAKE_BINDIR_BASE: 
[cmake] -- LIBRARY_OUTPUT_PATH_ROOT: 
[cmake] -- EXECUTABLE_OUTPUT_PATH: 
[cmake] -- LIBRARY_OUTPUT_PATH: 
[cmake] -- ----------
```

And the build output is located where I would expect it to be.