### PR TITLE
[build_osd.py] Set CMake policy version minimum

### DIFF
--- a/build_scripts/build_osd.py
+++ b/build_scripts/build_osd.py
@@ -227,6 +227,15 @@ def RunCMake(context, force, extraArgs = None):
     source code is located in the current working directory."""
     # Create a directory for out-of-source builds in the build directory
     # using the name of the current working directory.
+
+    # Ensure we can freely modify our extraArgs without affecting caller
+    if extraArgs is None:
+        extraArgs = []
+    else:
+        extraArgs = list(extraArgs)
+
+    extraArgs.append("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+
     srcDir = os.getcwd()
     instDir = (context.osdInstDir if srcDir == context.osdSrcDir
                else context.instDir)


### PR DESCRIPTION
This helps with the transition to CMake 4.x

The macOS-14 azure pipelines agents were recently updated to CMake 4.x causing builds to fail and this workaround will allow these builds to succeed.