### PR TITLE
Avoid referring to std::vector<T> members when T is incomplete.

### DIFF
--- a/opensubdiv/far/patchTable.cpp
+++ b/opensubdiv/far/patchTable.cpp
@@ -125,23 +125,6 @@ PatchTable::~PatchTable() {
 //
 // PatchArrays
 //
-struct PatchTable::PatchArray {
-
-    PatchArray(PatchDescriptor d, int np, Index v, Index p, Index qo) :
-            desc(d), numPatches(np), vertIndex(v),
-                patchIndex(p), quadOffsetIndex (qo) { }
-
-    void print() const;
-
-    PatchDescriptor desc;  // type of patches in the array
-
-    int numPatches;        // number of patches in the array
-
-    Index vertIndex,       // index to the first control vertex
-          patchIndex,      // absolute index of the first patch in the array
-          quadOffsetIndex; // index of the first quad offset entry
-
-};
 
 // debug helper
 void
@@ -165,43 +148,6 @@ void
 PatchTable::reservePatchArrays(int numPatchArrays) {
     _patchArrays.reserve(numPatchArrays);
 }
-
-//
-// FVarPatchChannel
-//
-// Stores a record for each patch in the primitive :
-//
-//  - Each patch in the PatchTable has a corresponding patch in each
-//    face-varying patch channel. Patch vertex indices are sorted in the same
-//    patch-type order as PatchTable::PTables. Face-varying data for a patch
-//    can therefore be quickly accessed by using the patch primitive ID as
-//    index into patchValueOffsets to locate the face-varying control vertex
-//    indices.
-//
-//  - Face-varying channels can have a different interpolation modes
-//
-//  - Unlike "vertex" patches, there are no transition masks required
-//    for face-varying patches.
-//
-//  - Face-varying patches still require boundary edge masks.
-//
-//  - currently most patches with sharp boundaries but smooth interiors have
-//    to be isolated to level 10 : we need a special type of bicubic patch
-//    similar to single-crease to resolve this condition without requiring
-//    isolation if possible
-//
-struct PatchTable::FVarPatchChannel {
-
-    Sdc::Options::FVarLinearInterpolation interpolation;
-
-    PatchDescriptor regDesc;
-    PatchDescriptor irregDesc;
-
-    int stride;
-
-    std::vector<Index> patchValues;
-    std::vector<PatchParam> patchParam;
-};
 
 void
 PatchTable::allocateVaryingVertices(

--- a/opensubdiv/far/patchTable.h
+++ b/opensubdiv/far/patchTable.h
@@ -545,8 +545,22 @@ private:
     //
     // Patch arrays
     //
+    struct PatchArray {
+        PatchArray(PatchDescriptor d, int np, Index v, Index p, Index qo) :
+            desc(d), numPatches(np), vertIndex(v),
+            patchIndex(p), quadOffsetIndex (qo) { }
 
-    struct PatchArray;
+        void print() const;
+
+        PatchDescriptor desc;  // type of patches in the array
+
+        int numPatches;        // number of patches in the array
+
+        Index vertIndex,       // index to the first control vertex
+              patchIndex,      // absolute index of the first patch in the array
+              quadOffsetIndex; // index of the first quad offset entry
+    };
+
     typedef std::vector<PatchArray> PatchArrayVector;
 
     PatchArray & getPatchArray(Index arrayIndex);
@@ -574,7 +588,41 @@ private:
     // Face-varying patch channels
     //
 
-    struct FVarPatchChannel;
+    //
+    // FVarPatchChannel
+    //
+    // Stores a record for each patch in the primitive :
+    //
+    //  - Each patch in the PatchTable has a corresponding patch in each
+    //    face-varying patch channel. Patch vertex indices are sorted in the same
+    //    patch-type order as PatchTable::PTables. Face-varying data for a patch
+    //    can therefore be quickly accessed by using the patch primitive ID as
+    //    index into patchValueOffsets to locate the face-varying control vertex
+    //    indices.
+    //
+    //  - Face-varying channels can have a different interpolation modes
+    //
+    //  - Unlike "vertex" patches, there are no transition masks required
+    //    for face-varying patches.
+    //
+    //  - Face-varying patches still require boundary edge masks.
+    //
+    //  - currently most patches with sharp boundaries but smooth interiors have
+    //    to be isolated to level 10 : we need a special type of bicubic patch
+    //    similar to single-crease to resolve this condition without requiring
+    //    isolation if possible
+    //
+    struct FVarPatchChannel {
+        Sdc::Options::FVarLinearInterpolation interpolation;
+
+        PatchDescriptor regDesc;
+        PatchDescriptor irregDesc;
+
+        int stride;
+
+        std::vector<Index> patchValues;
+        std::vector<PatchParam> patchParam;
+    };
     typedef std::vector<FVarPatchChannel> FVarPatchChannelVector;
 
     FVarPatchChannel & getFVarPatchChannel(int channel);


### PR DESCRIPTION
Avoid referring to std::vector<T> members when T is incomplete.

This is not legal according to the C++ standard, and causes build errors when using --std=c++20