### PR TITLE
Fix potential double free in Bfr::Surface::operator=()

### DIFF
--- a/opensubdiv/vtr/stackBuffer.h
+++ b/opensubdiv/vtr/stackBuffer.h
@@ -98,6 +98,7 @@ inline void
 StackBuffer<TYPE,SIZE,POD_TYPE>::deallocate() {
 
     ::operator delete(_dynamicData);
+    _dynamicData = nullptr;
 
     _data = reinterpret_cast<TYPE*>(_staticData);
     _capacity = SIZE;
@@ -135,7 +136,7 @@ StackBuffer<TYPE,SIZE,POD_TYPE>::StackBuffer() :
     _data(reinterpret_cast<TYPE*>(_staticData)),
     _size(0),
     _capacity(SIZE),
-    _dynamicData(0) {
+    _dynamicData(nullptr) {
 
 }
 
@@ -145,7 +146,7 @@ StackBuffer<TYPE,SIZE,POD_TYPE>::StackBuffer(size_type size) :
     _data(reinterpret_cast<TYPE*>(_staticData)),
     _size(size),
     _capacity(SIZE),
-    _dynamicData(0) {
+    _dynamicData(nullptr) {
 
     if (size > SIZE) {
         allocate(size);


### PR DESCRIPTION
As noted in #1379, an oversight in Vtr::internal::StackBuffer might lead to a double free when used by Bfr::Surface to resize the contributing number of CVs.

In most practical usage, i.e. re-population of a Surface via the SurfaceFactory, this is not possible, as the factory never resizes the number of CVs to zero. But use of Surface::operator=() can trigger the noted failure. When the instance on the left-hand side has had memory dynamically allocated, and the instance on the right-hand size was default-initialized (with 0 CVs), the left-hand side will be resized to zero -- triggering the double free.

The change here fixes the bug in StackBuffer with the missing pointer assignment. Additional use of "0" for pointer assignment in the file was also updated to make use of "nullptr".