### PR TITLE
Move cmake_minimum_required to be the first thing in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,9 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-project(OpenSubdiv)
-
 cmake_minimum_required(VERSION 2.8.6)
+
+project(OpenSubdiv)
 
 # Turn on folder support
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
Moving to be the very first thing in CMakeLists.txt per CMake's strong recommendation.

> **Note** Call the cmake_minimum_required() command at the beginning of the top-level CMakeLists.txt file even before calling the project() command. It is important to establish version and policy settings before invoking other commands whose behavior they may affect. See also policy CMP0000.

https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

There might be some other `CMAKE_` variables set that ideally should be set before `project`, but those would require some more investigation to identify.