### PR TITLE
Fixed Far::TopologyRefiner::GetMaxLevel() after call to Unrefine()

### DIFF
--- a/opensubdiv/far/topologyRefiner.cpp
+++ b/opensubdiv/far/topologyRefiner.cpp
@@ -118,6 +118,7 @@ TopologyRefiner::Unrefine() {
         delete _refinements[i];
     }
     _refinements.clear();
+    _maxLevel = 0;
 
     assembleFarLevels();
 }


### PR DESCRIPTION
This change fixes the reassignment of the _maxLevel member of Far::TopologyRefiner as part of the call to Unrefine().

The _maxLevel member was being left unmodified rather than being reset to 0, causing GetMaxLevel() to return an incorrect result.  Meanwhile the GetNumLevels() method returned the correct result before and after and so provides a simple workaround in place of GetMaxLevel().