### PR TITLE
Add [[fallthrough]] attribute to case statements when appropriate.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,9 @@ elseif(MSVC)
                     # warning C4548: expression before comma has no effect; expected expression with side-effect
                     /wd4548
 
+                    # warning C5051: attribute 'fallthrough' requires at least '/std:c++17'
+                    /wd5051
+
                     # Make sure WinDef.h does not define min and max macros which
                     # will conflict with std::min() and std::max().
                     /DNOMINMAX

--- a/opensubdiv/bfr/hash.cpp
+++ b/opensubdiv/bfr/hash.cpp
@@ -388,47 +388,47 @@ void SpookyHash::Short(
     {
     case 15:
     d += ((uint64)u.p8[14]) << 48;
-        // FALLTHRU
+        [[fallthrough]];
     case 14:
         d += ((uint64)u.p8[13]) << 40;
-        // FALLTHRU
+        [[fallthrough]];
     case 13:
         d += ((uint64)u.p8[12]) << 32;
-        // FALLTHRU
+        [[fallthrough]];
     case 12:
         d += u.p32[2];
         c += u.p64[0];
         break;
     case 11:
         d += ((uint64)u.p8[10]) << 16;
-        // FALLTHRU
+        [[fallthrough]];
     case 10:
         d += ((uint64)u.p8[9]) << 8;
-        // FALLTHRU
+        [[fallthrough]];
     case 9:
         d += (uint64)u.p8[8];
-        // FALLTHRU
+        [[fallthrough]];
     case 8:
         c += u.p64[0];
         break;
     case 7:
         c += ((uint64)u.p8[6]) << 48;
-        // FALLTHRU
+        [[fallthrough]];
     case 6:
         c += ((uint64)u.p8[5]) << 40;
-        // FALLTHRU
+        [[fallthrough]];
     case 5:
         c += ((uint64)u.p8[4]) << 32;
-        // FALLTHRU
+        [[fallthrough]];
     case 4:
         c += u.p32[0];
         break;
     case 3:
         c += ((uint64)u.p8[2]) << 16;
-        // FALLTHRU
+        [[fallthrough]];
     case 2:
         c += ((uint64)u.p8[1]) << 8;
-        // FALLTHRU
+        [[fallthrough]];
     case 1:
         c += (uint64)u.p8[0];
         break;


### PR DESCRIPTION
I added [`[[fallthrough]]`](https://en.cppreference.com/w/cpp/language/attributes/fallthrough) attributes to case statements when fallthrough behavior was intended.  
Fixes build warnings `-Wimplicit-fallthrough`.
```
opensubdiv/opensubdiv/bfr/hash.cpp:392:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  392 |     case 14:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:392:5: note: insert '[[fallthrough]];' to silence this warning
  392 |     case 14:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:392:5: note: insert 'break;' to avoid fall-through
  392 |     case 14:
      |     ^
      |     break; 
opensubdiv/opensubdiv/bfr/hash.cpp:395:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  395 |     case 13:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:395:5: note: insert '[[fallthrough]];' to silence this warning
  395 |     case 13:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:395:5: note: insert 'break;' to avoid fall-through
  395 |     case 13:
      |     ^
      |     break; 
opensubdiv/opensubdiv/bfr/hash.cpp:398:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  398 |     case 12:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:398:5: note: insert '[[fallthrough]];' to silence this warning
  398 |     case 12:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:398:5: note: insert 'break;' to avoid fall-through
  398 |     case 12:
      |     ^
      |     break; 
opensubdiv/opensubdiv/bfr/hash.cpp:405:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  405 |     case 10:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:405:5: note: insert '[[fallthrough]];' to silence this warning
  405 |     case 10:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:405:5: note: insert 'break;' to avoid fall-through
  405 |     case 10:
      |     ^
      |     break; 
opensubdiv/opensubdiv/bfr/hash.cpp:408:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  408 |     case 9:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:408:5: note: insert '[[fallthrough]];' to silence this warning
  408 |     case 9:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:408:5: note: insert 'break;' to avoid fall-through
  408 |     case 9:
      |     ^
      |     break; 
opensubdiv/opensubdiv/bfr/hash.cpp:411:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  411 |     case 8:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:411:5: note: insert '[[fallthrough]];' to silence this warning
  411 |     case 8:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:411:5: note: insert 'break;' to avoid fall-through
  411 |     case 8:
      |     ^
      |     break; 
opensubdiv/opensubdiv/bfr/hash.cpp:417:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  417 |     case 6:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:417:5: note: insert '[[fallthrough]];' to silence this warning
  417 |     case 6:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:417:5: note: insert 'break;' to avoid fall-through
  417 |     case 6:
      |     ^
      |     break; 
opensubdiv/opensubdiv/bfr/hash.cpp:420:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  420 |     case 5:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:420:5: note: insert '[[fallthrough]];' to silence this warning
  420 |     case 5:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:420:5: note: insert 'break;' to avoid fall-through
  420 |     case 5:
      |     ^
      |     break; 
opensubdiv/opensubdiv/bfr/hash.cpp:423:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  423 |     case 4:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:423:5: note: insert '[[fallthrough]];' to silence this warning
  423 |     case 4:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:423:5: note: insert 'break;' to avoid fall-through
  423 |     case 4:
      |     ^
      |     break; 
opensubdiv/opensubdiv/bfr/hash.cpp:429:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  429 |     case 2:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:429:5: note: insert '[[fallthrough]];' to silence this warning
  429 |     case 2:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:429:5: note: insert 'break;' to avoid fall-through
  429 |     case 2:
      |     ^
      |     break; 
opensubdiv/opensubdiv/bfr/hash.cpp:432:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  432 |     case 1:
      |     ^
opensubdiv/opensubdiv/bfr/hash.cpp:432:5: note: insert '[[fallthrough]];' to silence this warning
  432 |     case 1:
      |     ^
      |     [[fallthrough]]; 
opensubdiv/opensubdiv/bfr/hash.cpp:432:5: note: insert 'break;' to avoid fall-through
  432 |     case 1:
      |     ^
      |     break; 
11 errors generated.
```