### PR TITLE
Fixed FindDocutils.cmake for broken rst2html case

### DIFF
--- a/build_scripts/build_osd.py
+++ b/build_scripts/build_osd.py
@@ -46,26 +46,26 @@ verbosity = 1
 
 def Print(msg):
     if verbosity > 0:
-        print msg
+        print(msg)
 
 def PrintWarning(warning):
     if verbosity > 0:
-        print "WARNING:", warning
+        print("WARNING:", warning)
 
 def PrintStatus(status):
     if verbosity >= 1:
-        print "STATUS:", status
+        print("STATUS:", status)
 
 def PrintInfo(info):
     if verbosity >= 2:
-        print "INFO:", info
+        print("INFO:", info)
 
 def PrintCommandOutput(output):
     if verbosity >= 3:
         sys.stdout.write(output)
 
 def PrintError(error):
-    print "ERROR:", error
+    print("ERROR:", error)
 
 # Helpers for determining platform
 def Windows():

--- a/build_scripts/build_osd.py
+++ b/build_scripts/build_osd.py
@@ -46,26 +46,26 @@ verbosity = 1
 
 def Print(msg):
     if verbosity > 0:
-        print(msg)
+        print msg
 
 def PrintWarning(warning):
     if verbosity > 0:
-        print("WARNING:", warning)
+        print "WARNING:", warning
 
 def PrintStatus(status):
     if verbosity >= 1:
-        print("STATUS:", status)
+        print "STATUS:", status
 
 def PrintInfo(info):
     if verbosity >= 2:
-        print("INFO:", info)
+        print "INFO:", info
 
 def PrintCommandOutput(output):
     if verbosity >= 3:
         sys.stdout.write(output)
 
 def PrintError(error):
-    print("ERROR:", error)
+    print "ERROR:", error
 
 # Helpers for determining platform
 def Windows():

--- a/cmake/FindDocutils.cmake
+++ b/cmake/FindDocutils.cmake
@@ -32,60 +32,70 @@
 
 find_package(PackageHandleStandardArgs)
 
-find_program( RST2HTML_EXECUTABLE 
-    NAMES 
-        rst2html.py 
+find_program( RST2HTML_EXECUTABLE
+    NAMES
+        rst2html.py
         rst2html
-    DOC 
-        "The Python Docutils reStructuredText HTML converter"
+    DOC
+        "The Python Docutils reStructuredText to HTML converter"
 )
 
 if (RST2HTML_EXECUTABLE)
-
-    set(DOCUTILS_FOUND "YES")
-
-    # Note we only check for a python interpreter and use it for the command 
+    # Note we only check for a python interpreter and use it for the command
     # on Windows.  It would be cleaner if we could agree that this is the
     # right way to do it for all platforms, or find a way that works for all
     # platforms uniformly.
     if (WIN32)
         find_package(PythonInterp)
         if (NOT PYTHON_EXECUTABLE)
-            message(FATAL_ERROR "Could not find python interpreter, which is required for Docutils")
+            message(FATAL_ERROR "Could not find Python interpreter, which is required for Docutils")
         endif()
         execute_process(COMMAND ${PYTHON_EXECUTABLE} ${RST2HTML_EXECUTABLE} --version OUTPUT_VARIABLE VERSION_STRING )
     else()
         execute_process(COMMAND ${RST2HTML_EXECUTABLE} --version OUTPUT_VARIABLE VERSION_STRING )
     endif()
 
-    # find the version
-    # ex : rst2html (Docutils 0.6 [release], Python 2.6.6, on linux2)
-    string(REGEX MATCHALL "([^\ ]+\ |[^\ ]+$)" VERSION_TOKENS "${VERSION_STRING}")  
-    
-    # isolate the 3rd. word in the string
-    list (GET VERSION_TOKENS 2 VERSION_STRING)
-    
-    # remove white space
-    string(REGEX REPLACE "[ \t]+$" "" VERSION_STRING ${VERSION_STRING})
-    string(REGEX REPLACE "^[ \t]+" "" VERSION_STRING ${VERSION_STRING})
-    
-    set(DOCUTILS_VERSION ${VERSION_STRING})
-        
+    # The above code may fail to find a version. Which will make the REGEX
+    # REPLACE below fail and break the build. So we check for an empty
+    # VERSION_STRING.
+    if ("${VERSION_STRING}" STREQUAL "")
+
+        set(DOCUTILS_FOUND "NO")
+
+    else()
+
+        set(DOCUTILS_FOUND "YES")
+
+        # find the version
+        # ex : rst2html (Docutils 0.6 [release], Python 2.6.6, on linux2)
+        string(REGEX MATCHALL "([^\ ]+\ |[^\ ]+$)" VERSION_TOKENS "${VERSION_STRING}")
+
+        # isolate the 3rd. word in the string
+        list (GET VERSION_TOKENS 2 VERSION_STRING)
+
+        # remove white space
+        string(REGEX REPLACE "[ \t]+$" "" VERSION_STRING ${VERSION_STRING})
+        string(REGEX REPLACE "^[ \t]+" "" VERSION_STRING ${VERSION_STRING})
+
+        set(DOCUTILS_VERSION ${VERSION_STRING})
+
+        include(FindPackageHandleStandardArgs)
+
+        find_package_handle_standard_args(Docutils
+            REQUIRED_VARS
+                RST2HTML_EXECUTABLE
+            VERSION_VAR
+                DOCUTILS_VERSION
+        )
+
+        mark_as_advanced(
+            RST2HTML_EXECUTABLE
+        )
+
+    endif()
+
 else()
 
     set(DOCUTILS_FOUND "NO")
 
 endif()
-
-include(FindPackageHandleStandardArgs)
-
-find_package_handle_standard_args(Docutils 
-    REQUIRED_VARS
-        RST2HTML_EXECUTABLE
-    VERSION_VAR
-        DOCUTILS_VERSION
-)
-
-mark_as_advanced(
-    RST2HTML_EXECUTABLE
-)


### PR DESCRIPTION
I ran into this on macOS. I had a leftover `rst2html.py` referencing a non-exiting Python interpreter.
What happened in this case is that `FindDocutils` runs `rst2html.py --version` which returns an empty `VERSION_STRING` (as the OS fails to run `rst2html.py` at all).
This then cascades down to more errors with the `REGEX REPLACE`.
```
CMake Error at cmake/FindDocutils.cmake:66 (list):
  list GET given empty list
Call Stack (most recent call first):
  /Users/moritz/code/vcpkg/scripts/buildsystems/vcpkg.cmake:644 (_find_package)
  CMakeLists.txt:382 (find_package)

CMake Error at cmake/FindDocutils.cmake:69 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
Call Stack (most recent call first):
  /Users/moritz/code/vcpkg/scripts/buildsystems/vcpkg.cmake:644 (_find_package)
  CMakeLists.txt:382 (find_package)

CMake Error at cmake/FindDocutils.cmake:70 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
Call Stack (most recent call first):
  /Users/moritz/code/vcpkg/scripts/buildsystems/vcpkg.cmake:644 (_find_package)
  CMakeLists.txt:382 (find_package)
 ```
Just checking for the empty string is not enough because `FindDocutils` marked `RST2HTML_EXECUTABLE`, even when setting `DOCUTILS_FOUND` to `"NO"` (which then makes the build break later). So that entire section moved under the `else()` block.

See also [this issue on `vcpkg`](https://github.com/microsoft/vcpkg/issues/15695#issuecomment-762815126).