### PR TITLE
Updated azure pipelines for macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,10 +30,10 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: 'macOS-11'
+    vmImage: 'macOS-12'
   steps:
   - script: |
-      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_13.2.app/Contents/Developer"
+      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_14.2.app/Contents/Developer"
       python build_scripts/build_osd.py --tests --tbb --generator Xcode --build $HOME/OSDgen/build --src $HOME/OSDgen/src $HOME/OSDinst
     displayName: 'Building OpenSubdiv'
   - script: |


### PR DESCRIPTION
- macOS 12 Monterey (updated from macOS 11, unsupported after 6/28/2024)