### PR TITLE
Addressed warnings from Clang 16

### DIFF
--- a/examples/common/mtlControlMeshDisplay.h
+++ b/examples/common/mtlControlMeshDisplay.h
@@ -47,10 +47,10 @@ public:
 private:
     bool createProgram(MTLRenderPipelineDescriptor* pipelineDescriptor);
 
+    id<MTLDevice> _device;
+
     bool _displayEdges;
     bool _displayVertices;
-
-    id<MTLDevice> _device;
 
     int _numEdges, _numPoints;
     id<MTLRenderPipelineState> _renderPipelineState;

--- a/examples/dxPtexViewer/dxPtexViewer.cpp
+++ b/examples/dxPtexViewer/dxPtexViewer.cpp
@@ -1495,9 +1495,8 @@ initHUD() {
                        10, 300, callbackCheckBox, HUD_CB_ADAPTIVE, '`');
 
     for (int i = 1; i < 8; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        g_hud->AddRadioButton(HUD_RB_LEVEL, level, i == g_level,
+        const std::string level = "Lv. " + std::to_string(i);
+        g_hud->AddRadioButton(HUD_RB_LEVEL, level.c_str(), i == g_level,
                               10, 320+i*20, callbackLevel, i, '0'+i);
     }
 

--- a/examples/dxViewer/dxviewer.cpp
+++ b/examples/dxViewer/dxviewer.cpp
@@ -1285,9 +1285,9 @@ initHUD() {
     }
 
     for (int i = 1; i < 11; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        g_hud->AddRadioButton(3, level, i==2, 10, 290+i*20, callbackLevel, i, '0'+(i%10));
+        std::string level = "Lv. " + std::to_string(i);
+        g_hud->AddRadioButton(3, level.c_str(), i==2,
+                              10, 290+i*20, callbackLevel, i, '0'+(i%10));
     }
 
     int shapes_pulldown = g_hud->AddPullDown("Shape (N)", -300, 10, 300, callbackModel, 'N');

--- a/examples/farViewer/farViewer.cpp
+++ b/examples/farViewer/farViewer.cpp
@@ -1248,9 +1248,9 @@ initHUD() {
                     -900, -50, 100, false, callbackScale, 0);
 
     for (int i = 1; i < 11; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        g_hud.AddRadioButton(3, level, i==g_level, 10, 380+i*20, callbackLevel, i, '0'+(i%10));
+        const std::string level = "Lv. " + std::to_string(i);
+        g_hud.AddRadioButton(3, level.c_str(), i==g_level,
+                             10, 380+i*20, callbackLevel, i, '0'+(i%10));
     }
 
     int shapes_pulldown = g_hud.AddPullDown("Shape (N)", -300, 10, 300, callbackModel, 'n');

--- a/examples/glEvalLimit/glEvalLimit.cpp
+++ b/examples/glEvalLimit/glEvalLimit.cpp
@@ -1428,9 +1428,9 @@ initHUD() {
                             g_endCap == kEndCapGregoryBasis);
 
     for (int i = 1; i < 11; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        g_hud.AddRadioButton(3, level, i==g_level, 10, 270+i*20, callbackLevel, i, '0'+(i%10));
+        const std::string level = "Lv. " + std::to_string(i);
+        g_hud.AddRadioButton(3, level.c_str(), i==g_level,
+                             10, 270+i*20, callbackLevel, i, '0'+(i%10));
     }
 
     int pulldown_handle = g_hud.AddPullDown("Shape (N)", -300, 10, 300, callbackModel, 'n');

--- a/examples/glFVarViewer/glFVarViewer.cpp
+++ b/examples/glFVarViewer/glFVarViewer.cpp
@@ -1201,9 +1201,9 @@ initHUD() {
     }
 
     for (int i = 1; i < 11; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        g_hud.AddRadioButton(3, level, i == g_level, 10, 260 + i*20, callbackLevel, i, '0'+(i%10));
+        const std::string level = "Lv. " + std::to_string(i);
+        g_hud.AddRadioButton(3, level.c_str(), i == g_level,
+                             10, 260 + i*20, callbackLevel, i, '0'+(i%10));
     }
 
     typedef OpenSubdiv::Sdc::Options SdcOptions;

--- a/examples/glPaintTest/glPaintTest.cpp
+++ b/examples/glPaintTest/glPaintTest.cpp
@@ -311,9 +311,9 @@ fitFrame() {
 //------------------------------------------------------------------------------
 union Effect {
     struct {
-        int color:1;
-        int displacement:1;
-        int paint:1;
+        unsigned int color:1;
+        unsigned int displacement:1;
+        unsigned int paint:1;
         unsigned int wire:2;
     };
     int value;
@@ -992,9 +992,9 @@ initHUD() {
                      350, -60, 40, true, callbackBrushSize, 0);
 
     for (int i = 1; i < 11; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        g_hud.AddRadioButton(3, level, i==g_level, 10, 170+i*20, callbackLevel, i, '0'+(i%10));
+        const std::string level = "Lv. " + std::to_string(i);
+        g_hud.AddRadioButton(3, level.c_str(), i==g_level,
+                             10, 170+i*20, callbackLevel, i, '0'+(i%10));
     }
 
     int pulldown_handle = g_hud.AddPullDown("Shape (N)", -300, 10, 300, callbackModel, 'n');

--- a/examples/glPtexViewer/glPtexViewer.cpp
+++ b/examples/glPtexViewer/glPtexViewer.cpp
@@ -1873,9 +1873,8 @@ int main(int argc, char ** argv) {
                           10, 300, callbackCheckBox, HUD_CB_ADAPTIVE, '`');
 
     for (int i = 1; i < 8; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        g_hud.AddRadioButton(HUD_RB_LEVEL, level, i == g_level,
+        const std::string level = "Lv. " + std::to_string(i);
+        g_hud.AddRadioButton(HUD_RB_LEVEL, level.c_str(), i == g_level,
                              10, 320+i*20, callbackLevel, i, '0'+i);
     }
 

--- a/examples/glShareTopology/glShareTopology.cpp
+++ b/examples/glShareTopology/glShareTopology.cpp
@@ -1119,9 +1119,9 @@ initHUD() {
 
 
     for (int i = 1; i < 11; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        g_hud.AddRadioButton(3, level, i==g_level, 10, 210+i*20, callbackLevel, i, '0'+(i%10));
+        const std::string level = "Lv. " + std::to_string(i);
+        g_hud.AddRadioButton(3, level.c_str(), i==g_level,
+                             10, 210+i*20, callbackLevel, i, '0'+(i%10));
     }
 
     g_hud.Rebuild(windowWidth, windowHeight, frameBufferWidth, frameBufferHeight);

--- a/examples/glStencilViewer/glStencilViewer.cpp
+++ b/examples/glStencilViewer/glStencilViewer.cpp
@@ -1027,9 +1027,9 @@ initHUD() {
 #endif
 
     for (int i = 1; i < 11; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        g_hud.AddRadioButton(3, level, i==g_isolationLevel, 10, 250+i*20, callbackLevel, i, '0'+(i%10));
+        const std::string level = "Lv. " + std::to_string(i);
+        g_hud.AddRadioButton(3, level.c_str(), i==g_isolationLevel,
+                             10, 250+i*20, callbackLevel, i, '0'+(i%10));
     }
 
     int pulldown_handle = g_hud.AddPullDown("Shape (N)", -300, 10, 300, callbackModel, 'n');

--- a/examples/glViewer/glViewer.cpp
+++ b/examples/glViewer/glViewer.cpp
@@ -1627,9 +1627,9 @@ initHUD() {
     }
 
     for (int i = 1; i < 11; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        g_hud.AddRadioButton(3, level, i == g_level, 10, 310+i*20, callbackLevel, i, '0'+(i%10));
+        const std::string level = "Lv. " + std::to_string(i);
+        g_hud.AddRadioButton(3, level.c_str(), i == g_level,
+                             10, 310+i*20, callbackLevel, i, '0'+(i%10));
     }
 
     int shapes_pulldown = g_hud.AddPullDown("Shape (N)", -300, 10, 300, callbackModel, 'n');

--- a/examples/mtlPtexViewer/OSX/ViewController.h
+++ b/examples/mtlPtexViewer/OSX/ViewController.h
@@ -41,10 +41,6 @@
 @property (weak) IBOutlet OSDView *view;
 @property (nonatomic) OSDRenderer* osdRenderer;
 
-- (IBAction)checkboxChanged:(NSButton *)sender;
-- (IBAction)popupChanged:(NSPopUpButton *)sender;
-- (IBAction)sliderChanged:(NSSlider *)sender;
-
 @property (weak) IBOutlet NSTextField *frameTimeLabel;
 @property (weak) IBOutlet NSButton *wireframeCheckbox;
 @property (weak) IBOutlet NSButton *singleCreaseCheckbox;

--- a/examples/mtlPtexViewer/OSX/ViewController.mm
+++ b/examples/mtlPtexViewer/OSX/ViewController.mm
@@ -197,7 +197,7 @@ enum {
         }
     };
     
-    auto callbackScheme = [=](int scheme) {
+    auto callbackScheme = [=](int) {
         return;
     };
     
@@ -318,10 +318,10 @@ enum {
 //                       10, 300, callbackCheckbox, kHUD_CB_ADAPTIVE, '`');
     
     for (int i = 1; i < 8; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        hud.AddRadioButton(kHUD_RB_LEVEL, level, _osdRenderer.refinementLevel == i,
-                              10, 320+i*20, callbackLevel, i, '0'+i);
+        NSString *level = [NSString stringWithFormat:@"Lv. %d", i];
+        hud.AddRadioButton(kHUD_RB_LEVEL, [level UTF8String],
+                           i==(int)_osdRenderer.refinementLevel,
+                           10, 320+i*20, callbackLevel, i, '0'+i);
     }
     
     int compute_pulldown = hud.AddPullDown("Compute (K)", 475, 10, 300, callbackKernel, 'k');
@@ -428,7 +428,7 @@ enum {
     __weak auto blockSemaphore = _frameSemaphore;
     unsigned frameId = _currentFrame % FRAME_HISTORY;
     auto frameBeginTime = CACurrentMediaTime();
-    [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> _Nonnull c) {
+    [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> _Nonnull) {
         dispatch_semaphore_signal(blockSemaphore);
         _frameBeginTimestamp[frameId] = CACurrentMediaTime() - frameBeginTime;
     }];

--- a/examples/mtlPtexViewer/mtlPtexViewer.mm
+++ b/examples/mtlPtexViewer/mtlPtexViewer.mm
@@ -289,7 +289,7 @@ struct PipelineConfig {
 
     ArgOptions args;
 
-    args.Parse(argsVector.size(), argsVector.data());
+    args.Parse((int)argsVector.size(), argsVector.data());
 
     self.yup = args.GetYUp();
     self.useAdaptive = args.GetAdaptive();
@@ -856,7 +856,6 @@ struct PipelineConfig {
 }
 
 -(void)_rebuildBuffers {
-    auto totalPatches = 0;
     auto totalPerPatchVertexSize = 0;
     auto totalPerPatchTessFactorsSize = 0;
     auto totalTessFactorsSize = 0;
@@ -894,8 +893,6 @@ struct PipelineConfig {
                                                                  ? sizeof(MTLTriangleTessellationFactorsHalf)
                                                                  : sizeof(MTLQuadTessellationFactorsHalf));
             }
-
-            totalPatches += patch.GetNumPatches();
         }
 
         _tessFactorsBuffer.alloc(_context.device, totalTessFactorsSize, @"tessellation factors buffer", MTLResourceStorageModePrivate);

--- a/examples/mtlViewer/OSX/ViewController.mm
+++ b/examples/mtlViewer/OSX/ViewController.mm
@@ -405,9 +405,10 @@ enum {
     }
     
     for (int i = 1; i < 11; ++i) {
-        char level[16];
-        sprintf(level, "Lv. %d", i);
-        hud.AddRadioButton(3, level, i==_osdRenderer.refinementLevel, 10, 310+i*20, callbackLevel, i, '0'+(i%10));
+        NSString *level = [NSString stringWithFormat:@"Lv. %d", i];
+        hud.AddRadioButton(3, [level UTF8String],
+                           i==(int)_osdRenderer.refinementLevel,
+                           10, 310+i*20, callbackLevel, i, '0'+(i%10));
     }
 
     int shapes_pulldown = hud.AddPullDown("Shape (N)", -300, 10, 300, callbackModel, 'n');
@@ -470,7 +471,7 @@ enum {
     __weak auto blockSemaphore = _frameSemaphore;
     unsigned frameId = _currentFrame % FRAME_HISTORY;
     auto frameBeginTime = CACurrentMediaTime();
-    [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> _Nonnull c) {
+    [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> _Nonnull) {
         dispatch_semaphore_signal(blockSemaphore);
         _frameBeginTimestamp[frameId] = CACurrentMediaTime() - frameBeginTime;
     }];

--- a/examples/mtlViewer/mtlViewer.mm
+++ b/examples/mtlViewer/mtlViewer.mm
@@ -316,7 +316,7 @@ struct PipelineConfig {
 
     ArgOptions args;
 
-    args.Parse(argsVector.size(), argsVector.data());
+    args.Parse((int)argsVector.size(), argsVector.data());
 
     // Parse remaining args
     const std::vector<const char *> &rargs = args.GetRemainingArgs();
@@ -935,7 +935,6 @@ struct PipelineConfig {
 }
 
 -(void)_rebuildBuffers {
-    auto totalPatches = 0;
     auto totalPerPatchVertexSize = 0;
     auto totalPerPatchTessFactorsSize = 0;
     auto totalTessFactorsSize = 0;
@@ -973,8 +972,6 @@ struct PipelineConfig {
                                                                  ? sizeof(MTLTriangleTessellationFactorsHalf)
                                                                  : sizeof(MTLQuadTessellationFactorsHalf));
             }
-
-            totalPatches += patch.GetNumPatches();
         }
 
         _tessFactorsBuffer.alloc(_context.device, totalTessFactorsSize, @"tessellation factors buffer", MTLResourceStorageModePrivate);

--- a/opensubdiv/bfr/hash.cpp
+++ b/opensubdiv/bfr/hash.cpp
@@ -316,10 +316,12 @@ private:
     //
     static const uint64 sc_const = 0xdeadbeefdeadbeefLL;
 
+#ifdef OPENSUBDIV3_BFR_HASH_INCLUDE_UNUSED_FUNCTIONS
     uint64 m_data[2*sc_numVars];   // unhashed data, for partial messages
     uint64 m_state[sc_numVars];  // internal state of the hash
     size_t m_length;             // total length of the input so far
     uint8  m_remainder;          // length of unhashed data stashed in m_data
+#endif
 };
 
 #define ALLOW_UNALIGNED_READS 1

--- a/opensubdiv/osd/mtlComputeEvaluator.mm
+++ b/opensubdiv/osd/mtlComputeEvaluator.mm
@@ -109,13 +109,13 @@ static id<MTLBuffer> createBuffer(const std::vector<T> &vec,
 
     const auto length = sizeof(T) * vec.size();
 #if TARGET_OS_IOS || TARGET_OS_TV
-    return [context->device newBufferWithBytes:vec.data() length:length options:MTLResourceOptionCPUCacheModeDefault];
+    return [context->device newBufferWithBytes:vec.data() length:length options:MTLResourceCPUCacheModeDefaultCache];
 #elif TARGET_OS_OSX
   @autoreleasepool {
     auto cmdBuf = [context->commandQueue commandBuffer];
     auto blitEncoder = [cmdBuf blitCommandEncoder];
 
-    auto stageBuffer = [context->device newBufferWithBytes:vec.data() length:length options:MTLResourceOptionCPUCacheModeDefault];
+    auto stageBuffer = [context->device newBufferWithBytes:vec.data() length:length options:MTLResourceCPUCacheModeDefaultCache];
 
     auto finalBuffer = [context->device newBufferWithLength:length options:MTLResourceStorageModePrivate];
 
@@ -362,7 +362,7 @@ bool MTLComputeEvaluator::Compile(BufferDescriptor const &srcDesc,
 
     _parameterBuffer =
       [context->device newBufferWithLength:sizeof(mtl::KernelUniformArgs)
-                                   options:MTLResourceOptionCPUCacheModeDefault];
+                                   options:MTLResourceCPUCacheModeDefaultCache];
 
     return true;
 }

--- a/opensubdiv/osd/mtlLegacyGregoryPatchTable.mm
+++ b/opensubdiv/osd/mtlLegacyGregoryPatchTable.mm
@@ -36,7 +36,7 @@ static id<MTLBuffer> createBuffer(const void* data, const size_t length,
     auto cmdBuf = [context->commandQueue commandBuffer];
     auto blitEncoder = [cmdBuf blitCommandEncoder];
 
-    auto stageBuffer = [context->device newBufferWithBytes:data length:length options:MTLResourceOptionCPUCacheModeDefault];
+    auto stageBuffer = [context->device newBufferWithBytes:data length:length options:MTLResourceCPUCacheModeDefaultCache];
 
     auto finalBuffer = [context->device newBufferWithLength:length options:MTLResourceStorageModePrivate];
 
@@ -90,7 +90,7 @@ MTLLegacyGregoryPatchTable* MTLLegacyGregoryPatchTable::Create(const Far::PatchT
     return pt;
 }
 
-void MTLLegacyGregoryPatchTable::UpdateVertexBuffer(id<MTLBuffer> vbo, int numVertices, int numVertexElements, MTLContext* context)
+void MTLLegacyGregoryPatchTable::UpdateVertexBuffer(id<MTLBuffer> vbo, int, int, MTLContext*)
 {
     _vertexBuffer = vbo;
 }

--- a/opensubdiv/osd/mtlPatchTable.mm
+++ b/opensubdiv/osd/mtlPatchTable.mm
@@ -59,7 +59,7 @@ static id<MTLBuffer> createBuffer(const void* data, const size_t length,
     auto cmdBuf = [context->commandQueue commandBuffer];
     auto blitEncoder = [cmdBuf blitCommandEncoder];
 
-    auto stageBuffer = [context->device newBufferWithBytes:data length:length options:MTLResourceOptionCPUCacheModeDefault];
+    auto stageBuffer = [context->device newBufferWithBytes:data length:length options:MTLResourceCPUCacheModeDefaultCache];
 
     auto finalBuffer = [context->device newBufferWithLength:length options:MTLResourceStorageModePrivate];
 

--- a/opensubdiv/osd/mtlVertexBuffer.mm
+++ b/opensubdiv/osd/mtlVertexBuffer.mm
@@ -67,7 +67,7 @@ CPUMTLVertexBuffer* CPUMTLVertexBuffer::Create(int numElements, int numVertices,
     return instance;
 }
 
-void CPUMTLVertexBuffer::UpdateData(const float* src, int startVertex, int numVertices, MTLContext* context)
+void CPUMTLVertexBuffer::UpdateData(const float* src, int startVertex, int numVertices, MTLContext*)
 {
     _dirty = true;
     memcpy(((float*)_buffer.contents) + startVertex * _numElements, src, _numElements * numVertices * sizeof(float));
@@ -79,7 +79,7 @@ float* CPUMTLVertexBuffer::BindCpuBuffer()
     return (float*)_buffer.contents;
 }
 
-id<MTLBuffer> CPUMTLVertexBuffer::BindMTLBuffer(MTLContext* context)
+id<MTLBuffer> CPUMTLVertexBuffer::BindMTLBuffer(MTLContext*)
 {
 #if TARGET_OS_OSX
     if(_dirty)

--- a/opensubdiv/osd/tbbEvaluator.cpp
+++ b/opensubdiv/osd/tbbEvaluator.cpp
@@ -228,6 +228,8 @@ TbbEvaluator::SetNumThreads(int numThreads) {
     } else {
         tbb::task_scheduler_init init(numThreads);
     }
+#else
+    (void) numThreads;
 #endif
 }
 

--- a/opensubdiv/osd/tbbKernel.cpp
+++ b/opensubdiv/osd/tbbKernel.cpp
@@ -339,7 +339,6 @@ class TbbEvalPatchesKernel {
     float * _dstDuu;
     float * _dstDuv;
     float * _dstDvv;
-    int _numPatchCoords;
     const PatchCoord *_patchCoords;
     const PatchArray *_patchArrayBuffer;
     const int        *_patchIndexBuffer;
@@ -353,7 +352,7 @@ public:
                          float *dstDuu,    BufferDescriptor dstDuuDesc,
                          float *dstDuv,    BufferDescriptor dstDuvDesc,
                          float *dstDvv,    BufferDescriptor dstDvvDesc,
-                         int numPatchCoords,
+                         int /*numPatchCoords*/,
                          const PatchCoord *patchCoords,
                          const PatchArray *patchArrayBuffer,
                          const int *patchIndexBuffer,
@@ -364,7 +363,6 @@ public:
         _src(src), _dst(dst),
         _dstDu(dstDu), _dstDv(dstDv),
         _dstDuu(dstDuu), _dstDuv(dstDuv), _dstDvv(dstDvv),
-        _numPatchCoords(numPatchCoords),
         _patchCoords(patchCoords),
         _patchArrayBuffer(patchArrayBuffer),
         _patchIndexBuffer(patchIndexBuffer),


### PR DESCRIPTION
Most of these warning fixes are in example code, but also includes a few fixes in the core libraries encountered when building on macOS with Apple Clang 16.