### PR TITLE
allow absolute GNU install dirs

### DIFF
--- a/opensubdiv-config.cmake.in
+++ b/opensubdiv-config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-set_and_check(OpenSubdiv_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
-set_and_check(OpenSubdiv_LIB_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
+set_and_check(OpenSubdiv_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
+set_and_check(OpenSubdiv_LIB_DIR "@CMAKE_INSTALL_FULL_LIBDIR@")
 
 include("${CMAKE_CURRENT_LIST_DIR}/OpenSubdivTargets.cmake")


### PR DESCRIPTION
`CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_INCLUDEDIR` are allowed to be absolute [as per CMake docs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html), so they shouldn't be concatenated to absolute paths. Instead, use `CMAKE_INSTALL_FULL_LIBDIR` and `CMAKE_INSTALL_FULL_INCLUDEDIR`, which are known to be absolute.

Absolute `CMAKE_INSTALL_*DIR` paths are used at least on NixOS. This is because NixOS packages are allowed to have multiple outputs (e.g. put docs in one dir, headers and other files for development to another, the binaries to a third one), and NixOS isn't FHS-compliant (There's no `/usr`, each package output has its own directory instead).

GNU Guix is a similar distro, but I'm not sure how CMake packages are built there. Either way, it's good to fully conform to the spec.