### PR TITLE
fix opengl loader include error when build with opengl and examples

### DIFF
--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -71,6 +71,10 @@ if(CUDA_FOUND)
     )
 endif()
 
+if(DEFINED OPENGL_LOADER_INCLUDE_DIRS)
+    include_directories(${OPENGL_LOADER_INCLUDE_DIRS})
+endif()
+
 if(OPENGL_FOUND AND GLFW_FOUND)
 
     list(APPEND EXAMPLES_COMMON_GL_SOURCE_FILES
@@ -86,8 +90,6 @@ if(OPENGL_FOUND AND GLFW_FOUND)
         glUtils.h
         glShaderCache.h
     )
-
-    include_directories(${OPENGL_LOADER_INCLUDE_DIRS})
 
     if (GLFW_FOUND)
         include_directories("${GLFW_INCLUDE_DIR}")


### PR DESCRIPTION
when config with `-DNO_OPENGL=OFF  -DNO_EXAMPLES=OFF` we will get glLoader.h not found error, this is caused by in-consistent OPENGL and GLFW config in cmake