### PR TITLE
CMake: append should be used for CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,8 @@ if (MAIN_PROJECT)
 endif()
 
 # Specify the list of directories to search for cmake modules.
-set(CMAKE_MODULE_PATH
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+list(APPEND CMAKE_MODULE_PATH
+    "${PROJECT_SOURCE_DIR}/cmake"
 )
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
### Description of Change(s)
`CMAKE_MODULE_PATH` is a directory list and shall be appended via `list(APPEND`
- Additionally hardened paths by using PROJECT_SOURCE_DIR

### Note
No major change but ensures when `CMAKE_MODULE_PATH` has been defined with alternative defaults on the command-line or via use of `CMAKE_PROJECT_TOP_LEVEL_INCLUDES`
