### PR TITLE
Updated CMake minimum version to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 #   language governing permissions and limitations under the Apache License.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 
 project(OpenSubdiv)
 


### PR DESCRIPTION
We typically test with more recent versions of CMake and we will update this further, but this is the minimum version which allows us to continue improving support for building for embedded systems like iOS.