### PR TITLE
Corrections to allow for LLVM Clang builds on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,15 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANGCC OR CMAKE_COMPILER_IS_IC
         list(APPEND OSD_COMPILER_FLAGS -Wall -Wextra)
     endif()
 
+    if(WIN32)
+        # Make sure the constants in <math.h>/<cmath> get defined.
+        list(APPEND OSD_COMPILER_FLAGS -D_USE_MATH_DEFINES)
+
+        # Make sure WinDef.h does not define min and max macros which
+        # will conflict with std::min() and std::max().
+        list(APPEND OSD_COMPILER_FLAGS -DNOMINMAX)
+    endif()
+
     # HBR uses the offsetof macro on a templated struct, which appears
     # to spuriously set off this warning in both gcc and Clang
     list(APPEND OSD_COMPILER_FLAGS -Wno-invalid-offsetof)

--- a/examples/common/stopwatch.h
+++ b/examples/common/stopwatch.h
@@ -25,7 +25,7 @@
 #ifndef STOPWATCH_H
 #define STOPWATCH_H
 
-#if (_WIN32 || _WIN64)
+#if (_WIN32)
     #include <windows.h>
 #else
     #include <sys/types.h>
@@ -37,7 +37,7 @@ class Stopwatch {
 
 public:
 
-#ifndef _WINDOWS
+#ifndef _WIN32
     Stopwatch() : _totalElapsed(0) { }
 
     void Start() {
@@ -91,7 +91,7 @@ public:
 
 private:
 
-#ifndef _WINDOWS
+#ifndef _WIN32
     double _elapsed;
     double _totalElapsed;
 #else


### PR DESCRIPTION
I ran into some issues while getting OSD building on Windows with LLVM Clang.

My test configuration:

```
mkdir build
cmake ^
  -B build ^
  -S . ^
  -A x64 ^
  -T ClangCL ^
  -D CMAKE_TOOLCHAIN_FILE=C:/Users/Thomas/SourceTree/vcpkg/scripts/buildsystems/vcpkg.cmake ^
  -D CMAKE_CXX_FLAGS="-w" ^
  -D CMAKE_C_FLAGS="-w" ^
  -D NO_PTEX=1 ^
  -D NO_DOC=1 ^
  -D NO_OMP=1 ^
  -D NO_TBB=1 ^
  -D NO_CUDA=1 ^
  -D NO_OPENCL=1 ^
  -D NO_CLEW=1 ^
  -D NO_METAL=1 ^
  -D NO_GLFW_X11=1 ^
  -D NO_MACOS_FRAMEWORK=1
```
```
cmake --build build
```

Sample of errors this PR fixes:

```
C:\Users\Thomas\SourceTree\OpenSubdiv\opensubdiv\far\catmarkPatchBuilder.cpp(767,43): error : use of undeclared identifier 'M_PI' [C:\Users\Thomas\SourceTree\OpenSubdiv\build\opensubdiv\far\far_obj.vcxproj]
C:\Users\Thomas\SourceTree\OpenSubdiv\opensubdiv\far\catmarkPatchBuilder.cpp(767,64): error : use of undeclared identifier 'M_PI' [C:\Users\Thomas\SourceTree\OpenSubdiv\build\opensubdiv\far\far_obj.vcxproj]
C:\Users\Thomas\SourceTree\OpenSubdiv\opensubdiv\far\catmarkPatchBuilder.cpp(145,30): error : use of undeclared identifier 'M_PI' [C:\Users\Thomas\SourceTree\OpenSubdiv\build\opensubdiv\far\far_obj.vcxproj]
```

```
 osd_static_gpu.vcxproj -> C:\Users\Thomas\SourceTree\OpenSubdiv\build\lib\Debug\osdGPU.lib
  Generating shader.gen.h
  In file included from C:\Users\Thomas\SourceTree\OpenSubdiv\examples\dxViewer\dxviewer.cpp:66:
C:\Users\Thomas\SourceTree\OpenSubdiv\examples\dxViewer/../common/stopwatch.h(45,9): error : use of undeclared identifier 'gettimeofday' [C:\Users\Thomas\SourceTree\OpenSubdiv\build\examples\dxViewer\dxViewer.vcxproj]
C:\Users\Thomas\SourceTree\OpenSubdiv\examples\dxViewer/../common/stopwatch.h(52,9): error : use of undeclared identifier 'gettimeofday' [C:\Users\Thomas\SourceTree\OpenSubdiv\build\examples\dxViewer\dxViewer.vcxproj]
  In file included from C:\Users\Thomas\SourceTree\OpenSubdiv\regression\far_perf\far_perf.cpp:39:
C:\Users\Thomas\SourceTree\OpenSubdiv\regression\far_perf/../../examples/common/stopwatch.h(45,9): error : use of undeclared identifier 'gettimeofday' [C:\Users\Thomas\SourceTree\OpenSubdiv\build\regression\far_perf\far_perf.vcxproj]
C:\Users\Thomas\SourceTree\OpenSubdiv\regression\far_perf/../../examples/common/stopwatch.h(52,9): error : use of undeclared identifier 'gettimeofday' [C:\Users\Thomas\SourceTree\OpenSubdiv\build\regression\far_perf\far_perf.vcxproj]
  far_regression.vcxproj -> C:\Users\Thomas\SourceTree\OpenSubdiv\build\bin\Debug\far_regression.exe
```

```
C:\Users\Thomas\SourceTree\OpenSubdiv\opensubdiv\osd/../osd/types.h(79,21): error : expected unqualified-id [C:\Users\Thomas\SourceTree\OpenSubdiv\build\opensubdiv\osd\osd_gpu_obj.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\shared\minwindef.h(193,29): message : expanded from macro 'max' [C:\Users\Thomas\SourceTree\OpenSubdiv\build\opensubdiv\osd\osd_gpu_obj.vcxproj]
  In file included from C:\Users\Thomas\SourceTree\OpenSubdiv\opensubdiv\osd\glPatchTable.cpp:27:
```

Note, I muted all warnings using `-w` because there was a lot of them. What is this project's policy/goal towards compiler warnings?