### PR TITLE
Fixed link dependency on dl library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,8 @@ if(GLEW_FOUND AND GLEW_INCLUDE_DIR)
         ${PROJECT_SOURCE_DIR}/glLoader)
     set(OPENGL_LOADER_LIBRARIES
         ${GLEW_LIBRARY}
-        ${OPENGL_gl_LIBRARY})
+        ${OPENGL_gl_LIBRARY}
+        ${CMAKE_DL_LIBS})
 
 elseif(OPENGL_FOUND)
 
@@ -477,7 +478,8 @@ elseif(OPENGL_FOUND)
         ${OPENGL_INCLUDE_DIR}
         ${PROJECT_SOURCE_DIR}/glLoader)
     set(OPENGL_LOADER_LIBRARIES
-        ${OPENGL_gl_LIBRARY})
+        ${OPENGL_gl_LIBRARY}
+        ${CMAKE_DL_LIBS})
 
 endif()
 


### PR DESCRIPTION
This fixes a missing link dependency in the GL API Loader
on platforms like Linux that require linking with '-ldl'.

Fixes #1196 