### PR TITLE
cpp23: fix source so it compiles with c++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,13 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANGCC OR CMAKE_COMPILER_IS_IC
         list(APPEND OSD_COMPILER_FLAGS -DNOMINMAX)
     endif()
 
+    if(CMAKE_COMPILER_IS_CLANGCC)
+        # Since C++23 libc++ is in the process of splitting larger headers into smaller modular headers.
+        # Force this behavior for the older dialects to keep the C++23 build green.
+        # See https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html
+        list(APPEND OSD_COMPILER_FLAGS -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES)
+    endif()
+
     # HBR uses the offsetof macro on a templated struct, which appears
     # to spuriously set off this warning in both gcc and Clang
     list(APPEND OSD_COMPILER_FLAGS -Wno-invalid-offsetof)

--- a/opensubdiv/bfr/tessellation.cpp
+++ b/opensubdiv/bfr/tessellation.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cassert>
+#include <cmath>
 #include <limits>
 #include <algorithm>
 

--- a/tutorials/bfr/tutorial_1_1/objWriter.h
+++ b/tutorials/bfr/tutorial_1_1/objWriter.h
@@ -20,7 +20,7 @@ namespace tutorial {
 //
 class ObjWriter {
 public:
-    ObjWriter(std::string const &filename = 0);
+    ObjWriter(std::string const &filename = std::string());
     ~ObjWriter();
 
     int GetNumVertices() const { return _numVertices; }

--- a/tutorials/bfr/tutorial_1_2/objWriter.h
+++ b/tutorials/bfr/tutorial_1_2/objWriter.h
@@ -20,7 +20,7 @@ namespace tutorial {
 //
 class ObjWriter {
 public:
-    ObjWriter(std::string const &filename = 0);
+    ObjWriter(std::string const &filename = std::string());
     ~ObjWriter();
 
     int GetNumVertices() const { return _numVertices; }

--- a/tutorials/bfr/tutorial_1_3/objWriter.h
+++ b/tutorials/bfr/tutorial_1_3/objWriter.h
@@ -20,7 +20,7 @@ namespace tutorial {
 //
 class ObjWriter {
 public:
-    ObjWriter(std::string const &filename = 0);
+    ObjWriter(std::string const &filename = std::string());
     ~ObjWriter();
 
     int GetNumVertices() const { return _numVertices; }

--- a/tutorials/bfr/tutorial_1_4/objWriter.h
+++ b/tutorials/bfr/tutorial_1_4/objWriter.h
@@ -20,7 +20,7 @@ namespace tutorial {
 //
 class ObjWriter {
 public:
-    ObjWriter(std::string const &filename = 0);
+    ObjWriter(std::string const &filename = std::string());
     ~ObjWriter();
 
     int GetNumVertices() const { return _numVertices; }

--- a/tutorials/bfr/tutorial_1_5/objWriter.h
+++ b/tutorials/bfr/tutorial_1_5/objWriter.h
@@ -20,7 +20,7 @@ namespace tutorial {
 //
 class ObjWriter {
 public:
-    ObjWriter(std::string const &filename = 0);
+    ObjWriter(std::string const &filename = std::string());
     ~ObjWriter();
 
     int GetNumVertices() const { return _numVertices; }

--- a/tutorials/bfr/tutorial_2_1/objWriter.h
+++ b/tutorials/bfr/tutorial_2_1/objWriter.h
@@ -20,7 +20,7 @@ namespace tutorial {
 //
 class ObjWriter {
 public:
-    ObjWriter(std::string const &filename = 0);
+    ObjWriter(std::string const &filename = std::string());
     ~ObjWriter();
 
     int GetNumVertices() const { return _numVertices; }

--- a/tutorials/bfr/tutorial_2_2/objWriter.h
+++ b/tutorials/bfr/tutorial_2_2/objWriter.h
@@ -20,7 +20,7 @@ namespace tutorial {
 //
 class ObjWriter {
 public:
-    ObjWriter(std::string const &filename = 0);
+    ObjWriter(std::string const &filename = std::string());
     ~ObjWriter();
 
     int GetNumVertices() const { return _numVertices; }

--- a/tutorials/bfr/tutorial_3_1/objWriter.h
+++ b/tutorials/bfr/tutorial_3_1/objWriter.h
@@ -20,7 +20,7 @@ namespace tutorial {
 //
 class ObjWriter {
 public:
-    ObjWriter(std::string const &filename = 0);
+    ObjWriter(std::string const &filename = std::string());
     ~ObjWriter();
 
     int GetNumVertices() const { return _numVertices; }

--- a/tutorials/bfr/tutorial_3_2/objWriter.h
+++ b/tutorials/bfr/tutorial_3_2/objWriter.h
@@ -20,7 +20,7 @@ namespace tutorial {
 //
 class ObjWriter {
 public:
-    ObjWriter(std::string const &filename = 0);
+    ObjWriter(std::string const &filename = std::string());
     ~ObjWriter();
 
     int GetNumVertices() const { return _numVertices; }


### PR DESCRIPTION
there are 2 changes:
1. A missing header was added to `opensubdiv/bfr/tessellation.cpp`. This header is missing due to new clang policy. see See https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html. To prevent this in future `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` was added when OSD compiled with CLang.
2. `ObjWriter::ObjWriter()` ctor was fixed, since C++23 std::string doesnt accept nullptr. see `(8)` in https://en.cppreference.com/cpp/string/basic_string/basic_string.

TESTING:
```
cmake -B buildDir -D CMAKE_INSTALL_PREFIX=instDir -D CMAKE_CXX_STANDARD=23 -G Xcode -D NO_PTEX=1 -D NO_DOC=1 -D NO_OMP=1 -D NO_TBB=1 -D NO_CUDA=1 -D NO_OPENCL=1 -D NO_CLEW=1 -D "GLFW_LOCATION=/path/to/glfw" -S .
...
cmake --build buildDir --config Release --target install
...
** BUILD SUCCEEDED **
``` 