### PR TITLE
OpenGL Compute Evaluator: cache active program

### DIFF
--- a/opensubdiv/osd/glComputeEvaluator.cpp
+++ b/opensubdiv/osd/glComputeEvaluator.cpp
@@ -325,6 +325,8 @@ GLComputeEvaluator::EvalStencils(
     if (dvvWeightsBuffer)
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 15, dvvWeightsBuffer);
 
+    GLint activeProgram;
+    glGetIntegerv(GL_CURRENT_PROGRAM, &activeProgram);
     glUseProgram(_stencilKernel.program);
 
     glUniform1i(_stencilKernel.uniformStart,     start);
@@ -354,7 +356,7 @@ GLComputeEvaluator::EvalStencils(
 
     glDispatchCompute((count + _workGroupSize - 1) / _workGroupSize, 1, 1);
 
-    glUseProgram(0);
+    glUseProgram(activeProgram);
 
     glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT);
     for (int i = 0; i < 16; ++i) {
@@ -418,6 +420,8 @@ GLComputeEvaluator::EvalPatches(
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 6, patchIndexBuffer);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 7, patchParamsBuffer);
 
+    GLint activeProgram;
+    glGetIntegerv(GL_CURRENT_PROGRAM, &activeProgram);
     glUseProgram(_patchKernel.program);
 
     glUniform1i(_patchKernel.uniformSrcOffset, srcDesc.offset);
@@ -456,7 +460,7 @@ GLComputeEvaluator::EvalPatches(
 
     glDispatchCompute((numPatchCoords + _workGroupSize - 1) / _workGroupSize, 1, 1);
 
-    glUseProgram(0);
+    glUseProgram(activeProgram);
 
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, 0);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, 0);


### PR DESCRIPTION
Client applications may keep track of the active shader program so as to
not unnecessarily bind and unbind the same shader consecutively as
switching shaders is costly.

The current behavior of the OpenGL compute evaluator is to set the
active shader to 0 (zero) after running its program(s) which might
interfere with the aforementioned client applications' behavior,
leading to bugs.

Instead of unsetting any previously set shader program, cache the
current program before using the evaluator program, and reset the active
program to the previous one when done.

In Blender, this lead to some rendering artifacts. See
https://developer.blender.org/D15064 for more details on it.