### PR TITLE
[opensubdiv/osd] Fixed deprecated CUDA API

### DIFF
--- a/opensubdiv/osd/cudaEvaluator.cpp
+++ b/opensubdiv/osd/cudaEvaluator.cpp
@@ -359,7 +359,7 @@ CudaEvaluator::EvalPatches(
 /* static */
 void
 CudaEvaluator::Synchronize(void * /*deviceContext*/) {
-    cudaThreadSynchronize();
+    cudaDeviceSynchronize();
 }
 
 }  // end namespace Osd


### PR DESCRIPTION
Updated osd/cudaEvaluator.cpp to use cudaDeviceSynchronize() instead of cudaThreadSynchronize() which was deprecated and has been removed from CUDA 13.0.

Tested on Linux, Windows 11, and Windows 10 with CUDA 12.6 and 13.0.

Fixes #1377