### PR TITLE
Correct warning: "with mismatched bound [-Warray-parameter]" in level.cpp

### DIFF
--- a/opensubdiv/vtr/level.cpp
+++ b/opensubdiv/vtr/level.cpp
@@ -1130,7 +1130,7 @@ Level::gatherQuadRegularCornerPatchPoints(
 //             6           7           8
 */
 int
-Level::gatherTriRegularInteriorPatchPoints(Index fIndex, Index points[12], int rotation) const
+Level::gatherTriRegularInteriorPatchPoints(Index fIndex, Index points[], int rotation) const
 {
     ConstIndexArray  fVerts = getFaceVertices(fIndex);
     ConstIndexArray  fEdges = getFaceEdges(fIndex);


### PR DESCRIPTION
Warning from LLVM Clang 15:

```
[build] /Users/thomas/SourceTree/subd/ThirdParty/OpenSubdiv/opensubdiv/vtr/level.cpp:1133:64: warning: argument 'points' of type 'OpenSubdiv::v3_4_4::Vtr::Index[12]' (aka 'int[12]') with mismatched bound [-Warray-parameter]
[build] Level::gatherTriRegularInteriorPatchPoints(Index fIndex, Index points[12], int rotation) const
[build]                                                                ^
[build] /Users/thomas/SourceTree/subd/ThirdParty/OpenSubdiv/opensubdiv/vtr/../vtr/level.h:371:71: note: previously declared as 'OpenSubdiv::v3_4_4::Vtr::Index[]' (aka 'int[]') here
[build]     int gatherTriRegularInteriorPatchPoints(      Index fIndex, Index patchVerts[], int rotation = 0) const;
[build]                                                                       ^
[build] 1 warning generated.N
```

This stems from `level.h`/`level.cpp`:

```
// level.h
    int gatherTriRegularInteriorPatchPoints(      Index fIndex, Index patchVerts[], int rotation = 0) const;
    int gatherTriRegularBoundaryVertexPatchPoints(Index fIndex, Index patchVerts[], int boundaryVertInFace) const;
    int gatherTriRegularBoundaryEdgePatchPoints(  Index fIndex, Index patchVerts[], int boundaryEdgeInFace) const;
    int gatherTriRegularCornerVertexPatchPoints(  Index fIndex, Index patchVerts[], int cornerVertInFace) const;
    int gatherTriRegularCornerEdgePatchPoints(    Index fIndex, Index patchVerts[], int cornerEdgeInFace) const;
```

```
/// level.cpp
int
Level::gatherTriRegularInteriorPatchPoints(Index fIndex, Index points[12], int rotation) const

int
Level::gatherTriRegularBoundaryEdgePatchPoints(Index fIndex, Index points[], int boundaryFaceEdge) const
```

`gatherTriRegularInteriorPatchPoints` do appear to expect exactly 12 points. But the other functions also appeared to expect a fixed set of items in the arrays.

I did the minimal fix here and made the definition fit the declaration. But maybe the better fix is to update all definitions and declaration to reflect the fixed size of these array they expect?