### PR TITLE
Fixed Apple framework object dependencies

### DIFF
--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -312,7 +312,7 @@ if (NOT NO_LIB)
             $<TARGET_OBJECTS:far_obj>
             $<TARGET_OBJECTS:bfr_obj>
             $<TARGET_OBJECTS:osd_cpu_obj>
-            $<TARGET_OBJECTS:osd_gpu_obj>
+            $<$<TARGET_EXISTS:osd_gpu_obj>:$<TARGET_OBJECTS:osd_gpu_obj>>
             ${OPENGL_LOADER_OBJS}
         )
 
@@ -361,7 +361,7 @@ if (NOT NO_LIB)
                 $<TARGET_OBJECTS:far_obj>
                 $<TARGET_OBJECTS:bfr_obj>
                 $<TARGET_OBJECTS:osd_cpu_obj>
-                $<TARGET_OBJECTS:osd_gpu_obj>
+                $<$<TARGET_EXISTS:osd_gpu_obj>:$<TARGET_OBJECTS:osd_gpu_obj>>
                 ${OPENGL_LOADER_OBJS}
             )
 


### PR DESCRIPTION
Updated target object dependencies for Apple static and dynamic frameworks to use TARGET_EXISTS for osd_gpu_obj to allow correct linking when no OSD_GPU targets are enabled. We'll likely revisit these targets further for future releases of OpenSubdiv.

Fixes #1224
Fixes #1236