### PR TITLE
Additions and improvements to Bfr tutorials:

### DIFF
--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -188,9 +188,11 @@ if (DOCUTILS_FOUND AND PYTHONINTERP_FOUND)
         bfr/tutorial_1_2/bfr_tutorial_1_2.cpp
         bfr/tutorial_1_3/bfr_tutorial_1_3.cpp
         bfr/tutorial_1_4/bfr_tutorial_1_4.cpp
+        bfr/tutorial_1_5/bfr_tutorial_1_5.cpp
         bfr/tutorial_2_1/bfr_tutorial_2_1.cpp
         bfr/tutorial_2_2/bfr_tutorial_2_2.cpp
         bfr/tutorial_3_1/bfr_tutorial_3_1.cpp
+        bfr/tutorial_3_2/bfr_tutorial_3_2.cpp
         osd/tutorial_0/osd_tutorial_0.cpp
     )
 

--- a/documentation/tutorials.rst
+++ b/documentation/tutorials.rst
@@ -38,6 +38,17 @@ or in your local ``<repository root>/tutorials``.
 Bfr Tutorials
 =============
 
+All tutorials for the Bfr interface follow a similar pattern:  without any
+command line arguments, a default mesh (usually a cube) is used and the
+results printed to standard output in Obj format. Command line arguments
+can be used to specify an alternate mesh for input, as well as directing
+the output to a specified Obj file.
+
+Some tutorials may offer additional command line options to trigger internal
+options relevant to the topic, e.g. those illustrating tessellation may
+support a -quads option to use the option to tessellate quad-bases subdivision
+meshes with quads.
+
 1. Basic Evaluation and Tessellation
 ************************************
 
@@ -74,8 +85,14 @@ Tutorial 1.4
  position and UV by illustrating how additional mesh data interleaved with
  the position and UV data is easily handled.  `[code] <bfr_tutorial_1_4.html>`__
 
-2. More on Bfr::Tessellation
-****************************
+Tutorial 1.5
+^^^^^^^^^^^^
+ This tutorial is similar to the first tutorial showing uniform tessellation
+ of position but makes use of limit stencils for its evaluation of points of
+ the tessellation pattern. `[code] <bfr_tutorial_1_5.html>`__
+
+2. More on Tessellation
+***********************
 
 Tutorial 2.1
 ^^^^^^^^^^^^
@@ -99,8 +116,8 @@ Tutorial 2.2
  creating a topologically watertight tessellation of the mesh.
  `[code] <bfr_tutorial_2_2.html>`__
 
-3. Creating a Custom Bfr::SurfaceFactory
-****************************************
+3. Additional Topics
+********************
 
 Tutorial 3.1
 ^^^^^^^^^^^^
@@ -112,6 +129,15 @@ Tutorial 3.1
  here is that of the main program, not the separate header and source files
  of the custom subclass illustrated -- which current documentation scripts
  cannot import.)
+
+Tutorial 3.2
+^^^^^^^^^^^^
+ This tutorial shows how to initialize and retain Surfaces for later use.
+ The simple uniform tessellation tutorial is modified to first create and
+ populate a simple caching structure that initializes and stores the
+ Surfaces for all faces of the mesh. The loop for each face of the mesh
+ then retrieves its Surface and associated patch points from the cache.
+ `[code] <bfr_tutorial_3_2.html>`__
 
 ----
 

--- a/tutorials/bfr/CMakeLists.txt
+++ b/tutorials/bfr/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#   Copyright 2021
+#   Copyright 2021 Pixar
 #
 #   Licensed under the Apache License, Version 2.0 (the "Apache License")
 #   with the following modification; you may not use this file except in
@@ -29,6 +29,7 @@ macro(osd_add_bfr_tutorial NAME)
         $<TARGET_OBJECTS:vtr_obj>
         $<TARGET_OBJECTS:far_obj>
         $<TARGET_OBJECTS:bfr_obj>
