### PR TITLE
Further simplification of OpenGL import targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,7 +504,6 @@ elseif(OPENGL_FOUND)
     set(OPENGL_LOADER_INCLUDE_DIRS
         ${PROJECT_SOURCE_DIR}/glLoader)
     set(OPENGL_LOADER_LIBRARIES
-        OpenGL::GL
         ${CMAKE_DL_LIBS})
 
 endif()


### PR DESCRIPTION
The internal GL API Loader implementation is self contained and does not require the system OpenGL implementation at build time, so we don't need the OpenGL::GL import target for this case.

An earlier change added the OpenGL::GL import target for legacy uses of GLEW and it remains correct there.

Fixes #1277