### PR TITLE
Add CMake Option to Disable Static Libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,11 @@ option(OSD_PATCH_SHADER_SOURCE_MSL "MSL Patch Shader Source" OFF)
 option(OPENSUBDIV_GREGORY_EVAL_TRUE_DERIVATIVES "Enable true derivative evaluation for Gregory basis patches" OFF)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(BUILD_STATIC_LIBS "Build static libraries" ON)
+
+if (NOT BUILD_SHARED_LIBS AND NOT BUILD_STATIC_LIBS)
+    message(FATAL_ERROR "Must enable BUILD_SHARED_LIBS or BUILD_STATIC_LIBS.")
+endif()
 
 # Save the current value of BUILD_SHARED_LIBS and restore it after
 # processing Find* modules, since some of the Find* modules invoked

--- a/opensubdiv/CMakeLists.txt
+++ b/opensubdiv/CMakeLists.txt
@@ -120,6 +120,8 @@ if (NOT NO_LIB)
 
     #---------------------------------------------------------------------------
 
+    if (BUILD_STATIC_LIBS)
+
     # Build static libs ------------------------------------
     add_library(osd_static_cpu
         STATIC
@@ -178,6 +180,7 @@ if (NOT NO_LIB)
         install( TARGETS osd_static_gpu EXPORT opensubdiv-targets DESTINATION "${CMAKE_LIBDIR_BASE}" )
     endif()
 
+    endif() # Build static libs
 
     # Build dynamic libs  ----------------------------------
     if (BUILD_SHARED_LIBS AND NOT WIN32 AND NOT IOS)


### PR DESCRIPTION
In some cases, building only the shared libraries is desirable. The default behavior remains to build both shared and static libraries.