### PR TITLE
Remove libgomp.so link when building for TBB only.

### DIFF
--- a/opensubdiv/osd/CMakeLists.txt
+++ b/opensubdiv/osd/CMakeLists.txt
@@ -147,10 +147,6 @@ if( TBB_FOUND )
 
     list(APPEND PUBLIC_HEADER_FILES ${TBB_PUBLIC_HEADERS})
 
-    if (CMAKE_COMPILER_IS_GNUCXX)
-        list(APPEND PLATFORM_CPU_LIBRARIES gomp)
-    endif()
-
     list(APPEND PLATFORM_CPU_LIBRARIES
         TBB::tbb
     )


### PR DESCRIPTION
When building with `NO_TBB=OFF` and `NO_OMP=ON` the `osd_cpu_obj` objects target will be configured to link to `gomp`.

When OpenMP is disabled, the omp-specific files (`ompEvaluator` and `ompKernel`) are not actually built, and therefore the link is not needed.

Although this doesn't create problems in opensubdiv builds, downstream projects may face challenges as the link carries over through cmake to any project that links to opensubdiv.