### PR TITLE
hbr/mesh.h: Fix warning, numfaces written but not read.

### DIFF
--- a/opensubdiv/hbr/mesh.h
+++ b/opensubdiv/hbr/mesh.h
@@ -899,8 +899,8 @@ HbrMesh<T>::PrintStats(std::ostream &out) {
             sumsides += f->GetNumVertices();
         }
     }
-    out << "Mesh has " << nfaces << " faces\n";
-    out << "Average sidedness " << (float) sumsides / nfaces << "\n";
+    out << "Mesh has " << numfaces << " faces\n";
+    out << "Average sidedness " << (float) sumsides / numfaces << "\n";
 }
 
 template <class T>


### PR DESCRIPTION
While it was iterating over the faces and calculating counts, `numfaces` was being incremented, but then `nfaces` was used. These would differ if there was a null face.

Found when using roughly current compilers for emscripten and a WebAssembly build.