### PR TITLE
Fixed interface includes for cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -846,6 +846,7 @@ endmacro()
 #-------------------------------------------------------------------------------
 # Build targets
 
+include(GNUInstallDirs)
 
 # if you want to build examples against installed OpenSubdiv header files,
 # use OPENSUBDIV_INCLUDE_DIR.
@@ -887,34 +888,31 @@ if (NOT NO_DOC)
     add_subdirectory(documentation)
 endif()
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.2)
-    #
-    # CMake Config.
-    #
-    include(GNUInstallDirs)
-    include(CMakePackageConfigHelpers)
+#
+# CMake Config.
+#
+include(CMakePackageConfigHelpers)
 
-    set(OPENSUBDIV_CONFIG_PATH "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(OPENSUBDIV_CONFIG_PATH "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
-    configure_package_config_file(
-        opensubdiv-config.cmake.in
-        ${CMAKE_CURRENT_BINARY_DIR}/OpenSubdivConfig.cmake
-        INSTALL_DESTINATION ${OPENSUBDIV_CONFIG_PATH}
-    )
-    write_basic_package_version_file(
-        ${CMAKE_CURRENT_BINARY_DIR}/OpenSubdivConfigVersion.cmake
-        VERSION ${OSD_SONAME}
-        COMPATIBILITY SameMajorVersion
-    )
+configure_package_config_file(
+    opensubdiv-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/OpenSubdivConfig.cmake
+    INSTALL_DESTINATION ${OPENSUBDIV_CONFIG_PATH}
+)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/OpenSubdivConfigVersion.cmake
+    VERSION ${OSD_SONAME}
+    COMPATIBILITY SameMajorVersion
+)
 
-    install(EXPORT opensubdiv-targets
-        NAMESPACE OpenSubdiv::
-        FILE OpenSubdivTargets.cmake
-        DESTINATION ${OPENSUBDIV_CONFIG_PATH})
+install(EXPORT opensubdiv-targets
+    NAMESPACE OpenSubdiv::
+    FILE OpenSubdivTargets.cmake
+    DESTINATION ${OPENSUBDIV_CONFIG_PATH})
 
-    install(FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/OpenSubdivConfig.cmake
-        ${CMAKE_CURRENT_BINARY_DIR}/OpenSubdivConfigVersion.cmake
-        DESTINATION ${OPENSUBDIV_CONFIG_PATH}
-    )
-endif()
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/OpenSubdivConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/OpenSubdivConfigVersion.cmake
+    DESTINATION ${OPENSUBDIV_CONFIG_PATH}
+)

--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -141,6 +141,11 @@ if (NOT NO_LIB)
             FOLDER "opensubdiv"
     )
 
+    target_include_directories(osd_static_cpu
+        INTERFACE
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+
     target_link_libraries(osd_static_cpu
         ${PLATFORM_CPU_LIBRARIES}
     )
@@ -162,6 +167,11 @@ if (NOT NO_LIB)
                 OUTPUT_NAME osdGPU
                 EXPORT_NAME osdGPU_static
                 CLEAN_DIRECT_OUTPUT 1)
+
+        target_include_directories(osd_static_gpu
+            INTERFACE
+                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        )
 
         target_link_libraries(osd_static_gpu
             ${PLATFORM_CPU_LIBRARIES} ${PLATFORM_GPU_LIBRARIES}
@@ -204,6 +214,11 @@ if (NOT NO_LIB)
                 )
         endif()
 
+        target_include_directories(osd_dynamic_cpu
+            INTERFACE
+                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        )
+
         target_link_libraries(osd_dynamic_cpu
             ${PLATFORM_CPU_LIBRARIES}
         )
@@ -236,6 +251,11 @@ if (NOT NO_LIB)
                         CLEAN_DIRECT_OUTPUT 1
                     )
             endif()
+
+            target_include_directories(osd_dynamic_gpu
+                INTERFACE
+                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+            )
 
             target_link_libraries(osd_dynamic_gpu
                 osd_dynamic_cpu


### PR DESCRIPTION
Added target include directories for the library targets so that interface include directories are published with the OpenSubdiv cmake config.

Also, removed a cmake version test which is no longer needed.

Fixes #1278