### PR TITLE
[examples] Fixed example viewers use of OpenCL

### DIFF
--- a/examples/dxPtexViewer/CMakeLists.txt
+++ b/examples/dxPtexViewer/CMakeLists.txt
@@ -44,6 +44,7 @@ include_directories(
 
 if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 set(SOURCE_FILES

--- a/examples/dxViewer/CMakeLists.txt
+++ b/examples/dxViewer/CMakeLists.txt
@@ -40,6 +40,7 @@ include_directories(
 
 if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 set(SOURCE_FILES

--- a/examples/farViewer/CMakeLists.txt
+++ b/examples/farViewer/CMakeLists.txt
@@ -42,8 +42,9 @@ list(APPEND PLATFORM_LIBRARIES
     "${GLFW_LIBRARIES}"
 )
 
-if( OPENCL_FOUND )
+if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 osd_stringify("${SHADER_FILES}" INC_FILES)

--- a/examples/glEvalLimit/CMakeLists.txt
+++ b/examples/glEvalLimit/CMakeLists.txt
@@ -36,8 +36,9 @@ list(APPEND PLATFORM_LIBRARIES
     "${GLFW_LIBRARIES}"
 )
 
-if( OPENCL_FOUND )
+if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 if( TBB_FOUND )

--- a/examples/glFVarViewer/CMakeLists.txt
+++ b/examples/glFVarViewer/CMakeLists.txt
@@ -40,8 +40,9 @@ list(APPEND PLATFORM_LIBRARIES
     "${GLFW_LIBRARIES}"
 )
 
-if( OPENCL_FOUND )
+if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 osd_stringify("${SHADER_FILES}" INC_FILES)

--- a/examples/glImaging/CMakeLists.txt
+++ b/examples/glImaging/CMakeLists.txt
@@ -40,11 +40,9 @@ set(PLATFORM_LIBRARIES
     "${GLFW_LIBRARIES}"
 )
 
-if ( OPENCL_FOUND )
-    list(APPEND PLATFORM_LIBRARIES
-        "${OPENCL_LIBRARIES}"
-    )
+if (OPENCL_FOUND)
     include_directories( "${OPENCL_INCLUDE_DIRS}" )
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 osd_stringify("${SHADER_FILES}" INC_FILES)

--- a/examples/glPaintTest/CMakeLists.txt
+++ b/examples/glPaintTest/CMakeLists.txt
@@ -41,8 +41,9 @@ list(APPEND PLATFORM_LIBRARIES
     "${GLFW_LIBRARIES}"
 )
 
-if( OPENCL_FOUND )
+if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 osd_stringify("${SHADER_FILES}" INC_FILES)

--- a/examples/glPtexViewer/CMakeLists.txt
+++ b/examples/glPtexViewer/CMakeLists.txt
@@ -45,8 +45,9 @@ list(APPEND PLATFORM_LIBRARIES
     "${ZLIB_LIBRARY}"
 )
 
-if( OPENCL_FOUND )
+if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 osd_stringify("${SHADER_FILES}" INC_FILES)

--- a/examples/glShareTopology/CMakeLists.txt
+++ b/examples/glShareTopology/CMakeLists.txt
@@ -40,8 +40,9 @@ list(APPEND PLATFORM_LIBRARIES
     "${GLFW_LIBRARIES}"
 )
 
-if( OPENCL_FOUND )
+if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 osd_stringify("${SHADER_FILES}" INC_FILES)

--- a/examples/glStencilViewer/CMakeLists.txt
+++ b/examples/glStencilViewer/CMakeLists.txt
@@ -36,8 +36,9 @@ list(APPEND PLATFORM_LIBRARIES
     "${GLFW_LIBRARIES}"
 )
 
-if( OPENCL_FOUND )
+if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 osd_add_glfw_executable(glStencilViewer "examples"

--- a/examples/glViewer/CMakeLists.txt
+++ b/examples/glViewer/CMakeLists.txt
@@ -41,8 +41,9 @@ list(APPEND PLATFORM_LIBRARIES
     "${GLFW_LIBRARIES}"
 )
 
-if( OPENCL_FOUND )
+if (OPENCL_FOUND)
     include_directories("${OPENCL_INCLUDE_DIRS}")
+    list(APPEND PLATFORM_LIBRARIES OpenGL::GL)
 endif()
 
 osd_stringify("${SHADER_FILES}" INC_FILES)


### PR DESCRIPTION
The existing examples/common/clDeviceContext implementation depends on OpenGL but this was not correctly configured in the build system.

Also, updated the implementation to avoid some deprecation warnings.