### PR TITLE
Fix sharing of Bfr::Surface topology with valence-2 interior vertices

### DIFF
--- a/opensubdiv/bfr/irregularPatchBuilder.h
+++ b/opensubdiv/bfr/irregularPatchBuilder.h
@@ -74,6 +74,9 @@ public:
     void print() const;
 
 public:
+    //  This will not be necessary if use of the index map is ever removed:
+    bool ControlHullDependsOnMeshIndices() const { return _useControlVertMap; }
+
     //  Methods to query the number and indices of control vertices:
     int GetNumControlVertices() const { return _numControlVerts; }
 
@@ -104,6 +107,8 @@ private:
         int          numControlVerts;
         int          nextControlVert;
         int          surfaceIndicesOffset;
+        unsigned int isVal2Interior   : 1;
+        unsigned int preVal2Interior  : 1;
         unsigned int singleSharedVert : 1;
         unsigned int singleSharedFace : 1;
     };
@@ -127,7 +132,7 @@ private:
                                 int  corner,      int nextPerimeterVert) const;
     void getControlFaceVertices(int  faceVerts[], int numFaceVerts,
                                 int  corner,      int nextPerimeterVert,
-                                bool lastFace) const;
+                                bool lastFace,    int numVal2InLast) const;
     void getControlFaceVertices(int  faceVerts[], int numFaceVerts,
                                 int  corner,      Index const srcVerts[]) const;
 

--- a/opensubdiv/bfr/surfaceFactory.cpp
+++ b/opensubdiv/bfr/surfaceFactory.cpp
@@ -821,9 +821,14 @@ SurfaceFactory::assignIrregularSurface(SurfaceType * surfacePtr,
     //
     //  Construct a new irregular patch or identify one from the cache:
     //
+    //  Note that in rare cases where control faces overlap, the current
+    //  implementation of IrregularPatchBuilder may create patches whose
+    //  size varies with the indices of neighboring vertices (producing a
+    //  unique set). So we cannot use a cached result in such cases.
+    //
     internal::IrregularPatchSharedPtr patch(0);
 
-    if (_topologyCache == 0) {
+    if ((_topologyCache == 0) || builder.ControlHullDependsOnMeshIndices()) {
         patch = builder.Build();
     } else {
         //


### PR DESCRIPTION
These changes fix a bug in the Bfr::SurfaceFactory in rare topological cases where valence-2 interior vertices (which cause the control hull to fold over on itself) are present in combination with vertices that occur multiple times around the base face. The bug may cause memory overwrites or an incorrect limit surface when the irregular patch for a face with a valence-2 interior vertex is shared with another topologically similar face.

The problem is addressed with the following changes to the internal IrregularPatchBuilder class and its usage:

- the IrregularPatchBuilder was updated to assemble a reusable control hull for the more common case of only one valence-2 interior vertex -- reverting to the existing method of identifying control vertices from the unique set of mesh indices when any other valence-2 vertices are present.
- the SurfaceFactory was updated to avoid caching and sharing patch topology when the builder has constructed the patch using the mesh indices (since it may not be reusable for the same topology given a different set of indices).

So the more common valence-2 interior case now yields an irregular patch that can be cached and shared (beneficial if the same feature is heavily replicated/instantiated) while those less common cases that cannot be shared are excluded from the cache.