### PR TITLE
Improved documentation for OSD_CUDA_NVCC_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,10 +595,13 @@ if(CUDA_FOUND)
 
     if (UNIX)
         list( APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC )
+        # Use OSD_CUDA_NVCC_FLAGS to specify --gpu-architecture or other CUDA
+        # compilation options. The overrides here are only for compatibility
+        # with older OpenSubdiv releases and obsolete CUDA versions.
         if (NOT DEFINED OSD_CUDA_NVCC_FLAGS)
             if (CUDA_VERSION_MAJOR LESS 6)
                 set( OSD_CUDA_NVCC_FLAGS --gpu-architecture compute_11 )
-            else()
+            elseif (CUDA_VERSION_MAJOR LESS 8)
                 set( OSD_CUDA_NVCC_FLAGS --gpu-architecture compute_20 )
             endif()
         endif()

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ SDKROOT=$(xcrun --sdk iphoneos --show-sdk-path) cmake -D NO_PTEX=1 -D NO_DOC=1 \
 -DCMAKE_TOOLCHAIN_FILE=[toolchain file for crossplatform builds]
 
 -DCUDA_TOOLKIT_ROOT_DIR=[path to CUDA Toolkit]
+-DOSD_CUDA_NVCC_FLAGS=[CUDA options, e.g. --gpu-architecture]
+
 -DPTEX_LOCATION=[path to Ptex]
 -DGLFW_LOCATION=[path to GLFW]
 -DSTRINGIFY_LOCATION=[path to stringify utility]

--- a/documentation/cmake_build.rst
+++ b/documentation/cmake_build.rst
@@ -105,6 +105,8 @@ The following configuration arguments can be passed to the CMake command line.
    -DCMAKE_LIBDIR_BASE=[library directory basename (default: lib)]
 
    -DCUDA_TOOLKIT_ROOT_DIR=[path to CUDA]
+   -DOSD_CUDA_NVCC_FLAGS=[CUDA options, e.g. --gpu-architecture]
+
    -DPTEX_LOCATION=[path to Ptex]
    -DGLFW_LOCATION=[path to GLFW]
    -DTBB_LOCATION=[path to Intel's TBB]


### PR DESCRIPTION
Also fixed the build so that obsolete CUDA gpu architectures are specified as fallback values only when using older obsolete versions of CUDA. We'll likely remove these fallbacks from future releases of OpenSubdiv.

Fixes #961
Fixes #965
Fixes #1299