### PR TITLE
Added build options for patch shader source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,10 @@ option(NO_GLFW "Disable components depending on GLFW" OFF)
 option(NO_GLFW_X11 "Disable GLFW components depending on X11" OFF)
 option(NO_MACOS_FRAMEWORK "Disable generation of framework on macOS" OFF)
 
+option(OSD_PATCH_SHADER_SOURCE_GLSL "GLSL Patch Shader Source" OFF)
+option(OSD_PATCH_SHADER_SOURCE_HLSL "HLSL Patch Shader Source" OFF)
+option(OSD_PATCH_SHADER_SOURCE_MSL "MSL Patch Shader Source" OFF)
+
 option(OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES "Enable true derivative evaluation for Gregory basis patches" OFF)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
@@ -346,7 +350,16 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 # below may wind up stomping over this value.
 set(build_shared_libs "${BUILD_SHARED_LIBS}")
 
-set(OSD_GPU FALSE)
+# If the build is configured to have patch shader source then set the
+# internal flag OSD_GPU to TRUE, otherwise initialize to FALSE and allow
+# it to be enabled later while resolving other dependencies.
+if (OSD_PATCH_SHADER_SOURCE_GLSL OR
+    OSD_PATCH_SHADER_SOURCE_HLSL OR
+    OSD_PATCH_SHADER_SOURCE_MSL)
+    set(OSD_GPU TRUE)
+else()
+    set(OSD_GPU FALSE)
+endif()
 
 # Check for dependencies
 if(NOT NO_OMP)
@@ -742,7 +755,7 @@ endmacro()
 # use when cross compiling or building multi-architecture binaries.
 # We also provide a C++ binary implementation so that Python is not
 # required (for backward compatibility).
-if (OPENGL_FOUND OR OPENCL_FOUND OR DXSDK_FOUND OR METAL_FOUND)
+if (OPENGL_FOUND OR OPENCL_FOUND OR DXSDK_FOUND OR METAL_FOUND OR OSD_GPU)
     if(Python_Interpreter_FOUND)
         set(OSD_STRINGIFY_TOOL ${CMAKE_CURRENT_SOURCE_DIR}/tools/stringify/stringify.py)
         set(OSD_STRINGIFY ${Python_EXECUTABLE} ${OSD_STRINGIFY_TOOL})

--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -66,6 +66,70 @@ list(APPEND KERNEL_FILES
 )
 
 #-------------------------------------------------------------------------------
+# GLSL patch shader source
+if( OSD_PATCH_SHADER_SOURCE_GLSL OR
+        (NOT NO_OPENGL AND (OPENGL_FOUND OR OPENGLES_FOUND)) )
+    list(APPEND PUBLIC_HEADER_FILES
+        glslPatchShaderSource.h
+    )
+    list(APPEND GPU_SOURCE_FILES
+        glslPatchShaderSource.cpp
+    )
+    list(APPEND KERNEL_FILES
+        glslPatchCommon.glsl
+        glslPatchCommonTess.glsl
+        glslPatchBoxSplineTriangle.glsl
+        glslPatchBSpline.glsl
+        glslPatchGregory.glsl
+        glslPatchGregoryBasis.glsl
+        glslPatchGregoryTriangle.glsl
+        glslPatchLegacy.glsl
+    )
+endif()
+
+#-------------------------------------------------------------------------------
+# HLSL patch shader source
+if( OSD_PATCH_SHADER_SOURCE_HLSL OR DXSDK_FOUND )
+    list(APPEND PUBLIC_HEADER_FILES
+        hlslPatchShaderSource.h
+    )
+    list(APPEND GPU_SOURCE_FILES
+        hlslPatchShaderSource.cpp
+    )
+    list(APPEND KERNEL_FILES
+        hlslPatchCommon.hlsl
+        hlslPatchCommonTess.hlsl
+        hlslPatchBoxSplineTriangle.hlsl
+        hlslPatchBSpline.hlsl
+        hlslPatchGregory.hlsl
+        hlslPatchGregoryBasis.hlsl
+        hlslPatchGregoryTriangle.hlsl
+        hlslPatchLegacy.hlsl
+    )
+endif()
+
+#-------------------------------------------------------------------------------
+# MSL patch shader source
+if( OSD_PATCH_SHADER_SOURCE_MSL OR METAL_FOUND )
+    list(APPEND PUBLIC_HEADER_FILES
+        mtlPatchShaderSource.h
+    )
+    list(APPEND GPU_SOURCE_FILES
+        mtlPatchShaderSource.mm
+    )
+    list(APPEND KERNEL_FILES
+        mtlPatchCommon.metal
+        mtlPatchCommonTess.metal
+        mtlPatchBoxSplineTriangle.metal
+        mtlPatchBSpline.metal
+        mtlPatchGregory.metal
+        mtlPatchGregoryBasis.metal
+        mtlPatchGregoryTriangle.metal
+        mtlPatchLegacy.metal
+    )
+endif()
+
+#-------------------------------------------------------------------------------
 set(OPENMP_PUBLIC_HEADERS
     ompEvaluator.h
     ompKernel.h
@@ -119,7 +183,6 @@ set(GL_PUBLIC_HEADERS
     glPatchTable.h
     glVertexBuffer.h
     glMesh.h
-    glslPatchShaderSource.h
 )
 
 if( (NOT NO_OPENGL) AND (OPENGL_FOUND OR OPENGLES_FOUND) )
@@ -128,21 +191,8 @@ if( (NOT NO_OPENGL) AND (OPENGL_FOUND OR OPENGLES_FOUND) )
         glLegacyGregoryPatchTable.cpp
         glPatchTable.cpp
         glVertexBuffer.cpp
-        glslPatchShaderSource.cpp
     )
     list(APPEND PUBLIC_HEADER_FILES ${GL_PUBLIC_HEADERS})
