### PR TITLE
Improved osd patch drawing compatibility

### DIFF
--- a/opensubdiv/osd/glslPatchShaderSource.cpp
+++ b/opensubdiv/osd/glslPatchShaderSource.cpp
@@ -67,10 +67,18 @@ static const char *gregoryTriangleShaderSource =
 
 /*static*/
 std::string
-GLSLPatchShaderSource::GetCommonShaderSource() {
+GLSLPatchShaderSource::GetPatchDrawingShaderSource() {
     std::stringstream ss;
     ss << std::string(commonShaderSource);
     ss << std::string(commonTessShaderSource);
+    return ss.str();
+}
+
+/*static*/
+std::string
+GLSLPatchShaderSource::GetCommonShaderSource() {
+    std::stringstream ss;
+    ss << GetPatchDrawingShaderSource();
     ss << std::string(patchLegacyShaderSource);
     return ss.str();
 }

--- a/opensubdiv/osd/glslPatchShaderSource.h
+++ b/opensubdiv/osd/glslPatchShaderSource.h
@@ -26,19 +26,38 @@
 #define OPENSUBDIV3_OSD_GLSL_PATCH_SHADER_SOURCE_H
 
 #include "../version.h"
-#include <string>
+
 #include "../far/patchDescriptor.h"
+
+#include <string>
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Osd {
 
+/// \brief Provides shader source which can be used by client code.
 class GLSLPatchShaderSource {
 public:
-    static std::string GetCommonShaderSource();
-
+    /// \brief Returns shader source which can be used to evaluate
+    /// position and first and second derivatives on piecewise parametric
+    /// patches resulting from subdivision refinement.
     static std::string GetPatchBasisShaderSource();
+
+    /// \brief Returns shader source which can be used while drawing
+    /// piecewise parametric patches resulting from subdivision refinement,
+    /// e.g. while using GPU HW tessellation.
+    static std::string GetPatchDrawingShaderSource();
+
+    /// \name Alternative methods
+    /// \{
+    /// These methods return shader source which can be used
+    /// while drawing. Unlike the methods above, the source returned
+    /// by these methods includes support for legacy patch types along
+    /// with dependencies on specific resource bindings and interstage
+    /// shader variable declarations.
+
+    static std::string GetCommonShaderSource();
 
     static std::string GetVertexShaderSource(
         Far::PatchDescriptor::Type type);
@@ -48,6 +67,8 @@ public:
 
     static std::string GetTessEvalShaderSource(
         Far::PatchDescriptor::Type type);
+
+    /// \}
 };
 
 }  // end namespace Osd

--- a/opensubdiv/osd/hlslPatchLegacy.hlsl
+++ b/opensubdiv/osd/hlslPatchLegacy.hlsl
@@ -22,6 +22,128 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
+//----------------------------------------------------------
+// Patches.Common
+//----------------------------------------------------------
+
+struct InputVertex {
+    float4 position : POSITION;
+    float3 normal : NORMAL;
+};
+
+struct HullVertex {
+    float4 position : POSITION;
+#ifdef OSD_ENABLE_PATCH_CULL
+    int3 clipFlag : CLIPFLAG;
+#endif
+};
+
+// XXXdyu all downstream data can be handled by client code
+struct OutputVertex {
+    float4 positionOut : SV_Position;
+    float4 position : POSITION1;
+    float3 normal : NORMAL;
+    float3 tangent : TANGENT;
+    float3 bitangent : TANGENT1;
+    float4 patchCoord : PATCHCOORD; // u, v, faceLevel, faceId
+    noperspective float4 edgeDistance : EDGEDISTANCE;
+#if defined(OSD_COMPUTE_NORMAL_DERIVATIVES)
+    float3 Nu : TANGENT2;
+    float3 Nv : TANGENT3;
+#endif
+#if defined OSD_PATCH_ENABLE_SINGLE_CREASE
+    float2 vSegments : VSEGMENTS;
+#endif
+};
+
+float4x4 OsdModelViewProjectionMatrix();
+int OsdGregoryQuadOffsetBase();
+int OsdPrimitiveIdBase();
+int OsdBaseVertex();
+
+#ifndef OSD_DISPLACEMENT_CALLBACK
+#define OSD_DISPLACEMENT_CALLBACK
+#endif
+
+// These are stored in OsdPatchParamBuffer indexed by the value returned
+// from OsdGetPatchIndex() which is a function of the current PrimitiveID
+// along with an optional client provided offset.
+
+#if defined OSD_PATCH_ENABLE_SINGLE_CREASE
+    Buffer<uint3> OsdPatchParamBuffer : register( t0 );
+#else
+    Buffer<uint2> OsdPatchParamBuffer : register( t0 );
+#endif
+
+int OsdGetPatchIndex(int primitiveId)
+{
+    return (primitiveId + OsdPrimitiveIdBase());
+}
+
+int3 OsdGetPatchParam(int patchIndex)
+{
+#if defined OSD_PATCH_ENABLE_SINGLE_CREASE
+    return OsdPatchParamBuffer[patchIndex].xyz;
+#else
+    uint2 p = OsdPatchParamBuffer[patchIndex].xy;
+    return int3(p.x, p.y, 0);
+#endif
+}
+
+// ----------------------------------------------------------------------------
+// patch culling
+// ----------------------------------------------------------------------------
+
+#ifdef OSD_ENABLE_PATCH_CULL
+
+#define OSD_PATCH_CULL_COMPUTE_CLIPFLAGS(P)                     \
+    float4 clipPos = mul(OsdModelViewProjectionMatrix(), P);    \
+    int3 clip0 = int3(clipPos.x < clipPos.w,                    \
+                      clipPos.y < clipPos.w,                    \
+                      clipPos.z < clipPos.w);                   \
+    int3 clip1 = int3(clipPos.x > -clipPos.w,                   \
+                      clipPos.y > -clipPos.w,                   \
+                      clipPos.z > -clipPos.w);                  \
+    output.clipFlag = int3(clip0) + 2*int3(clip1);              \
+
+#define OSD_PATCH_CULL(N)                          \
+    int3 clipFlag = int3(0,0,0);                   \
+    for(int i = 0; i < N; ++i) {                   \
+        clipFlag |= patch[i].clipFlag;             \
+    }                                              \
+    if (any(clipFlag != int3(3,3,3))) {            \
+        output.tessLevelInner[0] = 0;              \
+        output.tessLevelInner[1] = 0;              \
+        output.tessLevelOuter[0] = 0;              \
+        output.tessLevelOuter[1] = 0;              \
+        output.tessLevelOuter[2] = 0;              \
+        output.tessLevelOuter[3] = 0;              \
+        output.tessOuterLo = float4(0,0,0,0);      \
+        output.tessOuterHi = float4(0,0,0,0);      \
+        return output;                             \
+    }
+
+#define OSD_PATCH_CULL_TRIANGLE(N)                          \
+    int3 clipFlag = int3(0,0,0);                   \
+    for(int i = 0; i < N; ++i) {                   \
+        clipFlag |= patch[i].clipFlag;             \
+    }                                              \
+    if (any(clipFlag != int3(3,3,3))) {            \
+        output.tessLevelInner[0] = 0;              \
+        output.tessLevelOuter[0] = 0;              \
+        output.tessLevelOuter[1] = 0;              \
+        output.tessLevelOuter[2] = 0;              \
+        output.tessOuterLo = float4(0,0,0,0);      \
+        output.tessOuterHi = float4(0,0,0,0);      \
+        return output;                             \
+    }
+
+#else
+#define OSD_PATCH_CULL_COMPUTE_CLIPFLAGS(P)
+#define OSD_PATCH_CULL(N)
+#define OSD_PATCH_CULL_TRIANGLE(N)
+#endif
+
 // ----------------------------------------------------------------------------
 // Legacy Gregory
 // ----------------------------------------------------------------------------

--- a/opensubdiv/osd/hlslPatchShaderSource.cpp
+++ b/opensubdiv/osd/hlslPatchShaderSource.cpp
@@ -69,10 +69,18 @@ static const char *gregoryTriangleShaderSource =
 
 /*static*/
 std::string
-HLSLPatchShaderSource::GetCommonShaderSource() {
+HLSLPatchShaderSource::GetPatchDrawingShaderSource() {
     std::stringstream ss;
     ss << std::string(commonShaderSource);
     ss << std::string(commonTessShaderSource);
+    return ss.str();
+}
+
+/*static*/
+std::string
+HLSLPatchShaderSource::GetCommonShaderSource() {
+    std::stringstream ss;
+    ss << GetPatchDrawingShaderSource();
     ss << std::string(patchLegacyShaderSource);
     return ss.str();
 }

--- a/opensubdiv/osd/hlslPatchShaderSource.h
+++ b/opensubdiv/osd/hlslPatchShaderSource.h
@@ -26,25 +26,46 @@
 #define OPENSUBDIV3_OSD_HLSL_PATCH_SHADER_SOURCE_H
 
 #include "../version.h"
-#include <string>
+
 #include "../far/patchDescriptor.h"
+
+#include <string>
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
 
 namespace Osd {
 
+/// \brief Provides shader source which can be used by client code.
 class HLSLPatchShaderSource {
 public:
-    static std::string GetCommonShaderSource();
-
+    /// \brief Returns shader source which can be used to evaluate
+    /// position and first and second derivatives on piecewise parametric
+    /// patches resulting from subdivision refinement.
     static std::string GetPatchBasisShaderSource();
+
+    /// \brief Returns shader source which can be used while drawing
+    /// piecewise parametric patches resulting from subdivision refinement,
+    /// e.g. while using GPU HW tessellation.
+    static std::string GetPatchDrawingShaderSource();
+
+    /// \name Alternative methods
+    /// \{
+    /// These methods return shader source which can be used
+    /// while drawing. Unlike the methods above, the source returned
+    /// by these methods includes support for legacy patch types along
+    /// with dependencies on specific resource bindings and interstage
+    /// shader variable declarations.
+
+    static std::string GetCommonShaderSource();
 
     static std::string GetVertexShaderSource(Far::PatchDescriptor::Type type);
 
     static std::string GetHullShaderSource(Far::PatchDescriptor::Type type);
 
     static std::string GetDomainShaderSource(Far::PatchDescriptor::Type type);
+
+    /// @}
 };
 
 }  // end namespace Osd

--- a/opensubdiv/osd/mtlPatchCommon.metal
+++ b/opensubdiv/osd/mtlPatchCommon.metal
@@ -24,173 +24,15 @@
 //   language governing permissions and limitations under the Apache License.
 //
 
-//----------------------------------------------------------
-// Patches.Common
-//----------------------------------------------------------
-
 #include <metal_stdlib>
-
-#define offsetof_(X, Y) &(((device X*)nullptr)->Y)
-
-#define OSD_IS_ADAPTIVE (OSD_PATCH_REGULAR || OSD_PATCH_BOX_SPLINE_TRIANGLE || OSD_PATCH_GREGORY_BASIS || OSD_PATCH_GREGORY_TRIANGLE || OSD_PATCH_GREGORY || OSD_PATCH_GREGORY_BOUNDARY)
-
-#ifndef OSD_MAX_TESS_LEVEL
-#define OSD_MAX_TESS_LEVEL 64
-#endif
-
-#ifndef OSD_NUM_ELEMENTS
-#define OSD_NUM_ELEMENTS 3
-#endif
 
 using namespace metal;
 
-using OsdPatchParamBufferType = packed_int3;
-
-struct OsdPerVertexGregory {
-    float3 P;
-    short3 clipFlag;
-    int valence;
-    float3 e0;
-    float3 e1;
-#if OSD_PATCH_GREGORY_BOUNDARY
-    int zerothNeighbor;
-    float3 org;
-#endif
-    float3 r[OSD_MAX_VALENCE];
-};
-
-struct OsdPerPatchVertexGregory {
-    packed_float3 P;
-    packed_float3 Ep;
-    packed_float3 Em;
-    packed_float3 Fp;
-    packed_float3 Fm;
-};
-
-//----------------------------------------------------------
-// HLSL->Metal Compatibility
-//----------------------------------------------------------
-
-float4 mul(float4x4 a, float4 b)
-{
-    return a * b;
-}
-
-float3 mul(float4x4 a, float3 b)
-{
-    float3x3 m(a[0].xyz, a[1].xyz, a[2].xyz);
-    return m * b;
-
-}
-
-//----------------------------------------------------------
-// Patches.Common
-//----------------------------------------------------------
-
-struct HullVertex {
-    float4 position;
-#if OSD_ENABLE_PATCH_CULL
-    short3 clipFlag;
-#endif
-
-    float3 GetPosition() threadgroup
-    {
-        return position.xyz;
-    }
-
-    void SetPosition(float3 v) threadgroup
-    {
-        position.xyz = v;
-    }
-};
-
-// XXXdyu all downstream data can be handled by client code
-struct OsdPatchVertex {
-    float3 position;
-    float3 normal;
-    float3 tangent;
-    float3 bitangent;
-    float4 patchCoord; //u, v, faceLevel, faceId
-    float2 tessCoord; // tesscoord.st
-#if OSD_COMPUTE_NORMAL_DERIVATIVES
-    float3 Nu;
-    float3 Nv;
-#endif
-#if OSD_PATCH_ENABLE_SINGLE_CREASE
-    float2 vSegments;
-#endif
-};
-
-struct OsdPerPatchTessFactors {
-    float4 tessOuterLo;
-    float4 tessOuterHi;
-};
-
-struct OsdPerPatchVertexBezier {
-    packed_float3 P;
-#if OSD_PATCH_ENABLE_SINGLE_CREASE
-    packed_float3 P1;
-    packed_float3 P2;
-#if !USE_PTVS_SHARPNESS
-    float2 vSegments;
-#endif
-#endif
-};
-
-struct OsdPerPatchVertexGregoryBasis {
-    packed_float3 P;
-};
-
-#if OSD_PATCH_REGULAR || OSD_PATCH_BOX_SPLINE_TRIANGLE
-using PatchVertexType = HullVertex;
-using PerPatchVertexType = OsdPerPatchVertexBezier;
-#elif OSD_PATCH_GREGORY || OSD_PATCH_GREGORY_BOUNDARY
-using PatchVertexType = OsdPerVertexGregory;
-using PerPatchVertexType = OsdPerPatchVertexGregory;
-#elif OSD_PATCH_GREGORY_BASIS || OSD_PATCH_GREGORY_TRIANGLE
-using PatchVertexType = HullVertex;
-using PerPatchVertexType = OsdPerPatchVertexGregoryBasis;
-#else
-using PatchVertexType = OsdInputVertexType;
-using PerPatchVertexType = OsdInputVertexType;
-#endif
-
-//Shared buffers used by OSD that are common to all kernels
-struct OsdPatchParamBufferSet
-{
-    const device OsdInputVertexType* vertexBuffer [[buffer(VERTEX_BUFFER_INDEX)]];
-    const device unsigned* indexBuffer [[buffer(CONTROL_INDICES_BUFFER_INDEX)]];
-
-    const device OsdPatchParamBufferType* patchParamBuffer [[buffer(OSD_PATCHPARAM_BUFFER_INDEX)]];
-
-    device PerPatchVertexType* perPatchVertexBuffer [[buffer(OSD_PERPATCHVERTEX_BUFFER_INDEX)]];
-
-#if !USE_PTVS_FACTORS
-    device OsdPerPatchTessFactors* patchTessBuffer [[buffer(OSD_PERPATCHTESSFACTORS_BUFFER_INDEX)]];
-#endif
-
-#if OSD_PATCH_GREGORY || OSD_PATCH_GREGORY_BOUNDARY
-    const device int* quadOffsetBuffer [[buffer(OSD_QUADOFFSET_BUFFER_INDEX)]];
-    const device int* valenceBuffer [[buffer(OSD_VALENCE_BUFFER_INDEX)]];
-#endif
-
-    const constant unsigned& kernelExecutionLimit [[buffer(OSD_KERNELLIMIT_BUFFER_INDEX)]];
-};
-
-//Shared buffers used by OSD that are common to all PTVS implementations
-struct OsdVertexBufferSet
-{
-    const device OsdInputVertexType* vertexBuffer [[buffer(VERTEX_BUFFER_INDEX)]];
-    const device unsigned* indexBuffer [[buffer(CONTROL_INDICES_BUFFER_INDEX)]];
-
-    const device OsdPatchParamBufferType* patchParamBuffer [[buffer(OSD_PATCHPARAM_BUFFER_INDEX)]];
-
-    device PerPatchVertexType* perPatchVertexBuffer [[buffer(OSD_PERPATCHVERTEX_BUFFER_INDEX)]];
-
-#if !USE_PTVS_FACTORS
-    device OsdPerPatchTessFactors* patchTessBuffer [[buffer(OSD_PERPATCHTESSFACTORS_BUFFER_INDEX)]];
-#endif
-};
+// The following callback functions are used when evaluating tessellation
+// rates and when using legacy patch drawing.
+float4x4 OsdModelViewMatrix();
+float4x4 OsdProjectionMatrix();
+float OsdTessLevel();
 
 // ----------------------------------------------------------------------------
 // Patch Parameters
@@ -204,25 +46,6 @@ struct OsdVertexBufferSet
 //    bitfield  -- refinement-level, non-quad, boundary, transition, uv-offset
 //    sharpness -- crease sharpness for single-crease patches
 //
-// These are stored in OsdPatchParamBuffer indexed by the value returned
-// from OsdGetPatchIndex() which is a function of the current PrimitiveID
-// along with an optional client provided offset.
-//
-
-int3 OsdGetPatchParam(int patchIndex, const device OsdPatchParamBufferType* osdPatchParamBuffer)
-{
-#if OSD_PATCH_ENABLE_SINGLE_CREASE
-    return int3(osdPatchParamBuffer[patchIndex]);
-#else
-    auto p = osdPatchParamBuffer[patchIndex];
-    return int3(p[0], p[1], 0);
-#endif
-}
-
-int OsdGetPatchIndex(int primitiveId)
-{
-    return primitiveId;
-}
 
 int OsdGetPatchFaceId(int3 patchParam)
 {
@@ -317,40 +140,6 @@ float4 OsdInterpolatePatchCoordTriangle(float2 localUV, int3 patchParam)
 }
 
 // ----------------------------------------------------------------------------
-// patch culling
-// ----------------------------------------------------------------------------
-
-bool OsdCullPerPatchVertex(
-        threadgroup PatchVertexType* patch,
-        float4x4 ModelViewMatrix
-        )
-{
-#if OSD_ENABLE_BACKPATCH_CULL && OSD_PATCH_REGULAR
-    auto v0 = float3(ModelViewMatrix * patch[5].position);
-    auto v3 = float3(ModelViewMatrix * patch[6].position);
-    auto v12 = float3(ModelViewMatrix * patch[9].position);
-
-    auto n = normalize(cross(v3 - v0, v12 - v0));
-    v0 = normalize(v0 + v3 + v12);
-
-    if(dot(v0, n) > 0.6f)
-    {
-        return false;
-    }
-#endif
-#if OSD_ENABLE_PATCH_CULL
-    short3 clipFlag = short3(0,0,0);
-    for(int i = 0; i < CONTROL_POINTS_PER_PATCH; ++i) {
-        clipFlag |= patch[i].clipFlag;
-    }
-    if (any(clipFlag != short3(3,3,3))) {
-        return false;
-    }
-#endif
-    return true;
-}
-
-// ----------------------------------------------------------------------------
 
 void
 OsdUnivar4x4(float u, thread float* B)
@@ -420,6 +209,17 @@ OsdUnivar4x4(float u, thread float* B, thread float* D, thread float* C)
 }
 
 // ----------------------------------------------------------------------------
+
+struct OsdPerPatchVertexBezier {
+    packed_float3 P;
+#if OSD_PATCH_ENABLE_SINGLE_CREASE
+    packed_float3 P1;
+    packed_float3 P2;
+#if !USE_PTVS_SHARPNESS
+    float2 vSegments;
+#endif
+#endif
+};
 
 float3
 OsdEvalBezier(float3 cp[16], float2 uv)
@@ -1088,6 +888,10 @@ OsdEvalPatchBezier(int3 patchParam, float2 UV,
 // Gregory Basis
 // ----------------------------------------------------------------------------
 
+struct OsdPerPatchVertexGregoryBasis {
+    packed_float3 P;
+};
+
 void
 OsdComputePerPatchVertexGregoryBasis(int3 patchParam, int ID, float3 cv,
                                      device OsdPerPatchVertexGregoryBasis& result)
@@ -1444,3 +1248,4 @@ OsdEvalPatchGregoryTriangle(int3 patchParam, float2 UV, float3 cv[18],
 
     OsdEvalPatchBezierTriangle(patchParam, UV, bezcv, P, dPu, dPv, N, dNu, dNv);
 }
+

--- a/opensubdiv/osd/mtlPatchCommonTess.metal
+++ b/opensubdiv/osd/mtlPatchCommonTess.metal
@@ -81,6 +81,10 @@
 // (0,0)                                         (1,0)
 //
 
+#ifndef OSD_MAX_TESS_LEVEL
+#define OSD_MAX_TESS_LEVEL 64
+#endif
+
 float OsdComputePostProjectionSphereExtent(
         const float4x4 OsdProjectionMatrix, float3 center, float diameter)
 {

--- a/opensubdiv/osd/mtlPatchShaderSource.h
+++ b/opensubdiv/osd/mtlPatchShaderSource.h
@@ -26,7 +26,9 @@
 #define OPENSUBDIV3_OSD_MTL_PATCH_SHADER_SOURCE_H
 
 #import "../version.h"
+
 #import "../far/patchDescriptor.h"
+
 #import <string>
 
 namespace OpenSubdiv {
@@ -34,11 +36,28 @@ namespace OPENSUBDIV_VERSION {
 
 namespace Osd {
 
+/// \brief Provides shader source which can be used by client code.
 class MTLPatchShaderSource {
-    public:
-    static std::string GetCommonShaderSource();
-
+public:
+    /// \brief Returns shader source which can be used to evaluate
+    /// position and first and second derivatives on piecewise parametric
+    /// patches resulting from subdivision refinement.
     static std::string GetPatchBasisShaderSource();
+
+    /// \brief Returns shader source which can be used while drawing
+    /// piecewise parametric patches resulting from subdivision refinement,
+    /// e.g. while using GPU HW tessellation.
+    static std::string GetPatchDrawingShaderSource();
+
+    /// \name Alternative methods
+    /// \{
+    /// These methods return shader source which can be used
+    /// while drawing. Unlike the methods above, the source returned
+    /// by these methods includes support for legacy patch types along
+    /// with dependencies on specific resource bindings and interstage
+    /// shader variable declarations.
+
+    static std::string GetCommonShaderSource();
 
     static std::string GetVertexShaderSource(Far::PatchDescriptor::Type type);
 
@@ -59,6 +78,9 @@ class MTLPatchShaderSource {
     static std::string GetDomainShaderSource(
         Far::PatchDescriptor::Type type,
         Far::PatchDescriptor::Type fvarType);
+
+    /// @}
+
 };
 
 }  // end namespace Osd

--- a/opensubdiv/osd/mtlPatchShaderSource.mm
+++ b/opensubdiv/osd/mtlPatchShaderSource.mm
@@ -147,18 +147,23 @@ GetPatchTypeSource(Far::PatchDescriptor::Type type) {
 
 /*static*/
 std::string
-MTLPatchShaderSource::GetCommonShaderSource() {
+MTLPatchShaderSource::GetPatchDrawingShaderSource() {
 #if TARGET_OS_IOS || TARGET_OS_TV
     return std::string("#define OSD_METAL_IOS 1\n")
                .append(commonShaderSource)
-               .append(commonTessShaderSource)
-               .append(patchLegacyShaderSource);
+               .append(commonTessShaderSource);
 #elif TARGET_OS_OSX
     return std::string("#define OSD_METAL_OSX 1\n")
                .append(commonShaderSource)
-               .append(commonTessShaderSource)
-               .append(patchLegacyShaderSource);
+               .append(commonTessShaderSource);
 #endif
+}
+
+/*static*/
+std::string
+MTLPatchShaderSource::GetCommonShaderSource() {
+    return GetPatchDrawingShaderSource()
+               .append(patchLegacyShaderSource);
 }
 
 /*static*/


### PR DESCRIPTION
Submitted as two commits for a cleaner commit history.

--

Reorganized legacy patch drawing shader source
    
Relocated from PatchCommon to PatchLegacy several aspects of the
shader source which can cause problems with typical use cases.
Specifically, things like resource bindings, input assembler and
interstage declarations are best left to client code.
    
These are not removed, just relocated and remain available for
backward compatibility. Updated the GLSL, HLSL, and MSL source.

--

Added GetPatchDrawingShaderSource()
    
This is a new method for GLSL, HLSL, and MSL which returns patch
drawing shader source which excludes legacy shader source aspects.
    
This improves portability and compatibility and may also improve
shader compile times since the resulting shader source strings
are smaller without the legacy shader source aspects.
    
Tested with Vulkan and DX12 in addition to GL, DX11, and Metal.

Fixes #938 #1153 

