### PR TITLE
Updated azure pipelines for macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,10 +30,10 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - script: |
-      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_14.2.app/Contents/Developer"
+      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_14.3.app/Contents/Developer"
       python build_scripts/build_osd.py --tests --tbb --generator Xcode --build $HOME/OSDgen/build --src $HOME/OSDgen/src $HOME/OSDinst
     displayName: 'Building OpenSubdiv'
   - script: |


### PR DESCRIPTION
- macOS 13 Ventura (updated from macOS 12 unsupported after 12/03/2024)