### PR TITLE
Updated CMake minimum version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-cmake_minimum_required(VERSION 2.8.6)
+cmake_minimum_required(VERSION 3.12)
 
 project(OpenSubdiv)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more details about OpenSubdiv, see [Pixar Graphics Technologies](http://grap
 
 | Lib                           | Min Version | Note       |
 | ----------------------------- | ----------- | ---------- |
-| [CMake](http://www.cmake.org) | 2.8.6       | *Required* |
+| [CMake](http://www.cmake.org) | 3.12        | *Required* |
 
  * Osd optional requirements:
 

--- a/documentation/cmake_build.rst
+++ b/documentation/cmake_build.rst
@@ -62,7 +62,7 @@ build and installation instructions.
 
 Required
 ________
-    - `CMake <http://www.cmake.org/>`__ version 2.8
+    - `CMake <http://www.cmake.org/>`__ version 3.12
 
 Optional
 ________


### PR DESCRIPTION
This avoids deprecation warnings resulting from the previous minimum version.

Version 3.12 matches the minimum version in our USD builds and is a version that is supported by our internal CI systems.
