### PR TITLE
Suppression of more GCC warnings with -Wconversion

### DIFF
--- a/opensubdiv/far/patchTableFactory.cpp
+++ b/opensubdiv/far/patchTableFactory.cpp
@@ -1276,7 +1276,7 @@ PatchTableBuilder::populatePatches() {
                    patchParam.GetU(), patchParam.GetV(),
                    patchParam.GetDepth(),
                    patchParam.NonQuadRoot(),
-                   fvcPatchInfo.paramBoundaryMask,
+                   (unsigned short) fvcPatchInfo.paramBoundaryMask,
                    patchParam.GetTransition(),
                    fvcPatchInfo.isRegular);
             }

--- a/opensubdiv/osd/cpuGLVertexBuffer.cpp
+++ b/opensubdiv/osd/cpuGLVertexBuffer.cpp
@@ -95,7 +95,7 @@ CpuGLVertexBuffer::BindVBO(void * /*deviceContext*/) {
     if (! _dataDirty)
         return _vbo;
 
-    int size = GetNumElements() * GetNumVertices() * sizeof(float);
+    int size = GetNumElements() * GetNumVertices() * (int) sizeof(float);
 
     if (! _vbo) {
         glGenBuffers(1, &_vbo);

--- a/opensubdiv/osd/glVertexBuffer.cpp
+++ b/opensubdiv/osd/glVertexBuffer.cpp
@@ -59,7 +59,7 @@ void
 GLVertexBuffer::UpdateData(const float *src, int startVertex, int numVertices,
                            void * /*deviceContext*/) {
 
-    int size = numVertices * _numElements * sizeof(float);
+    int size = numVertices * _numElements * (int) sizeof(float);
 #if defined(GL_ARB_direct_state_access)
     if (OSD_OPENGL_HAS(ARB_direct_state_access)) {
         glNamedBufferSubData(_vbo,
@@ -96,7 +96,7 @@ GLVertexBuffer::BindVBO(void * /*deviceContext*/) {
 bool
 GLVertexBuffer::allocate() {
 
-    int size = _numElements * _numVertices * sizeof(float);
+    int size = _numElements * _numVertices * (int) sizeof(float);
 
 
 #if defined(GL_ARB_direct_state_access)


### PR DESCRIPTION
These changes suppress a few more narrowing conversion warnings when building the library. Some of these were triggering warnings with other compilers in other contexts.