### PR TITLE
Marked deprecated Osd::*Evaluator::SetNumThreads()

### DIFF
--- a/opensubdiv/osd/ompEvaluator.cpp
+++ b/opensubdiv/osd/ompEvaluator.cpp
@@ -361,6 +361,8 @@ OmpEvaluator::Synchronize(void * /*deviceContext*/) {
 /* static */
 void
 OmpEvaluator::SetNumThreads(int numThreads) {
+    // This is deprecated functionality. We preserve the existing behavior
+    // for consistency.
     omp_set_num_threads(numThreads);
 }
 

--- a/opensubdiv/osd/ompEvaluator.h
+++ b/opensubdiv/osd/ompEvaluator.h
@@ -1225,6 +1225,7 @@ public:
 
     static void Synchronize(void *deviceContext = NULL);
 
+    /// \brief Deprecated. Client code should initialize OpenMP.
     static void SetNumThreads(int numThreads);
 };
 

--- a/opensubdiv/osd/tbbEvaluator.cpp
+++ b/opensubdiv/osd/tbbEvaluator.cpp
@@ -25,7 +25,12 @@
 #include "../osd/tbbEvaluator.h"
 #include "../osd/tbbKernel.h"
 
+// Get TBB version from tbb/parallel_for used by osd/tbbKernel
+#include <tbb/parallel_for.h>
+#if defined(TBB_INTERFACE_VERSION_MAJOR) && (TBB_INTERFACE_VERSION_MAJOR < 12)
+// This is deprecated functionality.
 #include <tbb/task_scheduler_init.h>
+#endif
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
@@ -215,11 +220,15 @@ TbbEvaluator::Synchronize(void *) {
 /* static */
 void
 TbbEvaluator::SetNumThreads(int numThreads) {
+#if defined(TBB_INTERFACE_VERSION_MAJOR) && (TBB_INTERFACE_VERSION_MAJOR < 12)
+    // This is deprecated functionality. We preserve the existing behavior
+    // for consistency (when using older versions of tbb).
     if (numThreads == -1) {
         tbb::task_scheduler_init init;
     } else {
         tbb::task_scheduler_init init(numThreads);
     }
+#endif
 }
 
 }  // end namespace Osd

--- a/opensubdiv/osd/tbbEvaluator.h
+++ b/opensubdiv/osd/tbbEvaluator.h
@@ -1226,8 +1226,7 @@ public:
     /// \brief synchronize all asynchronous computation invoked on this device.
     static void Synchronize(void *deviceContext = NULL);
 
-    /// \brief initialize tbb task schedular
-    ///        (optional: client may use tbb::task_scheduler_init)
+    /// \brief Deprecated. Client code should initialize TBB.
     ///
     /// @param numThreads      how many threads
     ///


### PR DESCRIPTION
The existing implementation in Osd::TbbEvaluator has never been implemented correctly and that implementation is incompatible with the oneTBB API.

These methods are now marked deprecated in the two places where defined in Osd::TbbEvaluator and Osd::OmpEvaluator, but for consistency we preserve the existing implementation when building with older versions of tbb.

We've already removed all use of these methods from the tests and examples.

Fixes #1211 #1234 #1307