### PR TITLE
Updated C++ standard to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,17 @@ cmake_minimum_required(VERSION 3.12)
 
 project(OpenSubdiv)
 
+# Set C++ standard requirements, allowing overrides
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 14)
+endif()
+if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+if (NOT DEFINED CMAKE_CXX_EXTENSIONS)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
 # Turn on folder support
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -437,12 +448,6 @@ endif()
 
 if( METAL_FOUND AND NOT NO_METAL)
     set(OSD_GPU TRUE)
-    if (CMAKE_COMPILER_IS_CLANGCC)
-        # When building with Metal support enabled, we need to explicitly
-        # request that the C++ code be compiled with C++11 since some example
-        # code for Metal relies on functionality only available in C++11.
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif()
 endif()
 
 if( OPENGL_FOUND AND NOT NO_OPENGL)

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -157,8 +157,6 @@ if(METAL_FOUND)
         mtlHud.h
     )
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-
     add_library(examples_common_mtl_obj
         OBJECT
             ${EXAMPLES_COMMON_SOURCE_FILES}

--- a/examples/mtlPtexViewer/CMakeLists.txt
+++ b/examples/mtlPtexViewer/CMakeLists.txt
@@ -108,10 +108,6 @@ if(IOS)
     )
 endif()
 
-
-
-set_property (TARGET mtlPtexViewer PROPERTY CXX_STANDARD 14)
-
 target_link_libraries(mtlPtexViewer
     ${PLATFORM_LIBRARIES}
 )

--- a/examples/mtlViewer/CMakeLists.txt
+++ b/examples/mtlViewer/CMakeLists.txt
@@ -104,10 +104,6 @@ if(IOS)
     )
 endif()
 
-
-
-set_property (TARGET mtlViewer PROPERTY CXX_STANDARD 14)
-
 target_link_libraries(mtlViewer
     ${PLATFORM_LIBRARIES}
 )

--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -80,7 +80,6 @@ if (NOT NO_LIB)
         list(APPEND PLATFORM_GPU_LIBRARIES
             ${METAL_LIBRARIES}
         )
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
     endif()
 
     if ( OPENCL_FOUND )


### PR DESCRIPTION
Updated C++ standard to C++14

The OpenSubdiv public interface currently requires only C++11 but we
choose this version since C++14 has been the default since GCC 6,
Clang 6, and Visual Studio 2017 (for the most part) and C++14 has been
the default for OpenSubdiv on macOS when support for Metal is enabled.

This setting is guarded so that it can be overridden by the caller when
running CMake.

Fixes #1276