-    if ( OPENGL_FOUND )
-        list(APPEND KERNEL_FILES
-            glslPatchCommon.glsl
-            glslPatchCommonTess.glsl
-            glslPatchBoxSplineTriangle.glsl
-            glslPatchBSpline.glsl
-            glslPatchGregory.glsl
-            glslPatchGregoryBasis.glsl
-            glslPatchGregoryTriangle.glsl
-            glslPatchLegacy.glsl
-        )
-    endif()
 endif()
 
 list(APPEND DOXY_HEADER_FILES ${GL_PUBLIC_HEADERS})
@@ -201,7 +251,6 @@ set(DXSDK_PUBLIC_HEADERS
     d3d11PatchTable.h
     d3d11VertexBuffer.h
     d3d11Mesh.h
-    hlslPatchShaderSource.h
 )
 if( DXSDK_FOUND )
     list(APPEND GPU_SOURCE_FILES
@@ -210,19 +259,10 @@ if( DXSDK_FOUND )
         d3d11LegacyGregoryPatchTable.cpp
         d3d11PatchTable.cpp
         d3d11VertexBuffer.cpp
-        hlslPatchShaderSource.cpp
     )
     list(APPEND PUBLIC_HEADER_FILES ${DXSDK_PUBLIC_HEADERS})
     list(APPEND KERNEL_FILES
         hlslComputeKernel.hlsl
-        hlslPatchCommon.hlsl
-        hlslPatchCommonTess.hlsl
-        hlslPatchBoxSplineTriangle.hlsl
-        hlslPatchBSpline.hlsl
-        hlslPatchGregory.hlsl
-        hlslPatchGregoryBasis.hlsl
-        hlslPatchGregoryTriangle.hlsl
-        hlslPatchLegacy.hlsl
     )
     list(APPEND PLATFORM_GPU_LIBRARIES
         ${DXSDK_LIBRARIES}
@@ -239,7 +279,6 @@ set(METAL_PUBLIC_HEADERS
     mtlLegacyGregoryPatchTable.h
     mtlPatchTable.h
     mtlMesh.h
-    mtlPatchShaderSource.h
     mtlCommon.h
 )
 
@@ -251,7 +290,6 @@ if( METAL_FOUND )
         mtlLegacyGregoryPatchTable.mm
         mtlPatchTable.mm
         mtlVertexBuffer.mm
-        mtlPatchShaderSource.mm
     )
 
     set_source_files_properties(
@@ -261,20 +299,9 @@ if( METAL_FOUND )
         "-fobjc-arc")
 
     list(APPEND GPU_SOURCE_FILES ${METAL_SOURCE_FILES})
-
-    
-
     list(APPEND PUBLIC_HEADER_FILES ${METAL_PUBLIC_HEADERS})
     list(APPEND KERNEL_FILES
        mtlComputeKernel.metal
-       mtlPatchCommon.metal
-       mtlPatchCommonTess.metal
-       mtlPatchBoxSplineTriangle.metal
-       mtlPatchBSpline.metal
-       mtlPatchGregory.metal
-       mtlPatchGregoryBasis.metal
-       mtlPatchGregoryTriangle.metal
-       mtlPatchLegacy.metal
     )
     list(APPEND PLATFORM_GPU_LIBRARIES
         ${METAL_LIBRARIES}


### PR DESCRIPTION
Added the following build configuration options:
    OSD_PATCH_SHADER_SOURCE_GLSL
    OSD_PATCH_SHADER_SOURCE_HLSL
    OSD_PATCH_SHADER_SOURCE_MSL

These options are disabled by default but can be enabled independently from other build configuration options allowing OpenSubdiv to provide GPU shader source without needing to compile or link with other external dependencies.

For example, this allows OpenSubdiv to be configured to provide GLSL patch shader source which can be used for either Vulkan or OpenGL client code without introducing Vulkan or OpenGL compile or link dependencies to the OpenSubdiv libraries.