### PR TITLE
Fixed cmake/FindOpenCL.cmake version parsing

### DIFF
--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -177,7 +177,7 @@ if(_OPENCL_CPP_INCLUDE_DIRS)
     
     if(EXISTS "${OPENCL_INCLUDE_DIRS}/CL/cl.h")
     
-        file(STRINGS "${OPENCL_INCLUDE_DIRS}/CL/cl.h" LINES REGEX "^#define CL_VERSION_.*$")
+        file(STRINGS "${OPENCL_INCLUDE_DIRS}/CL/cl.h" LINES REGEX "^#define CL_VERSION_[0-9]_[0-9]")
 
         foreach(LINE ${LINES})
         


### PR DESCRIPTION
Current versions of the OpenCL headers define several version macros and we want to make sure to parse just the main version macro.

This is a simple near-term fix, since we'd like to move to the standard CMake FindOpenCL module and delete this custom module.