### PR TITLE
[examples/mtlPtexViewer] Fixed ZLib dependency

### DIFF
--- a/examples/mtlPtexViewer/CMakeLists.txt
+++ b/examples/mtlPtexViewer/CMakeLists.txt
@@ -79,6 +79,7 @@ list(APPEND PLATFORM_LIBRARIES
     "-framework Foundation"
     "-framework QuartzCore"
     "${PTEX_LIBRARY}"
+    "${ZLIB_LIBRARY}"
 )
 
 osd_stringify("mtlPtexViewer.metal" INC_FILES)


### PR DESCRIPTION
Updated the mtlPtexViewer CMake configuration to specify a dependency on ZLib consistent with the other Ptex example viewers.