### PR TITLE
Fixed inconsistent warning levels for MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,9 +242,6 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANGCC OR CMAKE_COMPILER_IS_IC
 
 elseif(MSVC)
 
-    # Turn on all warnings
-    list(APPEND OSD_COMPILER_FLAGS /Wall)
-
     list(APPEND OSD_COMPILER_FLAGS
                     /W3     # Use warning level recommended for production purposes.
                     /WX     # Treat all compiler warnings as errors.


### PR DESCRIPTION
The MSVC build has been setting /W3 as an override for /Wall but this has been causing generator specfic build inconsistencies.

For examples, this override works when using the Visual Studio generators, but not when using the Ninja generator. This causes Ninja to build using /Wall instead of /W3.

This removes the initial setting of /Wall to avoid this inconsistency.

We plan to continue to address compiler warnings to allow us to raise this warning level further but that is a separate task.

Thanks to @LazyDodo for diagnosing the root cause of this inconsistency

Fixes #1269 #1283 