+        $<TARGET_OBJECTS:regression_common_obj>
      )
 
      install(TARGETS ${NAME} DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
@@ -41,9 +42,11 @@ set(TUTORIALS
     tutorial_1_2
     tutorial_1_3
     tutorial_1_4
+    tutorial_1_5
     tutorial_2_1
     tutorial_2_2
     tutorial_3_1
+    tutorial_3_2
 )
 
 foreach(tutorial ${TUTORIALS})

--- a/tutorials/bfr/tutorial_1_2/CMakeLists.txt
+++ b/tutorials/bfr/tutorial_1_2/CMakeLists.txt
@@ -22,18 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-set(SOURCE_FILES
+osd_add_bfr_tutorial(
+    bfr_tutorial_1_2
     bfr_tutorial_1_2.cpp
 )
-
-osd_add_executable(bfr_tutorial_1_2 "tutorials/bfr"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-    $<TARGET_OBJECTS:bfr_obj>
-    $<TARGET_OBJECTS:regression_common_obj>
-)
-
-install(TARGETS bfr_tutorial_1_2 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/bfr/tutorial_1_3/CMakeLists.txt
+++ b/tutorials/bfr/tutorial_1_3/CMakeLists.txt
@@ -22,18 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-set(SOURCE_FILES
+osd_add_bfr_tutorial(
+    bfr_tutorial_1_3
     bfr_tutorial_1_3.cpp
 )
-
-osd_add_executable(bfr_tutorial_1_3 "tutorials/bfr"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-    $<TARGET_OBJECTS:bfr_obj>
-    $<TARGET_OBJECTS:regression_common_obj>
-)
-
-install(TARGETS bfr_tutorial_1_3 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/bfr/tutorial_1_4/CMakeLists.txt
+++ b/tutorials/bfr/tutorial_1_4/CMakeLists.txt
@@ -22,18 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-set(SOURCE_FILES
+osd_add_bfr_tutorial(
+    bfr_tutorial_1_4
     bfr_tutorial_1_4.cpp
 )
-
-osd_add_executable(bfr_tutorial_1_4 "tutorials/bfr"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-    $<TARGET_OBJECTS:bfr_obj>
-    $<TARGET_OBJECTS:regression_common_obj>
-)
-
-install(TARGETS bfr_tutorial_1_4 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/bfr/tutorial_1_5/CMakeLists.txt
+++ b/tutorials/bfr/tutorial_1_5/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#   Copyright 2021 Pixar
+#   Copyright 2022 Pixar
 #
 #   Licensed under the Apache License, Version 2.0 (the "Apache License")
 #   with the following modification; you may not use this file except in
@@ -23,6 +23,6 @@
 #
 
 osd_add_bfr_tutorial(
-    bfr_tutorial_1_1
-    bfr_tutorial_1_1.cpp
+    bfr_tutorial_1_5
+    bfr_tutorial_1_5.cpp
 )

--- a/tutorials/bfr/tutorial_1_5/bfr_tutorial_1_5.cpp
+++ b/tutorials/bfr/tutorial_1_5/bfr_tutorial_1_5.cpp
@@ -1,0 +1,301 @@
+//
+//   Copyright 2021 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+//------------------------------------------------------------------------------
+//  Tutorial description:
+//
+//      This tutorial is an alternative to an earlier tutorial that showed
+//      uniform tessellation. This version differs by evaluating the points
+//      of the tessellation using limit stencils instead of the standard
+//      Surface evaluation methods.
+//
+//      Limit stencils factor the evaluation into a set of coefficients for
+//      each control point affecting the Surface.
+//
+
+#include <opensubdiv/far/topologyRefiner.h>
+#include <opensubdiv/bfr/refinerSurfaceFactory.h>
+#include <opensubdiv/bfr/surface.h>
+#include <opensubdiv/bfr/tessellation.h>
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <cstdio>
+
+//  Local headers with support for this tutorial in "namespace tutorial"
+#include "./meshLoader.h"
+#include "./objWriter.h"
+
+using namespace OpenSubdiv;
+
+//
+//  Simple command line arguments to provide input and run-time options:
+//
+class Args {
+public:
+    std::string     inputObjFile;
+    std::string     outputObjFile;
+    Sdc::SchemeType schemeType;
+    int             tessUniformRate;
+    bool            tessQuadsFlag;
+
+public:
+    Args(int argc, char * argv[]) :
+        inputObjFile(),
+        outputObjFile(),
+        schemeType(Sdc::SCHEME_CATMARK),
+        tessUniformRate(5),
+        tessQuadsFlag(false) {
+
+        for (int i = 1; i < argc; ++i) {
+            if (strstr(argv[i], ".obj")) {
+                if (inputObjFile.empty()) {
+                    inputObjFile = std::string(argv[i]);
+                } else {
+                    fprintf(stderr,
+                        "Warning: Extra Obj file '%s' ignored\n", argv[i]);
+                }
+            } else if (!strcmp(argv[i], "-o")) {
+                if (++i < argc) outputObjFile = std::string(argv[i]);
+            } else if (!strcmp(argv[i], "-bilinear")) {
+                schemeType = Sdc::SCHEME_BILINEAR;
+            } else if (!strcmp(argv[i], "-catmark")) {
+                schemeType = Sdc::SCHEME_CATMARK;
+            } else if (!strcmp(argv[i], "-loop")) {
+                schemeType = Sdc::SCHEME_LOOP;
+            } else if (!strcmp(argv[i], "-res")) {
+                if (++i < argc) tessUniformRate = atoi(argv[i]);
+            } else if (!strcmp(argv[i], "-quads")) {
+                tessQuadsFlag = true;
+            } else {
+                fprintf(stderr,
+                    "Warning: Unrecognized argument '%s' ignored\n", argv[i]);
+            }
+        }
+    }
+
+private:
+    Args() { }
+};
+
+//
+//  The main tessellation function:  given a mesh and vertex positions,
+//  tessellate each face -- writing results in Obj format.
+//
+void
+tessellateToObj(Far::TopologyRefiner const & meshTopology,
+                std::vector<float>   const & meshVertexPositions,
+                Args                 const & options) {
+
+    //
+    //  Use simpler local type names for the Surface and its factory:
+    //
+    typedef Bfr::RefinerSurfaceFactory<> SurfaceFactory;
+    typedef Bfr::Surface<float>          Surface;
+
+    //
+    //  Initialize the SurfaceFactory for the given base mesh (very low
+    //  cost in terms of both time and space) and tessellate each face
+    //  independently (i.e. no shared vertices):
+    //
+    //  Note that the SurfaceFactory is not thread-safe by default due to
+    //  use of an internal cache.  Creating a separate instance of the
+    //  SurfaceFactory for each thread is one way to safely parallelize
+    //  this loop.  Another (preferred) is to assign a thread-safe cache
+    //  to the single instance.
+    //
+    //  First declare any evaluation options when initializing (though
+    //  none are used in this simple case):
+    //
+    SurfaceFactory::Options surfaceOptions;
+
+    SurfaceFactory meshSurfaceFactory(meshTopology, surfaceOptions);
+
+    //
+    //  The Surface to be constructed and evaluated for each face -- as
+    //  well as the intermediate and output data associated with it -- can
+    //  be declared in the scope local to each face. But since dynamic
+    //  memory is involved with these variables, it is preferred to declare
+    //  them outside that loop to preserve and reuse that dynamic memory.
+    //
+    Surface faceSurface;
+
+    std::vector<float> faceControlPoints;
+
+    std::vector<float> limitStencils;
+
+    std::vector<float> outCoords;
+    std::vector<float> outPos, outDu, outDv;
+    std::vector<int>   outFacets;
+
+    //
+    //  Assign Tessellation Options applied for all faces.  Tessellations
+    //  allow the creating of either 3- or 4-sided faces -- both of which
+    //  are supported here via a command line option:
+    //
+    int const tessFacetSize = 3 + options.tessQuadsFlag;
+
+    Bfr::Tessellation::Options tessOptions;
+    tessOptions.SetFacetSize(tessFacetSize);
+    tessOptions.PreserveQuads(options.tessQuadsFlag);
+
+    //
+    //  Process each face, writing the output of each in Obj format:
+    //
+    tutorial::ObjWriter objWriter(options.outputObjFile);
+
+    int numFaces = meshSurfaceFactory.GetNumFaces();
+    for (int faceIndex = 0; faceIndex < numFaces; ++faceIndex) {
+        //
+        //  Initialize the Surface for this face -- if valid (skipping
+        //  holes and boundary faces in some rare cases):
+        //
+        if (!meshSurfaceFactory.InitVertexSurface(faceIndex, &faceSurface)) {
+            continue;
+        }
+
+        //
+        //  Resize stencils and control point arrays based on the number
+        //  of control points for the Surface:
+        //
+        int numControlPoints = faceSurface.GetNumControlPoints();
+
+        limitStencils.resize(3 * numControlPoints);
+
+        float * pStencil  = limitStencils.data();
+        float * duStencil = limitStencils.data() + numControlPoints;
+        float * dvStencil = limitStencils.data() + numControlPoints * 2;
+
+        //
+        //  Limit stencils can be applied using the control points in a
+        //  local array or directy from the mesh. Both are shown here, so
+        //  if using the local array, resize and populate it:
+        //
+        bool gatherControlPoints = true;
+        if (gatherControlPoints) {
+            faceControlPoints.resize(numControlPoints * 3);
+
+            faceSurface.GatherControlPoints(meshVertexPositions.data(), 3,
+                                            faceControlPoints.data(), 3);
+        }
+
+        //
+        //  Declare a simple uniform Tessellation for the Parameterization
+        //  of this face and identify coordinates of the points to evaluate:
+        //
+        Bfr::Tessellation tessPattern(faceSurface.GetParameterization(),
+                                      options.tessUniformRate, tessOptions);
+
+        int numOutCoords = tessPattern.GetNumCoords();
+
+        outCoords.resize(numOutCoords * 2);
+
+        tessPattern.GetCoords(outCoords.data());
+
+        //  
+        //  Evaluate and apply stencils to compute points of the tessellation:
+        //  
+        outPos.resize(numOutCoords * 3);
+        outDu.resize(numOutCoords * 3);
+        outDv.resize(numOutCoords * 3);
+
+        for (int i = 0; i < numOutCoords; ++i) {
+            float const * uv = outCoords.data() + i * 2;
+
+            faceSurface.EvaluateStencil(uv, pStencil, duStencil, dvStencil);
+
+            float * p  = outPos.data() + i * 3;
+            float * du = outDu.data()  + i * 3;
+            float * dv = outDv.data()  + i * 3;
+
+            if (gatherControlPoints) {
+                float const * controlPoints = faceControlPoints.data();
+
+                faceSurface.ApplyStencil(pStencil,  controlPoints, 3, p);
+                faceSurface.ApplyStencil(duStencil, controlPoints, 3, du);
+                faceSurface.ApplyStencil(dvStencil, controlPoints, 3, dv);
+            } else {
+                float const * meshPoints = meshVertexPositions.data();
+
+                faceSurface.ApplyStencilFromMesh(pStencil,  meshPoints, 3, p);
+                faceSurface.ApplyStencilFromMesh(duStencil, meshPoints, 3, du);
+                faceSurface.ApplyStencilFromMesh(dvStencil, meshPoints, 3, dv);
+            }
+        }
+
+        //
+        //  Identify the faces of the Tessellation:
+        //
+        //  Note the need to offset vertex indices for the output faces --
+        //  using the number of vertices generated prior to this face. One
+        //  of several Tessellation methods to transform the facet indices
+        //  simply translates all indices by the desired offset.
+        //
+        int objVertexIndexOffset = objWriter.GetNumVertices();
+
+        int numFacets = tessPattern.GetNumFacets();
+        outFacets.resize(numFacets * tessFacetSize);
+        tessPattern.GetFacets(outFacets.data());
+
+        tessPattern.TransformFacetCoordIndices(outFacets.data(),
+                                               objVertexIndexOffset);
+
+        //
+        //  Write the evaluated points and faces connecting them as Obj:
+        //
+        objWriter.WriteGroupName("baseFace_", faceIndex);
+
+        objWriter.WriteVertexPositions(outPos);
+        objWriter.WriteVertexNormals(outDu, outDv);
+
+        objWriter.WriteFaces(outFacets, tessFacetSize, true, false);
+    }
+}
+
+//
+//  Load command line arguments, specified or default geometry and process:
+//
+int
+main(int argc, char * argv[]) {
+
+    Args args(argc, argv);
+
+    Far::TopologyRefiner * meshTopology = 0;
+    std::vector<float>     meshVtxPositions;
+    std::vector<float>     meshFVarUVs;
+
+    meshTopology = tutorial::createTopologyRefiner(
+            args.inputObjFile, args.schemeType, meshVtxPositions, meshFVarUVs);
+    if (meshTopology == 0) {
+        return EXIT_FAILURE;
+    }
+
+    tessellateToObj(*meshTopology, meshVtxPositions, args);
+
+    delete meshTopology;
+    return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------

--- a/tutorials/bfr/tutorial_1_5/meshLoader.h
+++ b/tutorials/bfr/tutorial_1_5/meshLoader.h
@@ -1,0 +1,209 @@
+//
+//   Copyright 2021 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#include "../../../regression/common/far_utils.h"
+
+#include <opensubdiv/far/topologyRefiner.h>
+#include <opensubdiv/far/topologyDescriptor.h>
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+
+//  Utilities local to this tutorial:
+namespace tutorial {
+
+using namespace OpenSubdiv;
+
+//
+//  Create a TopologyRefiner from default geometry:
+//
+Far::TopologyRefiner *
+dfltTopologyRefiner(std::vector<float> & posVector,
+                    std::vector<float> & uvVector) {
+
+    //
+    //  Default topology and positions for a cube:
+    //
+    int dfltNumFaces = 6;
+    int dfltNumVerts = 8;
+    int dfltNumUVs   = 16;
+
+    int dfltFaceSizes[6] = { 4, 4, 4, 4, 4, 4 };
+
+    int dfltFaceVerts[24] = { 0, 1, 3, 2,
+                              2, 3, 5, 4,
+                              4, 5, 7, 6,
+                              6, 7, 1, 0,
+                              1, 7, 5, 3,
+                              6, 0, 2, 4 };
+
+    float dfltPositions[8][3] = {{ -0.5f, -0.5f,  0.5f },
+                                 {  0.5f, -0.5f,  0.5f },
+                                 { -0.5f,  0.5f,  0.5f },
+                                 {  0.5f,  0.5f,  0.5f },
+                                 { -0.5f,  0.5f, -0.5f },
+                                 {  0.5f,  0.5f, -0.5f },
+                                 { -0.5f, -0.5f, -0.5f },
+                                 {  0.5f, -0.5f, -0.5f }};
+
+    int dfltFaceFVars[24] = {  9, 10, 14, 13,
+                               4,  0,  1,  5,
+                               5,  1,  2,  6,
+                               6,  2,  3,  7,
+                              10, 11, 15, 14,
+                               8,  9, 13, 12 };
+
+    float dfltUVs[16][2] = {{ 0.05f, 0.05f },
+                            { 0.35f, 0.15f },
+                            { 0.65f, 0.15f },
+                            { 0.95f, 0.05f },
+                            { 0.05f, 0.35f },
+                            { 0.35f, 0.45f },
+                            { 0.65f, 0.45f },
+                            { 0.95f, 0.35f },
+                            { 0.05f, 0.65f },
+                            { 0.35f, 0.55f },
+                            { 0.65f, 0.55f },
+                            { 0.95f, 0.65f },
+                            { 0.05f, 0.95f },
+                            { 0.35f, 0.85f },
+                            { 0.65f, 0.85f },
+                            { 0.95f, 0.95f }};
+
+    posVector.resize(8 * 3);
+    std::memcpy(&posVector[0], dfltPositions, 8 * 3 * sizeof(float));
+
+    uvVector.resize(16 * 2);
+    std::memcpy(&uvVector[0], dfltUVs, 16 * 2 * sizeof(float));
+
+    //
+    //  Initialize a Far::TopologyDescriptor, from which to create
+    //  the Far::TopologyRefiner:
+    //
+    typedef Far::TopologyDescriptor Descriptor;
+
+    Descriptor::FVarChannel uvChannel;
+    uvChannel.numValues    = dfltNumUVs;
+    uvChannel.valueIndices = dfltFaceFVars;
+
+    Descriptor topDescriptor;
+    topDescriptor.numVertices        = dfltNumVerts;
+    topDescriptor.numFaces           = dfltNumFaces;
+    topDescriptor.numVertsPerFace    = dfltFaceSizes;
+    topDescriptor.vertIndicesPerFace = dfltFaceVerts;
+    topDescriptor.numFVarChannels    = 1;
+    topDescriptor.fvarChannels       = &uvChannel;
+
+    Sdc::SchemeType schemeType = Sdc::SCHEME_CATMARK;
+
+    Sdc::Options schemeOptions;
+    schemeOptions.SetVtxBoundaryInterpolation(
+                            Sdc::Options::VTX_BOUNDARY_EDGE_ONLY);
+    schemeOptions.SetFVarLinearInterpolation(
+                            Sdc::Options::FVAR_LINEAR_CORNERS_ONLY);
+
+    typedef Far::TopologyRefinerFactory<Descriptor> RefinerFactory;
+
+    Far::TopologyRefiner * topRefiner =
+        RefinerFactory::Create(topDescriptor,
+            RefinerFactory::Options(schemeType, schemeOptions));
+    assert(topRefiner);
+    return topRefiner;
+}
+
+//
+//  Create a TopologyRefiner from a specified Obj file:
+//
+Far::TopologyRefiner *
+readTopologyRefiner(std::string const & objFileName,
+                    Sdc::SchemeType schemeType,
+                    std::vector<float> & posVector,
+                    std::vector<float> & uvVector) {
+
+    const char *  filename = objFileName.c_str();
+    const Shape * shape = 0;
+
+    std::ifstream ifs(filename);
+    if (ifs) {
+        std::stringstream ss;
+        ss << ifs.rdbuf();
+        ifs.close();
+        std::string shapeString = ss.str();
+
+        shape = Shape::parseObj(
+            shapeString.c_str(), ConvertSdcTypeToShapeScheme(schemeType), false);
+        if (shape == 0) {
+            fprintf(stderr,
+                "Error:  Cannot create Shape from Obj file '%s'\n", filename);
+            return 0;
+        }
+    } else {
+        fprintf(stderr, "Error:  Cannot open Obj file '%s'\n", filename);
+        return 0;
+    }
+
+    Sdc::SchemeType sdcType    = GetSdcType(*shape);
+    Sdc::Options    sdcOptions = GetSdcOptions(*shape);
+
+    Far::TopologyRefiner * refiner = Far::TopologyRefinerFactory<Shape>::Create(
+        *shape, Far::TopologyRefinerFactory<Shape>::Options(sdcType, sdcOptions));
+    if (refiner == 0) {
+        fprintf(stderr,
+            "Error:  Unable to construct TopologyRefiner from Obj file '%s'\n",
+            filename);
+        return 0;
+    }
+
+    int numVertices = refiner->GetNumVerticesTotal();
+    posVector.resize(numVertices * 3);
+    std::memcpy(&posVector[0], &shape->verts[0], 3*numVertices*sizeof(float));
+
+    uvVector.resize(0);
+    if (refiner->GetNumFVarChannels()) {
+        int numUVs = refiner->GetNumFVarValuesTotal(0);
+        uvVector.resize(numUVs * 2);
+        std::memcpy(&uvVector[0], &shape->uvs[0], 2 * numUVs*sizeof(float));
+    }
+
+    delete shape;
+    return refiner;
+}
+
+Far::TopologyRefiner *
+createTopologyRefiner(std::string const & objFileName,
+                      Sdc::SchemeType schemeType,
+                      std::vector<float> & posVector,
+                      std::vector<float> & uvVector) {
+
+    if (objFileName.empty()) {
+        return dfltTopologyRefiner(posVector, uvVector);
+    } else {
+        return readTopologyRefiner(objFileName, schemeType,
+                                   posVector, uvVector);
+    }
+}
+
+} // end namespace

--- a/tutorials/bfr/tutorial_1_5/objWriter.h
+++ b/tutorials/bfr/tutorial_1_5/objWriter.h
@@ -1,0 +1,193 @@
+//
+//   Copyright 2021 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#include <string>
+#include <vector>
+#include <cstdio>
+#include <cmath>
+#include <cassert>
+
+//  Utilities local to this tutorial:
+namespace tutorial {
+
+//
+//  Simple class to write vertex positions, normals and faces to a
+//  specified Obj file:
+//
+class ObjWriter {
+public:
+    ObjWriter(std::string const &filename = 0);
+    ~ObjWriter();
+
+    int GetNumVertices() const { return _numVertices; }
+    int GetNumFaces()    const { return _numFaces; }
+
+    void WriteVertexPositions(std::vector<float> const & p, int size = 3);
+    void WriteVertexNormals(std::vector<float> const & du,
+                            std::vector<float> const & dv);
+    void WriteVertexUVs(std::vector<float> const & uv);
+
+    void WriteFaces(std::vector<int> const & faceVertices, int faceSize,
+                    bool writeNormalIndices = false,
+                    bool writeUVIndices = false);
+
+    void WriteGroupName(char const * prefix, int index);
+
+private:
+    void getNormal(float N[3], float const du[3], float const dv[3]) const;
+
+private:
+    std::string _filename;
+    FILE *      _fptr;
+
+    int _numVertices;
+    int _numNormals;
+    int _numUVs;
+    int _numFaces;
+};
+
+
+//
+//  Definitions ObjWriter methods:
+//
+ObjWriter::ObjWriter(std::string const &filename) :
+        _fptr(0), _numVertices(0), _numNormals(0), _numUVs(0), _numFaces(0) {
+
+    if (filename != std::string()) {
+        _fptr = fopen(filename.c_str(), "w");
+        if (_fptr == 0) {
+            fprintf(stderr, "Error:  ObjWriter cannot open Obj file '%s'\n",
+                filename.c_str());
+        }
+    }
+    if (_fptr == 0) _fptr = stdout;
+}
+
+ObjWriter::~ObjWriter() {
+
+    if (_fptr != stdout) fclose(_fptr);
+}
+
+void
+ObjWriter::WriteVertexPositions(std::vector<float> const & pos, int dim) {
+
+    assert(dim >= 2);
+    int numNewVerts = (int)pos.size() / dim;
+
+    float const * P = pos.data();
+    for (int i = 0; i < numNewVerts; ++i, P += dim) {
+        if (dim == 2) {
+            fprintf(_fptr, "v %f %f 0.0\n", P[0], P[1]);
+        } else {
+            fprintf(_fptr, "v %f %f %f\n", P[0], P[1], P[2]);
+        }
+    }
+    _numVertices += numNewVerts;
+}
+
+void
+ObjWriter::getNormal(float N[3], float const du[3], float const dv[3]) const {
+
+    N[0] = du[1] * dv[2] - du[2] * dv[1];
+    N[1] = du[2] * dv[0] - du[0] * dv[2];
+    N[2] = du[0] * dv[1] - du[1] * dv[0];
+
+    float lenSqrd = N[0] * N[0] + N[1] * N[1] + N[2] * N[2];
+    if (lenSqrd <= 0.0f) {
+        N[0] = 0.0f;
+        N[1] = 0.0f;
+        N[2] = 0.0f;
+    } else {
+        float lenInv = 1.0f / std::sqrt(lenSqrd);
+        N[0] *= lenInv;
+        N[1] *= lenInv;
+        N[2] *= lenInv;
+    }
+}
+
+void
+ObjWriter::WriteVertexNormals(std::vector<float> const & du,
+                              std::vector<float> const & dv) {
+
+    assert(du.size() == dv.size());
+    int numNewNormals = (int)du.size() / 3;
+
+    float const * dPdu = &du[0];
+    float const * dPdv = &dv[0];
+    for (int i = 0; i < numNewNormals; ++i, dPdu += 3, dPdv += 3) {
+        float N[3];
+        getNormal(N, dPdu, dPdv);
+        fprintf(_fptr, "vn %f %f %f\n", N[0], N[1], N[2]);
+    }
+    _numNormals += numNewNormals;
+}
+
+void
+ObjWriter::WriteVertexUVs(std::vector<float> const & uv) {
+
+    int numNewUVs = (int)uv.size() / 2;
+
+    for (int i = 0; i < numNewUVs; ++i) {
+        fprintf(_fptr, "vt %f %f\n", uv[i*2], uv[i*2+1]);
+    }
+    _numUVs += numNewUVs;
+}
+
+void
+ObjWriter::WriteFaces(std::vector<int> const & faceVertices, int faceSize,
+                      bool includeNormalIndices, bool includeUVIndices) {
+
+    int numNewFaces = (int)faceVertices.size() / faceSize;
+
+    int const * v = &faceVertices[0];
+    for (int i = 0; i < numNewFaces; ++i, v += faceSize) {
+        fprintf(_fptr, "f ");
+        for (int j = 0; j < faceSize; ++j) {
+            if (v[j] >= 0) {
+                //  Remember Obj indices start with 1:
+                int vIndex = 1 + v[j];
+
+                if (includeNormalIndices && includeUVIndices) {
+                    fprintf(_fptr, " %d/%d/%d", vIndex, vIndex, vIndex);
+                } else if (includeNormalIndices) {
+                    fprintf(_fptr, " %d//%d", vIndex, vIndex);
+                } else if (includeUVIndices) {
+                    fprintf(_fptr, " %d/%d", vIndex, vIndex);
+                } else {
+                    fprintf(_fptr, " %d", vIndex);
+                } 
+            }
+        }
+        fprintf(_fptr, "\n");
+    }
+    _numFaces += numNewFaces;
+}
+
+void
+ObjWriter::WriteGroupName(char const * prefix, int index) {
+
+    fprintf(_fptr, "g %s%d\n", prefix ? prefix : "", index);
+}
+
+} // end namespace

--- a/tutorials/bfr/tutorial_2_1/CMakeLists.txt
+++ b/tutorials/bfr/tutorial_2_1/CMakeLists.txt
@@ -22,18 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-set(SOURCE_FILES
+osd_add_bfr_tutorial(
+    bfr_tutorial_2_1
     bfr_tutorial_2_1.cpp
 )
-
-osd_add_executable(bfr_tutorial_2_1 "tutorials/bfr"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-    $<TARGET_OBJECTS:bfr_obj>
-    $<TARGET_OBJECTS:regression_common_obj>
-)
-
-install(TARGETS bfr_tutorial_2_1 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/bfr/tutorial_2_2/CMakeLists.txt
+++ b/tutorials/bfr/tutorial_2_2/CMakeLists.txt
@@ -22,18 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-set(SOURCE_FILES
+osd_add_bfr_tutorial(
+    bfr_tutorial_2_2
     bfr_tutorial_2_2.cpp
 )
-
-osd_add_executable(bfr_tutorial_2_2 "tutorials/bfr"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-    $<TARGET_OBJECTS:bfr_obj>
-    $<TARGET_OBJECTS:regression_common_obj>
-)
-
-install(TARGETS bfr_tutorial_2_2 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/bfr/tutorial_3_1/CMakeLists.txt
+++ b/tutorials/bfr/tutorial_3_1/CMakeLists.txt
@@ -22,19 +22,8 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-set(SOURCE_FILES
+osd_add_bfr_tutorial(
+    bfr_tutorial_3_1
     bfr_tutorial_3_1.cpp
     customSurfaceFactory.cpp
 )
-
-osd_add_executable(bfr_tutorial_3_1 "tutorials/bfr"
-    ${SOURCE_FILES}
-    $<TARGET_OBJECTS:sdc_obj>
-    $<TARGET_OBJECTS:vtr_obj>
-    $<TARGET_OBJECTS:far_obj>
-    $<TARGET_OBJECTS:bfr_obj>
-    $<TARGET_OBJECTS:regression_common_obj>
-)
-
-install(TARGETS bfr_tutorial_3_1 DESTINATION "${CMAKE_BINDIR_BASE}/tutorials")
-

--- a/tutorials/bfr/tutorial_3_2/CMakeLists.txt
+++ b/tutorials/bfr/tutorial_3_2/CMakeLists.txt
@@ -23,6 +23,6 @@
 #
 
 osd_add_bfr_tutorial(
-    bfr_tutorial_1_1
-    bfr_tutorial_1_1.cpp
+    bfr_tutorial_3_2
+    bfr_tutorial_3_2.cpp
 )

--- a/tutorials/bfr/tutorial_3_2/bfr_tutorial_3_2.cpp
+++ b/tutorials/bfr/tutorial_3_2/bfr_tutorial_3_2.cpp
@@ -1,0 +1,398 @@
+//
+//   Copyright 2021 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+//------------------------------------------------------------------------------
+//  Tutorial description:
+//
+//      This tutorial is a variation of tutorials showing simple uniform
+//      tessellation. Rather than constructing and evaluating a Surface at
+//      a time, this tutorial shows how Surfaces can be created and saved
+//      for repeated use.
+//
+//      A simple SurfaceCache class is created that creates and stores the
+//      Surface for each face, along with the patch points associated with
+//      it. The main tessellation function remains essentially the same,
+//      but here it access the Surfaces from the SurfaceCache rather than
+//      computing them locally.
+//
+//      Note that while this example illustrated the retention of all
+//      Surfaces for a mesh, this behavior is not recommended. It does not
+//      scale well for large meshes and undermines the memory savings that
+//      transient use of Surfaces is designed to achieve. Rather than
+//      storing Surfaces for all faces, maintaining a priority queue for a
+//      fixed number may be a reasonable compromise.
+//
+
+#include <opensubdiv/far/topologyRefiner.h>
+#include <opensubdiv/bfr/refinerSurfaceFactory.h>
+#include <opensubdiv/bfr/surface.h>
+#include <opensubdiv/bfr/tessellation.h>
+
+#include <vector>
+#include <memory>
+#include <string>
+#include <cstring>
+#include <cstdio>
+
+//  Local headers with support for this tutorial in "namespace tutorial"
+#include "./meshLoader.h"
+#include "./objWriter.h"
+
+using namespace OpenSubdiv;
+
+//
+//  Simple command line arguments to provide input and run-time options:
+//
+class Args {
+public:
+    std::string     inputObjFile;
+    std::string     outputObjFile;
+    Sdc::SchemeType schemeType;
+    int             tessUniformRate;
+    bool            tessQuadsFlag;
+
+public:
+    Args(int argc, char * argv[]) :
+        inputObjFile(),
+        outputObjFile(),
+        schemeType(Sdc::SCHEME_CATMARK),
+        tessUniformRate(5),
+        tessQuadsFlag(false) {
+
+        for (int i = 1; i < argc; ++i) {
+            if (strstr(argv[i], ".obj")) {
+                if (inputObjFile.empty()) {
+                    inputObjFile = std::string(argv[i]);
+                } else {
+                    fprintf(stderr,
+                        "Warning: Extra Obj file '%s' ignored\n", argv[i]);
+                }
+            } else if (!strcmp(argv[i], "-o")) {
+                if (++i < argc) outputObjFile = std::string(argv[i]);
+            } else if (!strcmp(argv[i], "-bilinear")) {
+                schemeType = Sdc::SCHEME_BILINEAR;
+            } else if (!strcmp(argv[i], "-catmark")) {
+                schemeType = Sdc::SCHEME_CATMARK;
+            } else if (!strcmp(argv[i], "-loop")) {
+                schemeType = Sdc::SCHEME_LOOP;
+            } else if (!strcmp(argv[i], "-res")) {
+                if (++i < argc) tessUniformRate = atoi(argv[i]);
+            } else if (!strcmp(argv[i], "-quads")) {
+                tessQuadsFlag = true;
+            } else {
+                fprintf(stderr,
+                    "Warning: Unrecognized argument '%s' ignored\n", argv[i]);
+            }
+        }
+    }
+
+private:
+    Args() { }
+};
+
+//
+//  This simple class creates and dispenses Surfaces for all faces of
+//  a mesh. It consists primarily of an array of simple structs (entries)
+//  for each face and a single array of patch points for all Surfaces
+//  created.
+//
+//  There are many ways to create such a cache depending on requirements.
+//  This is a simple example, but the interface presents some options that
+//  are worth considering. A SurfaceCache is constructed here given the
+//  following:
+//
+//      - a reference to the SurfaceFactory:
+//          - the cache could just as easily take a reference to the mesh
+//            and construct the SurfaceFactory internally
+//
+//      - the position data for the mesh:
+//          - this is needed to compute patch points for the Surfaces
+//          - if caching UVs or any other primvar, other data needs to be
+//            provided -- along with the interpolation type for that data
+//            (vertex, face-varying, etc.)
+//
+//      - option to "cache patch points":
+//          - the cache could store the Surfaces only or also include
+//            their patch points
+//          - storing patch points takes more memory but will eliminate
+//            any preparation time for evaluation of the Surface
+//
+//      - option to "cache all surfaces":
+//          - the benefits to caching simple linear or regular surfaces
+//            are minimal -- and may even be detrimental
+//          - so only caching non-linear irregular surfaces is an option
+//            worth considering
+//
+//  The SurfaceCache implementation here provides the options noted above.
+//  But for simplicity, the actual usage of the SurfaceCache does not deal
+//  with the permutations of additional work that is necessary when the
+//  Surfaces or their patch points are not cached.
+//
+class SurfaceCache {
+public:
+    typedef Bfr::Surface<float>          Surface;
+    typedef Bfr::RefinerSurfaceFactory<> SurfaceFactory;
+
+public:
+    SurfaceCache(SurfaceFactory     const & surfaceFactory,
+                 std::vector<float> const & meshPoints,
+                 bool                       cachePatchPoints = true,
+                 bool                       cacheAllSurfaces = true);
+    SurfaceCache() = delete;
+    ~SurfaceCache() = default;
+
+    //
+    //  Public methods to retrieved cached Surfaces and their pre-computed
+    //  patch points:
+    //
+    bool FaceHasLimitSurface(int face) { return _entries[face].hasLimit > 0; }
+
+    Surface const * GetSurface(int face) { return _entries[face].surface.get();}
+
+    float const * GetPatchPoints(int face) { return getPatchPoints(face); }
+
+private:
+    //  Simple struct to keep track of Surface and more for each face:
+    struct FaceEntry {
+        FaceEntry() : surface(), hasLimit(false), pointOffset(-1) { }
+
+        std::unique_ptr<Surface const> surface;
+        bool hasLimit;
+        int  pointOffset;
+    };
+
+    //  Non-const version to be used internally to aide assignment:
+    float * getPatchPoints(int face) {
+        return (_entries[face].surface && !_points.empty()) ?
+               (_points.data() + _entries[face].pointOffset * 3) : 0;
+    }
+
+private:
+    std::vector<FaceEntry> _entries;
+    std::vector<float>     _points;
+};
+
+SurfaceCache::SurfaceCache(SurfaceFactory     const & surfaceFactory,
+                           std::vector<float> const & meshPoints,
+                           bool                       cachePatchPoints,
+                           bool                       cacheAllSurfaces) {
+
+    int numFaces = surfaceFactory.GetNumFaces();
+
+    _entries.resize(numFaces);
+
+    int numPointsInCache = 0;
+    for (int face = 0; face < numFaces; ++face) {
+        Surface * s = surfaceFactory.CreateVertexSurface<float>(face);
+        if (s) {
+            FaceEntry & entry = _entries[face];
+            entry.hasLimit = true;
+
+            if (cacheAllSurfaces || (!s->IsRegular() && !s->IsLinear())) {
+                entry.surface.reset(s);
+                entry.pointOffset = numPointsInCache;
+
+                numPointsInCache += s->GetNumPatchPoints();
+            } else {
+                delete s;
+            }
+        }
+    }
+
+    if (cachePatchPoints) {
+        _points.resize(numPointsInCache * 3);
+        for (int face = 0; face < numFaces; ++face) {
+            float * patchPoints = getPatchPoints(face);
+            if (patchPoints) {
+                GetSurface(face)->PreparePatchPoints(meshPoints.data(), 3,
+                                                     patchPoints, 3);
+            }
+        }
+    }
+}
+
+//
+//  The main tessellation function:  given a mesh and vertex positions,
+//  tessellate each face -- writing results in Obj format.
+//
+void
+tessellateToObj(Far::TopologyRefiner const & meshTopology,
+                std::vector<float>   const & meshVertexPositions,
+                Args                 const & options) {
+
+    //
+    //  Use simpler local type names for the Surface and its factory:
+    //
+    typedef Bfr::RefinerSurfaceFactory<> SurfaceFactory;
+    typedef Bfr::Surface<float>          Surface;
+
+    //
+    //  Initialize the SurfaceFactory for the given base mesh (very low
+    //  cost in terms of both time and space) and tessellate each face
+    //  independently (i.e. no shared vertices):
+    //
+    //  Note that the SurfaceFactory is not thread-safe by default due to
+    //  use of an internal cache.  Creating a separate instance of the
+    //  SurfaceFactory for each thread is one way to safely parallelize
+    //  this loop.  Another (preferred) is to assign a thread-safe cache
+    //  to the single instance.
+    //
+    //  First declare any evaluation options when initializing (though
+    //  none are used in this simple case):
+    //
+    SurfaceFactory::Options surfaceOptions;
+
+    SurfaceFactory meshSurfaceFactory(meshTopology, surfaceOptions);
+
+    //
+    //  Initialize a SurfaceCache to construct Surfaces for all faces.
+    //  From this point forward the SurfaceFactory is no longer used to
+    //  access Surfaces. Note also that usage below is specific to the
+    //  options used to initialize the SurfaceCache:
+    //
+    bool cachePatchPoints = true;
+    bool cacheAllSurfaces = true;
+    SurfaceCache surfaceCache(meshSurfaceFactory, meshVertexPositions,
+                              cachePatchPoints, cacheAllSurfaces);
+
+    //
+    //  As with previous tutorials, output data associated with the face
+    //  can be declared in the scope local to each face. But since dynamic
+    //  memory is involved with these variables, it is preferred to declare
+    //  them outside that loop to preserve and reuse that dynamic memory.
+    //
+    std::vector<float> outCoords;
+    std::vector<float> outPos, outDu, outDv;
+    std::vector<int>   outFacets;
+
+    //
+    //  Assign Tessellation Options applied for all faces.  Tessellations
+    //  allow the creating of either 3- or 4-sided faces -- both of which
+    //  are supported here via a command line option:
+    //
+    int const tessFacetSize = 3 + options.tessQuadsFlag;
+
+    Bfr::Tessellation::Options tessOptions;
+    tessOptions.SetFacetSize(tessFacetSize);
+    tessOptions.PreserveQuads(options.tessQuadsFlag);
+
+    //
+    //  Process each face, writing the output of each in Obj format:
+    //
+    tutorial::ObjWriter objWriter(options.outputObjFile);
+
+    int numFaces = meshSurfaceFactory.GetNumFaces();
+    for (int faceIndex = 0; faceIndex < numFaces; ++faceIndex) {
+        //
+        //  Retrieve the Surface for this face when present:
+        //
+        if (!surfaceCache.FaceHasLimitSurface(faceIndex)) continue;
+
+        Surface const & faceSurface = * surfaceCache.GetSurface(faceIndex);
+
+        //
+        //  Declare a simple uniform Tessellation for the Parameterization
+        //  of this face and identify coordinates of the points to evaluate:
+        //
+        Bfr::Tessellation tessPattern(faceSurface.GetParameterization(),
+                                      options.tessUniformRate, tessOptions);
+
+        int numOutCoords = tessPattern.GetNumCoords();
+
+        outCoords.resize(numOutCoords * 2);
+
+        tessPattern.GetCoords(outCoords.data());
+
+        //
+        //  Retrieve the patch points for the Surface, then use them to
+        //  evaluate output points for all identified coordinates:
+        //
+        float const * facePatchPoints = surfaceCache.GetPatchPoints(faceIndex);
+
+        int pointSize = 3;
+
+        outPos.resize(numOutCoords * pointSize);
+        outDu.resize(numOutCoords * pointSize);
+        outDv.resize(numOutCoords * pointSize);
+
+        for (int i = 0, j = 0; i < numOutCoords; ++i, j += pointSize) {
+            faceSurface.Evaluate(&outCoords[i*2],
+                                 facePatchPoints, pointSize,
+                                 &outPos[j], &outDu[j], &outDv[j]);
+        }
+
+        //
+        //  Identify the faces of the Tessellation:
+        //
+        //  Note the need to offset vertex indices for the output faces --
+        //  using the number of vertices generated prior to this face. One
+        //  of several Tessellation methods to transform the facet indices
+        //  simply translates all indices by the desired offset.
+        //
+        int objVertexIndexOffset = objWriter.GetNumVertices();
+
+        int numFacets = tessPattern.GetNumFacets();
+        outFacets.resize(numFacets * tessFacetSize);
+        tessPattern.GetFacets(outFacets.data());
+
+        tessPattern.TransformFacetCoordIndices(outFacets.data(),
+                                               objVertexIndexOffset);
+
+        //
+        //  Write the evaluated points and faces connecting them as Obj:
+        //
+        objWriter.WriteGroupName("baseFace_", faceIndex);
+
+        objWriter.WriteVertexPositions(outPos);
+        objWriter.WriteVertexNormals(outDu, outDv);
+
+        objWriter.WriteFaces(outFacets, tessFacetSize, true, false);
+    }
+}
+
+//
+//  Load command line arguments, specified or default geometry and process:
+//
+int
+main(int argc, char * argv[]) {
+
+    Args args(argc, argv);
+
+    Far::TopologyRefiner * meshTopology = 0;
+    std::vector<float>     meshVtxPositions;
+    std::vector<float>     meshFVarUVs;
+
+    meshTopology = tutorial::createTopologyRefiner(
+            args.inputObjFile, args.schemeType, meshVtxPositions, meshFVarUVs);
+    if (meshTopology == 0) {
+        return EXIT_FAILURE;
+    }
+
+    tessellateToObj(*meshTopology, meshVtxPositions, args);
+
+    delete meshTopology;
+    return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------

--- a/tutorials/bfr/tutorial_3_2/bfr_tutorial_3_2.cpp
+++ b/tutorials/bfr/tutorial_3_2/bfr_tutorial_3_2.cpp
@@ -166,7 +166,7 @@ public:
     //  Public methods to retrieved cached Surfaces and their pre-computed
     //  patch points:
     //
-    bool FaceHasLimitSurface(int face) { return _entries[face].hasLimit > 0; }
+    bool FaceHasLimitSurface(int face) { return _entries[face].hasLimit; }
 
     Surface const * GetSurface(int face) { return _entries[face].surface.get();}
 

--- a/tutorials/bfr/tutorial_3_2/meshLoader.h
+++ b/tutorials/bfr/tutorial_3_2/meshLoader.h
@@ -1,0 +1,209 @@
+//
+//   Copyright 2021 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#include "../../../regression/common/far_utils.h"
+
+#include <opensubdiv/far/topologyRefiner.h>
+#include <opensubdiv/far/topologyDescriptor.h>
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+
+//  Utilities local to this tutorial:
+namespace tutorial {
+
+using namespace OpenSubdiv;
+
+//
+//  Create a TopologyRefiner from default geometry:
+//
+Far::TopologyRefiner *
+dfltTopologyRefiner(std::vector<float> & posVector,
+                    std::vector<float> & uvVector) {
+
+    //
+    //  Default topology and positions for a cube:
+    //
+    int dfltNumFaces = 6;
+    int dfltNumVerts = 8;
+    int dfltNumUVs   = 16;
+
+    int dfltFaceSizes[6] = { 4, 4, 4, 4, 4, 4 };
+
+    int dfltFaceVerts[24] = { 0, 1, 3, 2,
+                              2, 3, 5, 4,
+                              4, 5, 7, 6,
+                              6, 7, 1, 0,
+                              1, 7, 5, 3,
+                              6, 0, 2, 4 };
+
+    float dfltPositions[8][3] = {{ -0.5f, -0.5f,  0.5f },
+                                 {  0.5f, -0.5f,  0.5f },
+                                 { -0.5f,  0.5f,  0.5f },
+                                 {  0.5f,  0.5f,  0.5f },
+                                 { -0.5f,  0.5f, -0.5f },
+                                 {  0.5f,  0.5f, -0.5f },
+                                 { -0.5f, -0.5f, -0.5f },
+                                 {  0.5f, -0.5f, -0.5f }};
+
+    int dfltFaceFVars[24] = {  9, 10, 14, 13,
+                               4,  0,  1,  5,
+                               5,  1,  2,  6,
+                               6,  2,  3,  7,
+                              10, 11, 15, 14,
+                               8,  9, 13, 12 };
+
+    float dfltUVs[16][2] = {{ 0.05f, 0.05f },
+                            { 0.35f, 0.15f },
+                            { 0.65f, 0.15f },
+                            { 0.95f, 0.05f },
+                            { 0.05f, 0.35f },
+                            { 0.35f, 0.45f },
+                            { 0.65f, 0.45f },
+                            { 0.95f, 0.35f },
+                            { 0.05f, 0.65f },
+                            { 0.35f, 0.55f },
+                            { 0.65f, 0.55f },
+                            { 0.95f, 0.65f },
+                            { 0.05f, 0.95f },
+                            { 0.35f, 0.85f },
+                            { 0.65f, 0.85f },
+                            { 0.95f, 0.95f }};
+
+    posVector.resize(8 * 3);
+    std::memcpy(&posVector[0], dfltPositions, 8 * 3 * sizeof(float));
+
+    uvVector.resize(16 * 2);
+    std::memcpy(&uvVector[0], dfltUVs, 16 * 2 * sizeof(float));
+
+    //
+    //  Initialize a Far::TopologyDescriptor, from which to create
+    //  the Far::TopologyRefiner:
+    //
+    typedef Far::TopologyDescriptor Descriptor;
+
+    Descriptor::FVarChannel uvChannel;
+    uvChannel.numValues    = dfltNumUVs;
+    uvChannel.valueIndices = dfltFaceFVars;
+
+    Descriptor topDescriptor;
+    topDescriptor.numVertices        = dfltNumVerts;
+    topDescriptor.numFaces           = dfltNumFaces;
+    topDescriptor.numVertsPerFace    = dfltFaceSizes;
+    topDescriptor.vertIndicesPerFace = dfltFaceVerts;
+    topDescriptor.numFVarChannels    = 1;
+    topDescriptor.fvarChannels       = &uvChannel;
+
+    Sdc::SchemeType schemeType = Sdc::SCHEME_CATMARK;
+
+    Sdc::Options schemeOptions;
+    schemeOptions.SetVtxBoundaryInterpolation(
+                            Sdc::Options::VTX_BOUNDARY_EDGE_ONLY);
+    schemeOptions.SetFVarLinearInterpolation(
+                            Sdc::Options::FVAR_LINEAR_CORNERS_ONLY);
+
+    typedef Far::TopologyRefinerFactory<Descriptor> RefinerFactory;
+
+    Far::TopologyRefiner * topRefiner =
+        RefinerFactory::Create(topDescriptor,
+            RefinerFactory::Options(schemeType, schemeOptions));
+    assert(topRefiner);
+    return topRefiner;
+}
+
+//
+//  Create a TopologyRefiner from a specified Obj file:
+//
+Far::TopologyRefiner *
+readTopologyRefiner(std::string const & objFileName,
+                    Sdc::SchemeType schemeType,
+                    std::vector<float> & posVector,
+                    std::vector<float> & uvVector) {
+
+    const char *  filename = objFileName.c_str();
+    const Shape * shape = 0;
+
+    std::ifstream ifs(filename);
+    if (ifs) {
+        std::stringstream ss;
+        ss << ifs.rdbuf();
+        ifs.close();
+        std::string shapeString = ss.str();
+
+        shape = Shape::parseObj(
+            shapeString.c_str(), ConvertSdcTypeToShapeScheme(schemeType), false);
+        if (shape == 0) {
+            fprintf(stderr,
+                "Error:  Cannot create Shape from Obj file '%s'\n", filename);
+            return 0;
+        }
+    } else {
+        fprintf(stderr, "Error:  Cannot open Obj file '%s'\n", filename);
+        return 0;
+    }
+
+    Sdc::SchemeType sdcType    = GetSdcType(*shape);
+    Sdc::Options    sdcOptions = GetSdcOptions(*shape);
+
+    Far::TopologyRefiner * refiner = Far::TopologyRefinerFactory<Shape>::Create(
+        *shape, Far::TopologyRefinerFactory<Shape>::Options(sdcType, sdcOptions));
+    if (refiner == 0) {
+        fprintf(stderr,
+            "Error:  Unable to construct TopologyRefiner from Obj file '%s'\n",
+            filename);
+        return 0;
+    }
+
+    int numVertices = refiner->GetNumVerticesTotal();
+    posVector.resize(numVertices * 3);
+    std::memcpy(&posVector[0], &shape->verts[0], 3*numVertices*sizeof(float));
+
+    uvVector.resize(0);
+    if (refiner->GetNumFVarChannels()) {
+        int numUVs = refiner->GetNumFVarValuesTotal(0);
+        uvVector.resize(numUVs * 2);
+        std::memcpy(&uvVector[0], &shape->uvs[0], 2 * numUVs*sizeof(float));
+    }
+
+    delete shape;
+    return refiner;
+}
+
+Far::TopologyRefiner *
+createTopologyRefiner(std::string const & objFileName,
+                      Sdc::SchemeType schemeType,
+                      std::vector<float> & posVector,
+                      std::vector<float> & uvVector) {
+
+    if (objFileName.empty()) {
+        return dfltTopologyRefiner(posVector, uvVector);
+    } else {
+        return readTopologyRefiner(objFileName, schemeType,
+                                   posVector, uvVector);
+    }
+}
+
+} // end namespace

--- a/tutorials/bfr/tutorial_3_2/objWriter.h
+++ b/tutorials/bfr/tutorial_3_2/objWriter.h
@@ -1,0 +1,193 @@
+//
+//   Copyright 2021 Pixar
+//
+//   Licensed under the Apache License, Version 2.0 (the "Apache License")
+//   with the following modification; you may not use this file except in
+//   compliance with the Apache License and the following modification to it:
+//   Section 6. Trademarks. is deleted and replaced with:
+//
+//   6. Trademarks. This License does not grant permission to use the trade
+//      names, trademarks, service marks, or product names of the Licensor
+//      and its affiliates, except as required to comply with Section 4(c) of
+//      the License and to reproduce the content of the NOTICE file.
+//
+//   You may obtain a copy of the Apache License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the Apache License with the above modification is
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//   KIND, either express or implied. See the Apache License for the specific
+//   language governing permissions and limitations under the Apache License.
+//
+
+#include <string>
+#include <vector>
+#include <cstdio>
+#include <cmath>
+#include <cassert>
+
+//  Utilities local to this tutorial:
+namespace tutorial {
+
+//
+//  Simple class to write vertex positions, normals and faces to a
+//  specified Obj file:
+//
+class ObjWriter {
+public:
+    ObjWriter(std::string const &filename = 0);
+    ~ObjWriter();
+
+    int GetNumVertices() const { return _numVertices; }
+    int GetNumFaces()    const { return _numFaces; }
+
+    void WriteVertexPositions(std::vector<float> const & p, int size = 3);
+    void WriteVertexNormals(std::vector<float> const & du,
+                            std::vector<float> const & dv);
+    void WriteVertexUVs(std::vector<float> const & uv);
+
+    void WriteFaces(std::vector<int> const & faceVertices, int faceSize,
+                    bool writeNormalIndices = false,
+                    bool writeUVIndices = false);
+
+    void WriteGroupName(char const * prefix, int index);
+
+private:
+    void getNormal(float N[3], float const du[3], float const dv[3]) const;
+
+private:
+    std::string _filename;
+    FILE *      _fptr;
+
+    int _numVertices;
+    int _numNormals;
+    int _numUVs;
+    int _numFaces;
+};
+
+
+//
+//  Definitions ObjWriter methods:
+//
+ObjWriter::ObjWriter(std::string const &filename) :
+        _fptr(0), _numVertices(0), _numNormals(0), _numUVs(0), _numFaces(0) {
+
+    if (filename != std::string()) {
+        _fptr = fopen(filename.c_str(), "w");
+        if (_fptr == 0) {
+            fprintf(stderr, "Error:  ObjWriter cannot open Obj file '%s'\n",
+                filename.c_str());
+        }
+    }
+    if (_fptr == 0) _fptr = stdout;
+}
+
+ObjWriter::~ObjWriter() {
+
+    if (_fptr != stdout) fclose(_fptr);
+}
+
+void
+ObjWriter::WriteVertexPositions(std::vector<float> const & pos, int dim) {
+
+    assert(dim >= 2);
+    int numNewVerts = (int)pos.size() / dim;
+
+    float const * P = pos.data();
+    for (int i = 0; i < numNewVerts; ++i, P += dim) {
+        if (dim == 2) {
+            fprintf(_fptr, "v %f %f 0.0\n", P[0], P[1]);
+        } else {
+            fprintf(_fptr, "v %f %f %f\n", P[0], P[1], P[2]);
+        }
+    }
+    _numVertices += numNewVerts;
+}
+
+void
+ObjWriter::getNormal(float N[3], float const du[3], float const dv[3]) const {
+
+    N[0] = du[1] * dv[2] - du[2] * dv[1];
+    N[1] = du[2] * dv[0] - du[0] * dv[2];
+    N[2] = du[0] * dv[1] - du[1] * dv[0];
+
+    float lenSqrd = N[0] * N[0] + N[1] * N[1] + N[2] * N[2];
+    if (lenSqrd <= 0.0f) {
+        N[0] = 0.0f;
+        N[1] = 0.0f;
+        N[2] = 0.0f;
+    } else {
+        float lenInv = 1.0f / std::sqrt(lenSqrd);
+        N[0] *= lenInv;
+        N[1] *= lenInv;
+        N[2] *= lenInv;
+    }
+}
+
+void
+ObjWriter::WriteVertexNormals(std::vector<float> const & du,
+                              std::vector<float> const & dv) {
+
+    assert(du.size() == dv.size());
+    int numNewNormals = (int)du.size() / 3;
+
+    float const * dPdu = &du[0];
+    float const * dPdv = &dv[0];
+    for (int i = 0; i < numNewNormals; ++i, dPdu += 3, dPdv += 3) {
+        float N[3];
+        getNormal(N, dPdu, dPdv);
+        fprintf(_fptr, "vn %f %f %f\n", N[0], N[1], N[2]);
+    }
+    _numNormals += numNewNormals;
+}
+
+void
+ObjWriter::WriteVertexUVs(std::vector<float> const & uv) {
+
+    int numNewUVs = (int)uv.size() / 2;
+
+    for (int i = 0; i < numNewUVs; ++i) {
+        fprintf(_fptr, "vt %f %f\n", uv[i*2], uv[i*2+1]);
+    }
+    _numUVs += numNewUVs;
+}
+
+void
+ObjWriter::WriteFaces(std::vector<int> const & faceVertices, int faceSize,
+                      bool includeNormalIndices, bool includeUVIndices) {
+
+    int numNewFaces = (int)faceVertices.size() / faceSize;
+
+    int const * v = &faceVertices[0];
+    for (int i = 0; i < numNewFaces; ++i, v += faceSize) {
+        fprintf(_fptr, "f ");
+        for (int j = 0; j < faceSize; ++j) {
+            if (v[j] >= 0) {
+                //  Remember Obj indices start with 1:
+                int vIndex = 1 + v[j];
+
+                if (includeNormalIndices && includeUVIndices) {
+                    fprintf(_fptr, " %d/%d/%d", vIndex, vIndex, vIndex);
+                } else if (includeNormalIndices) {
+                    fprintf(_fptr, " %d//%d", vIndex, vIndex);
+                } else if (includeUVIndices) {
+                    fprintf(_fptr, " %d/%d", vIndex, vIndex);
+                } else {
+                    fprintf(_fptr, " %d", vIndex);
+                } 
+            }
+        }
+        fprintf(_fptr, "\n");
+    }
+    _numFaces += numNewFaces;
+}
+
+void
+ObjWriter::WriteGroupName(char const * prefix, int index) {
+
+    fprintf(_fptr, "g %s%d\n", prefix ? prefix : "", index);
+}
+
+} // end namespace


### PR DESCRIPTION
These changes to the Bfr tutorials  include:

- a new tutorial_1_5 to illustrate limit stencil evaluation of Surfaces
- a new tutorial_3_2 to show ways of caching Surfaces for later use
- improvements to tutorial_2_2 (more comments, simplification, some refactoring)
- updates to Bfr tutorial docs to include new tutorials and other improvements
- simplification of CMake files for all tutorials to a single call to osd_add_bfr_tutorial

