### PR TITLE
Fixed broken public headers dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,7 +712,7 @@ macro(osd_add_doxy_headers headers)
             list(APPEND headerfiles ${targetname} )
         endforeach()
 
-        add_dependencies( public_headers DEPENDS ${headerfiles} )
+        add_dependencies( public_headers ${headerfiles} )
     endif()
 endmacro()
 


### PR DESCRIPTION
Fixes a doc build error resulting from the CMake minimum version update.

Fixes #1263