### PR TITLE
Improved mixed partial at Gregory patch corners

### DIFF
--- a/opensubdiv/far/patchBasis.cpp
+++ b/opensubdiv/far/patchBasis.cpp
@@ -89,8 +89,8 @@ EvalBasisLinear(REAL s, REAL t,
 
             wDst[0] =  1.0f;
             wDst[1] = -1.0f;
-            wDst[2] = -1.0f;
-            wDst[3] =  1.0f;
+            wDst[2] =  1.0f;
+            wDst[3] = -1.0f;
         }
     }
     return 4;
@@ -412,7 +412,11 @@ EvalBasisGregory(REAL s, REAL t,
     REAL df2 = sC + tC;  df2 = (df2 <= 0.0f) ? (REAL)1.0f : (1.0f / df2);
     REAL df3 = s  + tC;  df3 = (df3 <= 0.0f) ? (REAL)1.0f : (1.0f / df3);
 
-    REAL G[8] = { s*df0, t*df0,  t*df1, sC*df1,  sC*df2, tC*df2,  tC*df3, s*df3 };
+    //  Make sure the G[i] for pairs of interior points sum to 1 in all cases:
+    REAL G[8] = { s*df0, (1.0f -  s*df0),
+                  t*df1, (1.0f -  t*df1),
+                 sC*df2, (1.0f - sC*df2),
+                 tC*df3, (1.0f - tC*df3) };
 
     //  Combined weights for boundary and interior points:
     for (int i = 0; i < 12; ++i) {

--- a/opensubdiv/osd/patchBasisCommon.h
+++ b/opensubdiv/osd/patchBasisCommon.h
@@ -65,8 +65,8 @@ Osd_EvalBasisLinear(OSD_REAL s, OSD_REAL t,
 
             wDst[0] =  1.0f;
             wDst[1] = -1.0f;
-            wDst[2] = -1.0f;
-            wDst[3] =  1.0f;
+            wDst[2] =  1.0f;
+            wDst[3] = -1.0f;
         }
     }
     return 4;
@@ -349,7 +349,11 @@ Osd_EvalBasisGregory(OSD_REAL s, OSD_REAL t,
     OSD_REAL df2 = sC + tC;  df2 = (df2 <= 0.0f) ? 1.0f : (1.0f / df2);
     OSD_REAL df3 = s  + tC;  df3 = (df3 <= 0.0f) ? 1.0f : (1.0f / df3);
 
-    OSD_REAL G[8] = OSD_ARRAY_8(OSD_REAL, s*df0, t*df0,  t*df1, sC*df1,  sC*df2, tC*df2,  tC*df3, s*df3 );
+    //  Make sure the G[i] for pairs of interior points sum to 1 in all cases:
+    OSD_REAL G[8] = OSD_ARRAY_8(OSD_REAL,  s*df0, (1.0f -  s*df0),
+                                           t*df1, (1.0f -  t*df1),
+                                          sC*df2, (1.0f - sC*df2),
+                                          tC*df3, (1.0f - tC*df3) );
 
     //  Combined weights for boundary and interior points:
     for (int i = 0; i < 12; ++i) {


### PR DESCRIPTION
This change improves the result of the mixed partial 2nd derivative at the corners of a Gregory patch.

Results for the mixed partial are undefined at corners due to the divisor of the rational weights being zero (weights are a/(a+b) and b/(a+b) for each pair of interior points at the corners). Only mixed partials are affected by this since all other derivatives at the corners are independent of the interior points.

Currently both weights for the pair end up as zero -- which removes their influence entirely. By ensuring an affine combination here a more effective result is obtained (i.e. one continuous with the mixed partial along one of the boundaries).

An error was also discovered and fixed for the mixed partial 2nd derivative of bi-linear patches, where the signs of two of the coefficients were swapped.