### PR TITLE
Add const qualifier to Bfr::Tessellation transform methods

### DIFF
--- a/opensubdiv/bfr/tessellation.cpp
+++ b/opensubdiv/bfr/tessellation.cpp
@@ -2477,7 +2477,8 @@ Tessellation::GetFacets(int facetIndices[]) const {
 }
 
 void
-Tessellation::TransformFacetCoordIndices(int facetIndices[], int commonOffset) {
+Tessellation::TransformFacetCoordIndices(int facetIndices[],
+                                         int commonOffset) const {
 
     if (_facetSize == 4) {
         for (int i = 0; i < _numFacets; ++i, facetIndices += _facetStride) {
@@ -2500,7 +2501,7 @@ Tessellation::TransformFacetCoordIndices(int facetIndices[], int commonOffset) {
 void
 Tessellation::TransformFacetCoordIndices(int facetIndices[],
                                          int const boundaryIndices[],
-                                         int interiorOffset) {
+                                         int interiorOffset) const {
 
     for (int i = 0; i < _numFacets; ++i, facetIndices += _facetStride) {
         for (int j = 0; j < (int)_facetSize; ++j) {
@@ -2517,7 +2518,7 @@ Tessellation::TransformFacetCoordIndices(int facetIndices[],
 void
 Tessellation::TransformFacetCoordIndices(int facetIndices[],
                                          int const boundaryIndices[],
-                                         int const interiorIndices[]) {
+                                         int const interiorIndices[]) const {
 
     for (int i = 0; i < _numFacets; ++i, facetIndices += _facetStride) {
         for (int j = 0; j < (int)_facetSize; ++j) {

--- a/opensubdiv/bfr/tessellation.h
+++ b/opensubdiv/bfr/tessellation.h
@@ -276,18 +276,18 @@ public:
     ///
 
     /// @brief Apply a common offset to all facet coordinate indices
-    void TransformFacetCoordIndices(int facetTuples[], int commonOffset);
+    void TransformFacetCoordIndices(int facetTuples[], int commonOffset) const;
 
     /// @brief Reassign indices of boundary coordinates while offseting
     ///        those of interior coordinates
     void TransformFacetCoordIndices(int facetTuples[],
                                     int const boundaryIndices[],
-                                    int       interiorOffset);
+                                    int       interiorOffset) const;
 
     /// @brief Reassign all facet coordinate indices
     void TransformFacetCoordIndices(int facetTuples[],
                                     int const boundaryIndices[],
-                                    int const interiorIndices[]);
+                                    int const interiorIndices[]) const;
     //@}
 
 private:


### PR DESCRIPTION
Changes here correct an oversight in the declarations of public methods of Bfr::Tessellation. The three methods that transform the coordinate indices of a given tessellation are now declared "const" as originally intended.
