### PR TITLE
Fixed example dependencies with CUDA on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -803,6 +803,11 @@ macro(osd_add_possibly_cuda_executable target folder)
 
     set_target_properties(${target} PROPERTIES FOLDER ${folder})
 
+    # Workaround link dependencies for cuda examples on platforms with GLX
+    if(CUDA_FOUND AND OpenGL_GLX_FOUND)
+        target_link_libraries(${target} OpenGL::GLX)
+    endif()
+
     if(CMAKE_COMPILER_IS_ICC)
         target_link_libraries(${target} ${ICC_LIBRARIES})
     endif()


### PR DESCRIPTION
Added an explicit target link dependency for OpenGL::GLX when building example programs with CUDA on systems with GLX since GLX is used by the example code used to initialize the CUDA device context.

This is a simple workaround and we'd like to revisit and improve how target dependencies are handled overall.

Fixes #1294