### PR TITLE
Updated azure pipelines configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,11 +51,10 @@ jobs:
 
 - job: Windows
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
   steps:
   - script: |
-      call C:\"Program Files (x86)"\"Microsoft Visual Studio"\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
-      call set PATH=C:/Python27amd64;C:/Python27amd64/Scripts;%PATH%
+      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       call python build_scripts/build_osd.py --tests --onetbb --omp --build %HOME%/OSDgen/build --src %HOME%/OSDgen/src %HOME%/OSDinst
     displayName: 'Building OpenSubdiv'
   - script: |

--- a/build_scripts/build_osd.py
+++ b/build_scripts/build_osd.py
@@ -124,6 +124,14 @@ def GetVisualStudioCompilerAndVersion():
             return (msvcCompiler, tuple(int(v) for v in match.groups()))
     return None
 
+def IsVisualStudio2022OrGreater():
+    VISUAL_STUDIO_2022_VERSION = (17, 0)
+    msvcCompilerAndVersion = GetVisualStudioCompilerAndVersion()
+    if msvcCompilerAndVersion:
+        _, version = msvcCompilerAndVersion
+        return version >= VISUAL_STUDIO_2022_VERSION
+    return False
+
 def IsVisualStudio2019OrGreater():
     VISUAL_STUDIO_2019_VERSION = (16, 0)
     msvcCompilerAndVersion = GetVisualStudioCompilerAndVersion()
@@ -235,7 +243,10 @@ def RunCMake(context, force, extraArgs = None):
     # On Windows, we need to explicitly specify the generator to ensure we're
     # building a 64-bit project. (Surely there is a better way to do this?)
     if generator is None and Windows():
-        if IsVisualStudio2019OrGreater():
+        if IsVisualStudio2022OrGreater():
+            generator = "Visual Studio 17 2022"
+            generatorPlatform = "x64"
+        elif IsVisualStudio2019OrGreater():
             generator = "Visual Studio 16 2019"
             generatorPlatform = "x64"
         elif IsVisualStudio2017OrGreater():


### PR DESCRIPTION
Windows: windows-2022, oneTBB

Updated to use the windows-2022 image since the windows-2019 image is scheduled to be disabled after June 2025.