### PR TITLE
Suppression of GCC warnings from -Wconversion with bitfields

### DIFF
--- a/opensubdiv/bfr/patchTreeBuilder.cpp
+++ b/opensubdiv/bfr/patchTreeBuilder.cpp
@@ -86,7 +86,8 @@ PatchTreeBuilder::PatchTreeBuilder(TopologyRefiner & faceRefiner,
     //
     TopologyRefiner::AdaptiveOptions adaptiveOptions(adaptiveLevelPrimary);
 
-    adaptiveOptions.secondaryLevel       = adaptiveLevelSecondary;
+    adaptiveOptions.SetSecondaryLevel(adaptiveLevelSecondary);
+
     adaptiveOptions.useInfSharpPatch     = true;
     adaptiveOptions.useSingleCreasePatch = false;
     adaptiveOptions.considerFVarChannels = false;

--- a/opensubdiv/far/patchTableFactory.h
+++ b/opensubdiv/far/patchTableFactory.h
@@ -67,7 +67,7 @@ public:
              triangulateQuads(false),
              useSingleCreasePatch(false),
              useInfSharpPatch(false),
-             maxIsolationLevel(maxIsolation),
+             maxIsolationLevel(maxIsolation & 0xf),
              endCapType(ENDCAP_GREGORY_BASIS),
              shareEndCapPatchPoints(true),
              generateVaryingTables(true),
@@ -85,7 +85,10 @@ public:
         EndCapType GetEndCapType() const { return (EndCapType)endCapType; }
 
         /// \brief Set endcap basis type
-        void SetEndCapType(EndCapType e) { endCapType = e; }
+        void SetEndCapType(EndCapType e) { endCapType = e & 0x7; }
+
+        /// \brief Set maximum isolation level
+        void SetMaxIsolationLevel(unsigned int level) { maxIsolationLevel = level & 0xf; }
 
         /// \brief Set precision of vertex patches
         template <typename REAL> void SetPatchPrecision();

--- a/opensubdiv/far/topologyRefiner.h
+++ b/opensubdiv/far/topologyRefiner.h
@@ -118,9 +118,12 @@ public:
     struct UniformOptions {
 
         UniformOptions(int level) :
-            refinementLevel(level),
+            refinementLevel(level & 0xf),
             orderVerticesFromFacesFirst(false),
             fullTopologyInLastLevel(false) { }
+
+        /// \brief Set uniform refinement level
+        void SetRefinementLevel(int level) { refinementLevel = level & 0xf; }
 
         unsigned int refinementLevel:4,             ///< Number of refinement iterations
                      orderVerticesFromFacesFirst:1, ///< Order child vertices from faces first
@@ -153,12 +156,18 @@ public:
     struct AdaptiveOptions {
 
         AdaptiveOptions(int level) :
-            isolationLevel(level),
-            secondaryLevel(15),
+            isolationLevel(level & 0xf),
+            secondaryLevel(0xf),
             useSingleCreasePatch(false),
             useInfSharpPatch(false),
             considerFVarChannels(false),
             orderVerticesFromFacesFirst(false) { }
+
+        /// \brief Set isolation level
+        void SetIsolationLevel(int level) { isolationLevel = level & 0xf; }
+
+        /// \brief Set secondary isolation level
+        void SetSecondaryLevel(int level) { secondaryLevel = level & 0xf; }
 
         unsigned int isolationLevel:4;              ///< Number of iterations applied to isolate
                                                     ///< extraordinary vertices and creases

--- a/regression/bfr_evaluate/farPatchEvaluator.cpp
+++ b/regression/bfr_evaluate/farPatchEvaluator.cpp
@@ -73,8 +73,8 @@ FarPatchEvaluator<REAL>::FarPatchEvaluator(
 
     Far::TopologyRefiner::AdaptiveOptions refineOptions =
             patchOptions.GetRefineAdaptiveOptions();
-    refineOptions.isolationLevel = primaryLevel;
-    refineOptions.secondaryLevel = secondaryLevel;
+    refineOptions.SetIsolationLevel(primaryLevel);
+    refineOptions.SetSecondaryLevel(secondaryLevel);
 
     //
     //  Create a TopologyRefiner (sharing the base) to adaptively refine


### PR DESCRIPTION
These changes suppress warnings arising from the use of GCC's -Wconversion option when including public OpenSubdiv headers that internally initialize bitfields.

The -Wconversion option is useful to catch a wide variety of narrowing conversions, but GCC does not provide an additional option to disable it when applied to bitfields (frustrating, since it does provide options to disable it for other specific contexts).

The only way to suppress assignments to non-unit bitfields is to apply a mask of the appropriate number of bits when assigned. So initialization of such bitfields in public headers now include such a mask. In order for users to assign such public bitfields without triggering the same warnings, new Set...() methods have been added to encapsulate use of the appropriate mask in the assignment.