### PR TITLE
Removed 'centroid' qualifier from GLSL struct

### DIFF
--- a/opensubdiv/osd/glslPatchCommon.glsl
+++ b/opensubdiv/osd/glslPatchCommon.glsl
@@ -97,8 +97,8 @@ struct OutputVertex {
     vec3 normal;
     vec3 tangent;
     vec3 bitangent;
-    centroid vec4 patchCoord; // u, v, faceLevel, faceId
-    centroid vec2 tessCoord; // tesscoord.st
+    vec4 patchCoord; // u, v, faceLevel, faceId
+    vec2 tessCoord; // tesscoord.st
 #if defined OSD_COMPUTE_NORMAL_DERIVATIVES
     vec3 Nu;
     vec3 Nv;


### PR DESCRIPTION
This is not valid (See GLSLang Spec, Sec 4.3) and raises shader compile time errors with some recent drivers.