### PR TITLE
Updated iOS build note regarding stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,9 @@ cmake --build . --config Release --target install
 
 ### iOS
 
-  * Because OpenSubdiv uses a self-built build tool (stringify) as part of the build process, you'll want to build for macOS and build the stringify target
-
 ```
 SDKROOT=$(xcrun --sdk iphoneos --show-sdk-path) cmake -D NO_PTEX=1 -D NO_DOC=1 \
       -D NO_OMP=1 -D NO_TBB=1 -D NO_CUDA=1 -D NO_OPENCL=1 -D NO_CLEW=1 \
-      -D STRINGIFY_LOCATION="*YOUR MACOS BUILD LOCATION*"/bin/stringify \
       -D CMAKE_TOOLCHAIN_FILE=../cmake/iOSToolchain.cmake -G Xcode \
       ..
 ```


### PR DESCRIPTION
Builds using Xcode now use the Python version of stringify including for cross compilation builds, e.g. iOS, universal, etc.