### PR TITLE
Fixed bug in double precision template for Far::StencilTableFactory

### DIFF
--- a/opensubdiv/far/stencilTableFactory.cpp
+++ b/opensubdiv/far/stencilTableFactory.cpp
@@ -100,10 +100,9 @@ StencilTableFactoryReal<REAL>::Create(TopologyRefiner const & refiner,
                                 /*compactWeights*/  true);
 
     //
-    // Interpolate stencils for each refinement level using
-    // PrimvarRefiner::InterpolateLevel<>() for vertex or varying
+    // Interpolate stencils for each refinement level
     //
-    PrimvarRefiner primvarRefiner(refiner);
+    PrimvarRefinerReal<REAL> primvarRefiner(refiner);
 
     typename StencilBuilder<REAL>::Index srcIndex(&builder, 0);
     typename StencilBuilder<REAL>::Index dstIndex(&builder, numControlVertices);


### PR DESCRIPTION
This change fixes a bug in the double precision template for Far::StencilTableFactory, i.e. Far::StencilTableFactoryReal<double>.

The Create() method uses the Far::PrimvarRefiner to assemble the stencils -- another class that is parameterized by precision.  But the template version of PrimvarRefiner was not declared with the appropriate precision parameter here.  Instead the backward-compatible single-precision version was used, which compromises the accuracy of refined vertices.