### PR TITLE
[opensubdiv/osd] Removed GL types from headers

### DIFF
--- a/opensubdiv/osd/clEvaluator.h
+++ b/opensubdiv/osd/clEvaluator.h
@@ -99,7 +99,7 @@ private:
 
 class CLEvaluator {
 public:
-    typedef bool Instantiatable;
+    using Instantiatable = bool;    // Enable compiled kernel evaluator cache
 
     /// Generic creator template.
     template <typename DEVICE_CONTEXT>

--- a/opensubdiv/osd/clGLVertexBuffer.cpp
+++ b/opensubdiv/osd/clGLVertexBuffer.cpp
@@ -90,7 +90,7 @@ CLGLVertexBuffer::BindCLBuffer(cl_command_queue queue) {
     return _clMemory;
 }
 
-GLuint
+CLGLVertexBuffer::ID
 CLGLVertexBuffer::BindVBO(void * /*deviceContext*/) {
 
     unmap();

--- a/opensubdiv/osd/clGLVertexBuffer.h
+++ b/opensubdiv/osd/clGLVertexBuffer.h
@@ -27,7 +27,6 @@
 
 #include "../version.h"
 
-#include "../osd/opengl.h"
 #include "../osd/opencl.h"
 
 namespace OpenSubdiv {
@@ -46,6 +45,8 @@ namespace Osd {
 ///
 class CLGLVertexBuffer {
 public:
+    using ID = unsigned int;    // GLuint resource ID
+
     /// Creator. Returns NULL if error.
     static CLGLVertexBuffer * Create(int numElements,
                                      int numVertices,
@@ -83,7 +84,7 @@ public:
 
     /// Returns the GL buffer object. If the buffer is mapped to CL memory
     /// space, it will be unmapped back to GL.
-    GLuint BindVBO(void *deviceContext = NULL);
+    ID BindVBO(void *deviceContext = NULL);
 
 protected:
     /// Constructor.
@@ -102,7 +103,7 @@ protected:
 private:
     int _numElements;
     int _numVertices;
-    GLuint _vbo;
+    ID _vbo;
     cl_command_queue _clQueue;
     cl_mem _clMemory;
 

--- a/opensubdiv/osd/cpuGLVertexBuffer.cpp
+++ b/opensubdiv/osd/cpuGLVertexBuffer.cpp
@@ -89,7 +89,7 @@ CpuGLVertexBuffer::BindCpuBuffer() {
     return _cpuBuffer;
 }
 
-GLuint
+CpuGLVertexBuffer::ID
 CpuGLVertexBuffer::BindVBO(void * /*deviceContext*/) {
 
     if (! _dataDirty)

--- a/opensubdiv/osd/cpuGLVertexBuffer.h
+++ b/opensubdiv/osd/cpuGLVertexBuffer.h
@@ -28,7 +28,6 @@
 #include "../version.h"
 
 #include <cstddef>
-#include "../osd/opengl.h"
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
@@ -46,6 +45,8 @@ namespace Osd {
 ///
 class CpuGLVertexBuffer {
 public:
+    using ID = unsigned int;    // GLuint resource ID
+
     /// Creator. Returns NULL if error.
     static CpuGLVertexBuffer * Create(int numElements, int numVertices,
                                       void *deviceContext = NULL);
@@ -70,7 +71,7 @@ public:
 
     /// Returns the name of GL buffer object. If the buffer is mapped
     /// to cpu address, it will be unmapped back to GL.
-    GLuint BindVBO(void *deviceContext = NULL);
+    ID BindVBO(void *deviceContext = NULL);
 
 protected:
     /// Constructor.
@@ -82,7 +83,7 @@ protected:
 private:
     int _numElements;
     int _numVertices;
-    GLuint _vbo;
+    ID _vbo;
     float *_cpuBuffer;
     bool _dataDirty;
 };

--- a/opensubdiv/osd/cudaGLVertexBuffer.cpp
+++ b/opensubdiv/osd/cudaGLVertexBuffer.cpp
@@ -97,7 +97,7 @@ CudaGLVertexBuffer::BindCudaBuffer() {
     return static_cast<float*>(_devicePtr);
 }
 
-GLuint
+CudaGLVertexBuffer::ID
 CudaGLVertexBuffer::BindVBO(void * /*deviceContext*/) {
 
     unmap();

--- a/opensubdiv/osd/cudaGLVertexBuffer.h
+++ b/opensubdiv/osd/cudaGLVertexBuffer.h
@@ -31,8 +31,6 @@
 #include <cstddef>
 #include <cuda_runtime.h>
 
-#include "../osd/opengl.h"    // needed before cuda_gl_interop.h
-
 #include <cuda_gl_interop.h>
 
 namespace OpenSubdiv {
@@ -50,6 +48,8 @@ namespace Osd {
 ///
 class CudaGLVertexBuffer {
 public:
+    using ID = unsigned int;    // GLuint resource ID
+
     /// Creator. Returns NULL if error.
     static CudaGLVertexBuffer * Create(int numElements, int numVertices,
                                        void *deviceContext = NULL);
@@ -74,7 +74,7 @@ public:
 
     /// Returns the GL buffer object. If the buffer is mapped as a cuda
     /// resource, it will be unmapped back to GL.
-    GLuint BindVBO(void *deviceContext = NULL);
+    ID BindVBO(void *deviceContext = NULL);
 
 protected:
     /// Constructor.
@@ -93,7 +93,7 @@ protected:
 private:
     int _numElements;
     int _numVertices;
-    GLuint _vbo;
+    ID _vbo;
     void *_devicePtr;
     struct cudaGraphicsResource *_cudaResource;
 };

--- a/opensubdiv/osd/d3d11ComputeEvaluator.h
+++ b/opensubdiv/osd/d3d11ComputeEvaluator.h
@@ -95,7 +95,8 @@ private:
 
 class D3D11ComputeEvaluator {
 public:
-    typedef bool Instantiatable;
+    using Instantiatable = bool;    // Enable compiled kernel evaluator cache
+
     static D3D11ComputeEvaluator * Create(BufferDescriptor const &srcDesc,
                                           BufferDescriptor const &dstDesc,
                                           BufferDescriptor const &duDesc,

--- a/opensubdiv/osd/d3d11PatchTable.h
+++ b/opensubdiv/osd/d3d11PatchTable.h
@@ -48,7 +48,7 @@ namespace Osd {
 
 class D3D11PatchTable : private NonCopyable<D3D11PatchTable> {
 public:
-    typedef ID3D11Buffer * VertexBufferBinding;
+    using VertexBufferBinding = ID3D11Buffer*;  // buffer binding type
 
     D3D11PatchTable();
     ~D3D11PatchTable();

--- a/opensubdiv/osd/glComputeEvaluator.cpp
+++ b/opensubdiv/osd/glComputeEvaluator.cpp
@@ -251,16 +251,16 @@ GLComputeEvaluator::Synchronize(void * /*kernel*/) {
 
 bool
 GLComputeEvaluator::EvalStencils(
-    GLuint srcBuffer, BufferDescriptor const &srcDesc,
-    GLuint dstBuffer, BufferDescriptor const &dstDesc,
-    GLuint duBuffer,  BufferDescriptor const &duDesc,
-    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-    GLuint sizesBuffer,
-    GLuint offsetsBuffer,
-    GLuint indicesBuffer,
-    GLuint weightsBuffer,
-    GLuint duWeightsBuffer,
-    GLuint dvWeightsBuffer,
+    ID srcBuffer, BufferDescriptor const &srcDesc,
+    ID dstBuffer, BufferDescriptor const &dstDesc,
+    ID duBuffer,  BufferDescriptor const &duDesc,
+    ID dvBuffer,  BufferDescriptor const &dvDesc,
+    ID sizesBuffer,
+    ID offsetsBuffer,
+    ID indicesBuffer,
+    ID weightsBuffer,
+    ID duWeightsBuffer,
+    ID dvWeightsBuffer,
     int start, int end) const {
 
     return EvalStencils(srcBuffer, srcDesc,
@@ -279,22 +279,22 @@ GLComputeEvaluator::EvalStencils(
 
 bool
 GLComputeEvaluator::EvalStencils(
-    GLuint srcBuffer, BufferDescriptor const &srcDesc,
-    GLuint dstBuffer, BufferDescriptor const &dstDesc,
-    GLuint duBuffer,  BufferDescriptor const &duDesc,
-    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-    GLuint duuBuffer, BufferDescriptor const &duuDesc,
-    GLuint duvBuffer, BufferDescriptor const &duvDesc,
-    GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
-    GLuint sizesBuffer,
-    GLuint offsetsBuffer,
-    GLuint indicesBuffer,
-    GLuint weightsBuffer,
-    GLuint duWeightsBuffer,
-    GLuint dvWeightsBuffer,
-    GLuint duuWeightsBuffer,
-    GLuint duvWeightsBuffer,
-    GLuint dvvWeightsBuffer,
+    ID srcBuffer, BufferDescriptor const &srcDesc,
+    ID dstBuffer, BufferDescriptor const &dstDesc,
+    ID duBuffer,  BufferDescriptor const &duDesc,
+    ID dvBuffer,  BufferDescriptor const &dvDesc,
+    ID duuBuffer, BufferDescriptor const &duuDesc,
+    ID duvBuffer, BufferDescriptor const &duvDesc,
+    ID dvvBuffer, BufferDescriptor const &dvvDesc,
+    ID sizesBuffer,
+    ID offsetsBuffer,
+    ID indicesBuffer,
+    ID weightsBuffer,
+    ID duWeightsBuffer,
+    ID dvWeightsBuffer,
+    ID duuWeightsBuffer,
+    ID duvWeightsBuffer,
+    ID dvvWeightsBuffer,
     int start, int end) const {
 
     if (!_stencilKernel.program) return false;
@@ -368,15 +368,15 @@ GLComputeEvaluator::EvalStencils(
 
 bool
 GLComputeEvaluator::EvalPatches(
-    GLuint srcBuffer, BufferDescriptor const &srcDesc,
-    GLuint dstBuffer, BufferDescriptor const &dstDesc,
-    GLuint duBuffer,  BufferDescriptor const &duDesc,
-    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+    ID srcBuffer, BufferDescriptor const &srcDesc,
+    ID dstBuffer, BufferDescriptor const &dstDesc,
+    ID duBuffer,  BufferDescriptor const &duDesc,
+    ID dvBuffer,  BufferDescriptor const &dvDesc,
     int numPatchCoords,
-    GLuint patchCoordsBuffer,
+    ID patchCoordsBuffer,
     const PatchArrayVector &patchArrays,
-    GLuint patchIndexBuffer,
-    GLuint patchParamsBuffer) const {
+    ID patchIndexBuffer,
+    ID patchParamsBuffer) const {
 
     return EvalPatches(srcBuffer, srcDesc,
                        dstBuffer, dstDesc,
@@ -394,18 +394,18 @@ GLComputeEvaluator::EvalPatches(
 
 bool
 GLComputeEvaluator::EvalPatches(
-    GLuint srcBuffer, BufferDescriptor const &srcDesc,
-    GLuint dstBuffer, BufferDescriptor const &dstDesc,
-    GLuint duBuffer,  BufferDescriptor const &duDesc,
-    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-    GLuint duuBuffer, BufferDescriptor const &duuDesc,
-    GLuint duvBuffer, BufferDescriptor const &duvDesc,
-    GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
+    ID srcBuffer, BufferDescriptor const &srcDesc,
+    ID dstBuffer, BufferDescriptor const &dstDesc,
+    ID duBuffer,  BufferDescriptor const &duDesc,
+    ID dvBuffer,  BufferDescriptor const &dvDesc,
+    ID duuBuffer, BufferDescriptor const &duuDesc,
+    ID duvBuffer, BufferDescriptor const &duvDesc,
+    ID dvvBuffer, BufferDescriptor const &dvvDesc,
     int numPatchCoords,
-    GLuint patchCoordsBuffer,
+    ID patchCoordsBuffer,
     const PatchArrayVector &patchArrays,
-    GLuint patchIndexBuffer,
-    GLuint patchParamsBuffer) const {
+    ID patchIndexBuffer,
+    ID patchParamsBuffer) const {
 
     if (!_patchKernel.program) return false;
 

--- a/opensubdiv/osd/glComputeEvaluator.h
+++ b/opensubdiv/osd/glComputeEvaluator.h
@@ -27,7 +27,6 @@
 
 #include "../version.h"
 
-#include "../osd/opengl.h"
 #include "../osd/types.h"
 #include "../osd/bufferDescriptor.h"
 
@@ -50,6 +49,8 @@ namespace Osd {
 ///
 class GLStencilTableSSBO {
 public:
+    using ID = unsigned int;    // GLuint resource ID
+
     static GLStencilTableSSBO *Create(Far::StencilTable const *stencilTable,
                                        void *deviceContext = NULL) {
         (void)deviceContext;  // unused
@@ -67,27 +68,27 @@ public:
     ~GLStencilTableSSBO();
 
     // interfaces needed for GLSLComputeKernel
-    GLuint GetSizesBuffer() const { return _sizes; }
-    GLuint GetOffsetsBuffer() const { return _offsets; }
-    GLuint GetIndicesBuffer() const { return _indices; }
-    GLuint GetWeightsBuffer() const { return _weights; }
-    GLuint GetDuWeightsBuffer() const { return _duWeights; }
-    GLuint GetDvWeightsBuffer() const { return _dvWeights; }
-    GLuint GetDuuWeightsBuffer() const { return _duuWeights; }
-    GLuint GetDuvWeightsBuffer() const { return _duvWeights; }
-    GLuint GetDvvWeightsBuffer() const { return _dvvWeights; }
+    ID GetSizesBuffer() const { return _sizes; }
+    ID GetOffsetsBuffer() const { return _offsets; }
+    ID GetIndicesBuffer() const { return _indices; }
+    ID GetWeightsBuffer() const { return _weights; }
+    ID GetDuWeightsBuffer() const { return _duWeights; }
+    ID GetDvWeightsBuffer() const { return _dvWeights; }
+    ID GetDuuWeightsBuffer() const { return _duuWeights; }
+    ID GetDuvWeightsBuffer() const { return _duvWeights; }
+    ID GetDvvWeightsBuffer() const { return _dvvWeights; }
     int GetNumStencils() const { return _numStencils; }
 
 private:
-    GLuint _sizes;
-    GLuint _offsets;
-    GLuint _indices;
-    GLuint _weights;
-    GLuint _duWeights;
-    GLuint _dvWeights;
-    GLuint _duuWeights;
-    GLuint _duvWeights;
-    GLuint _dvvWeights;
+    ID _sizes;
+    ID _offsets;
+    ID _indices;
+    ID _weights;
+    ID _duWeights;
+    ID _dvWeights;
+    ID _duuWeights;
+    ID _duvWeights;
+    ID _dvvWeights;
     int _numStencils;
 };
 
@@ -95,7 +96,9 @@ private:
 
 class GLComputeEvaluator {
 public:
-    typedef bool Instantiatable;
+    using ID = unsigned int;        // GLuint resource ID
+    using Instantiatable = bool;    // Enable compiled kernel evaluator cache
+
     static GLComputeEvaluator * Create(BufferDescriptor const &srcDesc,
                                        BufferDescriptor const &dstDesc,
                                        BufferDescriptor const &duDesc,
@@ -563,16 +566,16 @@ public:
     ///
     /// @param end              end index of stencil table
     ///
-    bool EvalStencils(GLuint srcBuffer, BufferDescriptor const &srcDesc,
-                      GLuint dstBuffer, BufferDescriptor const &dstDesc,
-                      GLuint duBuffer,  BufferDescriptor const &duDesc,
-                      GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-                      GLuint sizesBuffer,
-                      GLuint offsetsBuffer,
-                      GLuint indicesBuffer,
-                      GLuint weightsBuffer,
-                      GLuint duWeightsBuffer,
-                      GLuint dvWeightsBuffer,
+    bool EvalStencils(ID srcBuffer, BufferDescriptor const &srcDesc,
+                      ID dstBuffer, BufferDescriptor const &dstDesc,
+                      ID duBuffer,  BufferDescriptor const &duDesc,
+                      ID dvBuffer,  BufferDescriptor const &dvDesc,
+                      ID sizesBuffer,
+                      ID offsetsBuffer,
+                      ID indicesBuffer,
+                      ID weightsBuffer,
+                      ID duWeightsBuffer,
+                      ID dvWeightsBuffer,
                       int start,
                       int end) const;
 
@@ -629,22 +632,22 @@ public:
     ///
     /// @param end              end index of stencil table
     ///
-    bool EvalStencils(GLuint srcBuffer, BufferDescriptor const &srcDesc,
-                      GLuint dstBuffer, BufferDescriptor const &dstDesc,
-                      GLuint duBuffer,  BufferDescriptor const &duDesc,
-                      GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-                      GLuint duuBuffer, BufferDescriptor const &duuDesc,
-                      GLuint duvBuffer, BufferDescriptor const &duvDesc,
-                      GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
-                      GLuint sizesBuffer,
-                      GLuint offsetsBuffer,
-                      GLuint indicesBuffer,
-                      GLuint weightsBuffer,
-                      GLuint duWeightsBuffer,
-                      GLuint dvWeightsBuffer,
-                      GLuint duuWeightsBuffer,
-                      GLuint duvWeightsBuffer,
-                      GLuint dvvWeightsBuffer,
+    bool EvalStencils(ID srcBuffer, BufferDescriptor const &srcDesc,
+                      ID dstBuffer, BufferDescriptor const &dstDesc,
+                      ID duBuffer,  BufferDescriptor const &duDesc,
+                      ID dvBuffer,  BufferDescriptor const &dvDesc,
+                      ID duuBuffer, BufferDescriptor const &duuDesc,
+                      ID duvBuffer, BufferDescriptor const &duvDesc,
+                      ID dvvBuffer, BufferDescriptor const &dvvDesc,
+                      ID sizesBuffer,
+                      ID offsetsBuffer,
+                      ID indicesBuffer,
+                      ID weightsBuffer,
+                      ID duWeightsBuffer,
+                      ID dvWeightsBuffer,
+                      ID duuWeightsBuffer,
+                      ID duvWeightsBuffer,
+                      ID dvvWeightsBuffer,
                       int start,
                       int end) const;
 
@@ -1094,28 +1097,28 @@ public:
                            patchTable->GetPatchParamBuffer());
     }
 
-    bool EvalPatches(GLuint srcBuffer, BufferDescriptor const &srcDesc,
-                     GLuint dstBuffer, BufferDescriptor const &dstDesc,
-                     GLuint duBuffer,  BufferDescriptor const &duDesc,
-                     GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+    bool EvalPatches(ID srcBuffer, BufferDescriptor const &srcDesc,
+                     ID dstBuffer, BufferDescriptor const &dstDesc,
+                     ID duBuffer,  BufferDescriptor const &duDesc,
+                     ID dvBuffer,  BufferDescriptor const &dvDesc,
                      int numPatchCoords,
-                     GLuint patchCoordsBuffer,
+                     ID patchCoordsBuffer,
                      const PatchArrayVector &patchArrays,
-                     GLuint patchIndexBuffer,
-                     GLuint patchParamsBuffer) const;
+                     ID patchIndexBuffer,
+                     ID patchParamsBuffer) const;
 
-    bool EvalPatches(GLuint srcBuffer, BufferDescriptor const &srcDesc,
-                     GLuint dstBuffer, BufferDescriptor const &dstDesc,
-                     GLuint duBuffer,  BufferDescriptor const &duDesc,
-                     GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-                     GLuint duuBuffer, BufferDescriptor const &duuDesc,
-                     GLuint duvBuffer, BufferDescriptor const &duvDesc,
-                     GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
+    bool EvalPatches(ID srcBuffer, BufferDescriptor const &srcDesc,
+                     ID dstBuffer, BufferDescriptor const &dstDesc,
+                     ID duBuffer,  BufferDescriptor const &duDesc,
+                     ID dvBuffer,  BufferDescriptor const &dvDesc,
+                     ID duuBuffer, BufferDescriptor const &duuDesc,
+                     ID duvBuffer, BufferDescriptor const &duvDesc,
+                     ID dvvBuffer, BufferDescriptor const &dvvDesc,
                      int numPatchCoords,
-                     GLuint patchCoordsBuffer,
+                     ID patchCoordsBuffer,
                      const PatchArrayVector &patchArrays,
-                     GLuint patchIndexBuffer,
-                     GLuint patchParamsBuffer) const;
+                     ID patchIndexBuffer,
+                     ID patchParamsBuffer) const;
 
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
@@ -2066,16 +2069,16 @@ private:
                      BufferDescriptor const &duvDesc,
                      BufferDescriptor const &dvvDesc,
                      int workGroupSize);
-        GLuint program;
-        GLuint uniformStart;
-        GLuint uniformEnd;
-        GLuint uniformSrcOffset;
-        GLuint uniformDstOffset;
-        GLuint uniformDuDesc;
-        GLuint uniformDvDesc;
-        GLuint uniformDuuDesc;
-        GLuint uniformDuvDesc;
-        GLuint uniformDvvDesc;
+        ID program;
+        ID uniformStart;
+        ID uniformEnd;
+        ID uniformSrcOffset;
+        ID uniformDstOffset;
+        ID uniformDuDesc;
+        ID uniformDvDesc;
+        ID uniformDuuDesc;
+        ID uniformDuvDesc;
+        ID uniformDvvDesc;
     } _stencilKernel;
 
     struct _PatchKernel {
@@ -2089,19 +2092,19 @@ private:
                      BufferDescriptor const &duvDesc,
                      BufferDescriptor const &dvvDesc,
                      int workGroupSize);
-        GLuint program;
-        GLuint uniformSrcOffset;
-        GLuint uniformDstOffset;
-        GLuint uniformPatchArray;
-        GLuint uniformDuDesc;
-        GLuint uniformDvDesc;
-        GLuint uniformDuuDesc;
-        GLuint uniformDuvDesc;
-        GLuint uniformDvvDesc;
+        ID program;
+        ID uniformSrcOffset;
+        ID uniformDstOffset;
+        ID uniformPatchArray;
+        ID uniformDuDesc;
+        ID uniformDvDesc;
+        ID uniformDuuDesc;
+        ID uniformDuvDesc;
+        ID uniformDvvDesc;
     } _patchKernel;
 
     int _workGroupSize;
-    GLuint _patchArraysSSBO;
+    ID _patchArraysSSBO;
 };
 
 }  // end namespace Osd

--- a/opensubdiv/osd/glLegacyGregoryPatchTable.cpp
+++ b/opensubdiv/osd/glLegacyGregoryPatchTable.cpp
@@ -105,7 +105,7 @@ GLLegacyGregoryPatchTable::Create(Far::PatchTable const *farPatchTable) {
 }
 
 void
-GLLegacyGregoryPatchTable::UpdateVertexBuffer(GLuint vbo) {
+GLLegacyGregoryPatchTable::UpdateVertexBuffer(ID vbo) {
     glBindTexture(GL_TEXTURE_BUFFER, _vertexTextureBuffer);
     glTexBuffer(GL_TEXTURE_BUFFER, GL_R32F, vbo);
     glBindTexture(GL_TEXTURE_BUFFER, 0);

--- a/opensubdiv/osd/glLegacyGregoryPatchTable.h
+++ b/opensubdiv/osd/glLegacyGregoryPatchTable.h
@@ -29,7 +29,6 @@
 
 #include "../far/patchTable.h"
 #include "../osd/nonCopyable.h"
-#include "../osd/opengl.h"
 
 namespace OpenSubdiv {
 namespace OPENSUBDIV_VERSION {
@@ -39,25 +38,27 @@ namespace Osd {
 class GLLegacyGregoryPatchTable
     : private NonCopyable<GLLegacyGregoryPatchTable> {
 public:
+    using ID = unsigned int;    // GLuint resource ID
+
     ~GLLegacyGregoryPatchTable();
 
     static GLLegacyGregoryPatchTable *Create(Far::PatchTable const *patchTable);
 
-    void UpdateVertexBuffer(GLuint vbo);
+    void UpdateVertexBuffer(ID vbo);
 
-    GLuint GetVertexTextureBuffer() const {
+    ID GetVertexTextureBuffer() const {
         return _vertexTextureBuffer;
     }
 
-    GLuint GetVertexValenceTextureBuffer() const {
+    ID GetVertexValenceTextureBuffer() const {
         return _vertexValenceTextureBuffer;
     }
 
-    GLuint GetQuadOffsetsTextureBuffer() const {
+    ID GetQuadOffsetsTextureBuffer() const {
         return _quadOffsetsTextureBuffer;
     }
 
-    GLuint GetQuadOffsetsBase(Far::PatchDescriptor::Type type) {
+    ID GetQuadOffsetsBase(Far::PatchDescriptor::Type type) {
         if (type == Far::PatchDescriptor::GREGORY_BOUNDARY) {
             return _quadOffsetsBase[1];
         }
@@ -68,10 +69,10 @@ protected:
     GLLegacyGregoryPatchTable();
 
 private:
-    GLuint _vertexTextureBuffer;
-    GLuint _vertexValenceTextureBuffer;
-    GLuint _quadOffsetsTextureBuffer;
-    GLuint _quadOffsetsBase[2];       // gregory, boundaryGregory
+    ID _vertexTextureBuffer;
+    ID _vertexValenceTextureBuffer;
+    ID _quadOffsetsTextureBuffer;
+    ID _quadOffsetsBase[2];       // gregory, boundaryGregory
 };
 
 

--- a/opensubdiv/osd/glPatchTable.h
+++ b/opensubdiv/osd/glPatchTable.h
@@ -28,7 +28,6 @@
 #include "../version.h"
 
 #include "../osd/nonCopyable.h"
-#include "../osd/opengl.h"
 #include "../osd/types.h"
 
 #include <vector>
@@ -44,7 +43,8 @@ namespace Osd {
 
 class GLPatchTable : private NonCopyable<GLPatchTable> {
 public:
-    typedef GLuint VertexBufferBinding;
+    using ID = unsigned int;        // GLuint resource ID
+    using VertexBufferBinding = ID; // buffer binding type
 
     ~GLPatchTable();
 
@@ -57,22 +57,22 @@ public:
     }
 
     /// Returns the GL index buffer containing the patch control vertices
-    GLuint GetPatchIndexBuffer() const {
+    ID GetPatchIndexBuffer() const {
         return _patchIndexBuffer;
     }
 
     /// Returns the GL index buffer containing the patch parameter
-    GLuint GetPatchParamBuffer() const {
+    ID GetPatchParamBuffer() const {
         return _patchParamBuffer;
     }
 
     /// Returns the GL texture buffer containing the patch control vertices
-    GLuint GetPatchIndexTextureBuffer() const {
+    ID GetPatchIndexTextureBuffer() const {
         return _patchIndexTexture;
     }
 
     /// Returns the GL texture buffer containing the patch parameter
-    GLuint GetPatchParamTextureBuffer() const {
+    ID GetPatchParamTextureBuffer() const {
         return _patchParamTexture;
     }
 
@@ -82,12 +82,12 @@ public:
     }
 
     /// Returns the GL index buffer containing the varying control vertices
-    GLuint GetVaryingPatchIndexBuffer() const {
+    ID GetVaryingPatchIndexBuffer() const {
         return _varyingIndexBuffer;
     }
 
     /// Returns the GL texture buffer containing the varying control vertices
-    GLuint GetVaryingPatchIndexTextureBuffer() const {
+    ID GetVaryingPatchIndexTextureBuffer() const {
         return _varyingIndexTexture;
     }
 
@@ -100,22 +100,22 @@ public:
     }
 
     /// Returns the GL index buffer containing face-varying control vertices
-    GLuint GetFVarPatchIndexBuffer(int fvarChannel = 0) const {
+    ID GetFVarPatchIndexBuffer(int fvarChannel = 0) const {
         return _fvarIndexBuffers[fvarChannel];
     }
 
     /// Returns the GL texture buffer containing face-varying control vertices
-    GLuint GetFVarPatchIndexTextureBuffer(int fvarChannel = 0) const {
+    ID GetFVarPatchIndexTextureBuffer(int fvarChannel = 0) const {
         return _fvarIndexTextures[fvarChannel];
     }
 
     /// Returns the GL index buffer containing face-varying patch params
-    GLuint GetFVarPatchParamBuffer(int fvarChannel = 0) const {
+    ID GetFVarPatchParamBuffer(int fvarChannel = 0) const {
         return _fvarParamBuffers[fvarChannel];
     }
 
     /// Returns the GL texture buffer containing face-varying patch params
-    GLuint GetFVarPatchParamTextureBuffer(int fvarChannel = 0) const {
+    ID GetFVarPatchParamTextureBuffer(int fvarChannel = 0) const {
         return _fvarParamTextures[fvarChannel];
     }
 
@@ -127,22 +127,22 @@ protected:
 
     PatchArrayVector _patchArrays;
 
-    GLuint _patchIndexBuffer;
-    GLuint _patchParamBuffer;
+    ID _patchIndexBuffer;
+    ID _patchParamBuffer;
 
-    GLuint _patchIndexTexture;
-    GLuint _patchParamTexture;
+    ID _patchIndexTexture;
+    ID _patchParamTexture;
 
     PatchArrayVector _varyingPatchArrays;
-    GLuint _varyingIndexBuffer;
-    GLuint _varyingIndexTexture;
+    ID _varyingIndexBuffer;
+    ID _varyingIndexTexture;
 
     std::vector<PatchArrayVector> _fvarPatchArrays;
-    std::vector<GLuint> _fvarIndexBuffers;
-    std::vector<GLuint> _fvarIndexTextures;
+    std::vector<ID> _fvarIndexBuffers;
+    std::vector<ID> _fvarIndexTextures;
 
-    std::vector<GLuint> _fvarParamBuffers;
-    std::vector<GLuint> _fvarParamTextures;
+    std::vector<ID> _fvarParamBuffers;
+    std::vector<ID> _fvarParamTextures;
 };
 
 

--- a/opensubdiv/osd/glVertexBuffer.cpp
+++ b/opensubdiv/osd/glVertexBuffer.cpp
@@ -87,7 +87,7 @@ GLVertexBuffer::GetNumVertices() const {
     return _numVertices;
 }
 
-GLuint
+GLVertexBuffer::ID
 GLVertexBuffer::BindVBO(void * /*deviceContext*/) {
 
     return _vbo;

--- a/opensubdiv/osd/glVertexBuffer.h
+++ b/opensubdiv/osd/glVertexBuffer.h
@@ -27,7 +27,6 @@
 
 #include "../version.h"
 
-#include "../osd/opengl.h"
 #include <cstddef>
 
 namespace OpenSubdiv {
@@ -43,6 +42,8 @@ namespace Osd {
 ///
 class GLVertexBuffer {
 public:
+    using ID = unsigned int;    // GLuint resource ID
+
     /// Creator. Returns NULL if error.
     static GLVertexBuffer * Create(int numElements, int numVertices,
                                    void *deviceContext = NULL);
@@ -62,7 +63,7 @@ public:
     int GetNumVertices() const;
 
     /// Returns the GL buffer object.
-    GLuint BindVBO(void *deviceContext = NULL);
+    ID BindVBO(void *deviceContext = NULL);
 
 protected:
     /// Constructor.
@@ -75,7 +76,7 @@ protected:
 private:
     int _numElements;
     int _numVertices;
-    GLuint _vbo;
+    ID _vbo;
 };
 
 }  // end namespace Osd

--- a/opensubdiv/osd/glXFBEvaluator.cpp
+++ b/opensubdiv/osd/glXFBEvaluator.cpp
@@ -475,16 +475,16 @@ bindTexture(GLint sampler, GLuint texture, int unit) {
 
 bool
 GLXFBEvaluator::EvalStencils(
-    GLuint srcBuffer, BufferDescriptor const &srcDesc,
-    GLuint dstBuffer, BufferDescriptor const &dstDesc,
-    GLuint duBuffer,  BufferDescriptor const &duDesc,
-    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-    GLuint sizesBuffer,
-    GLuint offsetsBuffer,
-    GLuint indicesBuffer,
-    GLuint weightsBuffer,
-    GLuint duWeightsBuffer,
-    GLuint dvWeightsBuffer,
+    ID srcBuffer, BufferDescriptor const &srcDesc,
+    ID dstBuffer, BufferDescriptor const &dstDesc,
+    ID duBuffer,  BufferDescriptor const &duDesc,
+    ID dvBuffer,  BufferDescriptor const &dvDesc,
+    ID sizesBuffer,
+    ID offsetsBuffer,
+    ID indicesBuffer,
+    ID weightsBuffer,
+    ID duWeightsBuffer,
+    ID dvWeightsBuffer,
     int start, int end) const {
 
     return EvalStencils(srcBuffer, srcDesc,
@@ -503,22 +503,22 @@ GLXFBEvaluator::EvalStencils(
 
 bool
 GLXFBEvaluator::EvalStencils(
-    GLuint srcBuffer, BufferDescriptor const &srcDesc,
-    GLuint dstBuffer, BufferDescriptor const &dstDesc,
-    GLuint duBuffer,  BufferDescriptor const &duDesc,
-    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-    GLuint duuBuffer, BufferDescriptor const &duuDesc,
-    GLuint duvBuffer, BufferDescriptor const &duvDesc,
-    GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
-    GLuint sizesTexture,
-    GLuint offsetsTexture,
-    GLuint indicesTexture,
-    GLuint weightsTexture,
-    GLuint duWeightsTexture,
-    GLuint dvWeightsTexture,
-    GLuint duuWeightsTexture,
-    GLuint duvWeightsTexture,
-    GLuint dvvWeightsTexture,
+    ID srcBuffer, BufferDescriptor const &srcDesc,
+    ID dstBuffer, BufferDescriptor const &dstDesc,
+    ID duBuffer,  BufferDescriptor const &duDesc,
+    ID dvBuffer,  BufferDescriptor const &dvDesc,
+    ID duuBuffer, BufferDescriptor const &duuDesc,
+    ID duvBuffer, BufferDescriptor const &duvDesc,
+    ID dvvBuffer, BufferDescriptor const &dvvDesc,
+    ID sizesTexture,
+    ID offsetsTexture,
+    ID indicesTexture,
+    ID weightsTexture,
+    ID duWeightsTexture,
+    ID dvWeightsTexture,
+    ID duuWeightsTexture,
+    ID duvWeightsTexture,
+    ID dvvWeightsTexture,
     int start, int end) const {
 
     if (!_stencilKernel.program) return false;
@@ -684,15 +684,15 @@ GLXFBEvaluator::EvalStencils(
 
 bool
 GLXFBEvaluator::EvalPatches(
-    GLuint srcBuffer, BufferDescriptor const &srcDesc,
-    GLuint dstBuffer, BufferDescriptor const &dstDesc,
-    GLuint duBuffer,  BufferDescriptor const &duDesc,
-    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+    ID srcBuffer, BufferDescriptor const &srcDesc,
+    ID dstBuffer, BufferDescriptor const &dstDesc,
+    ID duBuffer,  BufferDescriptor const &duDesc,
+    ID dvBuffer,  BufferDescriptor const &dvDesc,
     int numPatchCoords,
-    GLuint patchCoordsBuffer,
+    ID patchCoordsBuffer,
     const PatchArrayVector &patchArrays,
-    GLuint patchIndexTexture,
-    GLuint patchParamTexture) const {
+    ID patchIndexTexture,
+    ID patchParamTexture) const {
 
     return EvalPatches(srcBuffer, srcDesc,
                        dstBuffer, dstDesc,
@@ -709,18 +709,18 @@ GLXFBEvaluator::EvalPatches(
 
 bool
 GLXFBEvaluator::EvalPatches(
-    GLuint srcBuffer, BufferDescriptor const &srcDesc,
-    GLuint dstBuffer, BufferDescriptor const &dstDesc,
-    GLuint duBuffer,  BufferDescriptor const &duDesc,
-    GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-    GLuint duuBuffer, BufferDescriptor const &duuDesc,
-    GLuint duvBuffer, BufferDescriptor const &duvDesc,
-    GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
+    ID srcBuffer, BufferDescriptor const &srcDesc,
+    ID dstBuffer, BufferDescriptor const &dstDesc,
+    ID duBuffer,  BufferDescriptor const &duDesc,
+    ID dvBuffer,  BufferDescriptor const &dvDesc,
+    ID duuBuffer, BufferDescriptor const &duuDesc,
+    ID duvBuffer, BufferDescriptor const &duvDesc,
+    ID dvvBuffer, BufferDescriptor const &dvvDesc,
     int numPatchCoords,
-    GLuint patchCoordsBuffer,
+    ID patchCoordsBuffer,
     const PatchArrayVector &patchArrays,
-    GLuint patchIndexTexture,
-    GLuint patchParamTexture) const {
+    ID patchIndexTexture,
+    ID patchParamTexture) const {
 
     bool deriv1 = (duDesc.length > 0 || dvDesc.length > 0);
     bool deriv2 = (duuDesc.length > 0 || duvDesc.length > 0 || dvvDesc.length > 0);

--- a/opensubdiv/osd/glXFBEvaluator.h
+++ b/opensubdiv/osd/glXFBEvaluator.h
@@ -27,7 +27,6 @@
 
 #include "../version.h"
 
-#include "../osd/opengl.h"
 #include "../osd/types.h"
 #include "../osd/bufferDescriptor.h"
 
@@ -51,6 +50,8 @@ namespace Osd {
 ///
 class GLStencilTableTBO {
 public:
+    using ID = unsigned int;    // GLuint resource ID
+
     static GLStencilTableTBO *Create(
         Far::StencilTable const *stencilTable, void *deviceContext = NULL) {
         (void)deviceContext;  // unused
@@ -69,27 +70,27 @@ public:
     ~GLStencilTableTBO();
 
     // interfaces needed for GLSLTransformFeedbackKernel
-    GLuint GetSizesTexture() const { return _sizes; }
-    GLuint GetOffsetsTexture() const { return _offsets; }
-    GLuint GetIndicesTexture() const { return _indices; }
-    GLuint GetWeightsTexture() const { return _weights; }
-    GLuint GetDuWeightsTexture() const { return _duWeights; }
-    GLuint GetDvWeightsTexture() const { return _dvWeights; }
-    GLuint GetDuuWeightsTexture() const { return _duuWeights; }
-    GLuint GetDuvWeightsTexture() const { return _duvWeights; }
-    GLuint GetDvvWeightsTexture() const { return _dvvWeights; }
+    ID GetSizesTexture() const { return _sizes; }
+    ID GetOffsetsTexture() const { return _offsets; }
+    ID GetIndicesTexture() const { return _indices; }
+    ID GetWeightsTexture() const { return _weights; }
+    ID GetDuWeightsTexture() const { return _duWeights; }
+    ID GetDvWeightsTexture() const { return _dvWeights; }
+    ID GetDuuWeightsTexture() const { return _duuWeights; }
+    ID GetDuvWeightsTexture() const { return _duvWeights; }
+    ID GetDvvWeightsTexture() const { return _dvvWeights; }
     int GetNumStencils() const { return _numStencils; }
 
 private:
-    GLuint _sizes;
-    GLuint _offsets;
-    GLuint _indices;
-    GLuint _weights;
-    GLuint _duWeights;
-    GLuint _dvWeights;
-    GLuint _duuWeights;
-    GLuint _duvWeights;
-    GLuint _dvvWeights;
+    ID _sizes;
+    ID _offsets;
+    ID _indices;
+    ID _weights;
+    ID _duWeights;
+    ID _dvWeights;
+    ID _duuWeights;
+    ID _duvWeights;
+    ID _dvvWeights;
     int _numStencils;
 };
 
@@ -97,7 +98,9 @@ private:
 
 class GLXFBEvaluator {
 public:
-    typedef bool Instantiatable;
+    using ID = unsigned int;        // GLuint resource ID
+    using LOCATION = int;           // GLint program location
+    using Instantiatable = bool;    // Enable compiled kernel evaluator cache
 
     /// Generic creator template.
     template <typename DEVICE_CONTEXT>
@@ -637,16 +640,16 @@ public:
     ///
     /// @param end              end index of stencil table
     ///
-    bool EvalStencils(GLuint srcBuffer, BufferDescriptor const &srcDesc,
-                      GLuint dstBuffer, BufferDescriptor const &dstDesc,
-                      GLuint duBuffer,  BufferDescriptor const &duDesc,
-                      GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-                      GLuint sizesBuffer,
-                      GLuint offsetsBuffer,
-                      GLuint indicesBuffer,
-                      GLuint weightsBuffer,
-                      GLuint duWeightsBuffer,
-                      GLuint dvWeightsBuffer,
+    bool EvalStencils(ID srcBuffer, BufferDescriptor const &srcDesc,
+                      ID dstBuffer, BufferDescriptor const &dstDesc,
+                      ID duBuffer,  BufferDescriptor const &duDesc,
+                      ID dvBuffer,  BufferDescriptor const &dvDesc,
+                      ID sizesBuffer,
+                      ID offsetsBuffer,
+                      ID indicesBuffer,
+                      ID weightsBuffer,
+                      ID duWeightsBuffer,
+                      ID dvWeightsBuffer,
                       int start,
                       int end) const;
 
@@ -703,22 +706,22 @@ public:
     ///
     /// @param end              end index of stencil table
     ///
-    bool EvalStencils(GLuint srcBuffer, BufferDescriptor const &srcDesc,
-                      GLuint dstBuffer, BufferDescriptor const &dstDesc,
-                      GLuint duBuffer,  BufferDescriptor const &duDesc,
-                      GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-                      GLuint duuBuffer, BufferDescriptor const &duuDesc,
-                      GLuint duvBuffer, BufferDescriptor const &duvDesc,
-                      GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
-                      GLuint sizesBuffer,
-                      GLuint offsetsBuffer,
-                      GLuint indicesBuffer,
-                      GLuint weightsBuffer,
-                      GLuint duWeightsBuffer,
-                      GLuint dvWeightsBuffer,
-                      GLuint duuWeightsBuffer,
-                      GLuint duvWeightsBuffer,
-                      GLuint dvvWeightsBuffer,
+    bool EvalStencils(ID srcBuffer, BufferDescriptor const &srcDesc,
+                      ID dstBuffer, BufferDescriptor const &dstDesc,
+                      ID duBuffer,  BufferDescriptor const &duDesc,
+                      ID dvBuffer,  BufferDescriptor const &dvDesc,
+                      ID duuBuffer, BufferDescriptor const &duuDesc,
+                      ID duvBuffer, BufferDescriptor const &duvDesc,
+                      ID dvvBuffer, BufferDescriptor const &dvvDesc,
+                      ID sizesBuffer,
+                      ID offsetsBuffer,
+                      ID indicesBuffer,
+                      ID weightsBuffer,
+                      ID duWeightsBuffer,
+                      ID dvWeightsBuffer,
+                      ID duuWeightsBuffer,
+                      ID duvWeightsBuffer,
+                      ID dvvWeightsBuffer,
                       int start,
                       int end) const;
 
@@ -1167,28 +1170,28 @@ public:
                            patchTable->GetPatchParamTextureBuffer());
     }
 
-    bool EvalPatches(GLuint srcBuffer, BufferDescriptor const &srcDesc,
-                     GLuint dstBuffer, BufferDescriptor const &dstDesc,
-                     GLuint duBuffer,  BufferDescriptor const &duDesc,
-                     GLuint dvBuffer,  BufferDescriptor const &dvDesc,
+    bool EvalPatches(ID srcBuffer, BufferDescriptor const &srcDesc,
+                     ID dstBuffer, BufferDescriptor const &dstDesc,
+                     ID duBuffer,  BufferDescriptor const &duDesc,
+                     ID dvBuffer,  BufferDescriptor const &dvDesc,
                      int numPatchCoords,
-                     GLuint patchCoordsBuffer,
+                     ID patchCoordsBuffer,
                      const PatchArrayVector &patchArrays,
-                     GLuint patchIndexBuffer,
-                     GLuint patchParamsBuffer) const;
+                     ID patchIndexBuffer,
+                     ID patchParamsBuffer) const;
 
-    bool EvalPatches(GLuint srcBuffer, BufferDescriptor const &srcDesc,
-                     GLuint dstBuffer, BufferDescriptor const &dstDesc,
-                     GLuint duBuffer,  BufferDescriptor const &duDesc,
-                     GLuint dvBuffer,  BufferDescriptor const &dvDesc,
-                     GLuint duuBuffer, BufferDescriptor const &duuDesc,
-                     GLuint duvBuffer, BufferDescriptor const &duvDesc,
-                     GLuint dvvBuffer, BufferDescriptor const &dvvDesc,
+    bool EvalPatches(ID srcBuffer, BufferDescriptor const &srcDesc,
+                     ID dstBuffer, BufferDescriptor const &dstDesc,
+                     ID duBuffer,  BufferDescriptor const &duDesc,
+                     ID dvBuffer,  BufferDescriptor const &dvDesc,
+                     ID duuBuffer, BufferDescriptor const &duuDesc,
+                     ID duvBuffer, BufferDescriptor const &duvDesc,
+                     ID dvvBuffer, BufferDescriptor const &dvvDesc,
                      int numPatchCoords,
-                     GLuint patchCoordsBuffer,
+                     ID patchCoordsBuffer,
                      const PatchArrayVector &patchArrays,
-                     GLuint patchIndexBuffer,
-                     GLuint patchParamsBuffer) const;
+                     ID patchIndexBuffer,
+                     ID patchParamsBuffer) const;
 
     /// \brief Generic limit eval function. This function has a same
     ///        signature as other device kernels have so that it can be called
@@ -2128,8 +2131,8 @@ public:
     static void Synchronize(void *kernel);
 
 private:
-    GLuint _srcBufferTexture;
-    GLuint _patchArraysUBO;
+    ID _srcBufferTexture;
+    ID _patchArraysUBO;
     bool _interleavedDerivativeBuffers;
 
     struct _StencilKernel {
@@ -2143,21 +2146,21 @@ private:
                      BufferDescriptor const &duvDesc,
                      BufferDescriptor const &dvvDesc,
                      bool interleavedDerivativeBuffers);
-        GLuint program;
-        GLint uniformSrcBufferTexture;
-        GLint uniformSrcOffset;    // src buffer offset (in elements)
+        ID program;
+        LOCATION uniformSrcBufferTexture;
+        LOCATION uniformSrcOffset;    // src buffer offset (in elements)
 
-        GLint uniformSizesTexture;
-        GLint uniformOffsetsTexture;
-        GLint uniformIndicesTexture;
-        GLint uniformWeightsTexture;
-        GLint uniformDuWeightsTexture;
-        GLint uniformDvWeightsTexture;
-        GLint uniformDuuWeightsTexture;
-        GLint uniformDuvWeightsTexture;
-        GLint uniformDvvWeightsTexture;
-        GLint uniformStart;     // range
-        GLint uniformEnd;
+        LOCATION uniformSizesTexture;
+        LOCATION uniformOffsetsTexture;
+        LOCATION uniformIndicesTexture;
+        LOCATION uniformWeightsTexture;
+        LOCATION uniformDuWeightsTexture;
+        LOCATION uniformDvWeightsTexture;
+        LOCATION uniformDuuWeightsTexture;
+        LOCATION uniformDuvWeightsTexture;
+        LOCATION uniformDvvWeightsTexture;
+        LOCATION uniformStart;     // range
+        LOCATION uniformEnd;
     } _stencilKernel;
 
     struct _PatchKernel {
@@ -2171,13 +2174,13 @@ private:
                      BufferDescriptor const &duvDesc,
                      BufferDescriptor const &dvvDesc,
                      bool interleavedDerivativeBuffers);
-        GLuint program;
-        GLint uniformSrcBufferTexture;
-        GLint uniformSrcOffset;    // src buffer offset (in elements)
+        ID program;
+        LOCATION uniformSrcBufferTexture;
+        LOCATION uniformSrcOffset;    // src buffer offset (in elements)
 
-        GLint uniformPatchArraysUBOBinding;
-        GLint uniformPatchParamTexture;
-        GLint uniformPatchIndexTexture;
+        LOCATION uniformPatchArraysUBOBinding;
+        LOCATION uniformPatchParamTexture;
+        LOCATION uniformPatchIndexTexture;
     } _patchKernel;
 
 };

--- a/opensubdiv/osd/mtlComputeEvaluator.h
+++ b/opensubdiv/osd/mtlComputeEvaluator.h
@@ -91,7 +91,7 @@ private:
 class MTLComputeEvaluator
 {
 public:
-    typedef bool Instantiatable;
+    using Instantiatable = bool;    // Enable compiled kernel evaluator cache
 
     static MTLComputeEvaluator * Create(BufferDescriptor const &srcDesc,
                                         BufferDescriptor const &dstDesc,

--- a/opensubdiv/osd/mtlPatchTable.h
+++ b/opensubdiv/osd/mtlPatchTable.h
@@ -45,7 +45,7 @@ namespace Osd {
 
 class MTLPatchTable : private NonCopyable<MTLPatchTable> {
 public:
-    typedef id<MTLBuffer> VertexBufferBinding;
+    using VertexBufferBinding = id<MTLBuffer>;  // buffer binding type
 
     MTLPatchTable();
     ~MTLPatchTable();


### PR DESCRIPTION
Updated header files to use locally defined type aliases for GLuint and GLint so that these header files no longer need to include the system GL headers.

This removes the last uses of the osd/opengl.h header.

Fixes #1332