### PR TITLE
Updated macOS azure pipelines agent

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,10 +30,10 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - script: |
-      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_10.1.app/Contents/Developer"
+      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12.4.app/Contents/Developer"
       python build_scripts/build_osd.py --tests --tbb --generator Xcode --build $HOME/OSDgen/build --src $HOME/OSDgen/src $HOME/OSDinst
     displayName: 'Building OpenSubdiv'
   - script: |


### PR DESCRIPTION
The current macOS-10.14 agent has been retired. This updates to use macOS-10.15 which matches the config for the USD repository. We may update this further to macOS-11 since the macOS-10.15 agent recently has been marked deprecated.