### PR TITLE
Suppression of compiler warnings from GCC

### DIFF
--- a/examples/common/stopwatch.h
+++ b/examples/common/stopwatch.h
@@ -43,14 +43,15 @@ public:
     void Start() {
         struct timeval l_rtime;
         gettimeofday(&l_rtime,0);
-        _elapsed = l_rtime.tv_sec + l_rtime.tv_usec/1000000.0;
+        _elapsed = (double)l_rtime.tv_sec + (double)l_rtime.tv_usec/1000000.0;
     }
 
     void Stop() {
         struct timeval l_rtime;
 
         gettimeofday(&l_rtime,0);
-        _elapsed = (l_rtime.tv_sec + l_rtime.tv_usec/1000000.0) - _elapsed;
+        _elapsed = ((double)l_rtime.tv_sec + (double)l_rtime.tv_usec/1000000.0)
+                 - _elapsed;
         _totalElapsed += _elapsed;
     }
 

--- a/opensubdiv/bfr/tessellation.cpp
+++ b/opensubdiv/bfr/tessellation.cpp
@@ -253,7 +253,7 @@ namespace {
     //
     struct FacetStrip {
     public:
-        FacetStrip() { std::memset(this, 0, sizeof(*this)); }
+        FacetStrip() { std::memset((void*) this, 0, sizeof(*this)); }
 
         int connectUniformQuads(    FacetArray facets) const;
         int connectUniformTris(     FacetArray facets) const;
@@ -1988,7 +1988,7 @@ qsub::GetNonUniformFacets(int N, int const outerRes[], int innerRes,
 void
 Tessellation::initializeDefaults() {
 
-    std::memset(this, 0, sizeof(*this));
+    std::memset((void*) this, 0, sizeof(*this));
 
     //  Assign any non-zero defaults:
     _triangulate = true;

--- a/opensubdiv/far/loopPatchBuilder.cpp
+++ b/opensubdiv/far/loopPatchBuilder.cpp
@@ -1618,6 +1618,7 @@ namespace {
         }
     }
 
+#ifdef FAR_DEBUG_LOOP_PATCH_BUILDER
     void
     _printSourcePatch(SourcePatch const & patch, bool printCornerInfo = true,
                                                  bool printRingPoints = true) {
@@ -1650,6 +1651,7 @@ namespace {
             }
         }
     }
+#endif
 }
 
 

--- a/opensubdiv/far/patchBuilder.cpp
+++ b/opensubdiv/far/patchBuilder.cpp
@@ -221,10 +221,10 @@ namespace {
         ConstIndexArray      vFaces   = level.getVertexFaces(vIndex);
         ConstLocalIndexArray vInFaces = level.getVertexFaceLocalIndices(vIndex);
 
-        vSpan._startFace = vFaces.size();
+        vSpan._startFace = (LocalIndex) vFaces.size();
         for (int i = 0; i < vFaces.size(); ++i) {
             if ((vFaces[i] == startFace) && (vInFaces[i] == startCorner)) {
-                vSpan._startFace = i;
+                vSpan._startFace = (LocalIndex) i;
                 break;
             }
         }
@@ -1137,8 +1137,8 @@ PatchBuilder::assembleIrregularSourcePatch(
         } else {
             ConstIndexArray vFaces = level.getVertexFaces(fVerts[corner]);
 
-            patchCorner._numFaces  = vFaces.size();
-            patchCorner._patchFace = vFaces.FindIndex(faceIndex);
+            patchCorner._numFaces  = (LocalIndex) vFaces.size();
+            patchCorner._patchFace = (LocalIndex) vFaces.FindIndex(faceIndex);
             patchCorner._boundary  = vTag._boundary;
         }
         patchCorner._sharp = cornerSpans[corner]._sharp;

--- a/opensubdiv/far/patchBuilder.h
+++ b/opensubdiv/far/patchBuilder.h
@@ -64,7 +64,7 @@ namespace Far {
 class SourcePatch {
 public:
     struct Corner {
-        Corner() { std::memset(this, 0, sizeof(Corner)); }
+        Corner() { std::memset((void*) this, 0, sizeof(Corner)); }
 
         LocalIndex _numFaces;   // valence of corner vertex
         LocalIndex _patchFace;  // location of patch within incident faces
@@ -81,7 +81,7 @@ public:
     };
 
 public:
-    SourcePatch() { std::memset(this, 0, sizeof(SourcePatch)); }
+    SourcePatch() { std::memset((void*) this, 0, sizeof(SourcePatch)); }
     ~SourcePatch() { }
 
     //  To be called after all Corners have been initialized (hope to

--- a/opensubdiv/far/patchDescriptor.h
+++ b/opensubdiv/far/patchDescriptor.h
@@ -77,6 +77,12 @@ public:
     PatchDescriptor( PatchDescriptor const & d ) :
         _type(d.GetType()) { }
 
+    /// \brief Assignment operator
+    PatchDescriptor & operator=( PatchDescriptor const & d ) {
+        _type = d.GetType();
+        return *this;
+    }
+
     /// \brief Returns the type of the patch
     Type GetType() const {
         return (Type)_type;

--- a/opensubdiv/far/primvarRefiner.h
+++ b/opensubdiv/far/primvarRefiner.h
@@ -969,9 +969,14 @@ PrimvarRefinerReal<REAL>::interpFVarFromVerts(int level, T const & src, U & dst,
             Vtr::internal::FVarLevel::ConstValueTagArray pValueTags = parentFVar.getVertexValueTags(vert);
             Vtr::internal::FVarLevel::ConstValueTagArray cValueTags = childFVar.getVertexValueTags(cVert);
 
-            for (int cSibling = 0; cSibling < cVertValues.size(); ++cSibling) {
-                int pSibling = refineFVar.getChildValueParentSource(cVert, cSibling);
-                assert(pSibling == cSibling);
+            for (int cSiblingIndex = 0; cSiblingIndex < cVertValues.size(); ++cSiblingIndex) {
+                int pSiblingIndex = refineFVar.getChildValueParentSource(cVert, cSiblingIndex);
+                assert(pSiblingIndex == cSiblingIndex);
+
+                typedef Vtr::internal::FVarLevel::Sibling SiblingIntType;
+
+                SiblingIntType cSibling = (SiblingIntType) cSiblingIndex;
+                SiblingIntType pSibling = (SiblingIntType) pSiblingIndex;
 
                 Vtr::Index pVertValue = pVertValues[pSibling];
                 Vtr::Index cVertValue = cVertValues[cSibling];

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -451,7 +451,7 @@ template <class MESH>
 inline void
 TopologyRefinerFactory<MESH>::setNumBaseFaceVertices(TopologyRefiner & newRefiner, Index f, int count) {
     newRefiner._levels[0]->resizeFaceVertices(f, count);
-    newRefiner._hasIrregFaces |= (count != newRefiner._regFaceSize);
+    newRefiner._hasIrregFaces = newRefiner._hasIrregFaces || (count != newRefiner._regFaceSize);
 }
 template <class MESH>
 inline void
@@ -553,7 +553,7 @@ template <class MESH>
 inline void
 TopologyRefinerFactory<MESH>::setBaseFaceHole(TopologyRefiner & newRefiner, Index f, bool b) {
     newRefiner._levels[0]->setFaceHole(f, b);
-    newRefiner._hasHoles |= b;
+    newRefiner._hasHoles = newRefiner._hasHoles || b;
 }
 
 template <class MESH>

--- a/opensubdiv/far/topologyRefinerFactory.h
+++ b/opensubdiv/far/topologyRefinerFactory.h
@@ -322,6 +322,19 @@ protected:
     //  Not to be specialized:
     //
     static bool populateBaseLevel(TopologyRefiner& refiner, MESH const& mesh, Options options);
+
+private:
+    //
+    //  An oversight in the interfaces of the error reporting function between the factory
+    //  class and the Vtr::Level requires this adapter function to avoid warnings.
+    //
+    //  The static class method requires a reference as the MESH argument, but the interface
+    //  for Vtr::Level requires a pointer (void*). So this adapter with a MESH* argument is
+    //  used to effectively cast the function pointer required by Vtr::Level error reporting:
+    //
+    static void reportInvalidTopologyAdapter(TopologyError errCode, char const * msg, MESH const * mesh) {
+        reportInvalidTopology(errCode, msg, *mesh);
+    }
 };
 
 
@@ -380,7 +393,7 @@ TopologyRefinerFactory<MESH>::populateBaseLevel(TopologyRefiner& refiner, MESH c
     //  Otherwise edges and remaining topology will be completed from the face-vertices:
     //
     bool             validate = options.validateFullTopology;
-    TopologyCallback callback = reinterpret_cast<TopologyCallback>(reportInvalidTopology);
+    TopologyCallback callback = reinterpret_cast<TopologyCallback>(reportInvalidTopologyAdapter);
     void const *     userData = &mesh;
         
     if (! assignComponentTopology(refiner, mesh)) return false;

--- a/opensubdiv/osd/glComputeEvaluator.cpp
+++ b/opensubdiv/osd/glComputeEvaluator.cpp
@@ -32,7 +32,7 @@
 
 #include <cassert>
 #include <sstream>
-#include <string>
+#include <cstring>
 #include <vector>
 
 
@@ -128,8 +128,8 @@ GLStencilTableSSBO::~GLStencilTableSSBO() {
 GLComputeEvaluator::GLComputeEvaluator()
     : _workGroupSize(64),
       _patchArraysSSBO(0) {
-    memset (&_stencilKernel, 0, sizeof(_stencilKernel));
-    memset (&_patchKernel, 0, sizeof(_patchKernel));
+    std::memset((void*) &_stencilKernel, 0, sizeof(_stencilKernel));
+    std::memset((void*) &_patchKernel, 0, sizeof(_patchKernel));
 
     // Initialize internal OpenGL loader library if necessary
     OpenSubdiv::internal::GLLoader::libraryInitializeGL();

--- a/opensubdiv/sdc/catmarkScheme.h
+++ b/opensubdiv/sdc/catmarkScheme.h
@@ -277,9 +277,11 @@ Scheme<SCHEME_CATMARK>::assignSmoothLimitMask(VERTEX const& vertex, MASK& posMas
         posMask.FaceWeight(2) = fWeight;
         posMask.FaceWeight(3) = fWeight;
     } else {
-        Weight fWeight = 1.0f / (Weight)(valence * (valence + 5.0f));
+        Weight Valence = (Weight) valence;
+
+        Weight fWeight = 1.0f / (Valence * (Valence + 5.0f));
         Weight eWeight = 4.0f * fWeight;
-        Weight vWeight = (Weight)(1.0f - valence * (eWeight + fWeight));
+        Weight vWeight = 1.0f - Valence * (eWeight + fWeight);
 
         posMask.VertexWeight(0) = vWeight;
         for (int i = 0; i < valence; ++i) {

--- a/opensubdiv/sdc/options.h
+++ b/opensubdiv/sdc/options.h
@@ -89,33 +89,34 @@ public:
     VtxBoundaryInterpolation GetVtxBoundaryInterpolation() const { return (VtxBoundaryInterpolation) _vtxBoundInterp; }
 
     /// \brief Set vertex boundary interpolation rule
-    void SetVtxBoundaryInterpolation(VtxBoundaryInterpolation b) { _vtxBoundInterp = b; }
+    void SetVtxBoundaryInterpolation(VtxBoundaryInterpolation b) { _vtxBoundInterp = (EnumIntType) b; }
 
     /// \brief Get face-varying interpolation rule
     FVarLinearInterpolation GetFVarLinearInterpolation() const { return (FVarLinearInterpolation) _fvarLinInterp; }
 
     /// \brief Set face-varying interpolation rule
-    void SetFVarLinearInterpolation(FVarLinearInterpolation b) { _fvarLinInterp = b; }
+    void SetFVarLinearInterpolation(FVarLinearInterpolation b) { _fvarLinInterp = (EnumIntType) b; }
 
     /// \brief Get edge crease rule
     CreasingMethod GetCreasingMethod() const { return (CreasingMethod) _creasingMethod; }
 
     /// \brief Set edge crease rule
-    void SetCreasingMethod(CreasingMethod c) { _creasingMethod = c; }
+    void SetCreasingMethod(CreasingMethod c) { _creasingMethod = (EnumIntType) c; }
 
     /// \brief Get triangle subdivision weights rule (Catmark scheme only !)
     TriangleSubdivision GetTriangleSubdivision() const { return (TriangleSubdivision) _triangleSub; }
 
     /// \brief Set triangle subdivision weights rule (Catmark scheme only !)
-    void SetTriangleSubdivision(TriangleSubdivision t) { _triangleSub = t; }
+    void SetTriangleSubdivision(TriangleSubdivision t) { _triangleSub = (EnumIntType) t; }
 
 private:
+    //  Use a small integer type to pack these rather than bitfields:
+    typedef unsigned char EnumIntType;
 
-    //  Bitfield members:
-    unsigned int _vtxBoundInterp  : 2,
-                 _fvarLinInterp   : 3,
-                 _creasingMethod  : 2,
-                 _triangleSub     : 2;
+    EnumIntType _vtxBoundInterp;
+    EnumIntType _fvarLinInterp;
+    EnumIntType _creasingMethod;
+    EnumIntType _triangleSub;
 };
 
 } // end namespace sdc

--- a/opensubdiv/vtr/level.h
+++ b/opensubdiv/vtr/level.h
@@ -100,7 +100,7 @@ public:
         //  When cleared, the VTag ALMOST represents a smooth, regular, interior
         //  vertex -- the Type enum requires a bit be explicitly set for Smooth,
         //  so that must be done explicitly if desired on initialization.
-        void clear() { std::memset(this, 0, sizeof(VTag)); }
+        void clear() { std::memset((void*) this, 0, sizeof(VTag)); }
 
         typedef unsigned short VTagSize;
 
@@ -141,7 +141,7 @@ public:
         ETag() { }
 
         //  When cleared, the ETag represents a smooth, manifold, interior edge
-        void clear() { std::memset(this, 0, sizeof(ETag)); }
+        void clear() { std::memset((void*) this, 0, sizeof(ETag)); }
 
         typedef unsigned char ETagSize;
 
@@ -165,7 +165,7 @@ public:
     struct FTag {
         FTag() { }
 
-        void clear() { std::memset(this, 0, sizeof(FTag)); }
+        void clear() { std::memset((void*) this, 0, sizeof(FTag)); }
 
         typedef unsigned char FTagSize;
 
@@ -191,9 +191,9 @@ public:
     //  use of the const method here to direct inspection of the member.
     //
     struct VSpan {
-        VSpan() { std::memset(this, 0, sizeof(VSpan)); }
+        VSpan() { std::memset((void*) this, 0, sizeof(VSpan)); }
 
-        void clear()            { std::memset(this, 0, sizeof(VSpan)); }
+        void clear()            { std::memset((void*) this, 0, sizeof(VSpan)); }
         bool isAssigned() const { return _numFaces > 0; }
 
         LocalIndex _numFaces;
@@ -801,7 +801,7 @@ Level::resizeFaces(int faceCount) {
     _faceVertCountsAndOffsets.resize(2 * faceCount);
 
     _faceTags.resize(faceCount);
-    std::memset(&_faceTags[0], 0, _faceCount * sizeof(FTag));
+    std::memset((void*) &_faceTags[0], 0, _faceCount * sizeof(FTag));
 }
 inline void
 Level::resizeFaceVertices(int totalFaceVertCount) {
@@ -822,7 +822,7 @@ Level::resizeEdges(int edgeCount) {
     _edgeTags.resize(edgeCount);
 
     if (edgeCount>0) {
-        std::memset(&_edgeTags[0], 0, _edgeCount * sizeof(ETag));
+        std::memset((void*) &_edgeTags[0], 0, _edgeCount * sizeof(ETag));
     }
 }
 inline void
@@ -846,7 +846,7 @@ Level::resizeVertices(int vertCount) {
 
     _vertSharpness.resize(vertCount);
     _vertTags.resize(vertCount);
-    std::memset(&_vertTags[0], 0, _vertCount * sizeof(VTag));
+    std::memset((void*) &_vertTags[0], 0, _vertCount * sizeof(VTag));
 }
 inline void
 Level::resizeVertexFaces(int totalVertFaceCount) {

--- a/regression/common/arg_utils.cpp
+++ b/regression/common/arg_utils.cpp
@@ -33,7 +33,7 @@
 static int
 parseIntArg(const char* argString, int dfltValue = 0) {
     char *argEndptr;
-    int argValue = strtol(argString, &argEndptr, 10);
+    int argValue = (int) strtol(argString, &argEndptr, 10);
     if (*argEndptr != 0) {
         printf("Warning: non-integer option parameter '%s' ignored\n", 
 			   argString);

--- a/regression/common/shape_utils.h
+++ b/regression/common/shape_utils.h
@@ -122,7 +122,7 @@ struct Shape {
     char FindMaterial(char const * name) {
         for (int i=0; i<(int)mtls.size(); ++i) {
             if (mtls[i]->name==name) {
-                return i;
+                return (char) i;
             }
         }
         return -1;

--- a/regression/far_perf/far_perf.cpp
+++ b/regression/far_perf/far_perf.cpp
@@ -134,10 +134,7 @@ RunPerfTest(Shape const & shape, TestOptions const & options) {
     FarStencilTable const * vertexStencils = NULL;
     if (options.createStencils) {
         s.Start();
-
-        typename FarStencilTableFactory::Options options;
-        vertexStencils = FarStencilTableFactory::Create(*refiner, options);
-
+        vertexStencils = FarStencilTableFactory::Create(*refiner);
         s.Stop();
         result.timeStencilFactory = s.GetElapsed();
     } else {
@@ -273,7 +270,7 @@ PrintResultCSV(TestResult const & result, PrintOptions const & options) {
 static int
 parseIntArg(char const * argString, int dfltValue = 0) {
     char *argEndptr;
-    int argValue = strtol(argString, &argEndptr, 10);
+    int argValue = (int) strtol(argString, &argEndptr, 10);
     if (*argEndptr != 0) {
         fprintf(stderr,
                 "Warning: non-integer option parameter '%s' ignored\n",


### PR DESCRIPTION
These changes address compiler warnings from GCC -- most notably those arising from more recent versions of GCC that trigger warnings from OpenSubdiv's public header files, and so interfere with the compilation of client code.

The changes consist of two commits:  the first addresses warnings arising from OpenSubdiv's use of -Wall and -Wextra, while the second addresses some of the additional warnings arising from -Wshadow and -Wconversion.

Warnings are addressed in the libraries, tutorials and regression tests, but not the examples or their common infrastructure.